### PR TITLE
fix: harden the long-lived HOME process against repository faults

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.data
 
+import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Context
 import android.content.pm.LauncherActivityInfo
@@ -21,8 +22,15 @@ import kotlinx.coroutines.withContext
  */
 class AppsRepository(
     private val context: Context,
+    launcher: ((ComponentName) -> Unit)? = null,
 ) {
     private val launcherApps: LauncherApps = checkNotNull(context.getSystemService())
+
+    // Seam: production launches via LauncherApps; tests inject a stub launcher.
+    private val startActivity: (ComponentName) -> Unit =
+        launcher ?: { componentName ->
+            launcherApps.startMainActivity(componentName, Process.myUserHandle(), null, null)
+        }
 
     /**
      * Return all main-launchable activities for the current user,
@@ -34,16 +42,28 @@ class AppsRepository(
         withContext(Dispatchers.IO) {
             launcherApps
                 .getActivityList(null, Process.myUserHandle())
-                .map(LauncherActivityInfo::toAppEntry)
+                // Isolate per-app resolution: getIcon() can throw
+                // Resources.NotFoundException or OOM on a pathological adaptive
+                // icon. One bad package must not blank the whole grid.
+                .mapNotNull { runCatching { it.toAppEntry() }.getOrNull() }
                 .sortedBy { it.label.lowercase() }
         }
 
     /**
-     * Launch the given activity. The bounds and options are unused
-     * for the MVP grid; pass `null` to defer to system defaults.
+     * Launch the given activity and report whether it resolved.
+     *
+     * Return `false` for [ActivityNotFoundException] — a stale shortcut
+     * after an uninstall must not crash the HOME launcher. Other errors
+     * still propagate (matches `MainActivity#startActivityIfResolved`).
      */
-    fun launch(componentName: ComponentName): Unit =
-        launcherApps.startMainActivity(componentName, Process.myUserHandle(), null, null)
+    fun launch(componentName: ComponentName): Boolean =
+        runCatching { startActivity(componentName) }
+            .fold(
+                onSuccess = { true },
+                onFailure = { error ->
+                    if (error is ActivityNotFoundException) false else throw error
+                },
+            )
 }
 
 private const val ICON_PIXELS = 192

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
@@ -64,8 +64,13 @@ internal class CalendarRepository(
                 hasEvent = false,
             )
         }
-        val events = if (hasPermission()) readEvents(today) else emptyList()
-        val datesWithEvents = readEventDates(today, events)
+        val granted = hasPermission()
+        val events = if (granted) readEvents(today) else emptyList()
+        // readEventDates runs its own full-window query (earlier-today events
+        // dot days the future-only readEvents window misses), so it must run
+        // whenever the permission is granted — not only when readEvents found
+        // future events.
+        val datesWithEvents = if (granted) readEventDates(today) else emptySet()
         val stripWithDots = strip.map { it.copy(hasEvent = it.date in datesWithEvents) }
         return CalendarSnapshot(
             today = today,
@@ -86,8 +91,7 @@ internal class CalendarRepository(
      * the time-of-day for display.
      */
     @SuppressLint("MissingPermission") // Caller checks READ_CALENDAR before subscribing.
-    private fun readEventDates(today: LocalDate, events: List<EventItem>): Set<LocalDate> {
-        if (events.isEmpty()) return emptySet()
+    private fun readEventDates(today: LocalDate): Set<LocalDate> {
         val begin = today.atStartOfDay(zone).toInstant().toEpochMilli()
         val end = today
             .plusDays(DAY_STRIP_LENGTH.toLong())
@@ -99,24 +103,28 @@ internal class CalendarRepository(
             .let { ContentUris.appendId(it, begin) }
             .let { ContentUris.appendId(it, end) }
             .build()
-        val dates = mutableSetOf<LocalDate>()
-        context.contentResolver
-            .query(
-                uri,
-                arrayOf(CalendarContract.Instances.BEGIN),
-                null,
-                null,
-                "${CalendarContract.Instances.BEGIN} ASC",
-            )?.use { cursor ->
-                while (cursor.moveToNext()) {
-                    val startMs = cursor.getLong(0)
-                    dates += java.time.Instant
-                        .ofEpochMilli(startMs)
-                        .atZone(zone)
-                        .toLocalDate()
+        // A mid-stream permission revoke (SecurityException) or an OEM provider
+        // fault (SQLiteException) must not tear down the dashboard StateFlow.
+        return runCatching {
+            val dates = mutableSetOf<LocalDate>()
+            context.contentResolver
+                .query(
+                    uri,
+                    arrayOf(CalendarContract.Instances.BEGIN),
+                    null,
+                    null,
+                    "${CalendarContract.Instances.BEGIN} ASC",
+                )?.use { cursor ->
+                    while (cursor.moveToNext()) {
+                        val startMs = cursor.getLong(0)
+                        dates += java.time.Instant
+                            .ofEpochMilli(startMs)
+                            .atZone(zone)
+                            .toLocalDate()
+                    }
                 }
-            }
-        return dates
+            dates.toSet()
+        }.getOrDefault(emptySet())
     }
 
     @SuppressLint("MissingPermission") // Caller checks READ_CALENDAR before subscribing.
@@ -135,28 +143,32 @@ internal class CalendarRepository(
         val now = java.time.Instant
             .now()
             .toEpochMilli()
-        val items = mutableListOf<EventItem>()
-        context.contentResolver
-            .query(
-                uri,
-                arrayOf(
-                    CalendarContract.Instances.BEGIN,
-                    CalendarContract.Instances.TITLE,
-                ),
-                "${CalendarContract.Instances.BEGIN} >= ?",
-                arrayOf(now.toString()),
-                "${CalendarContract.Instances.BEGIN} ASC",
-            )?.use { cursor ->
-                while (cursor.moveToNext() && items.size < EVENT_LIST_LIMIT) {
-                    val startMs = cursor.getLong(0)
-                    val title = cursor.getString(1) ?: continue
-                    items += EventItem(
-                        time = LocalTime.ofInstant(java.time.Instant.ofEpochMilli(startMs), zone),
-                        title = title,
-                    )
+        // A mid-stream permission revoke (SecurityException) or an OEM provider
+        // fault (SQLiteException) must not tear down the dashboard StateFlow.
+        return runCatching {
+            val items = mutableListOf<EventItem>()
+            context.contentResolver
+                .query(
+                    uri,
+                    arrayOf(
+                        CalendarContract.Instances.BEGIN,
+                        CalendarContract.Instances.TITLE,
+                    ),
+                    "${CalendarContract.Instances.BEGIN} >= ?",
+                    arrayOf(now.toString()),
+                    "${CalendarContract.Instances.BEGIN} ASC",
+                )?.use { cursor ->
+                    while (cursor.moveToNext() && items.size < EVENT_LIST_LIMIT) {
+                        val startMs = cursor.getLong(0)
+                        val title = cursor.getString(1) ?: continue
+                        items += EventItem(
+                            time = LocalTime.ofInstant(java.time.Instant.ofEpochMilli(startMs), zone),
+                            title = title,
+                        )
+                    }
                 }
-            }
-        return items
+            items.toList()
+        }.getOrDefault(emptyList())
     }
 
     /**

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerRoute.kt
@@ -22,7 +22,7 @@ internal fun AppDrawerRoute(
     val context = LocalContext.current
     var apps by remember { mutableStateOf<List<AppEntry>>(emptyList()) }
     LaunchedEffect(Unit) {
-        apps = AppsRepository(context).queryApps()
+        apps = runCatching { AppsRepository(context).queryApps() }.getOrDefault(emptyList())
     }
     BackHandler(onBack = onBack)
     AppDrawerScreen(apps = apps, onLaunch = onLaunch, modifier = modifier)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -196,7 +196,9 @@ internal class HomeViewModelFactory(
             tripStateFlow = trip.stateFlow(),
             sendMusicCommand = music::send,
         ).also { vm ->
-            vm.viewModelScope.launch { apps.value = appsRepo.queryApps() }
+            vm.viewModelScope.launch {
+                apps.value = runCatching { appsRepo.queryApps() }.getOrDefault(emptyList())
+            }
         } as T
     }
 }

--- a/app/src/test/java/io/github/seijikohara/femto/data/AppsRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/AppsRepositoryTest.kt
@@ -1,0 +1,44 @@
+package io.github.seijikohara.femto.data
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class AppsRepositoryTest {
+    private val application: Application = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `launch returns false and does not throw on ActivityNotFoundException`() {
+        val repo = AppsRepository(application, launcher = { throw ActivityNotFoundException() })
+
+        assertFalse(repo.launch(STALE_COMPONENT))
+    }
+
+    @Test
+    fun `launch rethrows non-ActivityNotFoundException errors`() {
+        val repo = AppsRepository(application, launcher = { throw SecurityException() })
+
+        assertFailsWith<SecurityException> { repo.launch(STALE_COMPONENT) }
+    }
+
+    @Test
+    fun `launch returns true on success`() {
+        val repo = AppsRepository(application, launcher = {})
+
+        assertTrue(repo.launch(STALE_COMPONENT))
+    }
+
+    private companion object {
+        val STALE_COMPONENT = ComponentName("com.example", "X")
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
@@ -1,0 +1,110 @@
+package io.github.seijikohara.femto.data
+
+import android.Manifest
+import android.app.Application
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.provider.CalendarContract
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class CalendarRepositoryTest {
+    private val application: Application = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `emits a clock-only snapshot when calendar permission is denied`() =
+        runTest {
+            // READ_CALENDAR is intentionally not granted: the events list must
+            // be empty while the clock-driven day strip still renders fully.
+            val repository =
+                CalendarRepository(
+                    application,
+                    clockFlow = flowOf(ClockTick(LocalTime.NOON, LocalDate.of(2026, 6, 3))),
+                )
+
+            val snapshot = repository.snapshotFlow().first()
+
+            assertNotNull(snapshot)
+            assertTrue(snapshot.events.isEmpty())
+            assertEquals(6, snapshot.dayStrip.size)
+        }
+
+    @Test
+    fun `keeps emitting when the calendar provider throws`() =
+        runTest {
+            // Grant the permission so the repository attempts the provider
+            // query, then make the registered provider throw to simulate a
+            // mid-stream revoke / OEM provider fault. The snapshot must still
+            // resolve with an empty events list rather than tearing down the
+            // dashboard StateFlow.
+            shadowOf(application).grantPermissions(Manifest.permission.READ_CALENDAR)
+            Robolectric
+                .buildContentProvider(ThrowingCalendarProvider::class.java)
+                .create(CalendarContract.AUTHORITY)
+
+            val repository =
+                CalendarRepository(
+                    application,
+                    clockFlow = flowOf(ClockTick(LocalTime.NOON, LocalDate.of(2026, 6, 3))),
+                )
+
+            val snapshot = repository.snapshotFlow().first()
+
+            assertNotNull(snapshot)
+            assertTrue(snapshot.events.isEmpty())
+            assertEquals(6, snapshot.dayStrip.size)
+        }
+
+    /**
+     * Stand-in calendar provider whose [query] throws [SecurityException], the
+     * fault the repository's `runCatching` guards must absorb.
+     */
+    class ThrowingCalendarProvider : ContentProvider() {
+        override fun onCreate(): Boolean = true
+
+        override fun query(
+            uri: Uri,
+            projection: Array<out String>?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+            sortOrder: String?,
+        ): Cursor = throw SecurityException("calendar provider unavailable")
+
+        override fun getType(uri: Uri): String? = null
+
+        override fun insert(
+            uri: Uri,
+            values: ContentValues?,
+        ): Uri? = null
+
+        override fun delete(
+            uri: Uri,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        override fun update(
+            uri: Uri,
+            values: ContentValues?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the completeness roadmap — **HOME-process resilience (P0)**. The
launcher runs as the persistent HOME app on always-on head units, so an
unguarded throw on the reactive path or a launch handler is catastrophic (a
relaunch loop or a permanently frozen dashboard).

## Changes

- **CalendarRepository**: wrap both `CalendarContract.Instances` queries in
  `runCatching` with empty fallbacks — a mid-stream permission revoke
  (`SecurityException`) or an OEM-provider `SQLiteException` can no longer tear
  down `HomeViewModel.uiState` (which would freeze clock, weather, music and
  apps). Also drop the `events.isEmpty()` early-return so earlier-today events
  still dot their day-strip cell.
- **AppsRepository**: `launch` now returns `Boolean` and swallows
  `ActivityNotFoundException` (a stale shortcut after uninstall must not crash
  the launcher); other errors still propagate. Per-app icon/label resolution is
  isolated with `mapNotNull { runCatching { … } }` so one pathological adaptive
  icon cannot blank the whole grid. A constructor launcher seam enables unit
  testing.
- Both `queryApps()` call sites (`HomeViewModel` factory, `AppDrawerRoute`) are
  wrapped in `runCatching` so a failed query degrades to an empty grid.

## Tests

- `CalendarRepositoryTest` — permission-denied and provider-throws paths both
  keep emitting a clock-only snapshot (Robolectric forces the provider throw).
- `AppsRepositoryTest` — `launch` returns false on `ActivityNotFoundException`,
  rethrows other errors, returns true on success.

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green (5 new JVM tests pass; lint 0 errors).