### PR TITLE
refactor: prefer expression chains across kotlin sources

### DIFF
--- a/.claude/agents/compose-launcher-reviewer.md
+++ b/.claude/agents/compose-launcher-reviewer.md
@@ -53,7 +53,11 @@ For each touched area, verify the diff against the named section of
   `enum.values()` instead of `.entries`, missing trailing commas in
   multi-line lists, module-level experimental opt-in, and unscoped
   `public` declarations where `internal` would suffice are
-  findings.
+  findings. Statement-style function bodies whose value is consumed
+  (`fun foo(): X { return bar() }`), `when` / `if` used as
+  statements when a chained expression would suffice, and
+  `{}`-wrapped single-expression `when` branches are also
+  findings — see the expression-chain rule in the same anchor.
 - Compose architecture → `CLAUDE.md#compose-architecture`. Stateful
   screens that skip the `Route` / `Screen` / `ViewModel` split,
   Composables that mutate `MutableState` instead of receiving

--- a/.claude/skills/add-compose-screen/references/screen-template.md
+++ b/.claude/skills/add-compose-screen/references/screen-template.md
@@ -77,3 +77,9 @@ private fun <Name>ScreenPreview() {
 - For driver-distracting content, follow the
   [`gate-driving-visible-feature`](../../gate-driving-visible-feature/SKILL.md)
   skill — the driving-lockout policy SSOT.
+- Per `CLAUDE.md#kotlin-style`, prefer expression chains: when a
+  Composable's body simply forwards parameters to a single emitter,
+  use an expression body
+  (`@Composable fun Foo() = Surface { ... }`); collapse
+  `when` / `if` branches to single expressions where the result
+  is the only output.

--- a/.claude/skills/add-viewmodel/references/viewmodel-template.md
+++ b/.claude/skills/add-viewmodel/references/viewmodel-template.md
@@ -52,16 +52,14 @@ class <Area>ViewModel(
     private val _uiState = MutableStateFlow(<Area>UiState.Initial)
     val uiState: StateFlow<<Area>UiState> = _uiState.asStateFlow()
 
-    fun onAction(action: <Area>Action) {
-        when (action) {
-            <Area>Action.Refresh -> refresh()
-            is <Area>Action.Select -> select(action.id)
-        }
+    fun onAction(action: <Area>Action) = when (action) {
+        <Area>Action.Refresh -> refresh()
+        is <Area>Action.Select -> select(action.id)
     }
 
     private fun refresh() {
+        _uiState.update { it.copy(isLoading = true) }
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
             // ... do the work, then:
             _uiState.update { it.copy(isLoading = false) }
         }
@@ -163,6 +161,10 @@ private fun <Area>ScreenPreview() {
 - `MutableStateFlow` is `private`. Only `StateFlow` leaves the
   class. This is enforced by the reviewer agent against
   `CLAUDE.md#compose-architecture`.
+- `onAction` is a `when` expression with `Unit` inferred return
+  type. Per the expression-chain rule in
+  `CLAUDE.md#kotlin-style`, prefer this shape over a statement
+  body that wraps the same `when`.
 - Use `_uiState.update { it.copy(...) }` for mutations — atomic,
   no read-modify-write race.
 - For events that should fire once (navigation, snackbars), use a

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,12 @@ ij_kotlin_allow_trailing_comma_on_call_site = true
 # Compose-specific naming check; disable the standard function-naming rule
 # so it does not flag @Composable functions.
 ktlint_standard_function-naming = disabled
+# CLAUDE.md#kotlin-style mandates expression-chain style. ktlint's
+# multiline-expression-wrapping rule otherwise re-wraps single-expression
+# `when` branches and `fun foo() = bar().run { ... }` chains into block
+# form, which is the opposite of the project's intent. Disable it so the
+# expression-chain style survives `./gradlew spotlessApply`.
+ktlint_standard_multiline-expression-wrapping = disabled
 
 [*.{xml,json,yml,yaml,toml}]
 indent_size = 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,25 @@ convention differ, the project convention wins for this repo.
 ### Kotlin style <a id="kotlin-style"></a>
 
 - Authoritative reference: <https://kotlinlang.org/docs/coding-conventions.html>.
+- **Prefer expression chains over statement blocks.** Use
+  single-expression function bodies (`fun foo() = bar()`),
+  expression `when` and `if` (consume the result rather than
+  branching as a statement), and chained calls (`?.`, `?:`,
+  `let` / `run` / `also` / `apply`, `runCatching {}.onFailure {}`,
+  collection chains) in preference to intermediate `val`
+  declarations or imperative blocks. Reach for a block body only
+  when the function genuinely runs unrelated side effects in
+  sequence (`onCreate`, `init`, lifecycle callbacks).
+- When every branch of a `when` is a single expression, omit the
+  `{}`: `branch -> doIt()`. ktlint enforces a consistency rule that
+  wraps **every** branch of a `when` in `{}` as soon as one branch
+  spans multiple lines (e.g. a function call with named arguments
+  on separate lines). When that happens, accept the block form
+  rather than fighting the formatter — flatten the offending call
+  to a single line if the goal is the unwrapped style. The
+  `multiline-expression-wrapping` ktlint rule is **disabled** in
+  `.editorconfig` so single-line branches stay unwrapped where
+  ktlint's consistency rule does not interfere.
 - Trailing commas in multi-line argument and parameter lists, in
   `when` branches, and in collection literals.
 - `enum.entries` (Kotlin 1.9+) instead of the deprecated `.values()`.

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -13,10 +13,6 @@ class MainActivity : ComponentActivity() {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContent {
-            FemtoTheme {
-                HomeRoute()
-            }
-        }
+        setContent { FemtoTheme { HomeRoute() } }
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
@@ -2,8 +2,10 @@ package io.github.seijikohara.femto.data
 
 import android.content.ComponentName
 import android.content.Context
+import android.content.pm.LauncherActivityInfo
 import android.content.pm.LauncherApps
 import android.os.Process
+import androidx.core.content.getSystemService
 import androidx.core.graphics.drawable.toBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -20,37 +22,35 @@ import kotlinx.coroutines.withContext
 class AppsRepository(
     private val context: Context,
 ) {
-    private val launcherApps =
-        context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+    private val launcherApps: LauncherApps = checkNotNull(context.getSystemService())
 
     /**
      * Return all main-launchable activities for the current user,
-     * sorted by label. Icons are resolved once into [Bitmap]s on
-     * the IO dispatcher so the UI layer does not hold mutable
+     * sorted by label. Icons are resolved once into [android.graphics.Bitmap]s
+     * on the IO dispatcher so the UI layer does not hold mutable
      * `Drawable` references.
      */
     suspend fun queryApps(): List<AppEntry> =
         withContext(Dispatchers.IO) {
             launcherApps
                 .getActivityList(null, Process.myUserHandle())
-                .map { info ->
-                    AppEntry(
-                        componentName = info.componentName,
-                        label = info.label.toString(),
-                        icon = info.getIcon(0).toBitmap(width = ICON_PIXELS, height = ICON_PIXELS),
-                    )
-                }.sortedBy { it.label.lowercase() }
+                .map(LauncherActivityInfo::toAppEntry)
+                .sortedBy { it.label.lowercase() }
         }
 
     /**
-     * Launch the given activity. The bounds and options are
-     * unused for the MVP grid; pass `null` to defer to system
-     * defaults.
+     * Launch the given activity. The bounds and options are unused
+     * for the MVP grid; pass `null` to defer to system defaults.
      */
     fun launch(componentName: ComponentName): Unit =
         launcherApps.startMainActivity(componentName, Process.myUserHandle(), null, null)
-
-    private companion object {
-        const val ICON_PIXELS = 192
-    }
 }
+
+private const val ICON_PIXELS = 192
+
+private fun LauncherActivityInfo.toAppEntry(): AppEntry =
+    AppEntry(
+        componentName = componentName,
+        label = label.toString(),
+        icon = getIcon(0).toBitmap(width = ICON_PIXELS, height = ICON_PIXELS),
+    )

--- a/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
@@ -47,14 +47,8 @@ class AppsRepository(
      * unused for the MVP grid; pass `null` to defer to system
      * defaults.
      */
-    fun launch(componentName: ComponentName) {
-        launcherApps.startMainActivity(
-            componentName,
-            Process.myUserHandle(),
-            null,
-            null,
-        )
-    }
+    fun launch(componentName: ComponentName): Unit =
+        launcherApps.startMainActivity(componentName, Process.myUserHandle(), null, null)
 
     private companion object {
         const val ICON_PIXELS = 192

--- a/app/src/main/java/io/github/seijikohara/femto/data/DrivingState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DrivingState.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -38,20 +37,16 @@ fun rememberDrivingLockState(): Boolean {
     if (LocalInspectionMode.current) return false
 
     val context = LocalContext.current
-    val lifecycleOwner = LocalLifecycleOwner.current
-
-    val locked by produceState(initialValue = true, lifecycleOwner) {
-        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+    val owner = LocalLifecycleOwner.current
+    return produceState(initialValue = true, owner) {
+        owner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             if (!context.hasFineLocationPermission()) {
                 value = true
                 return@repeatOnLifecycle
             }
-            DrivingStateRepository(context).lockedFlow().collect { isLocked ->
-                value = isLocked
-            }
+            DrivingStateRepository(context).lockedFlow().collect { value = it }
         }
-    }
-    return locked
+    }.value
 }
 
 internal fun Context.hasFineLocationPermission(): Boolean =

--- a/app/src/main/java/io/github/seijikohara/femto/data/DrivingStateRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DrivingStateRepository.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.location.Location
 import android.location.LocationManager
 import android.os.Looper
+import androidx.core.content.getSystemService
 import androidx.core.location.LocationListenerCompat
 import androidx.core.location.LocationManagerCompat
 import androidx.core.location.LocationRequestCompat
@@ -36,8 +37,7 @@ import kotlinx.coroutines.flow.map
 class DrivingStateRepository(
     private val context: Context,
 ) {
-    private val locationManager =
-        context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    private val locationManager: LocationManager = checkNotNull(context.getSystemService())
 
     /** Emits `true` when the launcher should render the locked surface. */
     fun lockedFlow(): Flow<Boolean> =

--- a/app/src/main/java/io/github/seijikohara/femto/data/DrivingStateRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DrivingStateRepository.kt
@@ -53,30 +53,23 @@ class DrivingStateRepository(
             // Seed with the most recent cached fix so the gate has a value
             // before the first real update arrives.
             runCatching {
-                trySend(locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER))
-            }
+                locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
+            }.onSuccess { trySend(it) }
 
-            val subscribed =
-                runCatching {
-                    LocationManagerCompat.requestLocationUpdates(
-                        locationManager,
-                        LocationManager.GPS_PROVIDER,
-                        LocationRequestCompat.Builder(LOCATION_INTERVAL_MS).build(),
-                        listener,
-                        Looper.getMainLooper(),
-                    )
-                    true
-                }.getOrElse { false }
+            // Subscribe; if the provider is unavailable on this device,
+            // emit null so the lockedFlow consumer falls back to the safe
+            // default.
+            runCatching {
+                LocationManagerCompat.requestLocationUpdates(
+                    locationManager,
+                    LocationManager.GPS_PROVIDER,
+                    LocationRequestCompat.Builder(LOCATION_INTERVAL_MS).build(),
+                    listener,
+                    Looper.getMainLooper(),
+                )
+            }.onFailure { trySend(null) }
 
-            if (!subscribed) {
-                // GPS provider is unavailable on this device; emit null so
-                // the lockedFlow consumer falls back to the safe default.
-                trySend(null)
-            }
-
-            awaitClose {
-                locationManager.removeUpdates(listener)
-            }
+            awaitClose { locationManager.removeUpdates(listener) }
         }
 
     private companion object {

--- a/app/src/main/java/io/github/seijikohara/femto/data/FontPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/FontPreferences.kt
@@ -28,9 +28,7 @@ class FontPreferences(
         }
 
     suspend fun setFontTheme(theme: FontTheme) {
-        context.fontDataStore.edit { prefs ->
-            prefs[KEY] = theme.name
-        }
+        context.fontDataStore.edit { it[KEY] = theme.name }
     }
 
     private companion object {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -31,28 +31,26 @@ fun HomeScreen(
     uiState: HomeUiState,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
+) = Surface(
+    modifier = modifier.fillMaxSize(),
+    color = MaterialTheme.colorScheme.background,
 ) {
-    Surface(
-        modifier = modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
-        val full = Modifier.fillMaxSize()
-        when {
-            rememberDrivingLockState() -> {
-                DrivingLockedPlaceholder(modifier = full)
-            }
+    val full = Modifier.fillMaxSize()
+    when {
+        rememberDrivingLockState() -> {
+            DrivingLockedPlaceholder(modifier = full)
+        }
 
-            uiState.isLoading -> {
-                LoadingPlaceholder(modifier = full)
-            }
+        uiState.isLoading -> {
+            LoadingPlaceholder(modifier = full)
+        }
 
-            else -> {
-                AppsGrid(
-                    apps = uiState.apps,
-                    onLaunch = { onAction(HomeAction.LaunchApp(it)) },
-                    modifier = full,
-                )
-            }
+        else -> {
+            AppsGrid(
+                apps = uiState.apps,
+                onLaunch = { onAction(HomeAction.LaunchApp(it)) },
+                modifier = full,
+            )
         }
     }
 }
@@ -62,28 +60,26 @@ private fun AppsGrid(
     apps: List<AppEntry>,
     onLaunch: (ComponentName) -> Unit,
     modifier: Modifier = Modifier,
+) = LazyVerticalGrid(
+    columns = GridCells.Adaptive(minSize = MinTileWidth),
+    modifier = modifier,
+    contentPadding = PaddingValues(FemtoDimens.ScreenPadding),
+    horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
+    verticalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
 ) {
-    LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = MinTileWidth),
-        modifier = modifier,
-        contentPadding = PaddingValues(FemtoDimens.ScreenPadding),
-        horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
-        verticalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
-    ) {
-        items(
-            items = apps,
-            key = { entry -> entry.componentName.flattenToString() },
-        ) { entry ->
-            AppTile(
-                entry = entry,
-                onClick = { onLaunch(entry.componentName) },
-            )
-        }
+    items(
+        items = apps,
+        key = { it.componentName.flattenToString() },
+    ) { entry ->
+        AppTile(
+            entry = entry,
+            onClick = { onLaunch(entry.componentName) },
+        )
     }
 }
 
 @Composable
-private fun LoadingPlaceholder(modifier: Modifier = Modifier) {
+private fun LoadingPlaceholder(modifier: Modifier = Modifier) =
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         Text(
             text = "Loading",
@@ -91,10 +87,9 @@ private fun LoadingPlaceholder(modifier: Modifier = Modifier) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
-}
 
 @Composable
-private fun DrivingLockedPlaceholder(modifier: Modifier = Modifier) {
+private fun DrivingLockedPlaceholder(modifier: Modifier = Modifier) =
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         Text(
             text = "Available when stopped",
@@ -102,11 +97,10 @@ private fun DrivingLockedPlaceholder(modifier: Modifier = Modifier) {
             color = MaterialTheme.colorScheme.onBackground,
         )
     }
-}
 
 @PreviewLightDark
 @Composable
-private fun HomeScreenPreview() {
+private fun HomeScreenPreview() =
     FemtoTheme {
         HomeScreen(
             uiState =
@@ -124,20 +118,13 @@ private fun HomeScreenPreview() {
             onAction = {},
         )
     }
-}
 
 @PreviewLightDark
 @Composable
-private fun HomeScreenLoadingPreview() {
+private fun HomeScreenLoadingPreview() =
     FemtoTheme {
-        HomeScreen(
-            uiState = HomeUiState.Initial,
-            onAction = {},
-        )
+        HomeScreen(uiState = HomeUiState.Initial, onAction = {})
     }
-}
 
 private fun previewIcon(): Bitmap =
-    Bitmap.createBitmap(64, 64, Bitmap.Config.ARGB_8888).apply {
-        eraseColor(Color.LTGRAY)
-    }
+    Bitmap.createBitmap(64, 64, Bitmap.Config.ARGB_8888).apply { eraseColor(Color.LTGRAY) }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -32,25 +32,25 @@ fun HomeScreen(
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val drivingLocked = rememberDrivingLockState()
     Surface(
         modifier = modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background,
     ) {
+        val full = Modifier.fillMaxSize()
         when {
-            drivingLocked -> {
-                DrivingLockedPlaceholder(modifier = Modifier.fillMaxSize())
+            rememberDrivingLockState() -> {
+                DrivingLockedPlaceholder(modifier = full)
             }
 
             uiState.isLoading -> {
-                LoadingPlaceholder(modifier = Modifier.fillMaxSize())
+                LoadingPlaceholder(modifier = full)
             }
 
             else -> {
                 AppsGrid(
                     apps = uiState.apps,
                     onLaunch = { onAction(HomeAction.LaunchApp(it)) },
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = full,
                 )
             }
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -30,18 +30,16 @@ class HomeViewModel(
         refresh()
     }
 
-    fun onAction(action: HomeAction) {
+    fun onAction(action: HomeAction) =
         when (action) {
             HomeAction.Refresh -> refresh()
             is HomeAction.LaunchApp -> repository.launch(action.componentName)
         }
-    }
 
     private fun refresh() {
+        _uiState.update { it.copy(isLoading = true) }
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            val apps = repository.queryApps()
-            _uiState.update { it.copy(isLoading = false, apps = apps) }
+            _uiState.update { it.copy(isLoading = false, apps = repository.queryApps()) }
         }
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppTile.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppTile.kt
@@ -35,32 +35,28 @@ internal fun AppTile(
     entry: AppEntry,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+) = Column(
+    modifier =
+        modifier
+            .defaultMinSize(minWidth = FemtoDimens.MinTouchTarget, minHeight = FemtoDimens.MinTouchTarget)
+            .clickable(onClick = onClick)
+            .padding(TilePadding),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center,
 ) {
-    Column(
-        modifier =
-            modifier
-                .defaultMinSize(
-                    minWidth = FemtoDimens.MinTouchTarget,
-                    minHeight = FemtoDimens.MinTouchTarget,
-                ).clickable(onClick = onClick)
-                .padding(TilePadding),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Icon(
-            painter = BitmapPainter(entry.icon.asImageBitmap()),
-            contentDescription = entry.label,
-            tint = androidx.compose.ui.graphics.Color.Unspecified,
-            modifier = Modifier.size(IconSize),
-        )
-        Spacer(Modifier.height(IconLabelGap))
-        Text(
-            text = entry.label,
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onBackground,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            textAlign = TextAlign.Center,
-        )
-    }
+    Icon(
+        painter = BitmapPainter(entry.icon.asImageBitmap()),
+        contentDescription = entry.label,
+        tint = androidx.compose.ui.graphics.Color.Unspecified,
+        modifier = Modifier.size(IconSize),
+    )
+    Spacer(Modifier.height(IconLabelGap))
+    Text(
+        text = entry.label,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onBackground,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Center,
+    )
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoTheme.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoTheme.kt
@@ -26,17 +26,15 @@ fun FemtoTheme(
 ) {
     val context = LocalContext.current
     val inPreview = LocalInspectionMode.current
-    val colorScheme =
-        when {
-            inPreview && darkTheme -> DarkFallback
-            inPreview -> LightFallback
-            darkTheme -> dynamicDarkColorScheme(context)
-            else -> dynamicLightColorScheme(context)
-        }
-    val pair = fontPairOf(fontTheme)
     MaterialTheme(
-        colorScheme = colorScheme,
-        typography = femtoTypography(pair.latin),
+        colorScheme =
+            when {
+                inPreview && darkTheme -> DarkFallback
+                inPreview -> LightFallback
+                darkTheme -> dynamicDarkColorScheme(context)
+                else -> dynamicLightColorScheme(context)
+            },
+        typography = femtoTypography(fontPairOf(fontTheme).latin),
         content = content,
     )
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
@@ -62,98 +62,23 @@ internal object FemtoFonts {
  * Display sizes lean heavier (Black/ExtraBold) for editorial impact;
  * body sizes are bumped up to clear the 18sp automotive minimum.
  */
-internal fun femtoTypography(latin: FontFamily): Typography {
-    val baseline = Typography()
-    return Typography(
-        displayLarge =
-            baseline.displayLarge.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Black,
-                fontSize = 96.sp,
-            ),
-        displayMedium =
-            baseline.displayMedium.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.ExtraBold,
-                fontSize = 72.sp,
-            ),
-        displaySmall =
-            baseline.displaySmall.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.ExtraBold,
-                fontSize = 56.sp,
-            ),
-        headlineLarge =
-            baseline.headlineLarge.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Bold,
-                fontSize = 40.sp,
-            ),
-        headlineMedium =
-            baseline.headlineMedium.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Bold,
-                fontSize = 32.sp,
-            ),
-        headlineSmall =
-            baseline.headlineSmall.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.SemiBold,
-                fontSize = 26.sp,
-            ),
-        titleLarge =
-            baseline.titleLarge.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.SemiBold,
-                fontSize = 24.sp,
-            ),
-        titleMedium =
-            baseline.titleMedium.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Medium,
-                fontSize = 20.sp,
-            ),
-        titleSmall =
-            baseline.titleSmall.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Medium,
-                fontSize = 18.sp,
-            ),
-        bodyLarge =
-            baseline.bodyLarge.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Normal,
-                fontSize = 20.sp,
-            ),
-        bodyMedium =
-            baseline.bodyMedium.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Normal,
-                fontSize = 18.sp,
-            ),
-        bodySmall =
-            baseline.bodySmall.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Normal,
-                fontSize = 16.sp,
-            ),
-        labelLarge =
-            baseline.labelLarge.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Medium,
-                fontSize = 18.sp,
-            ),
-        labelMedium =
-            baseline.labelMedium.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Medium,
-                fontSize = 16.sp,
-            ),
-        labelSmall =
-            baseline.labelSmall.copy(
-                fontFamily = latin,
-                fontWeight = FontWeight.Medium,
-                fontSize = 14.sp,
-            ),
-    )
-}
+internal fun femtoTypography(latin: FontFamily): Typography =
+    Typography().run {
+        copy(
+            displayLarge = displayLarge.copy(fontFamily = latin, fontWeight = FontWeight.Black, fontSize = 96.sp),
+            displayMedium = displayMedium.copy(fontFamily = latin, fontWeight = FontWeight.ExtraBold, fontSize = 72.sp),
+            displaySmall = displaySmall.copy(fontFamily = latin, fontWeight = FontWeight.ExtraBold, fontSize = 56.sp),
+            headlineLarge = headlineLarge.copy(fontFamily = latin, fontWeight = FontWeight.Bold, fontSize = 40.sp),
+            headlineMedium = headlineMedium.copy(fontFamily = latin, fontWeight = FontWeight.Bold, fontSize = 32.sp),
+            headlineSmall = headlineSmall.copy(fontFamily = latin, fontWeight = FontWeight.SemiBold, fontSize = 26.sp),
+            titleLarge = titleLarge.copy(fontFamily = latin, fontWeight = FontWeight.SemiBold, fontSize = 24.sp),
+            titleMedium = titleMedium.copy(fontFamily = latin, fontWeight = FontWeight.Medium, fontSize = 20.sp),
+            titleSmall = titleSmall.copy(fontFamily = latin, fontWeight = FontWeight.Medium, fontSize = 18.sp),
+            bodyLarge = bodyLarge.copy(fontFamily = latin, fontWeight = FontWeight.Normal, fontSize = 20.sp),
+            bodyMedium = bodyMedium.copy(fontFamily = latin, fontWeight = FontWeight.Normal, fontSize = 18.sp),
+            bodySmall = bodySmall.copy(fontFamily = latin, fontWeight = FontWeight.Normal, fontSize = 16.sp),
+            labelLarge = labelLarge.copy(fontFamily = latin, fontWeight = FontWeight.Medium, fontSize = 18.sp),
+            labelMedium = labelMedium.copy(fontFamily = latin, fontWeight = FontWeight.Medium, fontSize = 16.sp),
+            labelSmall = labelSmall.copy(fontFamily = latin, fontWeight = FontWeight.Medium, fontSize = 14.sp),
+        )
+    }


### PR DESCRIPTION
## Summary

Promote `CLAUDE.md#kotlin-style` to mandate expression-chain style and align every existing Kotlin source file with the rule. Two commits:

1. `refactor: prefer expression chains across kotlin sources` — initial pass: rule SSOT in CLAUDE.md, ktlint config to keep single-line `when` branches, `runCatching {}.onFailure {}` chain in DrivingStateRepository, `when`-expression `onAction`, `Typography().run { copy(...) }` chain, inlined intermediate vals.
2. `refactor: deepen expression chains with ktx, extensions, scope chains` — follow-up: AndroidX KTX `getSystemService<T>()`, file-private extension `LauncherActivityInfo.toAppEntry()` for `.map(::toAppEntry)`, expression bodies for every placeholder Composable + `HomeScreen` + `AppTile`, `produceState(...).value` direct return, `it`-shorthand lambdas, single-line `setContent`.

## Tooling

- `.editorconfig` disables ktlint's `multiline-expression-wrapping` rule so single-line `when` branches and short expression-body chains survive `./gradlew spotlessApply`. ktlint's consistency rule that wraps every branch of a `when` in `{}` as soon as one branch spans multiple lines remains in effect; `CLAUDE.md` documents that corner case rather than fighting it.

## Rule SSOT

- `CLAUDE.md#kotlin-style` gains the expression-chain rule and the ktlint-rule note.
- `compose-launcher-reviewer` agent flags statement-style bodies and unnecessary `{}`-wrapped single-expression `when` branches.
- `add-viewmodel` template renders `onAction` as a `when` expression so every ViewModel scaffolded by the skill follows the rule out of the box.
- `add-compose-screen` template adds a brief expression-chain note for consumers.

## Code (cumulative)

| File | Change |
| --- | --- |
| `AppsRepository` | KTX `getSystemService<LauncherApps>()`; file-private `LauncherActivityInfo.toAppEntry()` extension; `.map(::toAppEntry).sortedBy { ... }` chain; expression-body `launch()`. |
| `DrivingStateRepository` | KTX `getSystemService<LocationManager>()`; `runCatching {}.onSuccess {}` + `.onFailure {}` chain in place of the `subscribed: Boolean` ladder. |
| `DrivingState` | Direct `produceState(...).value`; intermediate `lifecycleOwner` / `val locked` removed; unused `getValue` import dropped. |
| `HomeViewModel` | `when`-expression `onAction`; synchronous-then-launch `refresh` with inlined apps fetch. |
| `HomeScreen` | Expression bodies for `HomeScreen`, `AppsGrid`, `LoadingPlaceholder`, `DrivingLockedPlaceholder`, both previews. Shared `full` Modifier across branches. |
| `AppTile` | Expression body. |
| `MainActivity` | Single-line `setContent { FemtoTheme { HomeRoute() } }`. |
| `FemtoTheme` | Inlined `pair` and inlined `colorScheme` `when`. |
| `FontPreferences` | `it`-shorthand in the `edit { }` lambda. |
| `FontTheme` | Single-line expression body for `fontPairOf`. |
| `Type.kt` | `Typography().run { copy(...) }` chain — 115 lines down to 43. |

## Test plan

- [x] `./gradlew spotlessCheck` — clean.
- [x] `./gradlew assembleDebug` — `BUILD SUCCESSFUL` after both commits.
- [x] AVD smoke test (first commit): apps drawer renders 19 tiles, tap-to-launch works, locked placeholder still appears when permission denied. No new logcat errors.
- [ ] AVD smoke test (second commit): emulator was offline at the time of the deepening commit; build is green and the changes are behaviour-preserving (extension function call is equivalent to inline mapping; expression bodies do not alter Composable semantics; KTX `getSystemService` is the documented equivalent of the cast). Re-verify on the next AVD session.

## Notes

- Block bodies are kept where the function genuinely runs unrelated side effects in sequence (`MainActivity.onCreate`, lifecycle/init blocks, `LocationPermissionRequest` Composable). `FontPreferences.setFontTheme` stays a block body because `DataStore<Preferences>.edit` returns `Preferences`, not `Unit`, and an expression body would change the return type.