### PR TITLE
feat(home): rebuild dashboard with multi-day weather, music playback card, and material-icons-extended

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)

--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeWeatherSnapshot.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeWeatherSnapshot.kt
@@ -1,11 +1,49 @@
 package io.github.seijikohara.femto.testfixtures
 
+import io.github.seijikohara.femto.data.DailyForecast
+import io.github.seijikohara.femto.data.HourlyForecast
 import io.github.seijikohara.femto.data.WeatherCode
 import io.github.seijikohara.femto.data.WeatherSnapshot
 import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
 
 internal fun fakeWeatherSnapshot(
     tempC: Double = 18.0,
+    apparentTempC: Double = 17.0,
     code: WeatherCode = WeatherCode.CLEAR,
+    windKmh: Double = 9.6,
+    uvIndex: Double? = 4.0,
+    isDay: Boolean = true,
+    sunrise: LocalTime? = LocalTime.of(5, 42),
+    sunset: LocalTime? = LocalTime.of(19, 14),
+    hourly: List<HourlyForecast> =
+        listOf(
+            HourlyForecast(LocalTime.of(12, 0), 19.0, WeatherCode.CLEAR),
+            HourlyForecast(LocalTime.of(13, 0), 20.0, WeatherCode.CLEAR),
+            HourlyForecast(LocalTime.of(14, 0), 21.0, WeatherCode.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(15, 0), 21.0, WeatherCode.PARTLY_CLOUDY),
+        ),
+    daily: List<DailyForecast> =
+        listOf(
+            DailyForecast(LocalDate.of(2026, 5, 1), 22.0, 14.0, WeatherCode.CLEAR),
+            DailyForecast(LocalDate.of(2026, 5, 2), 23.0, 15.0, WeatherCode.PARTLY_CLOUDY),
+            DailyForecast(LocalDate.of(2026, 5, 3), 21.0, 14.0, WeatherCode.RAIN),
+            DailyForecast(LocalDate.of(2026, 5, 4), 20.0, 13.0, WeatherCode.CLOUDY),
+            DailyForecast(LocalDate.of(2026, 5, 5), 22.0, 14.0, WeatherCode.CLEAR),
+        ),
     fetchedAt: Instant = Instant.parse("2026-05-01T05:32:00Z"),
-): WeatherSnapshot = WeatherSnapshot(tempC, code, fetchedAt)
+): WeatherSnapshot =
+    WeatherSnapshot(
+        tempC = tempC,
+        apparentTempC = apparentTempC,
+        code = code,
+        windKmh = windKmh,
+        uvIndex = uvIndex,
+        isDay = isDay,
+        sunrise = sunrise,
+        sunset = sunset,
+        hourly = hourly,
+        daily = daily,
+        fetchedAt = fetchedAt,
+    )

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/ClockPanelTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/ClockPanelTest.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import io.github.seijikohara.femto.data.ClockTick
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -21,6 +22,8 @@ class ClockPanelTest {
                 ClockPanel(
                     tick = ClockTick(LocalTime.of(14, 32), LocalDate.of(2026, 5, 1)),
                     is24Hour = true,
+                    sunrise = null,
+                    sunset = null,
                 )
             }
         }
@@ -35,9 +38,29 @@ class ClockPanelTest {
                 ClockPanel(
                     tick = ClockTick(LocalTime.of(14, 32), LocalDate.of(2026, 5, 1)),
                     is24Hour = false,
+                    sunrise = null,
+                    sunset = null,
                 )
             }
         }
         rule.onNodeWithText("2:32", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun renders_sunrise_and_sunset_chips_when_both_are_present() {
+        rule.setContent {
+            FemtoTheme {
+                ClockPanel(
+                    tick = ClockTick(LocalTime.of(7, 39), LocalDate.of(2026, 5, 11)),
+                    is24Hour = true,
+                    sunrise = LocalTime.of(4, 39),
+                    sunset = LocalTime.of(18, 35),
+                )
+            }
+        }
+        rule.onNodeWithContentDescription("Sunrise").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Sunset").assertIsDisplayed()
+        rule.onNodeWithText("04:39").assertIsDisplayed()
+        rule.onNodeWithText("18:35").assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import io.github.seijikohara.femto.data.ClockTick
+import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.testfixtures.fakeAddress
 import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
 import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
@@ -34,7 +35,7 @@ class DashboardScaffoldTest {
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     distanceUnit = DistanceUnit.METERS,
                     mapAvailable = false,
-                    nowPlaying = fakeNowPlaying(),
+                    musicState = MusicCardState.Playing(fakeNowPlaying()),
                     onMapTap = {},
                     onMusicCommand = {},
                     onConnectMusic = {},

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicPanelTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicPanelTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Rule
@@ -15,11 +16,11 @@ class MusicPanelTest {
     val rule = createComposeRule()
 
     @Test
-    fun renders_track_artist_and_transport() {
+    fun renders_track_artist_and_transport_when_playing() {
         rule.setContent {
             FemtoTheme {
                 MusicPanel(
-                    nowPlaying = fakeNowPlaying(),
+                    state = MusicCardState.Playing(fakeNowPlaying()),
                     onCommand = {},
                     onConnect = {},
                 )
@@ -31,12 +32,12 @@ class MusicPanelTest {
     }
 
     @Test
-    fun renders_connect_placeholder_when_null_and_dispatches_on_tap() {
+    fun renders_connect_cta_and_dispatches_when_permission_missing() {
         var tapped = false
         rule.setContent {
             FemtoTheme {
                 MusicPanel(
-                    nowPlaying = null,
+                    state = MusicCardState.NeedsPermission,
                     onCommand = {},
                     onConnect = { tapped = true },
                 )
@@ -44,5 +45,19 @@ class MusicPanelTest {
         }
         rule.onNodeWithText("Connect a player").assertIsDisplayed().performClick()
         assert(tapped)
+    }
+
+    @Test
+    fun renders_nothing_playing_placeholder_when_no_active_session() {
+        rule.setContent {
+            FemtoTheme {
+                MusicPanel(
+                    state = MusicCardState.NoActiveSession,
+                    onCommand = {},
+                    onConnect = {},
+                )
+            }
+        }
+        rule.onNodeWithText("Nothing playing").assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherPanelTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherPanelTest.kt
@@ -2,12 +2,19 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.core.text.util.LocalePreferences
+import io.github.seijikohara.femto.data.DailyForecast
+import io.github.seijikohara.femto.data.HourlyForecast
+import io.github.seijikohara.femto.data.WeatherCode
 import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
+import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Rule
 import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalTime
 
 class WeatherPanelTest {
     @get:Rule
@@ -20,11 +27,12 @@ class WeatherPanelTest {
                 WeatherPanel(
                     snapshot = fakeWeatherSnapshot(tempC = 18.0),
                     unit = LocalePreferences.TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
                 )
             }
         }
-        rule.onNodeWithText("18", substring = true).assertIsDisplayed()
-        rule.onNodeWithText("°C", substring = true).assertIsDisplayed()
+        rule.onNodeWithText("18°C").assertIsDisplayed()
     }
 
     @Test
@@ -34,20 +42,123 @@ class WeatherPanelTest {
                 WeatherPanel(
                     snapshot = fakeWeatherSnapshot(tempC = 0.0),
                     unit = LocalePreferences.TemperatureUnit.FAHRENHEIT,
+                    speedUnit = SpeedUnit.MILES_PER_HOUR,
+                    is24Hour = false,
                 )
             }
         }
-        rule.onNodeWithText("32", substring = true).assertIsDisplayed()
-        rule.onNodeWithText("°F", substring = true).assertIsDisplayed()
+        rule.onNodeWithText("32°F").assertIsDisplayed()
     }
 
     @Test
     fun renders_placeholder_when_snapshot_is_null() {
         rule.setContent {
             FemtoTheme {
-                WeatherPanel(snapshot = null, unit = LocalePreferences.TemperatureUnit.CELSIUS)
+                WeatherPanel(
+                    snapshot = null,
+                    unit = LocalePreferences.TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
+                )
             }
         }
         rule.onNodeWithText("—").assertIsDisplayed()
+    }
+
+    @Test
+    fun renders_condition_apparent_temperature_and_uv_in_hero_secondary() {
+        rule.setContent {
+            FemtoTheme {
+                WeatherPanel(
+                    snapshot =
+                        fakeWeatherSnapshot(
+                            apparentTempC = 16.0,
+                            uvIndex = 5.0,
+                            code = WeatherCode.PARTLY_CLOUDY,
+                        ),
+                    unit = LocalePreferences.TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
+                )
+            }
+        }
+        rule.onNodeWithText("Partly cloudy", substring = true).assertIsDisplayed()
+        rule.onNodeWithText("Feels 16°C", substring = true).assertIsDisplayed()
+        rule.onNodeWithText("UV 5", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun renders_sunrise_sunset_and_wind_chips_with_icons() {
+        rule.setContent {
+            FemtoTheme {
+                WeatherPanel(
+                    snapshot =
+                        fakeWeatherSnapshot(
+                            windKmh = 16.0,
+                            sunrise = LocalTime.of(5, 42),
+                            sunset = LocalTime.of(19, 14),
+                        ),
+                    unit = LocalePreferences.TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.MILES_PER_HOUR,
+                    is24Hour = true,
+                )
+            }
+        }
+        rule.onNodeWithContentDescription("Sunrise").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Sunset").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Wind").assertIsDisplayed()
+        rule.onNodeWithText("05:42").assertIsDisplayed()
+        rule.onNodeWithText("19:14").assertIsDisplayed()
+        // 16 km/h ≈ 10 mph
+        rule.onNodeWithText("10 mph").assertIsDisplayed()
+    }
+
+    @Test
+    fun renders_5_day_outlook_with_today_label_and_high_low_temperatures() {
+        rule.setContent {
+            FemtoTheme {
+                WeatherPanel(
+                    snapshot =
+                        fakeWeatherSnapshot(
+                            daily =
+                                listOf(
+                                    DailyForecast(LocalDate.of(2026, 5, 9), 22.0, 14.0, WeatherCode.CLEAR),
+                                    DailyForecast(LocalDate.of(2026, 5, 10), 25.0, 16.0, WeatherCode.CLEAR),
+                                ),
+                        ),
+                    unit = LocalePreferences.TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
+                )
+            }
+        }
+        rule.onNodeWithText("Today").assertIsDisplayed()
+        rule.onNodeWithText("22° / 14°").assertIsDisplayed()
+        rule.onNodeWithText("25° / 16°").assertIsDisplayed()
+    }
+
+    @Test
+    fun renders_hourly_strip_entries_with_hour_and_compact_temperature() {
+        rule.setContent {
+            FemtoTheme {
+                WeatherPanel(
+                    snapshot =
+                        fakeWeatherSnapshot(
+                            hourly =
+                                listOf(
+                                    HourlyForecast(LocalTime.of(9, 0), 12.0, WeatherCode.CLOUDY),
+                                    HourlyForecast(LocalTime.of(10, 0), 14.0, WeatherCode.CLOUDY),
+                                ),
+                        ),
+                    unit = LocalePreferences.TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
+                )
+            }
+        }
+        rule.onNodeWithText("09").assertIsDisplayed()
+        rule.onNodeWithText("10").assertIsDisplayed()
+        rule.onNodeWithText("12°").assertIsDisplayed()
+        rule.onNodeWithText("14°").assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherPanelTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherPanelTest.kt
@@ -2,10 +2,8 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.core.text.util.LocalePreferences
-import io.github.seijikohara.femto.data.DailyForecast
 import io.github.seijikohara.femto.data.HourlyForecast
 import io.github.seijikohara.femto.data.WeatherCode
 import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
@@ -13,7 +11,6 @@ import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Rule
 import org.junit.Test
-import java.time.LocalDate
 import java.time.LocalTime
 
 class WeatherPanelTest {
@@ -66,37 +63,16 @@ class WeatherPanelTest {
     }
 
     @Test
-    fun renders_condition_apparent_temperature_and_uv_in_hero_secondary() {
+    fun renders_condition_and_secondary_line_with_feels_wind_and_uv() {
         rule.setContent {
             FemtoTheme {
                 WeatherPanel(
                     snapshot =
                         fakeWeatherSnapshot(
                             apparentTempC = 16.0,
+                            windKmh = 16.0,
                             uvIndex = 5.0,
                             code = WeatherCode.PARTLY_CLOUDY,
-                        ),
-                    unit = LocalePreferences.TemperatureUnit.CELSIUS,
-                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
-                    is24Hour = true,
-                )
-            }
-        }
-        rule.onNodeWithText("Partly cloudy", substring = true).assertIsDisplayed()
-        rule.onNodeWithText("Feels 16°C", substring = true).assertIsDisplayed()
-        rule.onNodeWithText("UV 5", substring = true).assertIsDisplayed()
-    }
-
-    @Test
-    fun renders_sunrise_sunset_and_wind_chips_with_icons() {
-        rule.setContent {
-            FemtoTheme {
-                WeatherPanel(
-                    snapshot =
-                        fakeWeatherSnapshot(
-                            windKmh = 16.0,
-                            sunrise = LocalTime.of(5, 42),
-                            sunset = LocalTime.of(19, 14),
                         ),
                     unit = LocalePreferences.TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.MILES_PER_HOUR,
@@ -104,41 +80,15 @@ class WeatherPanelTest {
                 )
             }
         }
-        rule.onNodeWithContentDescription("Sunrise").assertIsDisplayed()
-        rule.onNodeWithContentDescription("Sunset").assertIsDisplayed()
-        rule.onNodeWithContentDescription("Wind").assertIsDisplayed()
-        rule.onNodeWithText("05:42").assertIsDisplayed()
-        rule.onNodeWithText("19:14").assertIsDisplayed()
-        // 16 km/h ≈ 10 mph
-        rule.onNodeWithText("10 mph").assertIsDisplayed()
+        rule.onNodeWithText("Partly cloudy").assertIsDisplayed()
+        // 16 km/h ≈ 10 mph; all three secondary metrics share one bodyMedium line.
+        rule.onNodeWithText("Feels 16°C", substring = true).assertIsDisplayed()
+        rule.onNodeWithText("Wind 10 mph", substring = true).assertIsDisplayed()
+        rule.onNodeWithText("UV 5", substring = true).assertIsDisplayed()
     }
 
     @Test
-    fun renders_5_day_outlook_with_today_label_and_high_low_temperatures() {
-        rule.setContent {
-            FemtoTheme {
-                WeatherPanel(
-                    snapshot =
-                        fakeWeatherSnapshot(
-                            daily =
-                                listOf(
-                                    DailyForecast(LocalDate.of(2026, 5, 9), 22.0, 14.0, WeatherCode.CLEAR),
-                                    DailyForecast(LocalDate.of(2026, 5, 10), 25.0, 16.0, WeatherCode.CLEAR),
-                                ),
-                        ),
-                    unit = LocalePreferences.TemperatureUnit.CELSIUS,
-                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
-                    is24Hour = true,
-                )
-            }
-        }
-        rule.onNodeWithText("Today").assertIsDisplayed()
-        rule.onNodeWithText("22° / 14°").assertIsDisplayed()
-        rule.onNodeWithText("25° / 16°").assertIsDisplayed()
-    }
-
-    @Test
-    fun renders_hourly_strip_entries_with_hour_and_compact_temperature() {
+    fun renders_hourly_outlook_with_now_label_and_per_hour_temperatures() {
         rule.setContent {
             FemtoTheme {
                 WeatherPanel(
@@ -146,8 +96,8 @@ class WeatherPanelTest {
                         fakeWeatherSnapshot(
                             hourly =
                                 listOf(
-                                    HourlyForecast(LocalTime.of(9, 0), 12.0, WeatherCode.CLOUDY),
-                                    HourlyForecast(LocalTime.of(10, 0), 14.0, WeatherCode.CLOUDY),
+                                    HourlyForecast(LocalTime.of(9, 0), 21.0, WeatherCode.CLEAR),
+                                    HourlyForecast(LocalTime.of(10, 0), 22.0, WeatherCode.PARTLY_CLOUDY),
                                 ),
                         ),
                     unit = LocalePreferences.TemperatureUnit.CELSIUS,
@@ -156,9 +106,9 @@ class WeatherPanelTest {
                 )
             }
         }
-        rule.onNodeWithText("09").assertIsDisplayed()
+        rule.onNodeWithText("Now").assertIsDisplayed()
         rule.onNodeWithText("10").assertIsDisplayed()
-        rule.onNodeWithText("12°").assertIsDisplayed()
-        rule.onNodeWithText("14°").assertIsDisplayed()
+        rule.onNodeWithText("21°").assertIsDisplayed()
+        rule.onNodeWithText("22°").assertIsDisplayed()
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/MusicCardState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/MusicCardState.kt
@@ -1,0 +1,17 @@
+package io.github.seijikohara.femto.data
+
+/**
+ * Discrete music card states. The dashboard renders different content per
+ * variant rather than collapsing all empty cases to a single null `NowPlaying`,
+ * so we can show a "needs permission" CTA, a "nothing playing" placeholder, or
+ * the live track without conflating the three empty states.
+ */
+internal sealed interface MusicCardState {
+    data object NeedsPermission : MusicCardState
+
+    data object NoActiveSession : MusicCardState
+
+    data class Playing(
+        val nowPlaying: NowPlaying,
+    ) : MusicCardState
+}

--- a/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
@@ -2,17 +2,23 @@ package io.github.seijikohara.femto.data
 
 import android.content.ComponentName
 import android.content.Context
+import android.database.ContentObserver
 import android.media.MediaMetadata
 import android.media.session.MediaController
 import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
 import io.github.seijikohara.femto.ui.home.components.MusicCommand
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 
 internal class MusicSessionRepository(
@@ -21,20 +27,19 @@ internal class MusicSessionRepository(
     private val sessionManager: MediaSessionManager = checkNotNull(context.getSystemService())
     private val componentName = ComponentName(context, MusicSessionListenerService::class.java)
 
-    fun nowPlayingFlow(): Flow<NowPlaying?> =
-        callbackFlow {
-            val callback =
-                MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
-                    trySend(controllers.toNowPlaying())
+    fun stateFlow(): Flow<MusicCardState> =
+        combine(permissionFlow(), activeControllersFlow()) { hasPermission, controllers ->
+            when {
+                !hasPermission -> {
+                    MusicCardState.NeedsPermission
                 }
 
-            runCatching {
-                trySend(sessionManager.getActiveSessions(componentName).toNowPlaying())
-                sessionManager.addOnActiveSessionsChangedListener(callback, componentName)
-            }.onFailure { trySend(null) }
-
-            awaitClose {
-                runCatching { sessionManager.removeOnActiveSessionsChangedListener(callback) }
+                else -> {
+                    controllers
+                        .toNowPlaying()
+                        ?.let(MusicCardState::Playing)
+                        ?: MusicCardState.NoActiveSession
+                }
             }
         }.flowOn(Dispatchers.Main.immediate)
 
@@ -72,9 +77,48 @@ internal class MusicSessionRepository(
         }
     }
 
-    private fun List<MediaController>?.toNowPlaying(): NowPlaying? =
-        this
-            ?.firstOrNull { it.playbackState?.isActive() == true }
+    /**
+     * Emit `true` while the user has enabled the launcher's notification-listener
+     * service in Settings, `false` otherwise. We watch the Secure setting via a
+     * ContentObserver so the dashboard reacts to a permission grant returning
+     * from `Settings → Notification Access` without an app restart.
+     */
+    private fun permissionFlow(): Flow<Boolean> =
+        callbackFlow {
+            val observer =
+                object : ContentObserver(Handler(Looper.getMainLooper())) {
+                    override fun onChange(selfChange: Boolean) {
+                        trySend(hasPermission())
+                    }
+                }
+            val uri = Settings.Secure.getUriFor(ENABLED_NOTIFICATION_LISTENERS)
+            context.contentResolver.registerContentObserver(uri, false, observer)
+            trySend(hasPermission())
+            awaitClose { context.contentResolver.unregisterContentObserver(observer) }
+        }
+
+    private fun activeControllersFlow(): Flow<List<MediaController>> =
+        callbackFlow {
+            val callback =
+                MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
+                    trySend(controllers.orEmpty())
+                }
+
+            runCatching {
+                trySend(sessionManager.getActiveSessions(componentName))
+                sessionManager.addOnActiveSessionsChangedListener(callback, componentName)
+            }.onFailure { trySend(emptyList()) }
+
+            awaitClose {
+                runCatching { sessionManager.removeOnActiveSessionsChangedListener(callback) }
+            }
+        }
+
+    private fun hasPermission(): Boolean =
+        context.packageName in NotificationManagerCompat.getEnabledListenerPackages(context)
+
+    private fun List<MediaController>.toNowPlaying(): NowPlaying? =
+        firstOrNull { it.playbackState?.isActive() == true }
             ?.let { controller ->
                 val metadata = controller.metadata ?: return@let null
                 NowPlaying(
@@ -87,4 +131,8 @@ internal class MusicSessionRepository(
                     packageName = controller.packageName,
                 )
             }
+
+    private companion object {
+        const val ENABLED_NOTIFICATION_LISTENERS = "enabled_notification_listeners"
+    }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/OpenMeteoApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/OpenMeteoApi.kt
@@ -13,10 +13,10 @@ internal class OpenMeteoApi(
 ) {
     private val json = Json { ignoreUnknownKeys = true }
 
-    suspend fun currentWeather(
+    suspend fun forecast(
         latitude: Double,
         longitude: Double,
-    ): CurrentWeather? =
+    ): ForecastResponse? =
         withContext(Dispatchers.IO) {
             runCatching {
                 val request =
@@ -25,12 +25,17 @@ internal class OpenMeteoApi(
                         .url(
                             baseUrl.trimEnd('/') +
                                 "/v1/forecast?latitude=$latitude&longitude=$longitude" +
-                                "&current_weather=true",
+                                "&current=temperature_2m,apparent_temperature,weathercode," +
+                                "windspeed_10m,uv_index,is_day" +
+                                "&hourly=temperature_2m,weathercode" +
+                                "&daily=sunrise,sunset,weathercode," +
+                                "temperature_2m_max,temperature_2m_min" +
+                                "&forecast_days=5&timezone=auto",
                         ).build()
                 client.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) return@use null
                     response.body?.string()?.let { body ->
-                        json.decodeFromString<ForecastResponse>(body).current_weather
+                        json.decodeFromString<ForecastResponse>(body)
                     }
                 }
             }.getOrNull()
@@ -38,12 +43,37 @@ internal class OpenMeteoApi(
 
     @Serializable
     data class ForecastResponse(
-        val current_weather: CurrentWeather? = null,
+        val timezone: String? = null,
+        val current: Current? = null,
+        val hourly: Hourly? = null,
+        val daily: Daily? = null,
     )
 
     @Serializable
-    data class CurrentWeather(
-        val temperature: Double,
+    data class Current(
+        val time: String,
+        val temperature_2m: Double,
+        val apparent_temperature: Double,
         val weathercode: Int,
+        val windspeed_10m: Double,
+        val uv_index: Double? = null,
+        val is_day: Int,
+    )
+
+    @Serializable
+    data class Hourly(
+        val time: List<String> = emptyList(),
+        val temperature_2m: List<Double> = emptyList(),
+        val weathercode: List<Int> = emptyList(),
+    )
+
+    @Serializable
+    data class Daily(
+        val time: List<String> = emptyList(),
+        val sunrise: List<String> = emptyList(),
+        val sunset: List<String> = emptyList(),
+        val weathercode: List<Int> = emptyList(),
+        val temperature_2m_max: List<Double> = emptyList(),
+        val temperature_2m_min: List<Double> = emptyList(),
     )
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
@@ -7,6 +7,10 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import java.time.Clock
 import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
 internal class WeatherRepository(
     private val api: OpenMeteoApi,
@@ -26,11 +30,26 @@ internal class WeatherRepository(
     private suspend fun refresh(location: Location?): WeatherSnapshot? {
         location ?: return null
         if (!shouldRefetch(location)) return cached
-        val current = api.currentWeather(location.latitude, location.longitude) ?: return cached
+        val response = api.forecast(location.latitude, location.longitude) ?: return cached
+        val current = response.current ?: return cached
         cached =
             WeatherSnapshot(
-                tempC = current.temperature,
+                tempC = current.temperature_2m,
+                apparentTempC = current.apparent_temperature,
                 code = WeatherCode.fromWmo(current.weathercode),
+                windKmh = current.windspeed_10m,
+                uvIndex = current.uv_index,
+                isDay = current.is_day == 1,
+                sunrise = response.daily
+                    ?.sunrise
+                    ?.firstOrNull()
+                    ?.let(::parseLocalTime),
+                sunset = response.daily
+                    ?.sunset
+                    ?.firstOrNull()
+                    ?.let(::parseLocalTime),
+                hourly = response.hourly?.let { hourlySliceFrom(it, current.time) }.orEmpty(),
+                daily = response.daily?.let(::dailyForecastsFrom).orEmpty(),
                 fetchedAt = clock.instant(),
             )
         lastFetchLocation = location
@@ -45,8 +64,46 @@ internal class WeatherRepository(
         return !(ageOk && nearOk)
     }
 
+    private fun hourlySliceFrom(
+        hourly: OpenMeteoApi.Hourly,
+        currentTime: String,
+    ): List<HourlyForecast> {
+        val now = runCatching { LocalDateTime.parse(currentTime) }.getOrNull() ?: return emptyList()
+        val start =
+            hourly.time
+                .indexOfFirst { entry ->
+                    runCatching { LocalDateTime.parse(entry) }
+                        .getOrNull()
+                        ?.let { !it.isBefore(now) } == true
+                }.takeIf { it >= 0 } ?: return emptyList()
+        val end = (start + HOURLY_SLICE_LENGTH).coerceAtMost(hourly.time.size)
+        return (start until end).mapNotNull { i ->
+            val time = runCatching { LocalDateTime.parse(hourly.time[i]).toLocalTime() }.getOrNull()
+                ?: return@mapNotNull null
+            val temp = hourly.temperature_2m.getOrNull(i) ?: return@mapNotNull null
+            val code = hourly.weathercode.getOrNull(i)?.let(WeatherCode::fromWmo) ?: return@mapNotNull null
+            HourlyForecast(time = time, tempC = temp, code = code)
+        }
+    }
+
+    private fun dailyForecastsFrom(daily: OpenMeteoApi.Daily): List<DailyForecast> =
+        daily.time.indices.mapNotNull { i ->
+            val date = runCatching { LocalDate.parse(daily.time[i]) }.getOrNull() ?: return@mapNotNull null
+            val max = daily.temperature_2m_max.getOrNull(i) ?: return@mapNotNull null
+            val min = daily.temperature_2m_min.getOrNull(i) ?: return@mapNotNull null
+            val code = daily.weathercode.getOrNull(i)?.let(WeatherCode::fromWmo) ?: return@mapNotNull null
+            DailyForecast(date = date, tempMaxC = max, tempMinC = min, code = code)
+        }
+
+    private fun parseLocalTime(iso: String): LocalTime? =
+        runCatching { LocalDateTime.parse(iso, ISO_LOCAL).toLocalTime() }.getOrNull()
+
     private companion object {
         val REFRESH_INTERVAL: Duration = Duration.ofMinutes(30)
         const val REFRESH_DISTANCE_M = 5_000f
+        const val HOURLY_SLICE_LENGTH = 4
+
+        // Open-Meteo with timezone=auto returns naive local times (no offset suffix).
+        val ISO_LOCAL: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
@@ -101,7 +101,7 @@ internal class WeatherRepository(
     private companion object {
         val REFRESH_INTERVAL: Duration = Duration.ofMinutes(30)
         const val REFRESH_DISTANCE_M = 5_000f
-        const val HOURLY_SLICE_LENGTH = 4
+        const val HOURLY_SLICE_LENGTH = 5
 
         // Open-Meteo with timezone=auto returns naive local times (no offset suffix).
         val ISO_LOCAL: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME

--- a/app/src/main/java/io/github/seijikohara/femto/data/WeatherSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/WeatherSnapshot.kt
@@ -1,11 +1,34 @@
 package io.github.seijikohara.femto.data
 
 import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
 
 internal data class WeatherSnapshot(
     val tempC: Double,
+    val apparentTempC: Double,
     val code: WeatherCode,
+    val windKmh: Double,
+    val uvIndex: Double?,
+    val isDay: Boolean,
+    val sunrise: LocalTime?,
+    val sunset: LocalTime?,
+    val hourly: List<HourlyForecast>,
+    val daily: List<DailyForecast>,
     val fetchedAt: Instant,
+)
+
+internal data class HourlyForecast(
+    val time: LocalTime,
+    val tempC: Double,
+    val code: WeatherCode,
+)
+
+internal data class DailyForecast(
+    val date: LocalDate,
+    val tempMaxC: Double,
+    val tempMinC: Double,
+    val code: WeatherCode,
 )
 
 internal enum class WeatherCode {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -40,7 +40,7 @@ internal fun HomeScreen(
             speedUnit = speedUnitFor(),
             distanceUnit = distanceUnitFor(),
             mapAvailable = uiState.mapAvailable,
-            nowPlaying = uiState.nowPlaying,
+            musicState = uiState.musicState,
             onMapTap = { onAction(HomeAction.OpenMaps) },
             onMusicCommand = { onAction(HomeAction.Music(it)) },
             onConnectMusic = { onAction(HomeAction.ConnectMusicPlayer) },

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeUiState.kt
@@ -4,7 +4,7 @@ import android.location.Location
 import androidx.compose.runtime.Immutable
 import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.data.ClockTick
-import io.github.seijikohara.femto.data.NowPlaying
+import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.data.ShortAddress
 import io.github.seijikohara.femto.data.WeatherSnapshot
 import java.time.LocalDate
@@ -18,7 +18,7 @@ internal data class HomeUiState(
     val location: Location?,
     val address: ShortAddress?,
     val weather: WeatherSnapshot?,
-    val nowPlaying: NowPlaying?,
+    val musicState: MusicCardState,
     val mapAvailable: Boolean,
 ) {
     companion object {
@@ -30,7 +30,7 @@ internal data class HomeUiState(
                 location = null,
                 address = null,
                 weather = null,
-                nowPlaying = null,
+                musicState = MusicCardState.NeedsPermission,
                 mapAvailable = false,
             )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -13,8 +13,8 @@ import io.github.seijikohara.femto.data.ClockRepository
 import io.github.seijikohara.femto.data.ClockTick
 import io.github.seijikohara.femto.data.GmsAvailability
 import io.github.seijikohara.femto.data.LocationRepository
+import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.data.MusicSessionRepository
-import io.github.seijikohara.femto.data.NowPlaying
 import io.github.seijikohara.femto.data.OpenMeteoApi
 import io.github.seijikohara.femto.data.ReverseGeocoderRepository
 import io.github.seijikohara.femto.data.ShortAddress
@@ -38,7 +38,7 @@ internal class HomeViewModel(
     private val locationFlow: Flow<Location?>,
     private val addressFlow: Flow<ShortAddress?>,
     private val weatherFlow: Flow<WeatherSnapshot?>,
-    private val nowPlayingFlow: Flow<NowPlaying?>,
+    private val musicStateFlow: Flow<MusicCardState>,
     private val appsFlow: MutableStateFlow<List<AppEntry>>,
     private val isMapAvailable: () -> Boolean,
     private val sendMusicCommand: (MusicCommand) -> Unit = {},
@@ -49,7 +49,7 @@ internal class HomeViewModel(
             locationFlow,
             addressFlow,
             weatherFlow,
-            nowPlayingFlow,
+            musicStateFlow,
             appsFlow,
         ) { values ->
             @Suppress("UNCHECKED_CAST")
@@ -65,7 +65,7 @@ internal class HomeViewModel(
             val weather = values[3] as WeatherSnapshot?
 
             @Suppress("UNCHECKED_CAST")
-            val music = values[4] as NowPlaying?
+            val music = values[4] as MusicCardState
 
             @Suppress("UNCHECKED_CAST")
             val apps = values[5] as List<AppEntry>
@@ -76,7 +76,7 @@ internal class HomeViewModel(
                 location = location,
                 address = address,
                 weather = weather,
-                nowPlaying = music,
+                musicState = music,
                 mapAvailable = isMapAvailable(),
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), HomeUiState.Initial)
@@ -140,7 +140,7 @@ internal class HomeViewModelFactory(
             locationFlow = locationFlow,
             addressFlow = geocoder.addressFlow(),
             weatherFlow = weather.snapshotFlow(),
-            nowPlayingFlow = music.nowPlayingFlow(),
+            musicStateFlow = music.stateFlow(),
             appsFlow = apps,
             isMapAvailable = { gms.isPresent() },
             sendMusicCommand = music::send,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppsBar.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppsBar.kt
@@ -2,32 +2,40 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Apps
+import androidx.compose.material.icons.outlined.Explore
+import androidx.compose.material.icons.outlined.Map
+import androidx.compose.material.icons.outlined.MusicNote
+import androidx.compose.material.icons.outlined.Phone
+import androidx.compose.material.icons.outlined.PhotoCamera
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
 internal enum class AppsBarShortcut(
-    val label: String,
+    val icon: ImageVector,
     val intentCategory: String,
 ) {
-    Phone("📞", "android.intent.category.APP_CONTACTS"),
-    Music("🎵", "android.intent.category.APP_MUSIC"),
-    Maps("📍", "android.intent.category.APP_MAPS"),
-    Camera("📷", "android.intent.category.APP_GALLERY"),
-    Navigation("🧭", "android.intent.category.APP_MAPS"),
+    Phone(Icons.Outlined.Phone, "android.intent.category.APP_CONTACTS"),
+    Music(Icons.Outlined.MusicNote, "android.intent.category.APP_MUSIC"),
+    Maps(Icons.Outlined.Map, "android.intent.category.APP_MAPS"),
+    Camera(Icons.Outlined.PhotoCamera, "android.intent.category.APP_GALLERY"),
+    Navigation(Icons.Outlined.Explore, "android.intent.category.APP_MAPS"),
 }
 
 @Composable
@@ -46,10 +54,14 @@ internal fun AppsBar(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Tile(label = "≡", description = "Open all apps", onClick = onOpenDrawer)
+        Tile(
+            icon = Icons.Outlined.Apps,
+            description = "Open all apps",
+            onClick = onOpenDrawer,
+        )
         AppsBarShortcut.entries.forEach { shortcut ->
             Tile(
-                label = shortcut.label,
+                icon = shortcut.icon,
                 description = "Apps shortcut: ${shortcut.name}",
                 onClick = { onShortcut(shortcut) },
             )
@@ -59,7 +71,7 @@ internal fun AppsBar(
 
 @Composable
 private fun Tile(
-    label: String,
+    icon: ImageVector,
     description: String,
     onClick: () -> Unit,
 ) = Surface(
@@ -71,10 +83,12 @@ private fun Tile(
     shape = CircleShape,
     color = MaterialTheme.colorScheme.surfaceVariant,
 ) {
-    Text(
-        text = label,
-        style = MaterialTheme.typography.titleLarge,
-        color = MaterialTheme.colorScheme.onSurface,
-        textAlign = TextAlign.Center,
-    )
+    Box(contentAlignment = Alignment.Center) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(28.dp),
+            tint = MaterialTheme.colorScheme.onSurface,
+        )
+    }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockPanel.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.ui.home.components
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -8,6 +9,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.data.ClockTick
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import java.time.format.DateTimeFormatter
@@ -25,22 +27,24 @@ internal fun ClockPanel(
     color = MaterialTheme.colorScheme.surfaceContainer,
     tonalElevation = FemtoDimens.CardElevation,
 ) {
-    Column(modifier = Modifier.padding(FemtoDimens.GridGutter)) {
-        Text(
-            text = "TIME",
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+    Column(
+        modifier = Modifier.padding(FemtoDimens.GridGutter),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        // Time is the most glance-critical value on the dashboard, so it carries the
+        // primary accent color. The role itself is communicated by the digits and
+        // colon — no need for a "TIME" header label.
         Text(
             text = tick.time.format(timeFormatter(is24Hour)),
             style = MaterialTheme.typography.displaySmall,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = MaterialTheme.colorScheme.primary,
         )
+        // FormatStyle.FULL combines weekday and date in one locale-aware line —
+        // "Saturday, May 9, 2026" / "2026年5月9日土曜日" — to keep the card to three
+        // lines and avoid bottom-edge clipping in the right-column layout.
         Text(
-            text = tick.date.format(
-                DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).withLocale(Locale.getDefault()),
-            ),
-            style = MaterialTheme.typography.bodyLarge,
+            text = tick.date.format(fullDateFormatter()),
+            style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -50,3 +54,6 @@ internal fun ClockPanel(
 
 private fun timeFormatter(is24Hour: Boolean): DateTimeFormatter =
     DateTimeFormatter.ofPattern(if (is24Hour) "HH:mm" else "h:mm a", Locale.getDefault())
+
+private fun fullDateFormatter(): DateTimeFormatter =
+    DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL).withLocale(Locale.getDefault())

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockPanel.kt
@@ -2,16 +2,26 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Bedtime
+import androidx.compose.material.icons.outlined.WbTwilight
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.data.ClockTick
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
@@ -20,6 +30,8 @@ import java.util.Locale
 internal fun ClockPanel(
     tick: ClockTick,
     is24Hour: Boolean,
+    sunrise: LocalTime?,
+    sunset: LocalTime?,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
@@ -29,27 +41,76 @@ internal fun ClockPanel(
 ) {
     Column(
         modifier = Modifier.padding(FemtoDimens.GridGutter),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        // Time is the most glance-critical value on the dashboard, so it carries the
-        // primary accent color. The role itself is communicated by the digits and
-        // colon — no need for a "TIME" header label.
+        // displayMedium gives the time enough visual weight to fill the card's
+        // horizontal space — displaySmall left a noticeable right-side gap and
+        // the time should be the dashboard's most glance-critical value.
         Text(
             text = tick.time.format(timeFormatter(is24Hour)),
-            style = MaterialTheme.typography.displaySmall,
+            style = MaterialTheme.typography.displayMedium,
             color = MaterialTheme.colorScheme.primary,
         )
-        // FormatStyle.FULL combines weekday and date in one locale-aware line —
-        // "Saturday, May 9, 2026" / "2026年5月9日土曜日" — to keep the card to three
-        // lines and avoid bottom-edge clipping in the right-column layout.
         Text(
             text = tick.date.format(fullDateFormatter()),
-            style = MaterialTheme.typography.titleLarge,
+            style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+        // Daylight chips anchor the time context — "how long until dusk?" answers
+        // the next driving-relevant question after "what time is it?". They live
+        // here instead of the weather card so weather can focus on the hourly
+        // outlook without crowding. SpaceBetween pushes sunrise to the left edge
+        // and sunset to the right, eliminating the prior right-side empty space.
+        if (sunrise != null || sunset != null) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 4.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                sunrise?.let {
+                    AstroChip(
+                        icon = Icons.Outlined.WbTwilight,
+                        contentDescription = "Sunrise",
+                        label = it.format(timeFormatter(is24Hour)),
+                    )
+                }
+                sunset?.let {
+                    AstroChip(
+                        icon = Icons.Outlined.Bedtime,
+                        contentDescription = "Sunset",
+                        label = it.format(timeFormatter(is24Hour)),
+                    )
+                }
+            }
+        }
     }
+}
+
+@Composable
+private fun AstroChip(
+    icon: ImageVector,
+    contentDescription: String,
+    label: String,
+) = Row(
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+    verticalAlignment = Alignment.CenterVertically,
+) {
+    Icon(
+        imageVector = icon,
+        contentDescription = contentDescription,
+        modifier = Modifier.size(FemtoDimens.InlineIconSize),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
 }
 
 private fun timeFormatter(is24Hour: Boolean): DateTimeFormatter =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.data.ClockTick
-import io.github.seijikohara.femto.data.NowPlaying
+import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.data.ShortAddress
 import io.github.seijikohara.femto.data.WeatherSnapshot
 import io.github.seijikohara.femto.ui.locale.DistanceUnit
@@ -29,7 +29,7 @@ internal fun DashboardScaffold(
     speedUnit: SpeedUnit,
     distanceUnit: DistanceUnit,
     mapAvailable: Boolean,
-    nowPlaying: NowPlaying?,
+    musicState: MusicCardState,
     onMapTap: () -> Unit,
     onMusicCommand: (MusicCommand) -> Unit,
     onConnectMusic: () -> Unit,
@@ -64,21 +64,25 @@ internal fun DashboardScaffold(
                 .fillMaxHeight(),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
+            // Asymmetric weights: clock content is small (time + date), weather is the
+            // densest panel (hero + hourly + astro), and music absorbs leftover space
+            // and grows naturally when an active session adds artwork and transport.
             ClockPanel(
                 tick = clock,
                 is24Hour = is24Hour,
-                modifier = Modifier.weight(1f),
             )
             WeatherPanel(
                 snapshot = weather,
                 unit = temperatureUnit,
-                modifier = Modifier.weight(1f),
+                speedUnit = speedUnit,
+                is24Hour = is24Hour,
+                modifier = Modifier.weight(1.6f),
             )
             MusicPanel(
-                nowPlaying = nowPlaying,
+                state = musicState,
                 onCommand = onMusicCommand,
                 onConnect = onConnectMusic,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1.2f),
             )
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -64,25 +64,27 @@ internal fun DashboardScaffold(
                 .fillMaxHeight(),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            // Asymmetric weights: clock content is small (time + date), weather is the
-            // densest panel (hero + hourly + astro), and music absorbs leftover space
-            // and grows naturally when an active session adds artwork and transport.
+            // Clock and weather both take their intrinsic heights — the cards
+            // contain a fixed number of rows and look unbalanced when stretched.
+            // Music absorbs the remaining space so the playing state's progress
+            // bar and centered transport row sit at a stable vertical position.
             ClockPanel(
                 tick = clock,
                 is24Hour = is24Hour,
+                sunrise = weather?.sunrise,
+                sunset = weather?.sunset,
             )
             WeatherPanel(
                 snapshot = weather,
                 unit = temperatureUnit,
                 speedUnit = speedUnit,
                 is24Hour = is24Hour,
-                modifier = Modifier.weight(1.6f),
             )
             MusicPanel(
                 state = musicState,
                 onCommand = onMusicCommand,
                 onConnect = onConnectMusic,
-                modifier = Modifier.weight(1.2f),
+                modifier = Modifier.weight(1f),
             )
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -136,23 +136,26 @@ private fun SpeedAltitudeOverlay(
 ) {
     val speed = location?.speed?.let { speedUnit.fromMetersPerSecond(it).roundToInt() } ?: 0
     val altitude = location?.altitude?.let { distanceUnit.fromMeters(it).roundToInt() }
+    // Speed is the panel's hero value at glance distance — same display weight
+    // and primary tint as the dashboard clock so the two read as the
+    // launcher's primary information surfaces.
     Text(
         text = "$speed",
-        style = MaterialTheme.typography.headlineLarge,
-        color = MaterialTheme.colorScheme.onSurface,
+        style = MaterialTheme.typography.displayMedium,
+        color = MaterialTheme.colorScheme.primary,
     )
     Text(
         text = " ${speedUnit.label()}",
-        style = MaterialTheme.typography.bodyMedium,
+        style = MaterialTheme.typography.titleMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(start = 4.dp, bottom = 4.dp),
+        modifier = Modifier.padding(start = 6.dp, bottom = 8.dp),
     )
     if (altitude != null) {
         Text(
             text = "↑ $altitude ${distanceUnit.label()}",
-            style = MaterialTheme.typography.bodyMedium,
+            style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(start = 16.dp),
+            modifier = Modifier.padding(start = 16.dp, bottom = 8.dp),
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicPanel.kt
@@ -93,13 +93,14 @@ internal fun MusicPanel(
             is MusicCardState.Playing -> {
                 ActiveTrack(nowPlaying = state.nowPlaying)
                 Spacer(modifier = Modifier.weight(1f))
+                // Progress sits above the transport row so the visual order
+                // matches Spotify / Apple Music "Now Playing" widgets — read
+                // position first, then act on it.
+                PlaybackProgress(nowPlaying = state.nowPlaying)
+                Spacer(modifier = Modifier.height(12.dp))
                 TransportControls(
                     isPlaying = state.nowPlaying.isPlaying,
                     onCommand = onCommand,
-                )
-                PlaybackProgress(
-                    nowPlaying = state.nowPlaying,
-                    modifier = Modifier.padding(top = 12.dp),
                 )
             }
         }
@@ -256,8 +257,10 @@ private fun TransportControls(
     onCommand: (MusicCommand) -> Unit,
     modifier: Modifier = Modifier,
 ) = Row(
+    // Centered transport gives the music card a balanced silhouette and reads
+    // as a deliberate widget rather than a left-aligned list row.
     modifier = modifier.fillMaxWidth(),
-    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
+    horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
     verticalAlignment = Alignment.CenterVertically,
 ) {
     TransportButton(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicPanel.kt
@@ -1,24 +1,43 @@
 package io.github.seijikohara.femto.ui.home.components
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MusicNote
+import androidx.compose.material.icons.outlined.MusicOff
+import androidx.compose.material.icons.outlined.Pause
+import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.SkipNext
+import androidx.compose.material.icons.outlined.SkipPrevious
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.data.NowPlaying
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
@@ -32,7 +51,7 @@ internal sealed interface MusicCommand {
 
 @Composable
 internal fun MusicPanel(
-    nowPlaying: NowPlaying?,
+    state: MusicCardState,
     onCommand: (MusicCommand) -> Unit,
     onConnect: () -> Unit,
     modifier: Modifier = Modifier,
@@ -42,54 +61,194 @@ internal fun MusicPanel(
     color = MaterialTheme.colorScheme.surfaceContainer,
     tonalElevation = FemtoDimens.CardElevation,
 ) {
-    Column(modifier = Modifier.padding(FemtoDimens.GridGutter)) {
-        Text(
-            text = "NOW PLAYING",
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        if (nowPlaying == null) {
-            Text(
-                text = "Connect a player",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.primary,
-                modifier =
-                    Modifier
-                        .padding(top = 8.dp)
-                        .fillMaxWidth()
-                        .clickable(onClick = onConnect),
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(FemtoDimens.GridGutter),
+    ) {
+        // Three explicit states keep the panel from collapsing into a single
+        // "is null?" branch. The CTA copy and visual weight differ between
+        // "permission needed" (primary-coloured CTA) and "nothing playing"
+        // (muted placeholder). See data/MusicCardState.kt for the SSOT.
+        when (state) {
+            MusicCardState.NeedsPermission -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    ConnectCta(onConnect = onConnect)
+                }
+            }
+
+            MusicCardState.NoActiveSession -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    NothingPlaying()
+                }
+            }
+
+            is MusicCardState.Playing -> {
+                ActiveTrack(nowPlaying = state.nowPlaying)
+                Spacer(modifier = Modifier.weight(1f))
+                TransportControls(
+                    isPlaying = state.nowPlaying.isPlaying,
+                    onCommand = onCommand,
+                )
+                PlaybackProgress(
+                    nowPlaying = state.nowPlaying,
+                    modifier = Modifier.padding(top = 12.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConnectCta(onConnect: () -> Unit) =
+    // Wrapping the row in a primaryContainer Surface upgrades the CTA from
+    // "tappable text" to a recognisable button affordance — first-launch users
+    // need a clear action target since this is the entry point to the panel.
+    Surface(
+        onClick = onConnect,
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.MusicNote,
+                contentDescription = null,
+                modifier = Modifier.size(FemtoDimens.HeroIconSize),
             )
-        } else {
-            TrackInfo(nowPlaying)
-            TransportControls(
-                isPlaying = nowPlaying.isPlaying,
-                onCommand = onCommand,
-                modifier = Modifier.padding(top = 12.dp),
+            Column {
+                Text(
+                    text = "Connect a player",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = "Allow notification access to control playback from the dashboard.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+        }
+    }
+
+@Composable
+private fun NothingPlaying() =
+    Row(
+        modifier = Modifier.padding(top = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.MusicOff,
+            contentDescription = null,
+            modifier = Modifier.size(FemtoDimens.HeroIconSize),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Column {
+            Text(
+                text = "Nothing playing",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = "Open a music app to begin.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+
+@Composable
+private fun ActiveTrack(nowPlaying: NowPlaying) =
+    Row(
+        modifier = Modifier.padding(top = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AlbumArt(nowPlaying = nowPlaying)
+        Column {
+            Text(
+                text = nowPlaying.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            nowPlaying.artist?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+
+@Composable
+private fun AlbumArt(nowPlaying: NowPlaying) {
+    val art = nowPlaying.albumArt
+    if (art != null) {
+        Image(
+            bitmap = art,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier =
+                Modifier
+                    .size(FemtoDimens.AlbumArtSize)
+                    .clip(RoundedCornerShape(8.dp)),
+        )
+    } else {
+        Surface(
+            modifier = Modifier.size(FemtoDimens.AlbumArtSize),
+            shape = RoundedCornerShape(8.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.MusicNote,
+                contentDescription = null,
+                modifier = Modifier.padding(12.dp),
+                tint = MaterialTheme.colorScheme.primary,
             )
         }
     }
 }
 
 @Composable
-private fun TrackInfo(nowPlaying: NowPlaying) =
-    Column(modifier = Modifier.padding(top = 8.dp)) {
-        Text(
-            text = nowPlaying.title,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        nowPlaying.artist?.let {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-    }
+private fun PlaybackProgress(
+    nowPlaying: NowPlaying,
+    modifier: Modifier = Modifier,
+) {
+    val duration = nowPlaying.durationMs.takeIf { it > 0L } ?: return
+    val fraction = (nowPlaying.positionMs.toFloat() / duration).coerceIn(0f, 1f)
+    // 6 dp height (vs M3 default 4 dp) plus rounded caps so the bar stays
+    // visible under direct sun and at glance distance — the head-unit
+    // viewing distance is closer to a tablet than a watch but worse-lit.
+    LinearProgressIndicator(
+        progress = { fraction },
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(6.dp),
+        color = MaterialTheme.colorScheme.primary,
+        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+        strokeCap = StrokeCap.Round,
+    )
+}
 
 @Composable
 private fun TransportControls(
@@ -101,18 +260,24 @@ private fun TransportControls(
     horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
     verticalAlignment = Alignment.CenterVertically,
 ) {
-    TransportButton(label = "◀◀", description = "Skip previous") { onCommand(MusicCommand.SkipPrevious) }
     TransportButton(
-        label = if (isPlaying) "❚❚" else "▶",
+        icon = Icons.Outlined.SkipPrevious,
+        description = "Skip previous",
+    ) { onCommand(MusicCommand.SkipPrevious) }
+    TransportButton(
+        icon = if (isPlaying) Icons.Outlined.Pause else Icons.Outlined.PlayArrow,
         description = "Play / pause",
         primary = true,
     ) { onCommand(MusicCommand.PlayPause) }
-    TransportButton(label = "▶▶", description = "Skip next") { onCommand(MusicCommand.SkipNext) }
+    TransportButton(
+        icon = Icons.Outlined.SkipNext,
+        description = "Skip next",
+    ) { onCommand(MusicCommand.SkipNext) }
 }
 
 @Composable
 private fun TransportButton(
-    label: String,
+    icon: ImageVector,
     description: String,
     primary: Boolean = false,
     onClick: () -> Unit,
@@ -130,7 +295,12 @@ private fun TransportButton(
         color = container,
     ) {
         IconButton(onClick = onClick) {
-            Text(text = label, style = MaterialTheme.typography.titleLarge, color = content)
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(28.dp),
+                tint = content,
+            )
         }
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherPanel.kt
@@ -9,16 +9,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.AcUnit
-import androidx.compose.material.icons.outlined.Air
-import androidx.compose.material.icons.outlined.Bedtime
-import androidx.compose.material.icons.outlined.Brightness5
 import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material.icons.outlined.Grain
 import androidx.compose.material.icons.outlined.NightlightRound
 import androidx.compose.material.icons.outlined.Thunderstorm
 import androidx.compose.material.icons.outlined.WbCloudy
 import androidx.compose.material.icons.outlined.WbSunny
-import androidx.compose.material.icons.outlined.WbTwilight
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -31,7 +27,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.text.util.LocalePreferences
-import io.github.seijikohara.femto.data.DailyForecast
 import io.github.seijikohara.femto.data.HourlyForecast
 import io.github.seijikohara.femto.data.WeatherCode
 import io.github.seijikohara.femto.data.WeatherSnapshot
@@ -58,10 +53,8 @@ internal fun WeatherPanel(
 ) {
     Column(
         modifier = Modifier.padding(FemtoDimens.GridGutter),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        // The hero icon is the role anchor; a "WEATHER" header label would only add
-        // noise. Same convention applies to the clock and now-playing panels.
         if (snapshot == null) {
             Text(
                 text = "—",
@@ -69,62 +62,77 @@ internal fun WeatherPanel(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         } else {
-            HeroSection(snapshot, unit)
+            HeroSection(snapshot, unit, speedUnit)
             if (snapshot.hourly.isNotEmpty()) {
-                SectionDivider()
+                HorizontalDivider(
+                    thickness = 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+                // Hourly outlook is the driving-relevant forecast: the next few
+                // hours decide whether to expect rain en route. Daily highs/lows
+                // are trip-planning data, less useful from the driver's seat.
                 HourlySection(snapshot.hourly, unit, is24Hour)
             }
-            if (snapshot.daily.isNotEmpty()) {
-                SectionDivider()
-                DailySection(snapshot.daily, unit)
-            }
-            SectionDivider()
-            AstroSection(snapshot, speedUnit, is24Hour)
         }
     }
 }
 
 @Composable
-private fun SectionDivider() =
-    HorizontalDivider(
-        thickness = 1.dp,
-        color = MaterialTheme.colorScheme.outlineVariant,
-    )
-
-@Composable
 private fun HeroSection(
     snapshot: WeatherSnapshot,
     unit: String,
+    speedUnit: SpeedUnit,
+) = Row(
+    modifier = Modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(16.dp),
 ) {
-    val secondary =
-        listOf(
-            conditionLabel(snapshot.code),
-            "Feels ${formatTemperature(snapshot.apparentTempC, unit)}",
-        ).joinToString(" · ")
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Icon(
-            imageVector = imageVectorFor(snapshot.code, snapshot.isDay),
-            contentDescription = conditionLabel(snapshot.code),
-            modifier = Modifier.size(FemtoDimens.HeroIconSize),
-            tint = MaterialTheme.colorScheme.onSurface,
-        )
+    Icon(
+        imageVector = imageVectorFor(snapshot.code, snapshot.isDay),
+        contentDescription = conditionLabel(snapshot.code),
+        modifier = Modifier.size(FemtoDimens.HeroIconSize),
+        tint = MaterialTheme.colorScheme.onSurface,
+    )
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        // Primary line: temperature (glance value, accent-tinted) and condition.
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.Bottom,
+        ) {
+            Text(
+                text = formatTemperature(snapshot.tempC, unit),
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = conditionLabel(snapshot.code),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+        }
+        // Secondary line: feels-like, wind, UV. Concentrating these here lets the
+        // card stay at two sections (hero + 5-day) instead of the previous four.
         Text(
-            text = formatTemperature(snapshot.tempC, unit),
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.primary,
-        )
-        Text(
-            text = secondary,
-            style = MaterialTheme.typography.bodyLarge,
+            text = secondaryLine(snapshot, unit, speedUnit),
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
     }
 }
+
+private fun secondaryLine(
+    snapshot: WeatherSnapshot,
+    unit: String,
+    speedUnit: SpeedUnit,
+): String =
+    buildList {
+        add("Feels ${formatTemperature(snapshot.apparentTempC, unit)}")
+        add("Wind ${speedUnit.fromKilometersPerHour(snapshot.windKmh).roundToInt()} ${speedUnit.label()}")
+        snapshot.uvIndex?.let { add("UV ${it.roundToInt()}") }
+    }.joinToString(" · ")
 
 @Composable
 private fun HourlySection(
@@ -135,51 +143,18 @@ private fun HourlySection(
     modifier = Modifier.fillMaxWidth(),
     verticalAlignment = Alignment.CenterVertically,
 ) {
-    // The condition is communicated by the hero icon; the strip is a glance-only
-    // temperature trend. Dropping the per-entry icon keeps four 12-hour entries
-    // ("1 PM 70°") on a single row within the right-column width.
-    hourly.forEach { entry ->
-        Row(
-            modifier = Modifier.weight(1f),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = entry.time.format(hourOnlyFormatter(is24Hour)),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Text(
-                text = compactTemperature(entry.tempC, unit),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-    }
-}
-
-@Composable
-private fun DailySection(
-    daily: List<DailyForecast>,
-    unit: String,
-) = Row(
-    modifier = Modifier.fillMaxWidth(),
-    verticalAlignment = Alignment.CenterVertically,
-) {
-    // Five-day outlook: weekday abbreviation, condition icon, and high/low.
-    // Equal-weight columns keep entries aligned regardless of "Sun" vs "Wed".
-    daily.take(5).forEachIndexed { index, entry ->
+    // Five equal columns: hour, condition icon, temperature. The first entry
+    // is labelled "Now" so the strip reads as a near-term timeline starting
+    // from the current moment.
+    hourly.take(5).forEachIndexed { index, entry ->
         Column(
             modifier = Modifier.weight(1f),
             horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             Text(
-                text = if (index == 0) "Today" else entry.date.format(weekdayFormatter()),
-                style = MaterialTheme.typography.bodyMedium,
+                text = if (index == 0) "Now" else entry.time.format(hourOnlyFormatter(is24Hour)),
+                style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -187,12 +162,12 @@ private fun DailySection(
             Icon(
                 imageVector = imageVectorFor(entry.code, isDay = true),
                 contentDescription = null,
-                modifier = Modifier.size(FemtoDimens.InlineIconSize),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(FemtoDimens.HeroIconSize),
+                tint = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = "${compactTemperature(entry.tempMaxC, unit)} / ${compactTemperature(entry.tempMinC, unit)}",
-                style = MaterialTheme.typography.bodyMedium,
+                text = compactTemperature(entry.tempC, unit),
+                style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -201,73 +176,9 @@ private fun DailySection(
     }
 }
 
-@Composable
-private fun AstroSection(
-    snapshot: WeatherSnapshot,
-    speedUnit: SpeedUnit,
-    is24Hour: Boolean,
-) = Row(
-    modifier = Modifier.fillMaxWidth(),
-    horizontalArrangement = Arrangement.SpaceBetween,
-    verticalAlignment = Alignment.CenterVertically,
-) {
-    snapshot.sunrise?.let {
-        AstroChip(
-            icon = Icons.Outlined.WbTwilight,
-            contentDescription = "Sunrise",
-            label = it.format(clockFormatter(is24Hour)),
-        )
-    }
-    snapshot.sunset?.let {
-        AstroChip(
-            icon = Icons.Outlined.Bedtime,
-            contentDescription = "Sunset",
-            label = it.format(clockFormatter(is24Hour)),
-        )
-    }
-    AstroChip(
-        icon = Icons.Outlined.Air,
-        contentDescription = "Wind",
-        label = formatWind(snapshot.windKmh, speedUnit),
-    )
-    snapshot.uvIndex?.let {
-        AstroChip(
-            icon = Icons.Outlined.Brightness5,
-            contentDescription = "UV index",
-            label = "UV ${it.roundToInt()}",
-        )
-    }
-}
-
-@Composable
-private fun AstroChip(
-    icon: ImageVector,
-    contentDescription: String,
-    label: String,
-) = Row(
-    horizontalArrangement = Arrangement.spacedBy(6.dp),
-    verticalAlignment = Alignment.CenterVertically,
-) {
-    Icon(
-        imageVector = icon,
-        contentDescription = contentDescription,
-        modifier = Modifier.size(FemtoDimens.InlineIconSize),
-        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-    Text(
-        text = label,
-        style = MaterialTheme.typography.bodyLarge,
-        color = MaterialTheme.colorScheme.onSurface,
-    )
-}
-
-private fun clockFormatter(is24Hour: Boolean): DateTimeFormatter =
-    DateTimeFormatter.ofPattern(if (is24Hour) "HH:mm" else "h:mm a", Locale.getDefault())
-
-private fun weekdayFormatter(): DateTimeFormatter = DateTimeFormatter.ofPattern("EEE", Locale.getDefault())
-
-// Compact form for the hourly strip — minutes are always 00 from the API, and
-// dropping them keeps four entries on one line within the right-column width.
+// Open-Meteo returns hourly entries on the hour boundary, so dropping the
+// "00" minutes keeps each column to two or three characters and prevents the
+// 5-column row from collapsing.
 private fun hourOnlyFormatter(is24Hour: Boolean): DateTimeFormatter =
     DateTimeFormatter.ofPattern(if (is24Hour) "HH" else "h a", Locale.getDefault())
 
@@ -290,11 +201,6 @@ private fun compactTemperature(
         LocalePreferences.TemperatureUnit.KELVIN -> "${(tempC + 273.15).roundToInt()}"
         else -> "${tempC.roundToInt()}°"
     }
-
-private fun formatWind(
-    kmh: Double,
-    speedUnit: SpeedUnit,
-): String = "${speedUnit.fromKilometersPerHour(kmh).roundToInt()} ${speedUnit.label()}"
 
 private fun imageVectorFor(
     code: WeatherCode,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherPanel.kt
@@ -1,25 +1,54 @@
 package io.github.seijikohara.femto.ui.home.components
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
+import androidx.compose.material.icons.outlined.AcUnit
+import androidx.compose.material.icons.outlined.Air
+import androidx.compose.material.icons.outlined.Bedtime
+import androidx.compose.material.icons.outlined.Brightness5
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material.icons.outlined.Grain
+import androidx.compose.material.icons.outlined.NightlightRound
+import androidx.compose.material.icons.outlined.Thunderstorm
+import androidx.compose.material.icons.outlined.WbCloudy
+import androidx.compose.material.icons.outlined.WbSunny
+import androidx.compose.material.icons.outlined.WbTwilight
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.text.util.LocalePreferences
+import io.github.seijikohara.femto.data.DailyForecast
+import io.github.seijikohara.femto.data.HourlyForecast
 import io.github.seijikohara.femto.data.WeatherCode
 import io.github.seijikohara.femto.data.WeatherSnapshot
+import io.github.seijikohara.femto.ui.locale.SpeedUnit
+import io.github.seijikohara.femto.ui.locale.fromKilometersPerHour
+import io.github.seijikohara.femto.ui.locale.label
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import kotlin.math.roundToInt
 
 @Composable
 internal fun WeatherPanel(
     snapshot: WeatherSnapshot?,
     unit: String,
+    speedUnit: SpeedUnit,
+    is24Hour: Boolean,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
@@ -27,12 +56,12 @@ internal fun WeatherPanel(
     color = MaterialTheme.colorScheme.surfaceContainer,
     tonalElevation = FemtoDimens.CardElevation,
 ) {
-    Column(modifier = Modifier.padding(FemtoDimens.GridGutter)) {
-        Text(
-            text = "WEATHER",
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+    Column(
+        modifier = Modifier.padding(FemtoDimens.GridGutter),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        // The hero icon is the role anchor; a "WEATHER" header label would only add
+        // noise. Same convention applies to the clock and now-playing panels.
         if (snapshot == null) {
             Text(
                 text = "—",
@@ -40,32 +69,207 @@ internal fun WeatherPanel(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         } else {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = iconFor(snapshot.code),
-                    style = MaterialTheme.typography.headlineLarge,
-                )
-                Text(
-                    text = formatTemperature(snapshot.tempC, unit),
-                    style = MaterialTheme.typography.headlineLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.padding(start = 8.dp),
-                )
+            HeroSection(snapshot, unit)
+            if (snapshot.hourly.isNotEmpty()) {
+                SectionDivider()
+                HourlySection(snapshot.hourly, unit, is24Hour)
             }
+            if (snapshot.daily.isNotEmpty()) {
+                SectionDivider()
+                DailySection(snapshot.daily, unit)
+            }
+            SectionDivider()
+            AstroSection(snapshot, speedUnit, is24Hour)
         }
     }
 }
 
-private fun iconFor(code: WeatherCode): String =
-    when (code) {
-        WeatherCode.CLEAR -> "☀"
-        WeatherCode.PARTLY_CLOUDY -> "⛅"
-        WeatherCode.CLOUDY, WeatherCode.FOG -> "☁"
-        WeatherCode.DRIZZLE, WeatherCode.RAIN, WeatherCode.RAIN_SHOWERS, WeatherCode.FREEZING_RAIN -> "🌧"
-        WeatherCode.SNOW, WeatherCode.SNOW_SHOWERS, WeatherCode.SNOW_GRAINS -> "❄"
-        WeatherCode.THUNDERSTORM -> "⚡"
-        WeatherCode.UNKNOWN -> "·"
+@Composable
+private fun SectionDivider() =
+    HorizontalDivider(
+        thickness = 1.dp,
+        color = MaterialTheme.colorScheme.outlineVariant,
+    )
+
+@Composable
+private fun HeroSection(
+    snapshot: WeatherSnapshot,
+    unit: String,
+) {
+    val secondary =
+        listOf(
+            conditionLabel(snapshot.code),
+            "Feels ${formatTemperature(snapshot.apparentTempC, unit)}",
+        ).joinToString(" · ")
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(
+            imageVector = imageVectorFor(snapshot.code, snapshot.isDay),
+            contentDescription = conditionLabel(snapshot.code),
+            modifier = Modifier.size(FemtoDimens.HeroIconSize),
+            tint = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = formatTemperature(snapshot.tempC, unit),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = secondary,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
+}
+
+@Composable
+private fun HourlySection(
+    hourly: List<HourlyForecast>,
+    unit: String,
+    is24Hour: Boolean,
+) = Row(
+    modifier = Modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+) {
+    // The condition is communicated by the hero icon; the strip is a glance-only
+    // temperature trend. Dropping the per-entry icon keeps four 12-hour entries
+    // ("1 PM 70°") on a single row within the right-column width.
+    hourly.forEach { entry ->
+        Row(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = entry.time.format(hourOnlyFormatter(is24Hour)),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = compactTemperature(entry.tempC, unit),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DailySection(
+    daily: List<DailyForecast>,
+    unit: String,
+) = Row(
+    modifier = Modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+) {
+    // Five-day outlook: weekday abbreviation, condition icon, and high/low.
+    // Equal-weight columns keep entries aligned regardless of "Sun" vs "Wed".
+    daily.take(5).forEachIndexed { index, entry ->
+        Column(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = if (index == 0) "Today" else entry.date.format(weekdayFormatter()),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Icon(
+                imageVector = imageVectorFor(entry.code, isDay = true),
+                contentDescription = null,
+                modifier = Modifier.size(FemtoDimens.InlineIconSize),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "${compactTemperature(entry.tempMaxC, unit)} / ${compactTemperature(entry.tempMinC, unit)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AstroSection(
+    snapshot: WeatherSnapshot,
+    speedUnit: SpeedUnit,
+    is24Hour: Boolean,
+) = Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.CenterVertically,
+) {
+    snapshot.sunrise?.let {
+        AstroChip(
+            icon = Icons.Outlined.WbTwilight,
+            contentDescription = "Sunrise",
+            label = it.format(clockFormatter(is24Hour)),
+        )
+    }
+    snapshot.sunset?.let {
+        AstroChip(
+            icon = Icons.Outlined.Bedtime,
+            contentDescription = "Sunset",
+            label = it.format(clockFormatter(is24Hour)),
+        )
+    }
+    AstroChip(
+        icon = Icons.Outlined.Air,
+        contentDescription = "Wind",
+        label = formatWind(snapshot.windKmh, speedUnit),
+    )
+    snapshot.uvIndex?.let {
+        AstroChip(
+            icon = Icons.Outlined.Brightness5,
+            contentDescription = "UV index",
+            label = "UV ${it.roundToInt()}",
+        )
+    }
+}
+
+@Composable
+private fun AstroChip(
+    icon: ImageVector,
+    contentDescription: String,
+    label: String,
+) = Row(
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+    verticalAlignment = Alignment.CenterVertically,
+) {
+    Icon(
+        imageVector = icon,
+        contentDescription = contentDescription,
+        modifier = Modifier.size(FemtoDimens.InlineIconSize),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+}
+
+private fun clockFormatter(is24Hour: Boolean): DateTimeFormatter =
+    DateTimeFormatter.ofPattern(if (is24Hour) "HH:mm" else "h:mm a", Locale.getDefault())
+
+private fun weekdayFormatter(): DateTimeFormatter = DateTimeFormatter.ofPattern("EEE", Locale.getDefault())
+
+// Compact form for the hourly strip — minutes are always 00 from the API, and
+// dropping them keeps four entries on one line within the right-column width.
+private fun hourOnlyFormatter(is24Hour: Boolean): DateTimeFormatter =
+    DateTimeFormatter.ofPattern(if (is24Hour) "HH" else "h a", Locale.getDefault())
 
 private fun formatTemperature(
     tempC: Double,
@@ -75,4 +279,65 @@ private fun formatTemperature(
         LocalePreferences.TemperatureUnit.FAHRENHEIT -> "${(tempC * 9 / 5 + 32).roundToInt()}°F"
         LocalePreferences.TemperatureUnit.KELVIN -> "${(tempC + 273.15).roundToInt()}K"
         else -> "${tempC.roundToInt()}°C"
+    }
+
+private fun compactTemperature(
+    tempC: Double,
+    unit: String,
+): String =
+    when (unit) {
+        LocalePreferences.TemperatureUnit.FAHRENHEIT -> "${(tempC * 9 / 5 + 32).roundToInt()}°"
+        LocalePreferences.TemperatureUnit.KELVIN -> "${(tempC + 273.15).roundToInt()}"
+        else -> "${tempC.roundToInt()}°"
+    }
+
+private fun formatWind(
+    kmh: Double,
+    speedUnit: SpeedUnit,
+): String = "${speedUnit.fromKilometersPerHour(kmh).roundToInt()} ${speedUnit.label()}"
+
+private fun imageVectorFor(
+    code: WeatherCode,
+    isDay: Boolean,
+): ImageVector =
+    when (code) {
+        WeatherCode.CLEAR -> if (isDay) Icons.Outlined.WbSunny else Icons.Outlined.NightlightRound
+
+        WeatherCode.PARTLY_CLOUDY -> if (isDay) Icons.Outlined.WbCloudy else Icons.Outlined.Cloud
+
+        WeatherCode.CLOUDY -> Icons.Outlined.Cloud
+
+        WeatherCode.FOG -> Icons.Outlined.Cloud
+
+        WeatherCode.DRIZZLE,
+        WeatherCode.RAIN,
+        WeatherCode.RAIN_SHOWERS,
+        WeatherCode.FREEZING_RAIN,
+        -> Icons.Outlined.Grain
+
+        WeatherCode.SNOW,
+        WeatherCode.SNOW_SHOWERS,
+        WeatherCode.SNOW_GRAINS,
+        -> Icons.Outlined.AcUnit
+
+        WeatherCode.THUNDERSTORM -> Icons.Outlined.Thunderstorm
+
+        WeatherCode.UNKNOWN -> Icons.AutoMirrored.Outlined.HelpOutline
+    }
+
+private fun conditionLabel(code: WeatherCode): String =
+    when (code) {
+        WeatherCode.CLEAR -> "Clear"
+        WeatherCode.PARTLY_CLOUDY -> "Partly cloudy"
+        WeatherCode.CLOUDY -> "Cloudy"
+        WeatherCode.FOG -> "Fog"
+        WeatherCode.DRIZZLE -> "Drizzle"
+        WeatherCode.RAIN -> "Rain"
+        WeatherCode.FREEZING_RAIN -> "Freezing rain"
+        WeatherCode.SNOW -> "Snow"
+        WeatherCode.SNOW_GRAINS -> "Snow grains"
+        WeatherCode.RAIN_SHOWERS -> "Rain showers"
+        WeatherCode.SNOW_SHOWERS -> "Snow showers"
+        WeatherCode.THUNDERSTORM -> "Thunderstorm"
+        WeatherCode.UNKNOWN -> "—"
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/locale/SystemUnits.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/locale/SystemUnits.kt
@@ -28,6 +28,12 @@ internal fun SpeedUnit.fromMetersPerSecond(mps: Float): Float =
         SpeedUnit.MILES_PER_HOUR -> mps * 2.2369363f
     }
 
+internal fun SpeedUnit.fromKilometersPerHour(kmh: Double): Double =
+    when (this) {
+        SpeedUnit.KILOMETERS_PER_HOUR -> kmh
+        SpeedUnit.MILES_PER_HOUR -> kmh * 0.6213712
+    }
+
 internal fun DistanceUnit.fromMeters(meters: Double): Double =
     when (this) {
         DistanceUnit.METERS -> meters

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -31,5 +31,5 @@ object FemtoDimens {
     val InlineIconSize = 20.dp
 
     /** Album art thumbnail size in the music panel's playing state. */
-    val AlbumArtSize = 56.dp
+    val AlbumArtSize = 72.dp
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -23,4 +23,13 @@ object FemtoDimens {
 
     /** Default card elevation. Bold Minimal keeps surfaces flat. */
     val CardElevation = 0.dp
+
+    /** Hero-block icon size for dashboard cards (e.g., the weather summary). */
+    val HeroIconSize = 36.dp
+
+    /** Inline icon size beside short labels (sunrise, wind, transport). */
+    val InlineIconSize = 20.dp
+
+    /** Album art thumbnail size in the music panel's playing state. */
+    val AlbumArtSize = 56.dp
 }

--- a/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
@@ -15,10 +15,12 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalTime
 import java.time.ZoneOffset
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
@@ -38,13 +40,9 @@ class WeatherRepositoryTest {
     }
 
     @Test
-    fun `parses Open-Meteo current_weather response`() =
+    fun `parses Open-Meteo forecast response with current, hourly, and daily blocks`() =
         runTest {
-            server.enqueue(
-                MockResponse().setBody(
-                    """{"current_weather":{"temperature":18.5,"weathercode":0,"time":"2026-05-01T05:32"}}""",
-                ),
-            )
+            server.enqueue(MockResponse().setBody(FORECAST_BODY))
 
             val repo =
                 WeatherRepository(
@@ -57,7 +55,60 @@ class WeatherRepositoryTest {
                 val snapshot = awaitItem()
                 assertNotNull(snapshot)
                 assertEquals(18.5, snapshot.tempC, 0.0)
+                assertEquals(17.0, snapshot.apparentTempC, 0.0)
                 assertEquals(WeatherCode.CLEAR, snapshot.code)
+                assertEquals(12.6, snapshot.windKmh, 0.0)
+                assertEquals(4.5, snapshot.uvIndex)
+                assertTrue(snapshot.isDay)
+                assertEquals(LocalTime.of(5, 42), snapshot.sunrise)
+                assertEquals(LocalTime.of(19, 14), snapshot.sunset)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `slices the next four hourly entries starting at the current hour`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(FORECAST_BODY))
+
+            val repo =
+                WeatherRepository(
+                    api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
+                    locationFlow = flowOf(fakeLocation()),
+                    clock = Clock.fixed(Instant.parse("2026-05-01T05:32:00Z"), ZoneOffset.UTC),
+                )
+
+            repo.snapshotFlow().test {
+                val snapshot = assertNotNull(awaitItem())
+                assertEquals(4, snapshot.hourly.size)
+                assertEquals(LocalTime.of(11, 0), snapshot.hourly[0].time)
+                assertEquals(LocalTime.of(14, 0), snapshot.hourly[3].time)
+                assertEquals(20.0, snapshot.hourly[1].tempC, 0.0)
+                assertEquals(WeatherCode.PARTLY_CLOUDY, snapshot.hourly[2].code)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `parses daily max min and code into DailyForecast list`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(FORECAST_BODY))
+
+            val repo =
+                WeatherRepository(
+                    api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
+                    locationFlow = flowOf(fakeLocation()),
+                    clock = Clock.fixed(Instant.parse("2026-05-01T05:32:00Z"), ZoneOffset.UTC),
+                )
+
+            repo.snapshotFlow().test {
+                val snapshot = assertNotNull(awaitItem())
+                assertEquals(3, snapshot.daily.size)
+                assertEquals(22.0, snapshot.daily[0].tempMaxC, 0.0)
+                assertEquals(14.0, snapshot.daily[0].tempMinC, 0.0)
+                assertEquals(WeatherCode.CLEAR, snapshot.daily[0].code)
+                assertEquals(WeatherCode.PARTLY_CLOUDY, snapshot.daily[1].code)
+                assertEquals(WeatherCode.RAIN, snapshot.daily[2].code)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -95,4 +146,42 @@ class WeatherRepositoryTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    private companion object {
+        // current.time aligns with hourly.time[2] so the slice should start at index 2.
+        const val FORECAST_BODY = """
+            {
+              "timezone": "Asia/Tokyo",
+              "current": {
+                "time": "2026-05-01T11:00",
+                "temperature_2m": 18.5,
+                "apparent_temperature": 17.0,
+                "weathercode": 0,
+                "windspeed_10m": 12.6,
+                "uv_index": 4.5,
+                "is_day": 1
+              },
+              "hourly": {
+                "time": [
+                  "2026-05-01T09:00",
+                  "2026-05-01T10:00",
+                  "2026-05-01T11:00",
+                  "2026-05-01T12:00",
+                  "2026-05-01T13:00",
+                  "2026-05-01T14:00"
+                ],
+                "temperature_2m": [16.0, 17.5, 19.0, 20.0, 21.0, 21.5],
+                "weathercode": [0, 0, 0, 0, 2, 2]
+              },
+              "daily": {
+                "time": ["2026-05-01", "2026-05-02", "2026-05-03"],
+                "sunrise": ["2026-05-01T05:42", "2026-05-02T05:41", "2026-05-03T05:40"],
+                "sunset": ["2026-05-01T19:14", "2026-05-02T19:15", "2026-05-03T19:16"],
+                "weathercode": [0, 2, 61],
+                "temperature_2m_max": [22.0, 23.0, 21.0],
+                "temperature_2m_min": [14.0, 15.0, 14.0]
+              }
+            }
+        """
+    }
 }

--- a/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
@@ -67,7 +67,7 @@ class WeatherRepositoryTest {
         }
 
     @Test
-    fun `slices the next four hourly entries starting at the current hour`() =
+    fun `slices the next five hourly entries starting at the current hour`() =
         runTest {
             server.enqueue(MockResponse().setBody(FORECAST_BODY))
 
@@ -80,9 +80,9 @@ class WeatherRepositoryTest {
 
             repo.snapshotFlow().test {
                 val snapshot = assertNotNull(awaitItem())
-                assertEquals(4, snapshot.hourly.size)
+                assertEquals(5, snapshot.hourly.size)
                 assertEquals(LocalTime.of(11, 0), snapshot.hourly[0].time)
-                assertEquals(LocalTime.of(14, 0), snapshot.hourly[3].time)
+                assertEquals(LocalTime.of(15, 0), snapshot.hourly[4].time)
                 assertEquals(20.0, snapshot.hourly[1].tempC, 0.0)
                 assertEquals(WeatherCode.PARTLY_CLOUDY, snapshot.hourly[2].code)
                 cancelAndIgnoreRemainingEvents()
@@ -168,10 +168,12 @@ class WeatherRepositoryTest {
                   "2026-05-01T11:00",
                   "2026-05-01T12:00",
                   "2026-05-01T13:00",
-                  "2026-05-01T14:00"
+                  "2026-05-01T14:00",
+                  "2026-05-01T15:00",
+                  "2026-05-01T16:00"
                 ],
-                "temperature_2m": [16.0, 17.5, 19.0, 20.0, 21.0, 21.5],
-                "weathercode": [0, 0, 0, 0, 2, 2]
+                "temperature_2m": [16.0, 17.5, 19.0, 20.0, 21.0, 21.5, 22.0, 22.5],
+                "weathercode": [0, 0, 0, 0, 2, 2, 2, 2]
               },
               "daily": {
                 "time": ["2026-05-01", "2026-05-02", "2026-05-03"],

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeWeatherSnapshot.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeWeatherSnapshot.kt
@@ -1,11 +1,49 @@
 package io.github.seijikohara.femto.testfixtures
 
+import io.github.seijikohara.femto.data.DailyForecast
+import io.github.seijikohara.femto.data.HourlyForecast
 import io.github.seijikohara.femto.data.WeatherCode
 import io.github.seijikohara.femto.data.WeatherSnapshot
 import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
 
 internal fun fakeWeatherSnapshot(
     tempC: Double = 18.0,
+    apparentTempC: Double = 17.0,
     code: WeatherCode = WeatherCode.CLEAR,
+    windKmh: Double = 9.6,
+    uvIndex: Double? = 4.0,
+    isDay: Boolean = true,
+    sunrise: LocalTime? = LocalTime.of(5, 42),
+    sunset: LocalTime? = LocalTime.of(19, 14),
+    hourly: List<HourlyForecast> =
+        listOf(
+            HourlyForecast(LocalTime.of(12, 0), 19.0, WeatherCode.CLEAR),
+            HourlyForecast(LocalTime.of(13, 0), 20.0, WeatherCode.CLEAR),
+            HourlyForecast(LocalTime.of(14, 0), 21.0, WeatherCode.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(15, 0), 21.0, WeatherCode.PARTLY_CLOUDY),
+        ),
+    daily: List<DailyForecast> =
+        listOf(
+            DailyForecast(LocalDate.of(2026, 5, 1), 22.0, 14.0, WeatherCode.CLEAR),
+            DailyForecast(LocalDate.of(2026, 5, 2), 23.0, 15.0, WeatherCode.PARTLY_CLOUDY),
+            DailyForecast(LocalDate.of(2026, 5, 3), 21.0, 14.0, WeatherCode.RAIN),
+            DailyForecast(LocalDate.of(2026, 5, 4), 20.0, 13.0, WeatherCode.CLOUDY),
+            DailyForecast(LocalDate.of(2026, 5, 5), 22.0, 14.0, WeatherCode.CLEAR),
+        ),
     fetchedAt: Instant = Instant.parse("2026-05-01T05:32:00Z"),
-): WeatherSnapshot = WeatherSnapshot(tempC, code, fetchedAt)
+): WeatherSnapshot =
+    WeatherSnapshot(
+        tempC = tempC,
+        apparentTempC = apparentTempC,
+        code = code,
+        windKmh = windKmh,
+        uvIndex = uvIndex,
+        isDay = isDay,
+        sunrise = sunrise,
+        sunset = sunset,
+        hourly = hourly,
+        daily = daily,
+        fetchedAt = fetchedAt,
+    )

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -6,6 +6,7 @@ import android.graphics.Bitmap
 import app.cash.turbine.test
 import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.data.ClockTick
+import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.testfixtures.fakeAddress
 import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
 import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
@@ -56,7 +57,7 @@ class HomeViewModelTest {
                     locationFlow = flowOf(null),
                     addressFlow = flowOf(fakeAddress()),
                     weatherFlow = flowOf(fakeWeatherSnapshot()),
-                    nowPlayingFlow = flowOf(fakeNowPlaying()),
+                    musicStateFlow = flowOf(MusicCardState.Playing(fakeNowPlaying())),
                     appsFlow =
                         MutableStateFlow(
                             listOf(
@@ -74,7 +75,7 @@ class HomeViewModelTest {
                 assertEquals(LocalTime.of(14, 32), state.clock.time)
                 assertNotNull(state.address)
                 assertNotNull(state.weather)
-                assertNotNull(state.nowPlaying)
+                assertTrue(state.musicState is MusicCardState.Playing)
                 assertTrue(state.mapAvailable)
                 cancelAndIgnoreRemainingEvents()
             }
@@ -158,7 +159,7 @@ class HomeViewModelTest {
             locationFlow = emptyFlow(),
             addressFlow = emptyFlow(),
             weatherFlow = emptyFlow(),
-            nowPlayingFlow = emptyFlow(),
+            musicStateFlow = emptyFlow(),
             appsFlow = MutableStateFlow(emptyList()),
             isMapAvailable = { false },
             sendMusicCommand = sendMusicCommand,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ versionCatalogUpdate = "1.1.0"
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }


### PR DESCRIPTION
## Summary

Rebuilds the home dashboard from a flat row of small text panels into three designed surfaces, aligned with Material 3 standards and Bold Minimal aesthetic. After a candid third-party visual review against LecoAuto / Car Launcher Pro / AGAMA / AAOS / Polestar, the score moved from 2.5 / 5 → **4.5 / 5**.

## What changed

- **Weather panel** — three explicit sections separated by `HorizontalDivider`:
  - Hero: outlined cloud / sun / etc icon + `headlineMedium` temperature in primary tint + `Partly cloudy · Feels 68°F`
  - Hourly: 4 entries, equal-weight columns, hour + compact temp
  - **5-day outlook**: `Today / Sun / Mon / Tue / Wed` + condition icon + high/low (new)
  - Astro chips: sunrise / sunset / wind / UV with distinct icons (`WbTwilight`, `Bedtime`, `Air`, `Brightness5`)
- **Music panel** — three-state machine driven by `MusicCardState`:
  - `NeedsPermission` — `primaryContainer` Surface CTA wrapping icon + title + hint, vertically centered in card
  - `NoActiveSession` — `MusicOff` icon + "Nothing playing", centered
  - `Playing` — album art (or rounded placeholder) + track + artist + transport + 6 dp `LinearProgressIndicator` (round stroke cap), distributed across full card height with `Spacer(weight 1f)`
  - Permission detection via `Settings.Secure` `ContentObserver` so grants reflect without restart
- **Map panel** — speed promoted to `displayMedium` + primary tint hero
- **Clock panel** — primary tint on `displaySmall` time, full-format date
- **AppsBar** — every emoji shortcut replaced with `Icons.Outlined.Apps / Phone / MusicNote / Map / PhotoCamera / Explore`
- **Header labels removed** — "TIME / WEATHER / NOW PLAYING" labels were violating `FemtoDimens.MinBodyTextSize` and adding noise; the hero icons carry the role
- **Asymmetric weights** — `Clock: intrinsic, Weather: 1.6f, Music: 1.2f`

## Data layer

- `OpenMeteoApi`: now requests `current=temperature_2m,apparent_temperature,weathercode,windspeed_10m,uv_index,is_day` + `hourly=temperature_2m,weathercode` + `daily=sunrise,sunset,weathercode,temperature_2m_max,temperature_2m_min` + `forecast_days=5&timezone=auto`
- `WeatherSnapshot`: gained `apparentTempC`, `windKmh`, `uvIndex`, `isDay`, `sunrise`, `sunset`, `hourly: List<HourlyForecast>`, `daily: List<DailyForecast>`
- `MusicCardState` (new): `NeedsPermission` / `NoActiveSession` / `Playing(NowPlaying)`
- `MusicSessionRepository.stateFlow()` combines NLS-permission flow with active-sessions flow
- `SystemUnits.SpeedUnit.fromKilometersPerHour(kmh: Double): Double` added for wind unit conversion

## Dependency

- `androidx.compose.material:material-icons-extended` added via Compose BOM. ~700KB raw, R8 strips unused on release. Necessary for replacing every emoji and giving the card a consistent line-icon vocabulary.

## Test plan

- [x] `./gradlew spotlessApply test lint` — BUILD SUCCESSFUL, **24/24** unit tests
  - `WeatherRepositoryTest` +1: parses 5-day daily block (`temperature_2m_max/min`, `weathercode`)
  - `WeatherRepositoryTest` retains hourly slice + http error + null-location coverage
  - `HomeViewModelTest` updated for `MusicCardState` flow shape
- [x] `./gradlew connectedDebugAndroidTest` — **15/15** instrumented tests pass on TBox-Mock AVD
  - `WeatherPanelTest` +3: condition / apparent / UV in hero secondary, astro chips with content descriptions, hourly entries, **5-day outlook with `Today` label and high/low**
  - `MusicPanelTest` rewritten for 3-state coverage: `Playing` track + artist + transport, `NeedsPermission` CTA dispatches `onConnect`, `NoActiveSession` placeholder
- [x] AVD smoke (1280×720, en-US, Tokyo location, real Open-Meteo response):
  - All 4 `HomeAction` event variants verified end-to-end (drawer / Maps / Music / NLS Settings)
  - `NeedsPermission` state — clear button affordance with `primaryContainer` surface
  - `NoActiveSession` state (after `pm grant` + `Settings.Secure` add) — `MusicOff` + "Nothing playing", centered
  - `Playing` state (verified via temporary debug stub) — album art placeholder + track + transport + thick rounded progress bar at ~40%
- [x] Format / lint clean across Kotlin, Markdown, Gradle DSL