### PR TITLE
feat(home): route drawer open through HomeViewModel events

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -28,9 +28,10 @@ class MainActivity : ComponentActivity() {
                             AppsRepository(this).launch(component)
                             showDrawer = false
                         },
+                        onBack = { showDrawer = false },
                     )
                 } else {
-                    HomeRoute()
+                    HomeRoute(onOpenDrawer = { showDrawer = true })
                 }
             }
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerRoute.kt
@@ -1,6 +1,7 @@
 package io.github.seijikohara.femto.ui.drawer
 
 import android.content.ComponentName
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -15,6 +16,7 @@ import io.github.seijikohara.femto.data.AppsRepository
 @Composable
 internal fun AppDrawerRoute(
     onLaunch: (ComponentName) -> Unit,
+    onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -22,5 +24,6 @@ internal fun AppDrawerRoute(
     LaunchedEffect(Unit) {
         apps = AppsRepository(context).queryApps()
     }
+    BackHandler(onBack = onBack)
     AppDrawerScreen(apps = apps, onLaunch = onLaunch, modifier = modifier)
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
@@ -1,0 +1,13 @@
+package io.github.seijikohara.femto.ui.home
+
+/**
+ * One-shot side-effect signals emitted by [HomeViewModel] for the host to act on.
+ *
+ * Events are distinct from [HomeAction] (input) and [HomeUiState] (output): they
+ * carry transient navigation / system-call requests that must not be replayed
+ * on configuration change. Subscribers collect them via a `SharedFlow` so the
+ * latest value is not retained.
+ */
+internal sealed interface HomeEvent {
+    data object OpenDrawer : HomeEvent
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -7,6 +7,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -14,12 +15,23 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.seijikohara.femto.data.hasFineLocationPermission
 
 @Composable
-internal fun HomeRoute(modifier: Modifier = Modifier) {
+internal fun HomeRoute(
+    onOpenDrawer: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val context = LocalContext.current
     val viewModel: HomeViewModel =
         viewModel(factory = HomeViewModelFactory(context.applicationContext as Application))
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     LocationPermissionRequest()
+    val currentOnOpenDrawer by rememberUpdatedState(onOpenDrawer)
+    LaunchedEffect(viewModel) {
+        viewModel.events.collect { event ->
+            when (event) {
+                HomeEvent.OpenDrawer -> currentOnOpenDrawer()
+            }
+        }
+    }
     HomeScreen(
         uiState = uiState,
         onAction = viewModel::onAction,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -20,9 +20,12 @@ import io.github.seijikohara.femto.data.ShortAddress
 import io.github.seijikohara.femto.data.WeatherRepository
 import io.github.seijikohara.femto.data.WeatherSnapshot
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -75,8 +78,23 @@ internal class HomeViewModel(
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), HomeUiState.Initial)
 
+    // extraBufferCapacity = 1 lets a single tryEmit succeed without a live collector,
+    // matching the semantics of a one-shot navigation request that is dropped if the
+    // host is already detached (e.g. during configuration change).
+    private val mutableEvents = MutableSharedFlow<HomeEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<HomeEvent> = mutableEvents.asSharedFlow()
+
     fun onAction(action: HomeAction) {
-        // Side-effect routing is wired by the host (MainActivity / HomeRoute) in Task 4.5+.
+        when (action) {
+            HomeAction.OpenAppDrawer -> mutableEvents.tryEmit(HomeEvent.OpenDrawer)
+
+            is HomeAction.LaunchApp,
+            HomeAction.OpenMaps,
+            HomeAction.ConnectMusicPlayer,
+            is HomeAction.Shortcut,
+            is HomeAction.Music,
+            -> Unit // Intent / MediaController routing is wired in a follow-up.
+        }
     }
 }
 

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -10,6 +10,7 @@ import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -71,6 +72,26 @@ class HomeViewModelTest {
                 assertNotNull(state.weather)
                 assertNotNull(state.nowPlaying)
                 assertTrue(state.mapAvailable)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `onAction OpenAppDrawer emits OpenDrawer event`() =
+        runTest {
+            val viewModel =
+                HomeViewModel(
+                    clockFlow = emptyFlow(),
+                    locationFlow = emptyFlow(),
+                    addressFlow = emptyFlow(),
+                    weatherFlow = emptyFlow(),
+                    nowPlayingFlow = emptyFlow(),
+                    appsFlow = MutableStateFlow(emptyList()),
+                    isMapAvailable = { false },
+                )
+            viewModel.events.test {
+                viewModel.onAction(HomeAction.OpenAppDrawer)
+                assertEquals(HomeEvent.OpenDrawer, awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }


### PR DESCRIPTION
## Summary

- Promote the home → drawer transition from a direct `MainActivity.showDrawer = true` mutation to a UDF event channel: `HomeAction.OpenAppDrawer` → `HomeViewModel.events: SharedFlow<HomeEvent>` → `HomeEvent.OpenDrawer` → host callback.
- Add `BackHandler` in `AppDrawerRoute(onBack)` so the drawer dismisses on system back even when the user does not launch an app.
- Set up the same channel pattern for the remaining stubbed actions (`OpenMaps`, `Shortcut`, `ConnectMusicPlayer`, `Music`) — currently routed through an explicit `Unit` branch with a `// wired in a follow-up.` note, which keeps the `when` exhaustive without adding scope.

This addresses the deferred follow-up #1 from PR #5 (route `OpenAppDrawer` through `HomeEvent`).

## Files changed

- `ui/home/HomeEvent.kt` (new) — `sealed interface HomeEvent { data object OpenDrawer }`.
- `ui/home/HomeViewModel.kt` — adds `MutableSharedFlow<HomeEvent>(extraBufferCapacity = 1)` + `events: SharedFlow<HomeEvent>`; populates `onAction` exhaustively.
- `ui/home/HomeRoute.kt` — accepts `onOpenDrawer: () -> Unit`; collects `viewModel.events` inside a `LaunchedEffect`, with `rememberUpdatedState` to satisfy the `compose:lambda-param-in-effect` ktlint rule.
- `ui/drawer/AppDrawerRoute.kt` — accepts `onBack: () -> Unit`; wires `BackHandler`.
- `MainActivity.kt` — passes `onOpenDrawer = { showDrawer = true }` and `onBack = { showDrawer = false }` to the two routes.
- `HomeViewModelTest.kt` — adds `onAction OpenAppDrawer emits OpenDrawer event` (Turbine).

## Test plan

- [x] `./gradlew spotlessApply test lint` — BUILD SUCCESSFUL; `HomeViewModelTest` 2/2 pass (existing `combines all flows into one HomeUiState` + new `onAction OpenAppDrawer emits OpenDrawer event`).
- [x] `./gradlew connectedDebugAndroidTest` on the TBox-Mock AVD (Android 13) — 10/10 instrumented tests pass.
- [x] AVD smoke on TBox-Mock (Android 13):
  - Install the debug APK and start as `HOME` activity → cold launch `TotalTime: 3429ms`, `topResumedActivity = io.github.seijikohara.femto/.MainActivity`.
  - Grant `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION`, relaunch.
  - Tap the "Open all apps" tile in `AppsBar` → drawer opens (full app list rendered: Calendar, Camera, Chrome, Clock, Contacts, …, YT Music).
  - Press the system back key → dashboard returns (`AppsBar` shortcuts and `Google Map` panel re-rendered, activity stays `MainActivity`).
  - No `AndroidRuntime` / `FATAL` entries in `logcat` across the round-trip.
- [ ] Real-device smoke on TBox Ambient hardware (deferred from PR #5; tracked separately).