### PR TITLE
feat(home): wire HomeAction to Intent / MediaController side-effects

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -1,6 +1,9 @@
 package io.github.seijikohara.femto
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
 import android.os.Bundle
+import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -11,10 +14,13 @@ import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import io.github.seijikohara.femto.data.AppsRepository
 import io.github.seijikohara.femto.ui.drawer.AppDrawerRoute
+import io.github.seijikohara.femto.ui.home.HomeEvent
 import io.github.seijikohara.femto.ui.home.HomeRoute
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 
 class MainActivity : ComponentActivity() {
+    private val appsRepository by lazy { AppsRepository(this) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
@@ -25,15 +31,62 @@ class MainActivity : ComponentActivity() {
                 if (showDrawer) {
                     AppDrawerRoute(
                         onLaunch = { component ->
-                            AppsRepository(this).launch(component)
+                            appsRepository.launch(component)
                             showDrawer = false
                         },
                         onBack = { showDrawer = false },
                     )
                 } else {
-                    HomeRoute(onOpenDrawer = { showDrawer = true })
+                    HomeRoute(
+                        onEvent = { event ->
+                            handleHomeEvent(event) { showDrawer = it }
+                        },
+                    )
                 }
             }
+        }
+    }
+
+    private fun handleHomeEvent(
+        event: HomeEvent,
+        setShowDrawer: (Boolean) -> Unit,
+    ) {
+        when (event) {
+            HomeEvent.OpenDrawer -> setShowDrawer(true)
+            is HomeEvent.LaunchComponent -> appsRepository.launch(event.component)
+            is HomeEvent.LaunchAppCategory -> launchAppCategory(event.intentCategory)
+            HomeEvent.OpenNotificationListenerSettings -> openNotificationListenerSettings()
+        }
+    }
+
+    private fun launchAppCategory(category: String) {
+        // makeMainSelectorActivity defers picker to whichever app the user has
+        // elected as the default for the given semantic category — works
+        // across markets without a hard-coded package list.
+        val intent =
+            Intent
+                .makeMainSelectorActivity(Intent.ACTION_MAIN, category)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivityIfResolved(intent)
+    }
+
+    private fun openNotificationListenerSettings() {
+        val intent =
+            Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivityIfResolved(intent)
+    }
+
+    /**
+     * Start [intent] but no-op if no activity resolves. Other failures (e.g.
+     * `SecurityException`) propagate so they surface as crashes rather than
+     * silent dead clicks during development.
+     */
+    private fun startActivityIfResolved(intent: Intent) {
+        try {
+            startActivity(intent)
+        } catch (_: ActivityNotFoundException) {
+            // Head-unit has no app for this category / settings target.
         }
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
@@ -8,6 +8,7 @@ import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.content.getSystemService
+import io.github.seijikohara.femto.ui.home.components.MusicCommand
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -36,6 +37,40 @@ internal class MusicSessionRepository(
                 runCatching { sessionManager.removeOnActiveSessionsChangedListener(callback) }
             }
         }.flowOn(Dispatchers.Main.immediate)
+
+    /**
+     * Forward a transport command to the active media session. The
+     * call is a no-op when no session is reachable — typically because
+     * the user has not granted the notification-listener permission, in
+     * which case the dashboard surfaces a "Connect music player" CTA
+     * via [io.github.seijikohara.femto.ui.home.HomeAction.ConnectMusicPlayer].
+     */
+    fun send(command: MusicCommand) {
+        val controller =
+            runCatching {
+                sessionManager
+                    .getActiveSessions(componentName)
+                    .firstOrNull { it.playbackState?.isActive() == true }
+            }.getOrNull() ?: return
+        val transport = controller.transportControls
+        when (command) {
+            MusicCommand.PlayPause -> {
+                if (controller.playbackState?.state == PlaybackState.STATE_PLAYING) {
+                    transport.pause()
+                } else {
+                    transport.play()
+                }
+            }
+
+            MusicCommand.SkipNext -> {
+                transport.skipToNext()
+            }
+
+            MusicCommand.SkipPrevious -> {
+                transport.skipToPrevious()
+            }
+        }
+    }
 
     private fun List<MediaController>?.toNowPlaying(): NowPlaying? =
         this

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
@@ -1,5 +1,7 @@
 package io.github.seijikohara.femto.ui.home
 
+import android.content.ComponentName
+
 /**
  * One-shot side-effect signals emitted by [HomeViewModel] for the host to act on.
  *
@@ -10,4 +12,22 @@ package io.github.seijikohara.femto.ui.home
  */
 internal sealed interface HomeEvent {
     data object OpenDrawer : HomeEvent
+
+    /** Launch a known launcher activity (typically picked from the app drawer or a home shortcut). */
+    data class LaunchComponent(
+        val component: ComponentName,
+    ) : HomeEvent
+
+    /**
+     * Launch whichever app is registered for an
+     * [android.content.Intent] selector category (e.g. `CATEGORY_APP_MAPS`).
+     * Categories let the launcher defer to whichever app is installed and
+     * elected by the user, rather than hard-coding a package.
+     */
+    data class LaunchAppCategory(
+        val intentCategory: String,
+    ) : HomeEvent
+
+    /** Open the system "Notification listener access" settings so the user can grant our NLS. */
+    data object OpenNotificationListenerSettings : HomeEvent
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -16,7 +16,7 @@ import io.github.seijikohara.femto.data.hasFineLocationPermission
 
 @Composable
 internal fun HomeRoute(
-    onOpenDrawer: () -> Unit,
+    onEvent: (HomeEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -24,13 +24,9 @@ internal fun HomeRoute(
         viewModel(factory = HomeViewModelFactory(context.applicationContext as Application))
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     LocationPermissionRequest()
-    val currentOnOpenDrawer by rememberUpdatedState(onOpenDrawer)
+    val currentOnEvent by rememberUpdatedState(onEvent)
     LaunchedEffect(viewModel) {
-        viewModel.events.collect { event ->
-            when (event) {
-                HomeEvent.OpenDrawer -> currentOnOpenDrawer()
-            }
-        }
+        viewModel.events.collect { event -> currentOnEvent(event) }
     }
     HomeScreen(
         uiState = uiState,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package io.github.seijikohara.femto.ui.home
 
 import android.app.Application
+import android.content.Intent
 import android.location.Location
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -19,6 +20,7 @@ import io.github.seijikohara.femto.data.ReverseGeocoderRepository
 import io.github.seijikohara.femto.data.ShortAddress
 import io.github.seijikohara.femto.data.WeatherRepository
 import io.github.seijikohara.femto.data.WeatherSnapshot
+import io.github.seijikohara.femto.ui.home.components.MusicCommand
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,6 +41,7 @@ internal class HomeViewModel(
     private val nowPlayingFlow: Flow<NowPlaying?>,
     private val appsFlow: MutableStateFlow<List<AppEntry>>,
     private val isMapAvailable: () -> Boolean,
+    private val sendMusicCommand: (MusicCommand) -> Unit = {},
 ) : ViewModel() {
     val uiState: StateFlow<HomeUiState> =
         combine(
@@ -86,14 +89,29 @@ internal class HomeViewModel(
 
     fun onAction(action: HomeAction) {
         when (action) {
-            HomeAction.OpenAppDrawer -> mutableEvents.tryEmit(HomeEvent.OpenDrawer)
+            HomeAction.OpenAppDrawer -> {
+                mutableEvents.tryEmit(HomeEvent.OpenDrawer)
+            }
 
-            is HomeAction.LaunchApp,
-            HomeAction.OpenMaps,
-            HomeAction.ConnectMusicPlayer,
-            is HomeAction.Shortcut,
-            is HomeAction.Music,
-            -> Unit // Intent / MediaController routing is wired in a follow-up.
+            is HomeAction.LaunchApp -> {
+                mutableEvents.tryEmit(HomeEvent.LaunchComponent(action.componentName))
+            }
+
+            HomeAction.OpenMaps -> {
+                mutableEvents.tryEmit(HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_MAPS))
+            }
+
+            is HomeAction.Shortcut -> {
+                mutableEvents.tryEmit(HomeEvent.LaunchAppCategory(action.target.intentCategory))
+            }
+
+            HomeAction.ConnectMusicPlayer -> {
+                mutableEvents.tryEmit(HomeEvent.OpenNotificationListenerSettings)
+            }
+
+            is HomeAction.Music -> {
+                sendMusicCommand(action.command)
+            }
         }
     }
 }
@@ -125,6 +143,7 @@ internal class HomeViewModelFactory(
             nowPlayingFlow = music.nowPlayingFlow(),
             appsFlow = apps,
             isMapAvailable = { gms.isPresent() },
+            sendMusicCommand = music::send,
         ).also { vm ->
             vm.viewModelScope.launch { apps.value = appsRepo.queryApps() }
         } as T

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -1,5 +1,7 @@
 package io.github.seijikohara.femto.ui.home
 
+import android.content.ComponentName
+import android.content.Intent
 import android.graphics.Bitmap
 import app.cash.turbine.test
 import io.github.seijikohara.femto.data.AppEntry
@@ -7,6 +9,8 @@ import io.github.seijikohara.femto.data.ClockTick
 import io.github.seijikohara.femto.testfixtures.fakeAddress
 import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
 import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
+import io.github.seijikohara.femto.ui.home.components.AppsBarShortcut
+import io.github.seijikohara.femto.ui.home.components.MusicCommand
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -79,20 +83,84 @@ class HomeViewModelTest {
     @Test
     fun `onAction OpenAppDrawer emits OpenDrawer event`() =
         runTest {
-            val viewModel =
-                HomeViewModel(
-                    clockFlow = emptyFlow(),
-                    locationFlow = emptyFlow(),
-                    addressFlow = emptyFlow(),
-                    weatherFlow = emptyFlow(),
-                    nowPlayingFlow = emptyFlow(),
-                    appsFlow = MutableStateFlow(emptyList()),
-                    isMapAvailable = { false },
-                )
+            stubViewModel().assertEvent(HomeAction.OpenAppDrawer, HomeEvent.OpenDrawer)
+        }
+
+    @Test
+    fun `onAction LaunchApp emits LaunchComponent with the same component`() =
+        runTest {
+            val component = ComponentName("p", "c")
+            stubViewModel().assertEvent(
+                action = HomeAction.LaunchApp(component),
+                expected = HomeEvent.LaunchComponent(component),
+            )
+        }
+
+    @Test
+    fun `onAction OpenMaps emits LaunchAppCategory APP_MAPS`() =
+        runTest {
+            stubViewModel().assertEvent(
+                action = HomeAction.OpenMaps,
+                expected = HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_MAPS),
+            )
+        }
+
+    @Test
+    fun `onAction Shortcut emits LaunchAppCategory carrying the shortcut category`() =
+        runTest {
+            stubViewModel().assertEvent(
+                action = HomeAction.Shortcut(AppsBarShortcut.Music),
+                expected = HomeEvent.LaunchAppCategory(AppsBarShortcut.Music.intentCategory),
+            )
+        }
+
+    @Test
+    fun `onAction ConnectMusicPlayer emits OpenNotificationListenerSettings`() =
+        runTest {
+            stubViewModel().assertEvent(
+                action = HomeAction.ConnectMusicPlayer,
+                expected = HomeEvent.OpenNotificationListenerSettings,
+            )
+        }
+
+    @Test
+    fun `onAction Music forwards the command to sendMusicCommand and emits no event`() =
+        runTest {
+            val received = mutableListOf<MusicCommand>()
+            val viewModel = stubViewModel(sendMusicCommand = { received += it })
             viewModel.events.test {
-                viewModel.onAction(HomeAction.OpenAppDrawer)
-                assertEquals(HomeEvent.OpenDrawer, awaitItem())
+                viewModel.onAction(HomeAction.Music(MusicCommand.PlayPause))
+                viewModel.onAction(HomeAction.Music(MusicCommand.SkipNext))
+                viewModel.onAction(HomeAction.Music(MusicCommand.SkipPrevious))
+                expectNoEvents()
                 cancelAndIgnoreRemainingEvents()
             }
+            assertEquals(
+                listOf(MusicCommand.PlayPause, MusicCommand.SkipNext, MusicCommand.SkipPrevious),
+                received,
+            )
         }
+
+    private suspend fun HomeViewModel.assertEvent(
+        action: HomeAction,
+        expected: HomeEvent,
+    ) {
+        events.test {
+            onAction(action)
+            assertEquals(expected, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun stubViewModel(sendMusicCommand: (MusicCommand) -> Unit = {}): HomeViewModel =
+        HomeViewModel(
+            clockFlow = emptyFlow(),
+            locationFlow = emptyFlow(),
+            addressFlow = emptyFlow(),
+            weatherFlow = emptyFlow(),
+            nowPlayingFlow = emptyFlow(),
+            appsFlow = MutableStateFlow(emptyList()),
+            isMapAvailable = { false },
+            sendMusicCommand = sendMusicCommand,
+        )
 }


### PR DESCRIPTION
## Summary

Implements the deferred follow-up #3 from PR #5 — replaces the placeholder `Unit` branches in `HomeViewModel.onAction` with concrete side-effect routing through the unified `events: SharedFlow<HomeEvent>` channel introduced in PR #6.

| Action | Effect |
|---|---|
| `LaunchApp(component)` | `HomeEvent.LaunchComponent` → `AppsRepository.launch(component)` |
| `OpenMaps` | `HomeEvent.LaunchAppCategory(CATEGORY_APP_MAPS)` |
| `Shortcut(target)` | `HomeEvent.LaunchAppCategory(target.intentCategory)` |
| `ConnectMusicPlayer` | `HomeEvent.OpenNotificationListenerSettings` |
| `Music(command)` | `MusicSessionRepository.send(command)` (no-op if NLS unbound) |

`HomeRoute` collapses the per-event `onOpenDrawer` callback (added in PR #6) into a single `onEvent: (HomeEvent) -> Unit` since the variant count is now > 1.

## Design notes

- **Multi-region first** (`CLAUDE.md#multi-region-first`): category-based launching uses `Intent.makeMainSelectorActivity(ACTION_MAIN, category)` so each market's user-elected default app for the semantic category (Maps, Music, Contacts, Gallery) wins. No package allowlist.
- **Silent-failure containment**: `startActivity` is wrapped to swallow only `ActivityNotFoundException` (a head-unit may genuinely lack a maps app); `SecurityException` and other failures propagate so they surface as crashes in development rather than silent dead clicks.
- **VM testability**: `sendMusicCommand: (MusicCommand) -> Unit` is a constructor-injected lambda (factory passes `MusicSessionRepository::send`); tests can capture invocations without a Robolectric `MediaSessionManager`.

## Files changed

- `ui/home/HomeEvent.kt` — adds `LaunchComponent`, `LaunchAppCategory`, `OpenNotificationListenerSettings`.
- `data/MusicSessionRepository.kt` — adds `send(MusicCommand)` using `MediaController.transportControls`.
- `ui/home/HomeViewModel.kt` — replaces placeholder `when {Unit}` with concrete dispatch; injects `sendMusicCommand`.
- `ui/home/HomeRoute.kt` — collapses `onOpenDrawer` → `onEvent: (HomeEvent) -> Unit`.
- `MainActivity.kt` — `handleHomeEvent` + `startActivityIfResolved` helpers.
- `HomeViewModelTest.kt` — adds emission tests for every action variant + a music-forwarding capture test (7 tests, all green).

## Test plan

- [x] `./gradlew spotlessApply test lint` — BUILD SUCCESSFUL; `HomeViewModelTest` 7/7 pass.
- [x] `./gradlew connectedDebugAndroidTest` on TBox-Mock AVD (Android 13) — 10/10 instrumented tests pass.
- [x] AVD smoke on TBox-Mock — each `HomeEvent` variant verified end-to-end:
  - Tap Maps shortcut → resolves to `com.google.android.apps.maps/.MapsActivity`.
  - Tap Music shortcut → resolves to `com.google.android.apps.youtube.music` (YT Music notification permission prompt confirms launch).
  - Tap "Connect a player" CTA → opens `com.android.settings/.Settings$NotificationAccessSettingsActivity` (NLS list visible).
  - Tap "Open all apps" tile → drawer opens (covered by PR #6 smoke; re-verified).
  - Press back from each → returns to launcher / system home cleanly.
  - No `AndroidRuntime` / `FATAL` entries in `logcat` across the round-trip.
- [ ] Music transport command on a real active session (AVD has no continuously playing session; covered by unit-test capture).
- [ ] Real-device smoke on TBox Ambient hardware (deferred).