### PR TITLE
chore: ignore per-user IntelliJ IDEA project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/.gitignore
+/.idea/appInsightsSettings.xml
+/.idea/markdown.xml
+/.idea/vcs.xml
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
Ignore the IDE-generated per-user `.idea/*` entries that are not shared team config and were cluttering `git status`:

- `.idea/.gitignore` — JetBrains-managed
- `.idea/appInsightsSettings.xml` — Android Studio App Insights
- `.idea/markdown.xml` — Markdown plugin settings
- `.idea/vcs.xml` — VCS-root mapping (IDE-regenerated)

The deliberately-tracked shared config under `.idea/` (`codeStyles/`, `compiler.xml`, `gradle.xml`, `runConfigurations.xml`, etc.) stays committed. No version bump (PoC).