### PR TITLE
feat: dashboard always renders + app-drawer Loading/Content/Error states

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeAppEntry.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeAppEntry.kt
@@ -1,0 +1,23 @@
+package io.github.seijikohara.femto.testfixtures
+
+import android.content.ComponentName
+import android.graphics.Bitmap
+import io.github.seijikohara.femto.data.AppEntry
+
+/**
+ * Build an [AppEntry] for UI tests with a 1x1 placeholder icon.
+ *
+ * The icon never renders meaningfully at 1x1 — tests assert on the
+ * label and the resolved [ComponentName], not on pixels — so the
+ * smallest valid [Bitmap] keeps allocation negligible per entry.
+ */
+internal fun fakeAppEntry(
+    packageName: String = "com.example.app",
+    className: String = ".MainActivity",
+    label: String = "Example",
+): AppEntry =
+    AppEntry(
+        componentName = ComponentName(packageName, className),
+        label = label,
+        icon = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888),
+    )

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
@@ -1,0 +1,76 @@
+package io.github.seijikohara.femto.ui.drawer
+
+import android.content.ComponentName
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.github.seijikohara.femto.testfixtures.fakeAppEntry
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class AppDrawerScreenTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun loading_renders_progress_indicator() {
+        rule.setContent {
+            FemtoTheme {
+                AppDrawerScreen(uiState = AppDrawerUiState.Loading, onLaunch = {}, onRetry = {})
+            }
+        }
+        rule.onNodeWithTag(APP_DRAWER_PROGRESS_TEST_TAG).assertIsDisplayed()
+    }
+
+    @Test
+    fun content_renders_tiles_and_dispatches_component_name_on_tap() {
+        var launched: ComponentName? = null
+        val maps = fakeAppEntry(packageName = "com.maps", className = ".Main", label = "Maps")
+        rule.setContent {
+            FemtoTheme {
+                AppDrawerScreen(
+                    uiState = AppDrawerUiState.Content(listOf(maps)),
+                    onLaunch = { launched = it },
+                    onRetry = {},
+                )
+            }
+        }
+        rule.onNodeWithText("Maps").assertIsDisplayed().performClick()
+        assertEquals(maps.componentName, launched)
+    }
+
+    @Test
+    fun empty_content_shows_no_apps_message() {
+        rule.setContent {
+            FemtoTheme {
+                AppDrawerScreen(
+                    uiState = AppDrawerUiState.Content(emptyList()),
+                    onLaunch = {},
+                    onRetry = {},
+                )
+            }
+        }
+        rule.onNodeWithText("No apps installed").assertIsDisplayed()
+    }
+
+    @Test
+    fun error_shows_retry_and_dispatches_on_tap() {
+        var retried = false
+        rule.setContent {
+            FemtoTheme {
+                AppDrawerScreen(
+                    uiState = AppDrawerUiState.Error,
+                    onLaunch = {},
+                    onRetry = { retried = true },
+                )
+            }
+        }
+        rule.onNodeWithText("Couldn't load apps").assertIsDisplayed()
+        rule.onNodeWithText("Retry").assertIsDisplayed().performClick()
+        assert(retried)
+    }
+}

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
@@ -31,7 +31,6 @@ class DashboardScaffoldTest {
         // music, and footer panels carry the stable assertions instead.
         val uiState =
             HomeUiState.Initial.copy(
-                isLoading = false,
                 clock = ClockTick(LocalTime.of(14, 32), LocalDate.of(2026, 5, 1)),
                 location = null,
                 address = fakeAddress(),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerRoute.kt
@@ -5,12 +5,12 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.data.AppsRepository
 
 @Composable
@@ -20,10 +20,21 @@ internal fun AppDrawerRoute(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    var apps by remember { mutableStateOf<List<AppEntry>>(emptyList()) }
-    LaunchedEffect(Unit) {
-        apps = runCatching { AppsRepository(context).queryApps() }.getOrDefault(emptyList())
+    var uiState by remember { mutableStateOf<AppDrawerUiState>(AppDrawerUiState.Loading) }
+    // Bumping the retry key both re-runs the query and flips the surface
+    // back to Loading, so a retry shows progress instead of stale Error.
+    var retryKey by remember { mutableIntStateOf(0) }
+    LaunchedEffect(retryKey) {
+        uiState = AppDrawerUiState.Loading
+        runCatching { AppsRepository(context).queryApps() }
+            .onSuccess { apps -> uiState = AppDrawerUiState.Content(apps) }
+            .onFailure { uiState = AppDrawerUiState.Error }
     }
     BackHandler(onBack = onBack)
-    AppDrawerScreen(apps = apps, onLaunch = onLaunch, modifier = modifier)
+    AppDrawerScreen(
+        uiState = uiState,
+        onLaunch = onLaunch,
+        onRetry = { retryKey++ },
+        modifier = modifier,
+    )
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -1,33 +1,71 @@
 package io.github.seijikohara.femto.ui.drawer
 
 import android.content.ComponentName
+import android.graphics.Bitmap
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.ui.home.components.AppTile
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 
 private val MinTileWidth = 96.dp
 
+internal const val APP_DRAWER_PROGRESS_TEST_TAG = "app-drawer-progress"
+
 @Composable
 internal fun AppDrawerScreen(
-    apps: List<AppEntry>,
+    uiState: AppDrawerUiState,
     onLaunch: (ComponentName) -> Unit,
+    onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier.fillMaxSize(),
     color = MaterialTheme.colorScheme.background,
 ) {
+    when (uiState) {
+        AppDrawerUiState.Loading -> LoadingState()
+        is AppDrawerUiState.Content -> ContentState(apps = uiState.apps, onLaunch = onLaunch)
+        AppDrawerUiState.Error -> ErrorState(onRetry = onRetry)
+    }
+}
+
+@Composable
+private fun LoadingState(modifier: Modifier = Modifier) =
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator(modifier = Modifier.testTag(APP_DRAWER_PROGRESS_TEST_TAG))
+    }
+
+@Composable
+private fun ContentState(
+    apps: List<AppEntry>,
+    onLaunch: (ComponentName) -> Unit,
+    modifier: Modifier = Modifier,
+) = if (apps.isEmpty()) {
+    CenteredMessage(text = "No apps installed", modifier = modifier)
+} else {
     LazyVerticalGrid(
+        modifier = modifier,
         columns = GridCells.Adaptive(minSize = MinTileWidth),
         contentPadding = PaddingValues(FemtoDimens.ScreenPadding),
         horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
@@ -36,5 +74,73 @@ internal fun AppDrawerScreen(
         items(items = apps, key = { it.componentName.flattenToString() }) { entry ->
             AppTile(entry = entry, onClick = { onLaunch(entry.componentName) })
         }
+    }
+}
+
+@Composable
+private fun ErrorState(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier = modifier.fillMaxSize().padding(FemtoDimens.ScreenPadding),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center,
+) {
+    Text(
+        text = "Couldn't load apps",
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onBackground,
+        textAlign = TextAlign.Center,
+        fontSize = FemtoDimens.MinBodyTextSize,
+    )
+    Button(
+        onClick = onRetry,
+        modifier =
+            Modifier
+                .padding(top = FemtoDimens.GridGutter)
+                .defaultMinSize(
+                    minWidth = FemtoDimens.MinTouchTarget,
+                    minHeight = FemtoDimens.MinTouchTarget,
+                ),
+    ) {
+        Text(text = "Retry", fontSize = FemtoDimens.MinBodyTextSize)
+    }
+}
+
+@Composable
+private fun CenteredMessage(
+    text: String,
+    modifier: Modifier = Modifier,
+) = Box(
+    modifier = modifier.fillMaxSize().padding(FemtoDimens.ScreenPadding),
+    contentAlignment = Alignment.Center,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onBackground,
+        textAlign = TextAlign.Center,
+        fontSize = FemtoDimens.MinBodyTextSize,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun AppDrawerContentPreview() {
+    val icon = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+    FemtoTheme {
+        AppDrawerScreen(
+            uiState =
+                AppDrawerUiState.Content(
+                    apps =
+                        listOf(
+                            AppEntry(ComponentName("com.maps", ".Main"), "Maps", icon),
+                            AppEntry(ComponentName("com.music", ".Main"), "Music", icon),
+                            AppEntry(ComponentName("com.phone", ".Main"), "Phone", icon),
+                        ),
+                ),
+            onLaunch = {},
+            onRetry = {},
+        )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerUiState.kt
@@ -1,0 +1,23 @@
+package io.github.seijikohara.femto.ui.drawer
+
+import io.github.seijikohara.femto.data.AppEntry
+
+/**
+ * Render state for the app drawer.
+ *
+ * [Content] with an empty [Content.apps] list is the legitimate
+ * "no apps installed" case — it is distinct from [Loading], which
+ * means the query has not finished yet, and from [Error], which means
+ * the query failed. The drawer surface previously collapsed all three
+ * into a blank grid, leaving the user unable to tell a slow or failed
+ * query from a genuinely empty device.
+ */
+internal sealed interface AppDrawerUiState {
+    data object Loading : AppDrawerUiState
+
+    data class Content(
+        val apps: List<AppEntry>,
+    ) : AppDrawerUiState
+
+    data object Error : AppDrawerUiState
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -1,13 +1,10 @@
 package io.github.seijikohara.femto.ui.home
 
 import android.text.format.DateFormat
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import io.github.seijikohara.femto.ui.home.components.DashboardScaffold
@@ -25,30 +22,15 @@ internal fun HomeScreen(
     modifier = modifier.fillMaxSize(),
     color = MaterialTheme.colorScheme.background,
 ) {
-    if (uiState.isLoading) {
-        LoadingPlaceholder(modifier = Modifier.fillMaxSize())
-    } else {
-        val is24Hour = DateFormat.is24HourFormat(LocalContext.current)
-        DashboardScaffold(
-            uiState = uiState,
-            is24Hour = is24Hour,
-            speedUnit = speedUnitFor(),
-            temperatureUnit = temperatureUnitFor(),
-            onAction = onAction,
-            modifier = Modifier.fillMaxSize(),
-        )
-    }
+    DashboardScaffold(
+        uiState = uiState,
+        is24Hour = DateFormat.is24HourFormat(LocalContext.current),
+        speedUnit = speedUnitFor(),
+        temperatureUnit = temperatureUnitFor(),
+        onAction = onAction,
+        modifier = Modifier.fillMaxSize(),
+    )
 }
-
-@Composable
-private fun LoadingPlaceholder(modifier: Modifier = Modifier) =
-    Box(modifier = modifier, contentAlignment = Alignment.Center) {
-        Text(
-            text = "Loading",
-            style = MaterialTheme.typography.titleLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
 
 @PreviewLightDark
 @Composable

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeUiState.kt
@@ -2,7 +2,6 @@ package io.github.seijikohara.femto.ui.home
 
 import android.location.Location
 import androidx.compose.runtime.Immutable
-import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.data.CalendarSnapshot
 import io.github.seijikohara.femto.data.ClockTick
 import io.github.seijikohara.femto.data.MusicCardState
@@ -15,8 +14,6 @@ import java.time.LocalTime
 
 @Immutable
 internal data class HomeUiState(
-    val isLoading: Boolean,
-    val apps: List<AppEntry>,
     val clock: ClockTick,
     val location: Location?,
     val address: ShortAddress?,
@@ -29,8 +26,6 @@ internal data class HomeUiState(
     companion object {
         val Initial: HomeUiState =
             HomeUiState(
-                isLoading = true,
-                apps = emptyList(),
                 clock = ClockTick(LocalTime.of(0, 0), LocalDate.now()),
                 location = null,
                 address = null,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -8,8 +8,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import io.github.seijikohara.femto.BuildConfig
-import io.github.seijikohara.femto.data.AppEntry
-import io.github.seijikohara.femto.data.AppsRepository
 import io.github.seijikohara.femto.data.CalendarRepository
 import io.github.seijikohara.femto.data.CalendarSnapshot
 import io.github.seijikohara.femto.data.ClockRepository
@@ -30,14 +28,12 @@ import io.github.seijikohara.femto.data.WeatherSnapshot
 import io.github.seijikohara.femto.ui.home.components.MusicCommand
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import java.util.Locale
 
@@ -47,7 +43,6 @@ internal class HomeViewModel(
     private val addressFlow: Flow<ShortAddress?>,
     private val weatherFlow: Flow<WeatherSnapshot?>,
     private val musicStateFlow: Flow<MusicCardState>,
-    private val appsFlow: MutableStateFlow<List<AppEntry>>,
     private val calendarFlow: Flow<CalendarSnapshot?>,
     private val systemStatusFlow: Flow<SystemStatus>,
     private val tripStateFlow: Flow<TripState>,
@@ -60,7 +55,6 @@ internal class HomeViewModel(
             addressFlow,
             weatherFlow,
             musicStateFlow,
-            appsFlow,
             calendarFlow,
             systemStatusFlow,
             tripStateFlow,
@@ -81,19 +75,14 @@ internal class HomeViewModel(
             val music = values[4] as MusicCardState
 
             @Suppress("UNCHECKED_CAST")
-            val apps = values[5] as List<AppEntry>
+            val calendar = values[5] as CalendarSnapshot?
 
             @Suppress("UNCHECKED_CAST")
-            val calendar = values[6] as CalendarSnapshot?
+            val systemStatus = values[6] as SystemStatus
 
             @Suppress("UNCHECKED_CAST")
-            val systemStatus = values[7] as SystemStatus
-
-            @Suppress("UNCHECKED_CAST")
-            val tripState = values[8] as TripState
+            val tripState = values[7] as TripState
             HomeUiState(
-                isLoading = apps.isEmpty(),
-                apps = apps,
                 clock = clock,
                 location = location,
                 address = address,
@@ -177,8 +166,6 @@ internal class HomeViewModelFactory(
         val weatherApi = OpenMeteoApi(client = httpClient)
         val weather = WeatherRepository(weatherApi, locationFlow)
         val music = MusicSessionRepository(application)
-        val apps = MutableStateFlow<List<AppEntry>>(emptyList())
-        val appsRepo = AppsRepository(application)
         val calendar = CalendarRepository(application, clockFlow)
         val systemStatus = SystemStatusRepository(application)
         val trip = TripRepository(locationFlow)
@@ -190,15 +177,10 @@ internal class HomeViewModelFactory(
             addressFlow = geocoder.addressFlow(),
             weatherFlow = weather.snapshotFlow(),
             musicStateFlow = music.stateFlow(),
-            appsFlow = apps,
             calendarFlow = calendar.snapshotFlow(),
             systemStatusFlow = systemStatus.statusFlow(),
             tripStateFlow = trip.stateFlow(),
             sendMusicCommand = music::send,
-        ).also { vm ->
-            vm.viewModelScope.launch {
-                apps.value = runCatching { appsRepo.queryApps() }.getOrDefault(emptyList())
-            }
-        } as T
+        ) as T
     }
 }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -2,9 +2,7 @@ package io.github.seijikohara.femto.ui.home
 
 import android.content.ComponentName
 import android.content.Intent
-import android.graphics.Bitmap
 import app.cash.turbine.test
-import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.data.ClockTick
 import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.testfixtures.fakeAddress
@@ -17,7 +15,6 @@ import io.github.seijikohara.femto.ui.home.components.AppsBarShortcut
 import io.github.seijikohara.femto.ui.home.components.MusicCommand
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -53,7 +50,6 @@ class HomeViewModelTest {
     @Test
     fun `combines all flows into one HomeUiState`() =
         runTest {
-            val placeholderIcon = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
             val calendar = fakeCalendarSnapshot()
             val systemStatus = fakeSystemStatus()
             val tripState = fakeTripState()
@@ -64,16 +60,6 @@ class HomeViewModelTest {
                     addressFlow = flowOf(fakeAddress()),
                     weatherFlow = flowOf(fakeWeatherSnapshot()),
                     musicStateFlow = flowOf(MusicCardState.Playing(fakeNowPlaying())),
-                    appsFlow =
-                        MutableStateFlow(
-                            listOf(
-                                AppEntry(
-                                    componentName = android.content.ComponentName("p", "c"),
-                                    label = "X",
-                                    icon = placeholderIcon,
-                                ),
-                            ),
-                        ),
                     calendarFlow = flowOf(calendar),
                     systemStatusFlow = flowOf(systemStatus),
                     tripStateFlow = flowOf(tripState),
@@ -170,7 +156,6 @@ class HomeViewModelTest {
             addressFlow = emptyFlow(),
             weatherFlow = emptyFlow(),
             musicStateFlow = emptyFlow(),
-            appsFlow = MutableStateFlow(emptyList()),
             calendarFlow = emptyFlow(),
             systemStatusFlow = emptyFlow(),
             tripStateFlow = emptyFlow(),


### PR DESCRIPTION
## Summary

Phase 2 (UI) of the completeness roadmap — decouple the dashboard from the apps
list and give the drawer real states.

## Dashboard (task 2.5)

`uiState.apps` was never read by the dashboard tree, yet `isLoading =
apps.isEmpty()` hid the **entire** dashboard behind a "Loading" placeholder when
the app query failed or the device had zero launchable apps.

- Removed the dead `apps`/`isLoading` fields from `HomeUiState`, the `appsFlow`
  slot from `HomeViewModel` (combine drops 9 → 8 flows), and the
  `AppsRepository`/`queryApps` block from the factory. `HomeScreen` always renders
  `DashboardScaffold`; the splash screen covers the first frame while flows stream
  in. App loading now lives solely in the drawer, which already queried
  independently.

## App drawer (task 2.6)

- New sealed `AppDrawerUiState` (`Loading` / `Content(apps)` / `Error`).
  `AppDrawerRoute` drives the state and exposes a retry; `AppDrawerScreen` shows a
  progress indicator while loading, a "No apps installed" message when empty, and a
  "Couldn't load apps" + **Retry** affordance (≥64 dp, ≥18 sp) on failure, instead
  of stranding a blank black surface.

## Tests

- `HomeViewModelTest` updated for the 8-flow combine (7 tests pass).
- New `AppDrawerScreenTest` covers Loading / Content / empty / Error + launch
  dispatch; `fakeAppEntry` fixture added (androidTest).

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green.