### PR TITLE
fix: reliable trip distance + weather outage retry throttle

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/TripRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/TripRepository.kt
@@ -10,50 +10,114 @@ import kotlinx.coroutines.flow.flowOn
  * In-memory trip aggregator.
  *
  * Subscribes to the shared location flow, walks the sequence of fixes,
- * and emits a running [TripState] each time a new fix lands. Two simple
+ * and emits a running [TripState] each time a new fix lands. Three
  * filters guard against the worst of GPS noise:
  *
- *  - Fixes reporting `speed < MIN_MOVING_SPEED_MS` (≈ 1.8 km/h) are
- *    treated as "not moving" — distance and time both stop accruing.
- *    This stops the average from collapsing toward zero at long stops.
- *  - Fixes whose timestamp delta is non-positive or larger than
- *    `MAX_GAP_MS` (a missing-fix gap, e.g. a tunnel) are skipped — we
- *    do not interpolate across them.
+ *  - Fixes whose *effective* speed (see below) is below
+ *    `MIN_MOVING_SPEED_MS` (≈ 1.8 km/h) are treated as "not moving" —
+ *    distance and time both stop accruing. This stops the average from
+ *    collapsing toward zero at long stops.
+ *  - Fixes whose elapsed-time delta is non-positive or larger than
+ *    `MAX_GAP_SECONDS` (a missing-fix gap, e.g. a tunnel) are skipped —
+ *    we do not interpolate across them.
+ *  - The delta is taken from `elapsedRealtimeNanos`, the monotonic boot
+ *    clock, not `Location.time`. AI boxes routinely apply an NTP /
+ *    system-clock correction mid-trip; the wall clock can jump
+ *    backward or forward, but the boot clock keeps ticking, so it is
+ *    the only safe basis for a delta. (Task 5.8.)
  *
- * Trip resets are out of scope for this pass; the aggregator lives for
- * the lifetime of the [ViewModel] subscription.
+ * "Effective speed" decouples accrual from the GPS chip's speed report.
+ * Cheap chips and raw `GPS_PROVIDER` HALs leave `Location.speed` at
+ * `0.0` and `Location.hasSpeed() == false`. Gating on the reported
+ * speed would then freeze distance/average at zero for the whole trip.
+ * Instead, when the fix carries no speed we derive one from the
+ * position delta (`previous.distanceTo(current) / deltaSeconds`).
+ * (Task 2.3.)
+ *
+ * The accumulators ([lastLocation], [totalMeters], [totalSeconds]) live
+ * on the instance, not inside the cold `flow {}`. Under
+ * `stateIn(WhileSubscribed)` the upstream collection stops ~5 s after
+ * the last subscriber leaves (e.g. the head unit foregrounds another
+ * app) and restarts when a subscriber returns; if the accumulators
+ * lived in the flow body they would reset to zero on every restart,
+ * silently breaking the "since process start" contract. Hoisting them
+ * makes the subscription window gate only *UI delivery*, never the
+ * accumulated total. WhileSubscribed guarantees a single live upstream
+ * collection at a time, so the plain (non-atomic) fields are safe.
+ *
+ * Accrual still *pauses* while fully backgrounded — there is no eager
+ * always-on GPS scope here — but the running total survives the gap and
+ * resumes on the next fix. This composes with the later location
+ * `shareIn` work. Trip resets are out of scope for this pass.
  */
 internal class TripRepository(
     private val locationFlow: Flow<Location?>,
 ) {
+    // Hoisted out of the cold flow {} so the running total survives a
+    // WhileSubscribed stop/restart; see the class KDoc.
+    private var lastLocation: Location? = null
+    private var totalMeters = 0.0
+    private var totalSeconds = 0.0
+    private var currentSpeedMs = 0.0
+
     fun stateFlow(): Flow<TripState> =
         flow {
-            emit(TripState.Initial)
-            var lastLocation: Location? = null
-            var totalMeters = 0.0
-            var totalSeconds = 0.0
+            // Replay the running total to a (re)subscriber instead of a
+            // hardcoded Initial, so distance does not appear to reset to
+            // zero when the window reopens.
+            emit(snapshot())
             locationFlow.collect { current ->
                 if (current == null) return@collect
-                val previous = lastLocation
-                if (previous != null && current.speed >= MIN_MOVING_SPEED_MS) {
-                    val deltaSeconds = (current.time - previous.time) / 1000.0
-                    if (deltaSeconds in MIN_DELTA_SECONDS..MAX_GAP_SECONDS) {
-                        totalMeters += previous.distanceTo(current).toDouble()
-                        totalSeconds += deltaSeconds
-                    }
-                }
-                lastLocation = current
-                val avg = if (totalSeconds > 0.0) totalMeters / totalSeconds else 0.0
-                emit(TripState(distanceMeters = totalMeters, avgSpeedMs = avg))
+                accrue(current)
+                emit(snapshot())
             }
         }.flowOn(Dispatchers.Default)
 
+    private fun accrue(current: Location) {
+        val previous = lastLocation
+        if (previous != null) {
+            val deltaSeconds =
+                (current.elapsedRealtimeNanos - previous.elapsedRealtimeNanos) / NANOS_PER_SECOND
+            if (deltaSeconds in MIN_DELTA_SECONDS..MAX_GAP_SECONDS) {
+                val effectiveSpeed = effectiveSpeed(previous, current, deltaSeconds)
+                currentSpeedMs = effectiveSpeed
+                if (effectiveSpeed >= MIN_MOVING_SPEED_MS) {
+                    totalMeters += previous.distanceTo(current).toDouble()
+                    totalSeconds += deltaSeconds
+                }
+            }
+        }
+        lastLocation = current
+    }
+
+    // The chip's reported speed when it has one; otherwise the
+    // position-derived speed so speed-less HALs still register motion.
+    private fun effectiveSpeed(
+        previous: Location,
+        current: Location,
+        deltaSeconds: Double,
+    ): Double =
+        if (current.hasSpeed()) {
+            current.speed.toDouble()
+        } else {
+            previous.distanceTo(current).toDouble() / deltaSeconds
+        }
+
+    private fun snapshot(): TripState =
+        TripState(
+            distanceMeters = totalMeters,
+            avgSpeedMs = if (totalSeconds > 0.0) totalMeters / totalSeconds else 0.0,
+            currentSpeedMs = currentSpeedMs,
+        )
+
     private companion object {
         // ~1.8 km/h — below this the device is treated as stationary.
-        const val MIN_MOVING_SPEED_MS = 0.5f
+        const val MIN_MOVING_SPEED_MS = 0.5
 
-        // Must be strictly positive; covers same-second emissions where
-        // the timestamp didn't tick over.
+        const val NANOS_PER_SECOND = 1_000_000_000.0
+
+        // Must be strictly positive; covers same-instant emissions where
+        // the boot clock didn't advance.
         const val MIN_DELTA_SECONDS = 0.001
 
         // Drop pairs separated by a long gap (parked, lost fix, tunnel).

--- a/app/src/main/java/io/github/seijikohara/femto/data/TripState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/TripState.kt
@@ -9,18 +9,22 @@ import androidx.compose.runtime.Immutable
  * activity (and therefore the launcher process) started. `avgSpeedMs`
  * is the moving average — total distance divided by the time the
  * device was actually moving (jitter at rest is filtered out at the
- * repository level).
+ * repository level). `currentSpeedMs` is the latest instantaneous
+ * effective speed: the reported fix speed when the GPS chip supplies
+ * one, otherwise the position-derived speed so the hero numeral still
+ * moves on speed-less HALs.
  *
- * Both default to zero so the speed overlay always renders; a fresh
- * subscriber sees `Initial` until the first non-trivial location pair
- * has been observed.
+ * All default to zero so the speed overlay always renders; a fresh
+ * subscriber sees the running total (or `Initial` before the first
+ * non-trivial location pair has been observed).
  */
 @Immutable
 data class TripState(
     val distanceMeters: Double,
     val avgSpeedMs: Double,
+    val currentSpeedMs: Double,
 ) {
     companion object {
-        val Initial: TripState = TripState(distanceMeters = 0.0, avgSpeedMs = 0.0)
+        val Initial: TripState = TripState(distanceMeters = 0.0, avgSpeedMs = 0.0, currentSpeedMs = 0.0)
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import java.time.Clock
 import java.time.Duration
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -21,6 +22,11 @@ internal class WeatherRepository(
     private var cached: WeatherSnapshot? = null
     private var lastFetchLocation: Location? = null
 
+    // Tracks the most recent refresh attempt regardless of outcome so a sustained
+    // outage (cached == null) cannot retry faster than MIN_RETRY_INTERVAL against
+    // the public Open-Meteo endpoint, which would risk a ban.
+    private var lastAttemptAt: Instant? = null
+
     fun snapshotFlow(): Flow<WeatherSnapshot?> =
         flow {
             locationFlow.collect { location ->
@@ -31,6 +37,9 @@ internal class WeatherRepository(
     private suspend fun refresh(location: Location?): WeatherSnapshot? {
         location ?: return null
         if (!shouldRefetch(location)) return cached
+        // Record the attempt before the network call so a failing call still throttles
+        // subsequent outage retries via MIN_RETRY_INTERVAL.
+        lastAttemptAt = clock.instant()
         val response = api.forecast(location.latitude, location.longitude) ?: return cached
         val current = response.current ?: return cached
         cached =
@@ -59,7 +68,12 @@ internal class WeatherRepository(
     }
 
     private fun shouldRefetch(location: Location): Boolean {
-        val snapshot = cached ?: return true
+        val snapshot =
+            cached ?: return lastAttemptAt?.let { attempt ->
+                // No successful cache yet: throttle outage retries so a sustained
+                // failure does not fire once per GPS tick.
+                Duration.between(attempt, clock.instant()).abs() >= MIN_RETRY_INTERVAL
+            } ?: true
         val anchor = lastFetchLocation ?: return true
         val ageOk = Duration.between(snapshot.fetchedAt, clock.instant()).abs() < REFRESH_INTERVAL
         val nearOk = anchor.distanceTo(location) < REFRESH_DISTANCE_M
@@ -102,6 +116,9 @@ internal class WeatherRepository(
 
     private companion object {
         val REFRESH_INTERVAL: Duration = Duration.ofMinutes(30)
+
+        // Floor between outage retries when no successful snapshot exists yet.
+        val MIN_RETRY_INTERVAL: Duration = Duration.ofMinutes(1)
         const val REFRESH_DISTANCE_M = 5_000f
         const val HOURLY_SLICE_LENGTH = 5
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -70,7 +70,11 @@ internal fun SpeedOverlay(
     speedUnit: SpeedUnit,
     modifier: Modifier = Modifier,
 ) {
-    val currentSpeed = location?.speed?.let { speedUnit.fromMetersPerSecond(it).roundToInt() } ?: 0
+    // Source the hero numeral from the trip's effective speed, not
+    // location.speed: cheap GPS chips leave Location.speed at 0.0
+    // (hasSpeed() == false) while moving, which would pin the numeral to
+    // zero. currentSpeedMs falls back to the position-derived speed.
+    val currentSpeed = speedUnit.fromMetersPerSecond(tripState.currentSpeedMs.toFloat()).roundToInt()
     val distance = speedUnit.tripDistanceFromMeters(tripState.distanceMeters)
     val avgSpeed = speedUnit.fromMetersPerSecond(tripState.avgSpeedMs.toFloat()).roundToInt()
     val shortAddress = address?.displayString().orEmpty()
@@ -231,7 +235,7 @@ private fun SpeedOverlayPreview() {
         SpeedOverlay(
             location = null,
             address = ShortAddress(locality = "Minato-ku", region = "Tokyo"),
-            tripState = TripState(distanceMeters = 24_400.0, avgSpeedMs = 11.7),
+            tripState = TripState(distanceMeters = 24_400.0, avgSpeedMs = 11.7, currentSpeedMs = 13.2),
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
         )
     }

--- a/app/src/test/java/io/github/seijikohara/femto/data/TripRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/TripRepositoryTest.kt
@@ -1,0 +1,209 @@
+package io.github.seijikohara.femto.data
+
+import android.location.Location
+import app.cash.turbine.test
+import io.github.seijikohara.femto.testfixtures.fakeLocation
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// Location is an Android type that Robolectric supplies; distanceTo() uses
+// the WGS84 model, so assertions check inequalities / deltas rather than
+// hardcoded metre counts.
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class TripRepositoryTest {
+    @Test
+    fun `accumulates distance over moving fixes`() =
+        runTest {
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 11f, elapsedRealtimeNanos = tenSeconds(1)),
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 2 * STEP,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(2),
+                    ),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix (no previous yet)
+                val afterTwoSteps = awaitItem()
+                assertTrue(afterTwoSteps.distanceMeters > 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `excludes stationary fixes below the moving-speed floor`() =
+        runTest {
+            // Same position, reported speed below MIN_MOVING_SPEED_MS.
+            val flow =
+                flowOf(
+                    fakeLocation(speedMps = 0.1f, elapsedRealtimeNanos = 0L),
+                    fakeLocation(speedMps = 0.1f, elapsedRealtimeNanos = tenSeconds(1)),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix
+                assertEquals(0.0, awaitItem().distanceMeters, 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `drops pairs separated by a gap larger than the max window`() =
+        runTest {
+            // 61 s apart on the boot clock exceeds MAX_GAP_SECONDS (60 s).
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 11f, elapsedRealtimeNanos = 61_000_000_000L),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix
+                assertEquals(0.0, awaitItem().distanceMeters, 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `drops non-positive elapsed-time deltas`() =
+        runTest {
+            // Identical elapsedRealtimeNanos: delta is zero, below MIN_DELTA_SECONDS.
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix
+                assertEquals(0.0, awaitItem().distanceMeters, 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `accrues on speed-less fixes that are actually moving`() =
+        runTest {
+            // hasSpeed = false (Location.hasSpeed() == false) but the positions
+            // differ over elapsed time, so the position-derived speed clears the
+            // floor and distance accrues.
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, hasSpeed = false, elapsedRealtimeNanos = 0L),
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, hasSpeed = false, elapsedRealtimeNanos = tenSeconds(1)),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix
+                assertTrue(awaitItem().distanceMeters > 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `uses elapsed-realtime not wall clock for the delta`() =
+        runTest {
+            // timeMs jumps backward (a mid-trip NTP correction) while the boot
+            // clock advances normally. If the delta used Location.time it would
+            // be negative and accrual would be skipped; using elapsedRealtimeNanos
+            // it stays positive and distance accrues.
+            val flow =
+                flowOf(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT,
+                        speedMps = 11f,
+                        timeMs = 10_000_000L,
+                        elapsedRealtimeNanos = 0L,
+                    ),
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + STEP,
+                        speedMps = 11f,
+                        timeMs = 5_000_000L,
+                        elapsedRealtimeNanos = tenSeconds(1),
+                    ),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix
+                assertTrue(awaitItem().distanceMeters > 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `persists distance across re-subscription`() =
+        runTest {
+            val source = MutableSharedFlow<Location?>(replay = 0)
+            val repository = TripRepository(source)
+
+            // First subscription: feed two moving fixes, capture the running total,
+            // then cancel the collection (simulating a WhileSubscribed stop).
+            var accumulated = 0.0
+            repository.stateFlow().test {
+                assertEquals(0.0, awaitItem().distanceMeters, 0.0) // initial snapshot
+                source.emit(fakeLocation(latitude = ORIGIN_LAT, speedMps = 11f, elapsedRealtimeNanos = 0L))
+                awaitItem()
+                source.emit(
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 11f, elapsedRealtimeNanos = tenSeconds(1)),
+                )
+                accumulated = awaitItem().distanceMeters
+                assertTrue(accumulated > 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            // Second subscription: the first re-emission must carry the previously
+            // accumulated total, not 0, and continue accruing from there.
+            repository.stateFlow().test {
+                val replayed = awaitItem()
+                assertEquals(accumulated, replayed.distanceMeters, 0.0)
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 2 * STEP,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(2),
+                    ),
+                )
+                assertTrue(awaitItem().distanceMeters > accumulated)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `publishes the effective speed as currentSpeedMs`() =
+        runTest {
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, speedMps = 9.5f, elapsedRealtimeNanos = 0L),
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 9.5f, elapsedRealtimeNanos = tenSeconds(1)),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix
+                // Reported speed wins when the fix has one (hasSpeed default true).
+                assertEquals(9.5, awaitItem().currentSpeedMs, 0.0001)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    private companion object {
+        const val ORIGIN_LAT = 35.6580
+
+        // ~0.001 deg latitude ≈ 111 m; over 10 s that is ~11 m/s, well above
+        // the moving-speed floor.
+        const val STEP = 0.001
+
+        // n * 10 s expressed in boot-clock nanoseconds.
+        fun tenSeconds(n: Long): Long = n * 10_000_000_000L
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.data
 
 import app.cash.turbine.test
 import io.github.seijikohara.femto.testfixtures.fakeLocation
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -14,8 +15,10 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -146,6 +149,82 @@ class WeatherRepositoryTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    @Test
+    fun `throttles outage retries within the minimum retry interval to a single request`() =
+        runTest {
+            // Sustained outage: every forecast call fails.
+            server.enqueue(MockResponse().setResponseCode(500))
+            server.enqueue(MockResponse().setResponseCode(500))
+
+            val clock = MutableClock(Instant.parse("2026-05-01T05:32:00Z"))
+            val repo =
+                WeatherRepository(
+                    api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
+                    // Second emit lands well inside MIN_RETRY_INTERVAL (one minute).
+                    locationFlow = flow {
+                        emit(fakeLocation())
+                        clock.advanceBy(Duration.ofSeconds(10))
+                        emit(fakeLocation())
+                    },
+                    clock = clock,
+                )
+
+            repo.snapshotFlow().test {
+                assertNull(awaitItem())
+                // The throttled second emit re-emits the still-null snapshot.
+                assertNull(awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            // Only the first attempt hit the network; the second was throttled.
+            assertEquals(1, server.requestCount)
+        }
+
+    @Test
+    fun `retries after the minimum retry interval elapses during an outage`() =
+        runTest {
+            server.enqueue(MockResponse().setResponseCode(500))
+            server.enqueue(MockResponse().setResponseCode(500))
+
+            val clock = MutableClock(Instant.parse("2026-05-01T05:32:00Z"))
+            val repo =
+                WeatherRepository(
+                    api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
+                    // Second emit lands just past MIN_RETRY_INTERVAL, so the retry fires.
+                    locationFlow = flow {
+                        emit(fakeLocation())
+                        clock.advanceBy(Duration.ofSeconds(61))
+                        emit(fakeLocation())
+                    },
+                    clock = clock,
+                )
+
+            repo.snapshotFlow().test {
+                assertNull(awaitItem())
+                assertNull(awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            assertEquals(2, server.requestCount)
+        }
+
+    // Mutable clock whose instant the test advances explicitly to exercise the
+    // outage-retry throttle without real-time waits.
+    private class MutableClock(
+        private var now: Instant,
+        private val zone: ZoneId = ZoneOffset.UTC,
+    ) : Clock() {
+        fun advanceBy(amount: Duration) {
+            now = now.plus(amount)
+        }
+
+        override fun getZone(): ZoneId = zone
+
+        override fun withZone(zone: ZoneId): Clock = MutableClock(now, zone)
+
+        override fun instant(): Instant = now
+    }
 
     private companion object {
         // current.time aligns with hourly.time[2] so the slice should start at index 2.

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeLocation.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeLocation.kt
@@ -7,12 +7,20 @@ internal fun fakeLocation(
     longitude: Double = 139.7016,
     speedMps: Float = 0f,
     altitudeM: Double = 47.0,
+    timeMs: Long = 0L,
+    elapsedRealtimeNanos: Long = 0L,
+    // When false, the fix carries no speed (Location.hasSpeed() == false),
+    // mirroring cheap GPS chips and raw GPS_PROVIDER HALs.
+    hasSpeed: Boolean = true,
 ): Location =
     Location("test").apply {
         this.latitude = latitude
         this.longitude = longitude
-        this.speed = speedMps
         this.altitude = altitudeM
-        this.time = 0L
-        this.elapsedRealtimeNanos = 0L
+        this.time = timeMs
+        this.elapsedRealtimeNanos = elapsedRealtimeNanos
+        // setSpeed flips hasSpeed() to true; removeSpeed() clears it. Only
+        // set a speed when the caller asks for one so the speed-less path
+        // stays exercisable.
+        if (hasSpeed) this.speed = speedMps else removeSpeed()
     }

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeTripState.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeTripState.kt
@@ -5,8 +5,10 @@ import io.github.seijikohara.femto.data.TripState
 internal fun fakeTripState(
     distanceMeters: Double = 24_400.0,
     avgSpeedMs: Double = 11.7,
+    currentSpeedMs: Double = 0.0,
 ): TripState =
     TripState(
         distanceMeters = distanceMeters,
         avgSpeedMs = avgSpeedMs,
+        currentSpeedMs = currentSpeedMs,
     )


### PR DESCRIPTION
## Summary

Phase 2 (data layer) of the completeness roadmap — **live-data correctness**.
Two surfaces that looked functional but fed the UI zeroed or storm-retried data.

## TripRepository (tasks 2.2, 2.3, 5.8)

- **Persistence**: the accumulators move from the cold `flow {}` body to instance
  fields, so the running total survives the `stateIn(WhileSubscribed(5_000))`
  stop/restart that happens ~5 s after the head unit foregrounds another app.
  Distance no longer silently resets to 0. The window now gates only UI delivery.
- **Speed-less GPS**: accrual is gated on an *effective speed* — the chip's
  reported speed when `hasSpeed()`, else a position-derived speed — so cheap GPS
  chips / raw `GPS_PROVIDER` HALs still register distance and average.
- **Monotonic clock**: the time delta is taken from `elapsedRealtimeNanos`, not
  the wall clock, so a mid-trip NTP/system-clock correction can't corrupt it.
- `TripState.currentSpeedMs` carries the instantaneous effective speed;
  `SpeedOverlay`'s hero numeral reads it instead of `location.speed`.

## WeatherRepository (task 2.4)

- A `MIN_RETRY_INTERVAL` (1 min) throttle on `lastAttemptAt` stops a sustained
  Open-Meteo outage from firing one request per ~1 Hz GPS tick against the public
  endpoint (ban risk). Happy path unchanged (first fetch fires; success still
  gates by 30 min / 5 km).

## Tests

- `TripRepositoryTest` — 8 cases: accumulation, stationary exclusion, gap drop,
  non-positive delta, **speed-less accrual**, **monotonic-clock delta**,
  **persistence across re-subscription**, currentSpeedMs.
- `WeatherRepositoryTest` — 2 new cases: outage retries throttled to one request
  within the interval; a retry fires after the interval elapses.

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green (15 JVM tests in the two suites pass).