### PR TITLE
feat: add apps drawer with launcher tiles and driving-lockout stub

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,20 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!--
+        Package visibility: declare interest in every app that registers
+        the LAUNCHER intent so LauncherApps.getActivityList() returns the
+        full set on Android 11+. This is the privacy-respecting path
+        recommended by the add-launcher-permission skill (the alternative,
+        QUERY_ALL_PACKAGES, requires a Play Store justification).
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -5,7 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import io.github.seijikohara.femto.ui.home.HomeScreen
+import io.github.seijikohara.femto.ui.home.HomeRoute
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 
 class MainActivity : ComponentActivity() {
@@ -15,7 +15,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             FemtoTheme {
-                HomeScreen()
+                HomeRoute()
             }
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/data/AppEntry.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/AppEntry.kt
@@ -1,0 +1,19 @@
+package io.github.seijikohara.femto.data
+
+import android.content.ComponentName
+import android.graphics.Bitmap
+import androidx.compose.runtime.Immutable
+
+/**
+ * A launchable app exposed by the home screen.
+ *
+ * The icon is captured once as a [Bitmap] in the repository so the
+ * UI layer can render it without holding `Drawable` references that
+ * mutate at runtime.
+ */
+@Immutable
+data class AppEntry(
+    val componentName: ComponentName,
+    val label: String,
+    val icon: Bitmap,
+)

--- a/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
@@ -1,0 +1,62 @@
+package io.github.seijikohara.femto.data
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.LauncherApps
+import android.os.Process
+import androidx.core.graphics.drawable.toBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Wraps [LauncherApps] for the launcher home grid.
+ *
+ * Apps with category.HOME (this app) may call
+ * [LauncherApps.getActivityList] without `QUERY_ALL_PACKAGES`
+ * thanks to the launcher exception in the package-visibility
+ * model. Adding new permissions for this feature is therefore not
+ * required.
+ */
+class AppsRepository(
+    private val context: Context,
+) {
+    private val launcherApps =
+        context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+
+    /**
+     * Return all main-launchable activities for the current user,
+     * sorted by label. Icons are resolved once into [Bitmap]s on
+     * the IO dispatcher so the UI layer does not hold mutable
+     * `Drawable` references.
+     */
+    suspend fun queryApps(): List<AppEntry> =
+        withContext(Dispatchers.IO) {
+            launcherApps
+                .getActivityList(null, Process.myUserHandle())
+                .map { info ->
+                    AppEntry(
+                        componentName = info.componentName,
+                        label = info.label.toString(),
+                        icon = info.getIcon(0).toBitmap(width = ICON_PIXELS, height = ICON_PIXELS),
+                    )
+                }.sortedBy { it.label.lowercase() }
+        }
+
+    /**
+     * Launch the given activity. The bounds and options are
+     * unused for the MVP grid; pass `null` to defer to system
+     * defaults.
+     */
+    fun launch(componentName: ComponentName) {
+        launcherApps.startMainActivity(
+            componentName,
+            Process.myUserHandle(),
+            null,
+            null,
+        )
+    }
+
+    private companion object {
+        const val ICON_PIXELS = 192
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/data/DrivingState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DrivingState.kt
@@ -1,0 +1,27 @@
+package io.github.seijikohara.femto.data
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import io.github.seijikohara.femto.BuildConfig
+
+/**
+ * Driving-lockout signal stub.
+ *
+ * The single source of truth for the lockout policy is the
+ * `gate-driving-visible-feature` skill under `.claude/skills/`.
+ * Until the real signal lands (GPS speed, vehicle CAN, AI-Box
+ * driving flag), this stub determines whether driver-distracting
+ * UI is shown.
+ *
+ * Default behaviour:
+ * - Release builds: locked. The user sees the safe placeholder
+ *   surface until the real signal is wired.
+ * - Debug builds: unlocked. This is the documented build-variant
+ *   override that the lockout SSOT permits, so development and
+ *   AVD smoke tests can exercise the full UI.
+ *
+ * TODO(driving-lockout): replace with a real DrivingState source
+ * (GPS speed >= 5 km/h, ACC line, OBD-II RPM > idle, etc.).
+ */
+@Composable
+fun rememberDrivingLockState(): Boolean = remember { !BuildConfig.DEBUG }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -1,0 +1,20 @@
+package io.github.seijikohara.femto.ui.home
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@Composable
+fun HomeRoute(
+    modifier: Modifier = Modifier,
+    viewModel: HomeViewModel = viewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    HomeScreen(
+        uiState = uiState,
+        onAction = viewModel::onAction,
+        modifier = modifier,
+    )
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -1,49 +1,106 @@
 package io.github.seijikohara.femto.ui.home
 
+import android.content.ComponentName
+import android.graphics.Bitmap
+import android.graphics.Color
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.data.AppEntry
+import io.github.seijikohara.femto.data.rememberDrivingLockState
+import io.github.seijikohara.femto.ui.home.components.AppTile
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 
+private val MinTileWidth = 96.dp
+
 @Composable
-fun HomeScreen(modifier: Modifier = Modifier) {
+fun HomeScreen(
+    uiState: HomeUiState,
+    onAction: (HomeAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val drivingLocked = rememberDrivingLockState()
     Surface(
         modifier = modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background,
     ) {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(FemtoDimens.ScreenPadding),
-            contentAlignment = Alignment.Center,
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
-            ) {
-                Text(
-                    text = "Femto",
-                    style = MaterialTheme.typography.displayLarge,
-                    color = MaterialTheme.colorScheme.onBackground,
-                )
-                Text(
-                    text = "Car Launcher",
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+        when {
+            drivingLocked -> {
+                DrivingLockedPlaceholder(modifier = Modifier.fillMaxSize())
+            }
+
+            uiState.isLoading -> {
+                LoadingPlaceholder(modifier = Modifier.fillMaxSize())
+            }
+
+            else -> {
+                AppsGrid(
+                    apps = uiState.apps,
+                    onLaunch = { onAction(HomeAction.LaunchApp(it)) },
+                    modifier = Modifier.fillMaxSize(),
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun AppsGrid(
+    apps: List<AppEntry>,
+    onLaunch: (ComponentName) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = MinTileWidth),
+        modifier = modifier,
+        contentPadding = PaddingValues(FemtoDimens.ScreenPadding),
+        horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
+        verticalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
+    ) {
+        items(
+            items = apps,
+            key = { entry -> entry.componentName.flattenToString() },
+        ) { entry ->
+            AppTile(
+                entry = entry,
+                onClick = { onLaunch(entry.componentName) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingPlaceholder(modifier: Modifier = Modifier) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Text(
+            text = "Loading",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun DrivingLockedPlaceholder(modifier: Modifier = Modifier) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Text(
+            text = "Available when stopped",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
     }
 }
 
@@ -51,6 +108,36 @@ fun HomeScreen(modifier: Modifier = Modifier) {
 @Composable
 private fun HomeScreenPreview() {
     FemtoTheme {
-        HomeScreen()
+        HomeScreen(
+            uiState =
+                HomeUiState(
+                    isLoading = false,
+                    apps =
+                        listOf("Maps", "Music", "Settings", "Phone", "Messages", "Camera").map { name ->
+                            AppEntry(
+                                componentName = ComponentName("preview.${name.lowercase()}", name),
+                                label = name,
+                                icon = previewIcon(),
+                            )
+                        },
+                ),
+            onAction = {},
+        )
     }
 }
+
+@PreviewLightDark
+@Composable
+private fun HomeScreenLoadingPreview() {
+    FemtoTheme {
+        HomeScreen(
+            uiState = HomeUiState.Initial,
+            onAction = {},
+        )
+    }
+}
+
+private fun previewIcon(): Bitmap =
+    Bitmap.createBitmap(64, 64, Bitmap.Config.ARGB_8888).apply {
+        eraseColor(Color.LTGRAY)
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeUiState.kt
@@ -1,0 +1,27 @@
+package io.github.seijikohara.femto.ui.home
+
+import android.content.ComponentName
+import androidx.compose.runtime.Immutable
+import io.github.seijikohara.femto.data.AppEntry
+
+@Immutable
+data class HomeUiState(
+    val isLoading: Boolean,
+    val apps: List<AppEntry>,
+) {
+    companion object {
+        val Initial: HomeUiState =
+            HomeUiState(
+                isLoading = true,
+                apps = emptyList(),
+            )
+    }
+}
+
+sealed interface HomeAction {
+    data object Refresh : HomeAction
+
+    data class LaunchApp(
+        val componentName: ComponentName,
+    ) : HomeAction
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -1,0 +1,47 @@
+package io.github.seijikohara.femto.ui.home
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import io.github.seijikohara.femto.data.AppsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the launcher home state. Queries [AppsRepository] for the
+ * installed-app list once on creation; the screen emits actions
+ * back through [onAction]. The ViewModel takes [Application] only
+ * because [android.content.pm.LauncherApps] requires a `Context`;
+ * once dependency injection is introduced this should switch to
+ * constructor injection of the repository.
+ */
+class HomeViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+    private val repository = AppsRepository(application)
+
+    private val _uiState = MutableStateFlow(HomeUiState.Initial)
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun onAction(action: HomeAction) {
+        when (action) {
+            HomeAction.Refresh -> refresh()
+            is HomeAction.LaunchApp -> repository.launch(action.componentName)
+        }
+    }
+
+    private fun refresh() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val apps = repository.queryApps()
+            _uiState.update { it.copy(isLoading = false, apps = apps) }
+        }
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppTile.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppTile.kt
@@ -1,0 +1,66 @@
+package io.github.seijikohara.femto.ui.home.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.data.AppEntry
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+
+private val IconSize = 64.dp
+private val IconLabelGap = 8.dp
+private val TilePadding = 8.dp
+
+/**
+ * A single app tile in the launcher grid: icon + label, ≥ 64 dp
+ * tap target enforced by [FemtoDimens.MinTouchTarget].
+ */
+@Composable
+internal fun AppTile(
+    entry: AppEntry,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .defaultMinSize(
+                    minWidth = FemtoDimens.MinTouchTarget,
+                    minHeight = FemtoDimens.MinTouchTarget,
+                ).clickable(onClick = onClick)
+                .padding(TilePadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            painter = BitmapPainter(entry.icon.asImageBitmap()),
+            contentDescription = entry.label,
+            tint = androidx.compose.ui.graphics.Color.Unspecified,
+            modifier = Modifier.size(IconSize),
+        )
+        Spacer(Modifier.height(IconLabelGap))
+        Text(
+            text = entry.label,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onBackground,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- **Apps drawer** — `LauncherApps`-backed grid that lists every launchable app on the device and starts the underlying activity on tap. UDF shape (`HomeRoute` → `HomeScreen` → `HomeViewModel` + `HomeUiState` + `HomeAction`) per `CLAUDE.md#compose-architecture`.
- **`AppsRepository`** wraps `LauncherApps.getActivityList()` on the IO dispatcher and produces `@Immutable AppEntry` values whose icon is captured once as a 192 px `Bitmap`. No new permissions: the `AndroidManifest` declares `<queries>` with the `LAUNCHER` intent, the privacy-respecting path the `add-launcher-permission` skill recommends over `QUERY_ALL_PACKAGES`.
- **Driving-lockout stub** — `data/DrivingState.kt` ships `rememberDrivingLockState()` keyed on `BuildConfig.DEBUG`: locked in release (safe default per the `gate-driving-visible-feature` SSOT), unlocked in debug builds via the documented build-variant override. The grid is replaced with a glanceable "Available when stopped" placeholder when locked. `TODO(driving-lockout)` markers will resolve when a real signal lands.
- **`AppTile`** component renders a 64 dp icon plus a `labelLarge` label with a ≥ 64 dp tap target via `FemtoDimens.MinTouchTarget`. Bold Minimal styling, no elevation.

## Test plan

- [x] `./gradlew spotlessCheck` — clean.
- [x] `./gradlew assembleDebug` — `BUILD SUCCESSFUL`.
- [x] AVD smoke test on `TBox-Mock` (Android 13 / 1280×720):
    - Installed via `adb install -r app-debug.apk`.
    - Without `<queries>`: only 3 system apps were visible (the `LauncherApps` call requires either `QUERY_ALL_PACKAGES` or default-home status — `<queries>` declarations satisfy the package-visibility filter).
    - With `<queries>`: 19 of 38 launchable apps render above the fold.
    - Tapped the Settings tile → `topResumedActivity` switched to `com.android.settings/.Settings$NetworkDashboardActivity`.
    - Re-launched `MainActivity` → grid restored.
- [x] `@PreviewLightDark` covers both populated and loading states for design review.

## Deferred (out of scope for this PR)

- Real-device verification on Carlinkit / OTTOCAST hardware. Re-evaluate once a unit is available.
- Driving-locked rendering verification — the placeholder is exercised today via release-build runtime; once a real `DrivingState` signal lands (next PR, Plan C), end-to-end review can include the locked path.

## Notes

- ViewModel uses `AndroidViewModel(Application)` because `LauncherApps` requires a `Context`. Once dependency injection lands, this should switch to constructor injection of the repository per `CLAUDE.md#compose-architecture`.
- Icons are `Bitmap`-based (eager conversion in the repository) for MVP simplicity. A future iteration can introduce a Coil-backed loader if the icon set grows large enough that the eager allocation matters.
- No `<uses-permission>` entries were added; the audit log in `CLAUDE.md` remains empty as expected.