### PR TITLE
feat(data): reverse-geocode via OSM Nominatim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ targets that matter for any head-unit UI, regardless of motion.
 | `ACCESS_NETWORK_STATE` | MapLibre connectivity probe before fetching OpenFreeMap vector map tiles. |
 | `ACCESS_WIFI_STATE` | Read Wi-Fi transport / validation state so the footer status cluster reports a live Wi-Fi indicator. Normal protection; auto-granted at install. |
 | `BLUETOOTH_CONNECT` | Read the set of currently-connected Bluetooth devices (HEADSET / A2DP / GATT) so the footer status cluster reflects head-unit pairing state. Dangerous on Android 12+; runtime grant. The BT indicator dims when denied, the rest of the launcher remains functional. |
-| `INTERNET` | Open-Meteo weather API and OpenFreeMap vector map tile fetch (MapLibre). |
+| `INTERNET` | Open-Meteo weather API, OpenFreeMap vector map tile fetch (MapLibre), and Nominatim/OSM reverse geocoding. |
 | `READ_CALENDAR` | Query `CalendarContract.Instances` for the dashboard's Calendar card — the 6-day strip dots and the upcoming-event list. Dangerous; runtime grant. The card falls back to "today's date only" when denied. |
 
 ### Dependencies <a id="dependencies"></a>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,6 +52,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     testOptions {
         unitTests {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,8 @@
 
     <!--
         INTERNET: Open-Meteo weather API + OpenFreeMap vector-tile
-        fetch (MapLibre). Justification mirrored in CLAUDE.md#permissions.
+        fetch (MapLibre) + Nominatim/OSM reverse geocoding.
+        Justification mirrored in CLAUDE.md#permissions.
     -->
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/app/src/main/java/io/github/seijikohara/femto/data/AddressComposer.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/AddressComposer.kt
@@ -1,0 +1,186 @@
+package io.github.seijikohara.femto.data
+
+import io.github.seijikohara.femto.data.NominatimApi.NominatimAddress
+
+/**
+ * Compose a readable [ShortAddress] from a Nominatim structured address.
+ *
+ * This object is the single source of truth for address composition. It never
+ * trims `display_name`; it reads the structured slots, picks the first
+ * non-blank candidate per slot, de-duplicates overlapping values (suburb /
+ * neighbourhood / quarter commonly repeat), and orders the slots by
+ * [NominatimAddress.countryCode]:
+ *
+ * - East-Asian markets emit slots LARGE-to-SMALL with no separator
+ *   (e.g. "東京都新宿区新宿三丁目").
+ * - Other markets emit slots SMALL-to-LARGE joined with ", "
+ *   (e.g. "1600 Amphitheatre Parkway, Mountain View, CA").
+ */
+internal object AddressComposer {
+    fun composeAddress(address: NominatimAddress): ShortAddress? =
+        if (address.countryCode?.lowercase() in EAST_ASIAN_COUNTRIES) {
+            composeEastAsian(address)
+        } else {
+            composeWestern(address)
+        }
+
+    private fun composeEastAsian(address: NominatimAddress): ShortAddress? {
+        val used = mutableSetOf<String>()
+        val prefecture =
+            firstUnused(
+                used,
+                address.state,
+                address.province,
+                address.region,
+                address.stateDistrict,
+            ) ?: jpPrefecture(address.isoLvl4)?.also { used += it }
+        val municipality =
+            firstUnused(
+                used,
+                address.city,
+                address.town,
+                address.municipality,
+                address.village,
+                address.county,
+            )
+        val subWard = firstUnused(used, address.cityDistrict, address.suburb, address.district, address.borough)
+        val district = firstUnused(used, address.quarter, address.neighbourhood, address.suburb, address.town)
+        val chome = firstUnused(used, address.neighbourhood, address.quarter, address.cityBlock, address.residential)
+        // `road` is intentionally NOT used for East-Asian addresses: Japanese
+        // addresses are administrative (prefecture→ward→district→chome→banchi)
+        // and do not use street names, so OSM's `road` here is usually a POI /
+        // landmark / station (e.g. "JR新宿駅;1階;15番線") that reads as noise. The
+        // banchi (`house_number`) is kept when present.
+        val houseNumber = firstUnused(used, address.houseNumber)
+
+        // Nothing meaningful to show when neither a municipality nor a
+        // prefecture resolves.
+        if (municipality == null && prefecture == null) return null
+
+        // The fine-grained place slots overlap in Japan: Nominatim reports a
+        // coarse name ("新宿", quarter) and a finer one that contains it
+        // ("新宿三丁目", neighbourhood) in adjacent slots. Drop any place name
+        // that is a substring of a more specific sibling so the line keeps only
+        // the most specific value (yields "新宿三丁目", not "新宿新宿三丁目").
+        val fine = dropContained(listOfNotNull(subWard, district, chome))
+
+        val line = (listOfNotNull(prefecture, municipality) + fine + listOfNotNull(houseNumber)).joinToString("")
+        return ShortAddress(
+            locality = municipality.orEmpty(),
+            region = prefecture,
+            line = line,
+        )
+    }
+
+    // Remove any value that is a substring of another value in the list,
+    // preserving the original order of the survivors.
+    private fun dropContained(values: List<String>): List<String> =
+        values.filter { candidate ->
+            values.none { other -> other != candidate && other.contains(candidate) }
+        }
+
+    private fun composeWestern(address: NominatimAddress): ShortAddress? {
+        val used = mutableSetOf<String>()
+        val street =
+            listOfNotNull(address.houseNumber, address.road)
+                .filter { it.isNotBlank() }
+                .joinToString(" ")
+                .ifBlank { null }
+                ?.also { used += it }
+        val city =
+            firstUnused(
+                used,
+                address.city,
+                address.town,
+                address.village,
+                address.municipality,
+            )
+        val state =
+            isoSuffix(address.isoLvl4)?.also { used += it }
+                ?: firstUnused(used, address.state, address.province, address.region)
+
+        // Nothing meaningful to show when neither a city nor a state resolves.
+        if (city == null && state == null) return null
+
+        val line = listOfNotNull(street, city, state).joinToString(", ")
+        return ShortAddress(
+            locality = city.orEmpty(),
+            region = state,
+            line = line,
+        )
+    }
+
+    // Return the first candidate that is non-blank and not already emitted, and
+    // record it as used so a later slot does not repeat the same value.
+    private fun firstUnused(
+        used: MutableSet<String>,
+        vararg candidates: String?,
+    ): String? =
+        candidates
+            .firstOrNull { !it.isNullOrBlank() && it !in used }
+            ?.also { used += it }
+
+    private fun jpPrefecture(isoLvl4: String?): String? = JP_PREFECTURES[isoLvl4]
+
+    // "US-CA" -> "CA"; null when the code carries no "-" suffix.
+    private fun isoSuffix(isoLvl4: String?): String? =
+        isoLvl4
+            ?.substringAfter('-', "")
+            ?.takeIf { it.isNotBlank() }
+}
+
+private val EAST_ASIAN_COUNTRIES = setOf("jp", "cn", "kr", "tw", "hk", "mo")
+
+// ISO 3166-2:JP -> prefecture name in kanji. Nominatim omits the prefecture
+// from the structured keys for Japanese addresses, so recover it from the
+// "ISO3166-2-lvl4" code (e.g. "JP-13" -> "東京都").
+private val JP_PREFECTURES =
+    mapOf(
+        "JP-01" to "北海道",
+        "JP-02" to "青森県",
+        "JP-03" to "岩手県",
+        "JP-04" to "宮城県",
+        "JP-05" to "秋田県",
+        "JP-06" to "山形県",
+        "JP-07" to "福島県",
+        "JP-08" to "茨城県",
+        "JP-09" to "栃木県",
+        "JP-10" to "群馬県",
+        "JP-11" to "埼玉県",
+        "JP-12" to "千葉県",
+        "JP-13" to "東京都",
+        "JP-14" to "神奈川県",
+        "JP-15" to "新潟県",
+        "JP-16" to "富山県",
+        "JP-17" to "石川県",
+        "JP-18" to "福井県",
+        "JP-19" to "山梨県",
+        "JP-20" to "長野県",
+        "JP-21" to "岐阜県",
+        "JP-22" to "静岡県",
+        "JP-23" to "愛知県",
+        "JP-24" to "三重県",
+        "JP-25" to "滋賀県",
+        "JP-26" to "京都府",
+        "JP-27" to "大阪府",
+        "JP-28" to "兵庫県",
+        "JP-29" to "奈良県",
+        "JP-30" to "和歌山県",
+        "JP-31" to "鳥取県",
+        "JP-32" to "島根県",
+        "JP-33" to "岡山県",
+        "JP-34" to "広島県",
+        "JP-35" to "山口県",
+        "JP-36" to "徳島県",
+        "JP-37" to "香川県",
+        "JP-38" to "愛媛県",
+        "JP-39" to "高知県",
+        "JP-40" to "福岡県",
+        "JP-41" to "佐賀県",
+        "JP-42" to "長崎県",
+        "JP-43" to "熊本県",
+        "JP-44" to "大分県",
+        "JP-45" to "宮崎県",
+        "JP-46" to "鹿児島県",
+        "JP-47" to "沖縄県",
+    )

--- a/app/src/main/java/io/github/seijikohara/femto/data/NominatimApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/NominatimApi.kt
@@ -1,0 +1,97 @@
+package io.github.seijikohara.femto.data
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Reverse-geocode a coordinate through an OSM Nominatim-compatible endpoint.
+ *
+ * The PoC targets the public Nominatim service; production swaps in LocationIQ,
+ * which returns the same jsonv2 shape — only [baseUrl] and [apiKey] change.
+ * Nominatim blocks stock HTTP User-Agents, so [userAgent] is mandatory.
+ */
+internal class NominatimApi(
+    private val client: OkHttpClient,
+    private val baseUrl: String = "https://nominatim.openstreetmap.org/",
+    private val userAgent: String,
+    private val language: String = "ja",
+    // Token for a keyed Nominatim-compatible host (e.g. LocationIQ). Null for the
+    // public keyless Nominatim service; when set it is appended as `key`.
+    private val apiKey: String? = null,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun reverse(
+        lat: Double,
+        lon: Double,
+    ): NominatimResponse? =
+        withContext(ioDispatcher) {
+            runCatching {
+                val url =
+                    baseUrl
+                        .toHttpUrl()
+                        .newBuilder()
+                        .addPathSegment("reverse")
+                        .addQueryParameter("format", "jsonv2")
+                        .addQueryParameter("addressdetails", "1")
+                        .addQueryParameter("accept-language", language)
+                        .addQueryParameter("lat", lat.toString())
+                        .addQueryParameter("lon", lon.toString())
+                        .apply { apiKey?.let { addQueryParameter("key", it) } }
+                        .build()
+                val request =
+                    Request
+                        .Builder()
+                        .url(url)
+                        .header("User-Agent", userAgent)
+                        .build()
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use null
+                    response.body?.string()?.let { body ->
+                        json.decodeFromString<NominatimResponse>(body)
+                    }
+                }
+            }.getOrNull()
+        }
+
+    @Serializable
+    data class NominatimResponse(
+        val address: NominatimAddress? = null,
+        @SerialName("display_name") val displayName: String? = null,
+    )
+
+    @Serializable
+    data class NominatimAddress(
+        val road: String? = null,
+        @SerialName("house_number") val houseNumber: String? = null,
+        val neighbourhood: String? = null,
+        val quarter: String? = null,
+        @SerialName("city_district") val cityDistrict: String? = null,
+        val district: String? = null,
+        val borough: String? = null,
+        val suburb: String? = null,
+        val city: String? = null,
+        val town: String? = null,
+        val village: String? = null,
+        val municipality: String? = null,
+        val county: String? = null,
+        val state: String? = null,
+        val province: String? = null,
+        val region: String? = null,
+        @SerialName("state_district") val stateDistrict: String? = null,
+        @SerialName("city_block") val cityBlock: String? = null,
+        val residential: String? = null,
+        @SerialName("ISO3166-2-lvl4") val isoLvl4: String? = null,
+        val postcode: String? = null,
+        val country: String? = null,
+        @SerialName("country_code") val countryCode: String? = null,
+    )
+}

--- a/app/src/main/java/io/github/seijikohara/femto/data/ReverseGeocoderRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/ReverseGeocoderRepository.kt
@@ -1,51 +1,75 @@
 package io.github.seijikohara.femto.data
 
-import android.content.Context
-import android.location.Geocoder
 import android.location.Location
-import android.os.Build
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.suspendCancellableCoroutine
-import java.util.Locale
-import kotlin.coroutines.resume
+import kotlin.math.roundToLong
 
+/**
+ * Reverse-geocode the current location through OSM Nominatim and expose a
+ * readable [ShortAddress].
+ *
+ * The OSM geocoding data is licensed under "© OpenStreetMap contributors";
+ * the map surface already renders the OSM/MapLibre attribution that covers
+ * this data, so no extra attribution UI is required here.
+ */
 internal class ReverseGeocoderRepository(
-    context: Context,
     private val locationFlow: Flow<Location?>,
+    private val api: NominatimApi,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val geocoder: Geocoder = Geocoder(context, Locale.getDefault()),
+    // Injectable clock so the request throttle is deterministic under a test
+    // dispatcher's virtual time. Production reads the wall clock.
+    private val nowMs: () -> Long = System::currentTimeMillis,
 ) {
+    // Per-bucket cache keyed by the 100 m bucket (lat/lon rounded to 3
+    // decimals). A revisited bucket returns the cached address without a
+    // network call, and a failed lookup falls back to the most recent value.
+    private val cache = mutableMapOf<String, ShortAddress>()
+    private var lastResult: ShortAddress? = null
+    private var lastRequestAtMs = 0L
+
     fun addressFlow(): Flow<ShortAddress?> =
         locationFlow
             .distinctUntilChangedByBucket()
             .map { location -> location?.let { resolve(it) } }
             .flowOn(ioDispatcher)
 
-    private suspend fun resolve(location: Location): ShortAddress? =
-        runCatching {
-            if (!Geocoder.isPresent()) return@runCatching null
-            requestAddresses(location)
-                .firstOrNull()
-                ?.let { ShortAddress(locality = shortLocality(it.locality.orEmpty()), region = it.adminArea) }
-                ?.takeIf { it.locality.isNotEmpty() }
-        }.getOrNull()
+    private suspend fun resolve(location: Location): ShortAddress? {
+        val key = bucketKey(location.latitude, location.longitude)
+        cache[key]?.let { return it }
 
-    @Suppress("DEPRECATION")
-    private suspend fun requestAddresses(location: Location): List<android.location.Address> =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            suspendCancellableCoroutine { cont ->
-                geocoder.getFromLocation(location.latitude, location.longitude, 1) { addresses ->
-                    cont.resume(addresses)
-                }
+        // Nominatim's usage policy caps callers at 1 request per second; the
+        // 100 m bucket already collapses most calls, and this spacing guards
+        // the remaining boundary crossings.
+        throttle()
+
+        return runCatching {
+            api.reverse(location.latitude, location.longitude)?.address?.let {
+                AddressComposer.composeAddress(it)
             }
-        } else {
-            geocoder.getFromLocation(location.latitude, location.longitude, 1) ?: emptyList()
-        }
+        }.getOrNull()
+            ?.also {
+                cache[key] = it
+                lastResult = it
+            }
+            ?: lastResult
+    }
+
+    private suspend fun throttle() {
+        val elapsed = nowMs() - lastRequestAtMs
+        if (elapsed < MIN_REQUEST_SPACING_MS) delay(MIN_REQUEST_SPACING_MS - elapsed)
+        lastRequestAtMs = nowMs()
+    }
+
+    private fun bucketKey(
+        lat: Double,
+        lon: Double,
+    ): String = "${(lat * 1000).roundToLong()}:${(lon * 1000).roundToLong()}"
 
     private fun Flow<Location?>.distinctUntilChangedByBucket(): Flow<Location?> =
         distinctUntilChanged { old, new ->
@@ -55,24 +79,6 @@ internal class ReverseGeocoderRepository(
 
     private companion object {
         const val BUCKET_M = 100f
-    }
-}
-
-// Administrative suffixes the platform geocoder appends to a locality
-// (e.g. "Chiyoda City", "Westminster District"). The dashboard's city
-// slots are narrow, so the trailing suffix is stripped to leave a
-// compact core name. The geocoder returns the locality in the device
-// locale; this list covers Latin-script suffixes, and a market adds its
-// own entries here when its locale needs them. The strictest match wins:
-// only an exact trailing word is removed, never a substring.
-private val AdminSuffixes = setOf("City", "Ward", "District", "Municipality", "Town", "Village", "Borough")
-
-internal fun shortLocality(raw: String): String {
-    val trimmed = raw.trim()
-    val lastWord = trimmed.substringAfterLast(' ', "")
-    return if (lastWord.isNotEmpty() && AdminSuffixes.any { it.equals(lastWord, ignoreCase = true) }) {
-        trimmed.substringBeforeLast(' ').trim().ifEmpty { trimmed }
-    } else {
-        trimmed
+        const val MIN_REQUEST_SPACING_MS = 1_000L
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/ShortAddress.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/ShortAddress.kt
@@ -3,6 +3,12 @@ package io.github.seijikohara.femto.data
 internal data class ShortAddress(
     val locality: String,
     val region: String?,
+    val line: String = "",
 ) {
-    fun displayString(): String = listOfNotNull(locality, region).joinToString(", ")
+    /**
+     * Return the full formatted street address for the location overlay
+     * (e.g. "東京都新宿区西新宿１丁目１−３"). Falls back to the compact
+     * "locality, region" pair when the geocoder gives no address line.
+     */
+    fun displayString(): String = line.ifBlank { listOfNotNull(locality, region).joinToString(", ") }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import io.github.seijikohara.femto.BuildConfig
 import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.data.AppsRepository
 import io.github.seijikohara.femto.data.CalendarRepository
@@ -16,6 +17,7 @@ import io.github.seijikohara.femto.data.ClockTick
 import io.github.seijikohara.femto.data.LocationRepository
 import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.data.MusicSessionRepository
+import io.github.seijikohara.femto.data.NominatimApi
 import io.github.seijikohara.femto.data.OpenMeteoApi
 import io.github.seijikohara.femto.data.ReverseGeocoderRepository
 import io.github.seijikohara.femto.data.ShortAddress
@@ -37,6 +39,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
+import java.util.Locale
 
 internal class HomeViewModel(
     private val clockFlow: Flow<ClockTick>,
@@ -156,8 +159,22 @@ internal class HomeViewModelFactory(
         val locationFlow = location.locationFlow()
         val clock = ClockRepository(application)
         val clockFlow = clock.tickFlow()
-        val geocoder = ReverseGeocoderRepository(application, locationFlow)
-        val weatherApi = OpenMeteoApi(client = OkHttpClient())
+        // Share one OkHttpClient across the weather and geocoding APIs so the
+        // connection pool and dispatcher are reused instead of duplicated.
+        val httpClient = OkHttpClient()
+        // Nominatim blocks stock HTTP User-Agents; identify the launcher with a
+        // contact URL per the OSM usage policy.
+        val userAgent =
+            "FemtoCarLauncher/" + BuildConfig.VERSION_NAME +
+                " (+https://github.com/seijikohara/femto-car-launcher)"
+        val nominatimApi =
+            NominatimApi(
+                client = httpClient,
+                userAgent = userAgent,
+                language = Locale.getDefault().language,
+            )
+        val geocoder = ReverseGeocoderRepository(locationFlow, nominatimApi)
+        val weatherApi = OpenMeteoApi(client = httpClient)
         val weather = WeatherRepository(weatherApi, locationFlow)
         val music = MusicSessionRepository(application)
         val apps = MutableStateFlow<List<AppEntry>>(emptyList())

--- a/app/src/test/java/io/github/seijikohara/femto/data/AddressComposerTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/AddressComposerTest.kt
@@ -1,0 +1,164 @@
+package io.github.seijikohara.femto.data
+
+import io.github.seijikohara.femto.data.NominatimApi.NominatimAddress
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class AddressComposerTest {
+    @Test
+    fun `composes east-asian line large-to-small when country is japan`() {
+        val address =
+            NominatimAddress(
+                neighbourhood = "新宿三丁目",
+                quarter = "新宿",
+                city = "新宿区",
+                isoLvl4 = "JP-13",
+                countryCode = "jp",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("東京都新宿区新宿三丁目", result.line)
+    }
+
+    @Test
+    fun `sets locality to ward and region to prefecture for japan`() {
+        val address =
+            NominatimAddress(
+                neighbourhood = "新宿三丁目",
+                quarter = "新宿",
+                city = "新宿区",
+                isoLvl4 = "JP-13",
+                countryCode = "jp",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("新宿区", result.locality)
+        assertEquals("東京都", result.region)
+    }
+
+    @Test
+    fun `orders prefecture municipality and sub-ward large-to-small for yokohama`() {
+        val address =
+            NominatimAddress(
+                suburb = "西区",
+                city = "横浜市",
+                province = "神奈川県",
+                countryCode = "jp",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("神奈川県横浜市西区", result.line)
+    }
+
+    @Test
+    fun `sets locality to city for yokohama`() {
+        val address =
+            NominatimAddress(
+                suburb = "西区",
+                city = "横浜市",
+                province = "神奈川県",
+                countryCode = "jp",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("横浜市", result.locality)
+    }
+
+    @Test
+    fun `composes western line small-to-large comma-joined for mountain view`() {
+        val address =
+            NominatimAddress(
+                houseNumber = "1600",
+                road = "Amphitheatre Parkway",
+                city = "Mountain View",
+                isoLvl4 = "US-CA",
+                countryCode = "us",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("1600 Amphitheatre Parkway, Mountain View, CA", result.line)
+    }
+
+    @Test
+    fun `derives western state from iso suffix for mountain view`() {
+        val address =
+            NominatimAddress(
+                houseNumber = "1600",
+                road = "Amphitheatre Parkway",
+                city = "Mountain View",
+                isoLvl4 = "US-CA",
+                countryCode = "us",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("Mountain View", result.locality)
+        assertEquals("CA", result.region)
+    }
+
+    @Test
+    fun `emits an overlapping value once when suburb equals neighbourhood`() {
+        val address =
+            NominatimAddress(
+                neighbourhood = "本町",
+                suburb = "本町",
+                city = "中央区",
+                province = "大阪府",
+                countryCode = "jp",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("大阪府中央区本町", result.line)
+    }
+
+    @Test
+    fun `excludes the road poi from a japanese address line`() {
+        val address =
+            NominatimAddress(
+                road = "JR新宿駅;1階;15番線",
+                neighbourhood = "新宿三丁目",
+                quarter = "新宿",
+                city = "新宿区",
+                isoLvl4 = "JP-13",
+                countryCode = "jp",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("東京都新宿区新宿三丁目", result.line)
+    }
+
+    @Test
+    fun `keeps the house number as the banchi in a japanese address line`() {
+        val address =
+            NominatimAddress(
+                houseNumber = "1-3",
+                neighbourhood = "西新宿一丁目",
+                city = "新宿区",
+                isoLvl4 = "JP-13",
+                countryCode = "jp",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("東京都新宿区西新宿一丁目1-3", result.line)
+    }
+
+    @Test
+    fun `returns null when neither municipality nor prefecture resolves`() {
+        val address =
+            NominatimAddress(
+                road = "Some Road",
+                countryCode = "jp",
+            )
+
+        assertEquals(null, AddressComposer.composeAddress(address))
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/NominatimApiTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/NominatimApiTest.kt
@@ -1,0 +1,118 @@
+package io.github.seijikohara.femto.data
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NominatimApiTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        client = OkHttpClient()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `parses structured address city from a jsonv2 response`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+
+            val response = newApi().reverse(LAT, LON)
+
+            assertEquals("新宿区", response?.address?.city)
+        }
+
+    @Test
+    fun `sends format and addressdetails query parameters`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+
+            newApi().reverse(LAT, LON)
+            val path = server.takeRequest().path.orEmpty()
+
+            assertTrue(path.contains("format=jsonv2"))
+            assertTrue(path.contains("addressdetails=1"))
+        }
+
+    @Test
+    fun `sends accept-language and the requested coordinates`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+
+            newApi().reverse(LAT, LON)
+            val path = server.takeRequest().path.orEmpty()
+
+            assertTrue(path.contains("accept-language=ja"))
+            assertTrue(path.contains("lat=$LAT"))
+            assertTrue(path.contains("lon=$LON"))
+        }
+
+    @Test
+    fun `sends the configured user-agent header`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+
+            newApi().reverse(LAT, LON)
+            val request = server.takeRequest()
+
+            assertEquals(USER_AGENT, request.getHeader("User-Agent"))
+        }
+
+    @Test
+    fun `returns null on a 429 rate-limit response`() =
+        runTest {
+            server.enqueue(MockResponse().setResponseCode(429))
+
+            assertNull(newApi().reverse(LAT, LON))
+        }
+
+    @Test
+    fun `returns null on a malformed response body`() =
+        runTest {
+            server.enqueue(MockResponse().setBody("{ not json"))
+
+            assertNull(newApi().reverse(LAT, LON))
+        }
+
+    private fun newApi(): NominatimApi =
+        NominatimApi(
+            client = client,
+            baseUrl = server.url("/").toString(),
+            userAgent = USER_AGENT,
+        )
+
+    private companion object {
+        const val LAT = 35.690
+        const val LON = 139.700
+        const val USER_AGENT = "femto-car-launcher/1.0 (test)"
+
+        const val SHINJUKU_BODY = """
+            {
+              "display_name": "..., 新宿三丁目, 新宿, 新宿区, 東京都, 160-0022, 日本",
+              "address": {
+                "neighbourhood": "新宿三丁目",
+                "quarter": "新宿",
+                "city": "新宿区",
+                "ISO3166-2-lvl4": "JP-13",
+                "postcode": "160-0022",
+                "country": "日本",
+                "country_code": "jp"
+              }
+            }
+        """
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/ReverseGeocoderRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/ReverseGeocoderRepositoryTest.kt
@@ -2,18 +2,22 @@
 
 package io.github.seijikohara.femto.data
 
-import android.location.Address
-import android.location.Geocoder
-import androidx.test.core.app.ApplicationProvider
+import android.location.Location
 import app.cash.turbine.test
 import io.github.seijikohara.femto.testfixtures.fakeLocation
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -21,48 +25,94 @@ import kotlin.test.assertNull
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
 class ReverseGeocoderRepositoryTest {
-    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        client = OkHttpClient()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
 
     @Test
-    fun `emits short address when geocoder returns full result`() =
+    fun `emits the composed short address for a fix`() =
         runTest {
-            val geocoder = Geocoder(context)
-            val response =
-                Address(java.util.Locale.US).apply {
-                    locality = "Shibuya"
-                    adminArea = "Tokyo"
-                }
-            shadowOf(geocoder).setFromLocation(listOf(response))
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
 
-            val repo =
-                ReverseGeocoderRepository(
-                    context = context,
-                    locationFlow = flowOf(fakeLocation()),
-                    ioDispatcher = UnconfinedTestDispatcher(testScheduler),
-                    geocoder = geocoder,
-                )
-
-            repo.addressFlow().test {
-                assertEquals(ShortAddress("Shibuya", "Tokyo"), awaitItem())
+            newRepo(flowOf(fakeLocation())).addressFlow().test {
+                val address = awaitItem()
+                assertEquals("新宿区", address?.locality)
+                assertEquals("東京都新宿区新宿三丁目", address?.displayString())
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun `emits null when geocoder returns no result`() =
+    fun `dedupes consecutive near locations to a single network call`() =
         runTest {
-            val geocoder = Geocoder(context)
-            shadowOf(geocoder).setFromLocation(emptyList())
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
 
-            val repo =
-                ReverseGeocoderRepository(
-                    context = context,
-                    locationFlow = flowOf(fakeLocation()),
-                    ioDispatcher = UnconfinedTestDispatcher(testScheduler),
-                    geocoder = geocoder,
-                )
+            // Two fixes within the 100 m bucket collapse to one emission and
+            // one request.
+            val flow = flowOf(fakeLocation(), fakeLocation(latitude = 35.65805))
+            newRepo(flow).addressFlow().test {
+                assertEquals("新宿区", awaitItem()?.locality)
+                cancelAndIgnoreRemainingEvents()
+            }
 
-            repo.addressFlow().test {
+            assertEquals(1, server.requestCount)
+        }
+
+    @Test
+    fun `does not issue a second request when revisiting a cached bucket`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+            // The far fix gets its own response so the near-bucket revisit is
+            // the only call that must hit the cache instead of the network.
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+
+            val near = fakeLocation()
+            val far = fakeLocation(latitude = 35.7000)
+            // Drain all three fixes (near, far, near) so the cached revisit is
+            // exercised before the request count is asserted.
+            newRepo(flowOf(near, far, near)).addressFlow().test {
+                assertEquals("新宿区", awaitItem()?.locality)
+                awaitItem()
+                assertEquals("新宿区", awaitItem()?.locality)
+                awaitComplete()
+            }
+
+            // One request for the near bucket, one for the far bucket; the
+            // revisit of the near bucket is served from the cache.
+            assertEquals(2, server.requestCount)
+        }
+
+    @Test
+    fun `falls back to the last cached value on a rate-limit response`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+            server.enqueue(MockResponse().setResponseCode(429))
+
+            val flow = flowOf(fakeLocation(), fakeLocation(latitude = 35.7000))
+            newRepo(flow).addressFlow().test {
+                assertEquals("新宿区", awaitItem()?.locality)
+                // The throttled second bucket returns the cached value, not null.
+                assertEquals("新宿区", awaitItem()?.locality)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `emits null when the first lookup fails with no cached value`() =
+        runTest {
+            server.enqueue(MockResponse().setResponseCode(429))
+
+            newRepo(flowOf(fakeLocation())).addressFlow().test {
                 assertNull(awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
@@ -71,51 +121,45 @@ class ReverseGeocoderRepositoryTest {
     @Test
     fun `emits null when location flow yields null`() =
         runTest {
-            val repo =
-                ReverseGeocoderRepository(
-                    context = context,
-                    locationFlow = flowOf(null),
-                    ioDispatcher = UnconfinedTestDispatcher(testScheduler),
-                )
-
-            repo.addressFlow().test {
+            newRepo(flowOf(null)).addressFlow().test {
                 assertNull(awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
-    @Test
-    fun `strips administrative suffix from a long locality`() =
-        runTest {
-            val geocoder = Geocoder(context)
-            val response =
-                Address(java.util.Locale.US).apply {
-                    locality = "Chiyoda City"
-                    adminArea = "Tokyo"
-                }
-            shadowOf(geocoder).setFromLocation(listOf(response))
+    private fun TestScope.newRepo(locationFlow: Flow<Location?>): ReverseGeocoderRepository {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        return ReverseGeocoderRepository(
+            locationFlow = locationFlow,
+            api =
+                NominatimApi(
+                    client = client,
+                    baseUrl = server.url("/").toString(),
+                    userAgent = USER_AGENT,
+                    ioDispatcher = dispatcher,
+                ),
+            ioDispatcher = dispatcher,
+            // Tie the throttle clock to the scheduler so delay() advances it.
+            nowMs = { testScheduler.currentTime },
+        )
+    }
 
-            val repo =
-                ReverseGeocoderRepository(
-                    context = context,
-                    locationFlow = flowOf(fakeLocation()),
-                    ioDispatcher = UnconfinedTestDispatcher(testScheduler),
-                    geocoder = geocoder,
-                )
+    private companion object {
+        const val USER_AGENT = "femto-car-launcher/1.0 (test)"
 
-            repo.addressFlow().test {
-                assertEquals(ShortAddress("Chiyoda", "Tokyo"), awaitItem())
-                cancelAndIgnoreRemainingEvents()
+        const val SHINJUKU_BODY = """
+            {
+              "display_name": "..., 新宿三丁目, 新宿, 新宿区, 東京都, 160-0022, 日本",
+              "address": {
+                "neighbourhood": "新宿三丁目",
+                "quarter": "新宿",
+                "city": "新宿区",
+                "ISO3166-2-lvl4": "JP-13",
+                "postcode": "160-0022",
+                "country": "日本",
+                "country_code": "jp"
+              }
             }
-        }
-
-    @Test
-    fun `shortLocality drops a trailing admin word but keeps plain names`() {
-        assertEquals("Chiyoda", shortLocality("Chiyoda City"))
-        assertEquals("Westminster", shortLocality("Westminster District"))
-        assertEquals("Setagaya", shortLocality("Setagaya Ward"))
-        assertEquals("Tokyo", shortLocality("Tokyo"))
-        assertEquals("San Francisco", shortLocality("San Francisco"))
-        assertEquals("千代田区", shortLocality("千代田区"))
+        """
     }
 }


### PR DESCRIPTION
## Summary

Resolves the current-location address (the speed-overlay line and the
weather-card city) from **OpenStreetMap** data via **Nominatim**,
replacing the Google-backed `android.location.Geocoder` and the ad-hoc
regex line-parsing. This aligns reverse geocoding with the
OpenFreeMap/MapLibre map.

**PoC iteration — no version bump (`versionCode` / `versionName`
unchanged).**

Investigated the OSM API against the live response before implementing
(no patchwork string parsing).

## What changed

- **`NominatimApi`** — OkHttp + kotlinx.serialization (modelled on
  `OpenMeteoApi`), `reverse?format=jsonv2&addressdetails=1&accept-language=<lang>`.
  A custom `User-Agent` is mandatory (Nominatim blocks stock UAs), built
  from `BuildConfig.VERSION_NAME` (`buildConfig` enabled). An optional
  `apiKey` makes swapping the PoC public Nominatim for a production
  **LocationIQ** host a base-URL + token change (identical jsonv2 shape).
- **`AddressComposer`** — a pure, JVM-tested SSOT that builds the address
  from the structured `address` object (never trimming `display_name`):
  per-slot priority + de-duplication, ordered by `country_code`
  (East-Asian large-to-small, no separator; others small-to-large,
  comma-joined). The JP prefecture is absent from structured keys, so it
  is recovered from `ISO3166-2-lvl4` via a 47-row table (JP-13 → 東京都).
  The `road` slot is dropped for East-Asian addresses (OSM's `road` is
  usually a station/POI there) → e.g. **東京都新宿区新宿三丁目**.
- **`ReverseGeocoderRepository`** — keeps the 100 m bucket debounce; adds
  a ≥1 req/s spacing throttle, an in-memory per-bucket cache, and a
  `runCatching` fallback to the last cached value on offline / 429, per
  the OSM usage policy. OSM attribution is already shown by the map.
- INTERNET permission justification updated (manifest + `CLAUDE.md`);
  no new permission.

## Provider

PoC uses the public `nominatim.openstreetmap.org` (keyless, compliant via
UA + throttle + cache + attribution). Production must not use the public
endpoint — switch to LocationIQ (key) or self-host via the `apiKey` +
`baseUrl` seam.

## Verification

`spotlessCheck` + `testDebugUnitTest` + `assembleDebug` + `lint` all
green. 16 new unit tests (composer: JP / Yokohama sub-ward / US ordering /
de-dup / road exclusion / banchi; API: User-Agent / params / 429 /
malformed; repository: bucket / cache / rate-limit fallback). Manually
verified on the emulator under the `ja-JP` locale against the live
Nominatim service: the overlay shows **東京都新宿区新宿三丁目** and the
weather card shows **新宿区**.
