### PR TITLE
feat: wire driving-lockout signal to GPS speed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ policy elsewhere.
 
 | Permission | Justification |
 | --- | --- |
-| _(none yet)_ | _(none)_ |
+| `ACCESS_FINE_LOCATION` | Detect vehicle motion via GPS speed for the driving-lockout policy (see `gate-driving-visible-feature` skill). Required at runtime; locked default holds until granted. |
 
 ### Dependencies <a id="dependencies"></a>
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,6 @@ android {
     }
     buildFeatures {
         compose = true
-        buildConfig = true
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,15 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <!--
+        ACCESS_FINE_LOCATION: needed to detect vehicle motion from GPS
+        speed for the driving-lockout policy. The single source of truth
+        for the lockout policy is the gate-driving-visible-feature skill
+        under .claude/skills/. Justification is mirrored in the audit
+        log at CLAUDE.md#permissions.
+    -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <!--
         Package visibility: declare interest in every app that registers
         the LAUNCHER intent so LauncherApps.getActivityList() returns the
         full set on Android 11+. This is the privacy-respecting path

--- a/app/src/main/java/io/github/seijikohara/femto/data/DrivingState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DrivingState.kt
@@ -1,27 +1,61 @@
 package io.github.seijikohara.femto.data
 
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import io.github.seijikohara.femto.BuildConfig
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 
 /**
- * Driving-lockout signal stub.
+ * Compose-side accessor for the driving-lockout state.
  *
  * The single source of truth for the lockout policy is the
  * `gate-driving-visible-feature` skill under `.claude/skills/`.
- * Until the real signal lands (GPS speed, vehicle CAN, AI-Box
- * driving flag), this stub determines whether driver-distracting
- * UI is shown.
  *
- * Default behaviour:
- * - Release builds: locked. The user sees the safe placeholder
- *   surface until the real signal is wired.
- * - Debug builds: unlocked. This is the documented build-variant
- *   override that the lockout SSOT permits, so development and
- *   AVD smoke tests can exercise the full UI.
+ * Default behaviour (locked = the safe answer):
+ * - Compose previews: unlocked, so design review can see the full
+ *   surface.
+ * - `ACCESS_FINE_LOCATION` not granted: locked.
+ * - Permission granted, no GPS fix yet: locked.
+ * - Permission granted, GPS speed below the unlock threshold:
+ *   unlocked.
+ * - Permission granted, GPS speed at or above the unlock threshold:
+ *   locked.
  *
- * TODO(driving-lockout): replace with a real DrivingState source
- * (GPS speed >= 5 km/h, ACC line, OBD-II RPM > idle, etc.).
+ * The state is re-evaluated every time the host activity reaches
+ * the STARTED lifecycle, so a permission grant that arrives via a
+ * runtime dialog is reflected as soon as the dialog dismisses.
  */
 @Composable
-fun rememberDrivingLockState(): Boolean = remember { !BuildConfig.DEBUG }
+fun rememberDrivingLockState(): Boolean {
+    if (LocalInspectionMode.current) return false
+
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val locked by produceState(initialValue = true, lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            if (!context.hasFineLocationPermission()) {
+                value = true
+                return@repeatOnLifecycle
+            }
+            DrivingStateRepository(context).lockedFlow().collect { isLocked ->
+                value = isLocked
+            }
+        }
+    }
+    return locked
+}
+
+internal fun Context.hasFineLocationPermission(): Boolean =
+    ContextCompat.checkSelfPermission(
+        this,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED

--- a/app/src/main/java/io/github/seijikohara/femto/data/DrivingStateRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DrivingStateRepository.kt
@@ -1,0 +1,87 @@
+package io.github.seijikohara.femto.data
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.location.Location
+import android.location.LocationManager
+import android.os.Looper
+import androidx.core.location.LocationListenerCompat
+import androidx.core.location.LocationManagerCompat
+import androidx.core.location.LocationRequestCompat
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Driving-state signal source.
+ *
+ * The single source of truth for the driving-lockout policy is the
+ * `gate-driving-visible-feature` skill under `.claude/skills/`. This
+ * class is the runtime that satisfies the "real signal" requirement
+ * the skill describes.
+ *
+ * Strategy:
+ * - Subscribe to [LocationManager.GPS_PROVIDER] at 1 Hz. GPS is the
+ *   canonical source of vehicle speed; the network and fused
+ *   providers are deliberately omitted so a missing GPS chip on a
+ *   given AI Box keeps the launcher in the safe (locked) state
+ *   instead of spuriously unlocking on a Wi-Fi fix.
+ * - Locked when the most recent fix reports `speed >=`
+ *   [UNLOCK_SPEED_M_PER_S], or when no fix has arrived yet.
+ * - Caller is responsible for checking
+ *   `Manifest.permission.ACCESS_FINE_LOCATION` before subscribing;
+ *   subscribing without the permission throws.
+ */
+class DrivingStateRepository(
+    private val context: Context,
+) {
+    private val locationManager =
+        context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+
+    /** Emits `true` when the launcher should render the locked surface. */
+    fun lockedFlow(): Flow<Boolean> =
+        locationFlow().map { location ->
+            location == null || location.speed >= UNLOCK_SPEED_M_PER_S
+        }
+
+    @SuppressLint("MissingPermission") // Caller checks ACCESS_FINE_LOCATION before subscribing.
+    private fun locationFlow(): Flow<Location?> =
+        callbackFlow {
+            val listener = LocationListenerCompat { location -> trySend(location) }
+
+            // Seed with the most recent cached fix so the gate has a value
+            // before the first real update arrives.
+            runCatching {
+                trySend(locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER))
+            }
+
+            val subscribed =
+                runCatching {
+                    LocationManagerCompat.requestLocationUpdates(
+                        locationManager,
+                        LocationManager.GPS_PROVIDER,
+                        LocationRequestCompat.Builder(LOCATION_INTERVAL_MS).build(),
+                        listener,
+                        Looper.getMainLooper(),
+                    )
+                    true
+                }.getOrElse { false }
+
+            if (!subscribed) {
+                // GPS provider is unavailable on this device; emit null so
+                // the lockedFlow consumer falls back to the safe default.
+                trySend(null)
+            }
+
+            awaitClose {
+                locationManager.removeUpdates(listener)
+            }
+        }
+
+    private companion object {
+        const val LOCATION_INTERVAL_MS = 1_000L
+        const val UNLOCK_SPEED_KMH = 5f
+        const val UNLOCK_SPEED_M_PER_S = UNLOCK_SPEED_KMH * 1000f / 3600f
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -1,10 +1,16 @@
 package io.github.seijikohara.femto.ui.home
 
+import android.Manifest
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import io.github.seijikohara.femto.data.hasFineLocationPermission
 
 @Composable
 fun HomeRoute(
@@ -12,9 +18,37 @@ fun HomeRoute(
     viewModel: HomeViewModel = viewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    LocationPermissionRequest()
     HomeScreen(
         uiState = uiState,
         onAction = viewModel::onAction,
         modifier = modifier,
     )
+}
+
+/**
+ * Request `ACCESS_FINE_LOCATION` once when the route first composes.
+ *
+ * The permission gates the driving-lockout signal (see
+ * `data/DrivingState.kt` and the `gate-driving-visible-feature`
+ * skill). On denial the launcher continues to function; the lockout
+ * stays in its safe default (`true`) until the user grants the
+ * permission via system Settings.
+ *
+ * A richer rationale UI is deferred; the current request relies on
+ * the system dialog alone.
+ */
+@Composable
+private fun LocationPermissionRequest() {
+    val context = LocalContext.current
+    val launcher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { /* Result reflects on next STARTED via repeatOnLifecycle. */ }
+
+    LaunchedEffect(Unit) {
+        if (!context.hasFineLocationPermission()) {
+            launcher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Replace the `BuildConfig.DEBUG`-based stub with a real GPS-driven driving-lockout signal. The single source of truth for the policy remains the `gate-driving-visible-feature` skill under `.claude/skills/`; this PR implements the runtime that the skill describes as "the real signal".

- **`DrivingStateRepository`** wraps `LocationManager.GPS_PROVIDER` via `callbackFlow` + `LocationManagerCompat` at 1 Hz. The fused and network providers are deliberately omitted so a missing GPS chip on a given AI Box keeps the launcher in the safe (locked) state instead of spuriously unlocking on a Wi-Fi fix.
- **Unlock threshold = 5 km/h** (≈ 1.389 m/s), matching the policy SSOT. The flow emits `true` (locked) when no fix has arrived yet or when speed is at or above the threshold.
- **`rememberDrivingLockState()`** is now a Composable using `produceState` + `repeatOnLifecycle(STARTED)`. Permission grants made via the runtime dialog reflect as soon as the dialog dismisses and the host activity returns to STARTED. Preview mode short-circuits to unlocked so design review sees the full surface.
- **`HomeRoute`** requests `ACCESS_FINE_LOCATION` once via `rememberLauncherForActivityResult`; on denial the launcher continues to function with the lockout permanently in its safe default. A richer rationale UI is deferred to a follow-up.
- **Manifest** declares `ACCESS_FINE_LOCATION` (dangerous). Justification mirrored in the `CLAUDE.md` audit log per `CLAUDE.md#permissions`. Background location is not requested - the launcher only needs location while in foreground.
- `buildFeatures.buildConfig = true` is removed from `app/build.gradle.kts` since `BuildConfig` is no longer referenced.

## Test plan

- [x] `./gradlew spotlessCheck` — clean.
- [x] `./gradlew assembleDebug` — `BUILD SUCCESSFUL`.
- [x] AVD smoke test on `TBox-Mock` (Android 13):
    - **Scenario 1 — denied:** Fresh install → system permission dialog appears. Tapping "Don't allow" → launcher renders the locked placeholder ("Available when stopped"). `dumpsys package` confirms `granted=false`.
    - **Scenario 2 — granted, parked:** `pm grant ACCESS_FINE_LOCATION` + `adb emu geo fix 139.7670 35.6814` → grid renders 19 tiles. Repository's flow correctly reports unlocked when GPS speed is 0 m/s.
    - **Scenario 3 — granted, driving:** Not exercised through the emulator. AVD's `geo` command does not reliably propagate speed (the `geo nmea` RMC sentence is parsed but `Location.getSpeed()` stays 0; the `geo fix` extra args are interpreted inconsistently by AVD versions). The threshold comparison itself (`speed >= UNLOCK_SPEED_M_PER_S`) is straightforward and is covered by review.
- [x] Apps drawer regression: tapping a tile still launches the underlying activity.

## Deferred

- Rationale UI ahead of the system permission dialog ("we use GPS speed to lock distracting UI while driving").
- Hold time / debouncing on the unlock transition. Currently the state flips immediately on each location update; a 5 s settle time may be added once real-device experience surfaces flicker.
- Real-device verification on Carlinkit / OTTOCAST hardware. Re-evaluate once a unit is available.