### PR TITLE
feat: live music card (MediaController.Callback + progress ticker + paused sessions)

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicCardTest.kt
@@ -32,6 +32,21 @@ class MusicCardTest {
     }
 
     @Test
+    fun keeps_paused_session_on_screen_instead_of_collapsing_to_empty() {
+        rule.setContent {
+            FemtoTheme {
+                MusicCard(
+                    state = MusicCardState.Playing(fakeNowPlaying(isPlaying = false)),
+                    onCommand = {},
+                    onConnect = {},
+                )
+            }
+        }
+        rule.onNodeWithText("Strobe").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Play / pause").assertIsDisplayed()
+    }
+
+    @Test
     fun renders_connect_cta_and_dispatches_when_permission_missing() {
         var tapped = false
         rule.setContent {

--- a/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
@@ -53,9 +53,7 @@ internal class MusicSessionRepository(
     fun send(command: MusicCommand) {
         val controller =
             runCatching {
-                sessionManager
-                    .getActiveSessions(componentName)
-                    .firstOrNull { it.playbackState?.isActive() == true }
+                selectPrimaryController(sessionManager.getActiveSessions(componentName))
             }.getOrNull() ?: return
         val transport = controller.transportControls
         when (command) {
@@ -99,18 +97,56 @@ internal class MusicSessionRepository(
 
     private fun activeControllersFlow(): Flow<List<MediaController>> =
         callbackFlow {
-            val callback =
+            // The OnActiveSessionsChangedListener only fires when the SET of
+            // sessions changes, so on its own the flow is a one-shot snapshot:
+            // progress, play/pause, and in-session metadata never update. We
+            // additionally register a MediaController.Callback on the primary
+            // controller and re-send the latest controller list on every live
+            // change, so the downstream combine recomputes toNowPlaying.
+            var current: List<MediaController> = emptyList()
+            var watched: MediaController? = null
+            val watcher =
+                object : MediaController.Callback() {
+                    override fun onPlaybackStateChanged(state: PlaybackState?) {
+                        trySend(current)
+                    }
+
+                    override fun onMetadataChanged(metadata: MediaMetadata?) {
+                        trySend(current)
+                    }
+
+                    override fun onSessionDestroyed() {
+                        trySend(current)
+                    }
+                }
+
+            fun rewatch(controllers: List<MediaController>) {
+                current = controllers
+                val next = selectPrimaryController(controllers)
+                // Re-register only when the active controller changes; unregister
+                // the previous one first so we never leak a stale callback.
+                if (next !== watched) {
+                    runCatching { watched?.unregisterCallback(watcher) }
+                    watched = next
+                    runCatching { watched?.registerCallback(watcher) }
+                }
+            }
+
+            val sessionsListener =
                 MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
-                    trySend(controllers.orEmpty())
+                    rewatch(controllers.orEmpty())
+                    trySend(current)
                 }
 
             runCatching {
-                trySend(sessionManager.getActiveSessions(componentName))
-                sessionManager.addOnActiveSessionsChangedListener(callback, componentName)
+                rewatch(sessionManager.getActiveSessions(componentName))
+                trySend(current)
+                sessionManager.addOnActiveSessionsChangedListener(sessionsListener, componentName)
             }.onFailure { trySend(emptyList()) }
 
             awaitClose {
-                runCatching { sessionManager.removeOnActiveSessionsChangedListener(callback) }
+                runCatching { watched?.unregisterCallback(watcher) }
+                runCatching { sessionManager.removeOnActiveSessionsChangedListener(sessionsListener) }
             }
         }
 
@@ -118,21 +154,48 @@ internal class MusicSessionRepository(
         context.packageName in NotificationManagerCompat.getEnabledListenerPackages(context)
 
     private fun List<MediaController>.toNowPlaying(): NowPlaying? =
-        firstOrNull { it.playbackState?.isActive() == true }
+        selectPrimaryController(this)
             ?.let { controller ->
                 val metadata = controller.metadata ?: return@let null
+                val playbackState = controller.playbackState
                 NowPlaying(
-                    title = metadata.getString(MediaMetadata.METADATA_KEY_TITLE).orEmpty(),
+                    // METADATA_KEY_TITLE is empty for many podcast / radio / stream
+                    // sessions; fall back to the display title and finally the source
+                    // label so the 23sp title line is never blank.
+                    title =
+                        metadata.getString(MediaMetadata.METADATA_KEY_TITLE)?.takeIf { it.isNotBlank() }
+                            ?: metadata.getString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE)?.takeIf { it.isNotBlank() }
+                            ?: sourceLabel(controller.packageName),
                     artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST),
                     albumArt = metadata.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)?.asImageBitmap(),
-                    isPlaying = controller.playbackState?.state == PlaybackState.STATE_PLAYING,
-                    positionMs = controller.playbackState?.position ?: 0L,
+                    // A paused controller renders with isPlaying=false (Play icon,
+                    // resumable), but stays on screen via selectPrimaryController.
+                    isPlaying = playbackState?.state == PlaybackState.STATE_PLAYING,
+                    positionMs = playbackState?.position ?: 0L,
                     durationMs = metadata.getLong(MediaMetadata.METADATA_KEY_DURATION),
                     packageName = controller.packageName,
+                    playbackSpeed = playbackState?.playbackSpeed ?: 1f,
+                    positionUpdateTimeMs = playbackState?.lastPositionUpdateTime ?: 0L,
                 )
             }
 
     private companion object {
         const val ENABLED_NOTIFICATION_LISTENERS = "enabled_notification_listeners"
+
+        /**
+         * Return `true` when the state is PLAYING or PAUSED. A paused session is
+         * still resumable and must stay on the card, so the plain [isActive] check
+         * (which excludes STATE_PAUSED) is not enough here.
+         */
+        private fun PlaybackState?.isPlayingOrPaused(): Boolean =
+            this != null && (isActive() || state == PlaybackState.STATE_PAUSED)
+
+        /**
+         * Pick the highest-priority controller that is playing or paused.
+         * [MediaSessionManager.getActiveSessions] is priority-ordered, so the
+         * first match is the session the user is most likely interacting with.
+         */
+        private fun selectPrimaryController(controllers: List<MediaController>): MediaController? =
+            controllers.firstOrNull { it.playbackState.isPlayingOrPaused() }
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/NowPlaying.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/NowPlaying.kt
@@ -10,4 +10,26 @@ internal data class NowPlaying(
     val positionMs: Long,
     val durationMs: Long,
     val packageName: String,
+    val playbackSpeed: Float = 1f,
+    /**
+     * `SystemClock.elapsedRealtime()` basis captured from
+     * [android.media.session.PlaybackState.getLastPositionUpdateTime]. The UI
+     * interpolates the live position by adding the elapsed wall-clock time since
+     * this basis (scaled by [playbackSpeed]) to [positionMs] while playing.
+     */
+    val positionUpdateTimeMs: Long = 0L,
 )
+
+/**
+ * Map a media-session package name to a human-readable source label. This is the
+ * SSOT shared by the repository (title fallback for blank-title sessions) and the
+ * music card eyebrow, so the two never drift apart.
+ */
+internal fun sourceLabel(packageName: String): String =
+    when {
+        packageName.contains("spotify", ignoreCase = true) -> "Spotify"
+        packageName.contains("apple", ignoreCase = true) -> "Apple Music"
+        packageName.contains("youtube", ignoreCase = true) -> "YouTube Music"
+        packageName.contains("amazon", ignoreCase = true) -> "Amazon Music"
+        else -> "Now playing"
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.ui.home.components
 
+import android.os.SystemClock
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -21,6 +22,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,11 +48,13 @@ import com.composables.icons.lucide.SkipBack
 import com.composables.icons.lucide.SkipForward
 import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.data.NowPlaying
+import io.github.seijikohara.femto.data.sourceLabel
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.TabularFigures
 import io.github.seijikohara.femto.ui.theme.sectionLabel
+import kotlinx.coroutines.delay
 
 /**
  * Transport commands the dashboard can dispatch to the music session.
@@ -112,7 +117,13 @@ private fun PlayingState(
         title = nowPlaying.title,
         artist = nowPlaying.artist,
     )
-    Progress(positionMs = nowPlaying.positionMs, durationMs = nowPlaying.durationMs)
+    Progress(
+        positionMs = nowPlaying.positionMs,
+        durationMs = nowPlaying.durationMs,
+        positionUpdateTimeMs = nowPlaying.positionUpdateTimeMs,
+        isPlaying = nowPlaying.isPlaying,
+        playbackSpeed = nowPlaying.playbackSpeed,
+    )
     TransportRow(isPlaying = nowPlaying.isPlaying, onCommand = onCommand)
 }
 
@@ -220,10 +231,39 @@ private fun Meta(
 private fun Progress(
     positionMs: Long,
     durationMs: Long,
+    positionUpdateTimeMs: Long,
+    isPlaying: Boolean,
+    playbackSpeed: Float,
 ) {
+    // Interpolate the displayed position from the PlaybackState basis while
+    // playing, so the bar and elapsed label advance smoothly without waiting for
+    // the next session callback. Held at positionMs when paused.
+    val livePosition by
+        produceState(
+            initialValue = positionMs.coerceIn(0L, durationMs.coerceAtLeast(0L)),
+            positionMs,
+            positionUpdateTimeMs,
+            isPlaying,
+            playbackSpeed,
+            durationMs,
+        ) {
+            val maxMs = durationMs.coerceAtLeast(0L)
+            // Hold the reported position when paused, or when the session gives no
+            // valid update-time basis (a 0 basis would interpolate from boot and
+            // snap the bar to the end).
+            if (!isPlaying || positionUpdateTimeMs <= 0L) {
+                value = positionMs.coerceIn(0L, maxMs)
+                return@produceState
+            }
+            while (true) {
+                val elapsed = SystemClock.elapsedRealtime() - positionUpdateTimeMs
+                value = (positionMs + (elapsed * playbackSpeed)).toLong().coerceIn(0L, maxMs)
+                delay(500L)
+            }
+        }
     val fraction =
         if (durationMs > 0L) {
-            (positionMs.toFloat() / durationMs).coerceIn(0f, 1f)
+            (livePosition.toFloat() / durationMs).coerceIn(0f, 1f)
         } else {
             0f
         }
@@ -233,7 +273,7 @@ private fun Progress(
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Text(
-            text = formatMillis(positionMs),
+            text = formatMillis(livePosition),
             style =
                 MaterialTheme.typography.labelSmall.copy(
                     fontSize = 11.sp,
@@ -422,15 +462,6 @@ private fun EmptyState() =
             modifier = Modifier.widthIn(max = 280.dp),
         )
         Box(modifier = Modifier.weight(0.9f))
-    }
-
-private fun sourceLabel(packageName: String): String =
-    when {
-        packageName.contains("spotify", ignoreCase = true) -> "Spotify"
-        packageName.contains("apple", ignoreCase = true) -> "Apple Music"
-        packageName.contains("youtube", ignoreCase = true) -> "YouTube Music"
-        packageName.contains("amazon", ignoreCase = true) -> "Amazon Music"
-        else -> "Now playing"
     }
 
 private fun formatMillis(ms: Long): String {


### PR DESCRIPTION
## Summary

Phase 2/4 of the completeness roadmap — **music card completeness** (tasks 2.1 +
4.4). The card looked functional but fed the UI a frozen snapshot.

## Changes

- **Live updates (2.1)**: register a `MediaController.Callback` on the primary
  controller (in addition to the existing `OnActiveSessionsChangedListener`) and
  re-send the controller list on `onPlaybackStateChanged` / `onMetadataChanged` /
  `onSessionDestroyed`, so progress, the play/pause icon, and in-session track /
  album-art changes update live. Re-registers on controller change; unregisters
  both callbacks on close.
- **Paused sessions (4.4)**: a shared `selectPrimaryController` picks the
  highest-priority PLAYING-or-PAUSED controller in both the display and command
  paths, so a paused track stays on screen (Play icon, resume works) instead of
  collapsing to "Nothing is playing".
- **Title fallback (4.4)**: `METADATA_KEY_TITLE` → `DISPLAY_TITLE` → source label,
  so podcast / radio / stream sessions never render a blank title line.
- **Progress ticker (2.1)**: `Progress` interpolates the displayed position from
  the `PlaybackState` basis (`lastPositionUpdateTime` + `playbackSpeed`) on a 500ms
  tick while playing, holding the reported position when paused or when the session
  gives no valid update-time basis.

## Tests

- Compose `MusicCardTest` gains a paused-session case (stays on screen, shows the
  Play/pause control). The `MediaController`/`MediaSessionManager` wiring has no
  meaningful Robolectric shadow, so the repository change is covered by compile +
  review (consistent with the area having no prior JVM tests).

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green.