### PR TITLE
fix: multi-region correctness (units, all-day events, month label, geo handoff, uses-feature)

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import io.github.seijikohara.femto.data.WeatherCode
 import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
+import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Rule
@@ -22,6 +23,7 @@ class WeatherCardTest {
                     snapshot = fakeWeatherSnapshot(tempC = 18.0),
                     city = "Shibuya",
                     temperatureUnit = TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                 )
             }
         }
@@ -37,6 +39,7 @@ class WeatherCardTest {
                     snapshot = null,
                     city = "Shibuya",
                     temperatureUnit = TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                 )
             }
         }
@@ -51,6 +54,7 @@ class WeatherCardTest {
                     snapshot = fakeWeatherSnapshot(code = WeatherCode.PARTLY_CLOUDY),
                     city = "Shibuya",
                     temperatureUnit = TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                 )
             }
         }
@@ -66,6 +70,7 @@ class WeatherCardTest {
                     snapshot = fakeWeatherSnapshot(),
                     city = "Shibuya",
                     temperatureUnit = TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                 )
             }
         }
@@ -82,6 +87,7 @@ class WeatherCardTest {
                     snapshot = fakeWeatherSnapshot(),
                     city = "Shibuya",
                     temperatureUnit = TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                 )
             }
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,18 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <!--
+        Declare location hardware as optional so Play does not implicitly
+        hard-require GPS / network-location hardware (requesting the
+        location permissions above otherwise implies required=true). The
+        location-driven panels degrade gracefully — they emit null until
+        a fix is available — so a head unit or region without this
+        hardware must still see and install the launcher (multi-region
+        distribution).
+    -->
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+    <uses-feature android:name="android.hardware.location.network" android:required="false" />
+
+    <!--
         ACCESS_NETWORK_STATE: MapLibre connectivity probe before
         OpenFreeMap vector-tile fetch. Justification mirrored in
         CLAUDE.md#permissions.

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -3,6 +3,7 @@ package io.github.seijikohara.femto
 import android.Manifest
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -68,6 +69,7 @@ class MainActivity : ComponentActivity() {
             HomeEvent.OpenDrawer -> setShowDrawer(true)
             is HomeEvent.LaunchComponent -> appsRepository.launch(event.component)
             is HomeEvent.LaunchAppCategory -> launchAppCategory(event.intentCategory)
+            is HomeEvent.LaunchGeo -> launchGeo(event.latitude, event.longitude)
             HomeEvent.OpenNotificationListenerSettings -> openNotificationListenerSettings()
             HomeEvent.OpenSystemSettings -> openSystemSettings()
         }
@@ -87,6 +89,18 @@ class MainActivity : ComponentActivity() {
         val intent =
             Intent
                 .makeMainSelectorActivity(Intent.ACTION_MAIN, category)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivityIfResolved(intent)
+    }
+
+    private fun launchGeo(
+        latitude: Double,
+        longitude: Double,
+    ) {
+        // A bare geo: URI lets whichever maps app the user has elected resolve
+        // the position — no provider or package is hard-coded.
+        val intent =
+            Intent(Intent.ACTION_VIEW, Uri.parse("geo:$latitude,$longitude?z=$MAPS_ZOOM_LEVEL"))
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         startActivityIfResolved(intent)
     }
@@ -158,3 +172,7 @@ private fun isProbablyEmulator(): Boolean =
         Build.BRAND.startsWith("generic")
 
 private const val QEMU_PROPERTY = "ro.kernel.qemu"
+
+// Street-level zoom for the geo: handoff — close enough to read nearby roads
+// without dropping below neighbourhood context.
+private const val MAPS_ZOOM_LEVEL = 15

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
@@ -11,6 +11,7 @@ import android.database.ContentObserver
 import android.os.Handler
 import android.os.Looper
 import android.provider.CalendarContract
+import android.text.format.DateFormat
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
@@ -21,9 +22,12 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onStart
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.util.Locale
 
@@ -75,11 +79,26 @@ internal class CalendarRepository(
         return CalendarSnapshot(
             today = today,
             weekday = today.dayOfWeek.getDisplayName(TextStyle.FULL, locale),
-            monthLabel = "${today.month.getDisplayName(TextStyle.FULL, locale)} ${today.year}",
+            monthLabel = monthLabelOf(today),
             dayStrip = stripWithDots,
             events = events.take(EVENT_LIST_LIMIT),
         )
     }
+
+    /**
+     * Format the "month year" head label using the locale's preferred field
+     * order. `getBestDateTimePattern` resolves the skeleton "yMMMM" to e.g.
+     * "MMMM y" for en (March 2026) but a year-first pattern for ja / ko
+     * (2026年3月). A hand-joined "Month Year" string would force English
+     * ordering on every locale.
+     */
+    private fun monthLabelOf(today: LocalDate): String =
+        today.format(
+            DateTimeFormatter.ofPattern(
+                DateFormat.getBestDateTimePattern(locale, "yMMMM"),
+                locale,
+            ),
+        )
 
     private fun hasPermission(): Boolean =
         ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR) ==
@@ -110,17 +129,18 @@ internal class CalendarRepository(
             context.contentResolver
                 .query(
                     uri,
-                    arrayOf(CalendarContract.Instances.BEGIN),
+                    arrayOf(
+                        CalendarContract.Instances.BEGIN,
+                        CalendarContract.Instances.ALL_DAY,
+                    ),
                     null,
                     null,
                     "${CalendarContract.Instances.BEGIN} ASC",
                 )?.use { cursor ->
                     while (cursor.moveToNext()) {
                         val startMs = cursor.getLong(0)
-                        dates += java.time.Instant
-                            .ofEpochMilli(startMs)
-                            .atZone(zone)
-                            .toLocalDate()
+                        val allDay = cursor.getInt(1) != 0
+                        dates += localDateOf(startMs, allDay)
                     }
                 }
             dates.toSet()
@@ -140,7 +160,7 @@ internal class CalendarRepository(
             .let { ContentUris.appendId(it, begin) }
             .let { ContentUris.appendId(it, end) }
             .build()
-        val now = java.time.Instant
+        val now = Instant
             .now()
             .toEpochMilli()
         // A mid-stream permission revoke (SecurityException) or an OEM provider
@@ -153,6 +173,7 @@ internal class CalendarRepository(
                     arrayOf(
                         CalendarContract.Instances.BEGIN,
                         CalendarContract.Instances.TITLE,
+                        CalendarContract.Instances.ALL_DAY,
                     ),
                     "${CalendarContract.Instances.BEGIN} >= ?",
                     arrayOf(now.toString()),
@@ -161,8 +182,12 @@ internal class CalendarRepository(
                     while (cursor.moveToNext() && items.size < EVENT_LIST_LIMIT) {
                         val startMs = cursor.getLong(0)
                         val title = cursor.getString(1) ?: continue
+                        val allDay = cursor.getInt(2) != 0
                         items += EventItem(
-                            time = LocalTime.ofInstant(java.time.Instant.ofEpochMilli(startMs), zone),
+                            // All-day rows carry no clock time; surface null so
+                            // the card renders an "all day" label instead of a
+                            // spurious 00:00 derived from the system zone.
+                            time = if (allDay) null else LocalTime.ofInstant(Instant.ofEpochMilli(startMs), zone),
                             title = title,
                         )
                     }
@@ -170,6 +195,23 @@ internal class CalendarRepository(
             items.toList()
         }.getOrDefault(emptyList())
     }
+
+    /**
+     * Resolve an Instances.BEGIN epoch-millis to the local calendar day.
+     *
+     * All-day instances store BEGIN as UTC midnight of the event day, so they
+     * must be read with [ZoneOffset.UTC]; applying the system zone west of UTC
+     * shifts the day one earlier. Timed instances are absolute instants and
+     * resolve in the system [zone].
+     */
+    private fun localDateOf(
+        startMs: Long,
+        allDay: Boolean,
+    ): LocalDate =
+        Instant
+            .ofEpochMilli(startMs)
+            .atZone(if (allDay) ZoneOffset.UTC else zone)
+            .toLocalDate()
 
     /**
      * Re-emit whenever the calendar provider notifies a change. Debounced

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarSnapshot.kt
@@ -33,6 +33,8 @@ data class DayCell(
 
 @Immutable
 data class EventItem(
-    val time: LocalTime,
+    // null marks an all-day event: it has no clock time, so the card renders
+    // an "all day" label instead of a formatted time.
+    val time: LocalTime?,
     val title: String,
 )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
@@ -28,6 +28,17 @@ internal sealed interface HomeEvent {
         val intentCategory: String,
     ) : HomeEvent
 
+    /**
+     * Open whichever maps app handles a `geo:` URI, centred on the given
+     * coordinates. The event carries only the position; the host builds the
+     * package-agnostic `geo:` intent so the user's elected maps app resolves it,
+     * rather than hard-coding a provider or scheme.
+     */
+    data class LaunchGeo(
+        val latitude: Double,
+        val longitude: Double,
+    ) : HomeEvent
+
     /** Open the system "Notification listener access" settings so the user can grant our NLS. */
     data object OpenNotificationListenerSettings : HomeEvent
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -111,7 +111,14 @@ internal class HomeViewModel(
             }
 
             HomeAction.OpenMaps -> {
-                mutableEvents.tryEmit(HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_MAPS))
+                // Carry the latest fix so the maps app opens at the user's
+                // position; fall back to the category launcher (maps home) when
+                // no location has arrived yet.
+                mutableEvents.tryEmit(
+                    uiState.value.location
+                        ?.let { HomeEvent.LaunchGeo(it.latitude, it.longitude) }
+                        ?: HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_MAPS),
+                )
             }
 
             is HomeAction.Shortcut -> {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -201,7 +201,10 @@ private fun Events(events: List<EventItem>) =
         } else {
             events.forEachIndexed { index, event ->
                 EventRow(
-                    time = event.time.format(EventTimeFormatter),
+                    // A null time marks an all-day event. The plain string is a
+                    // placeholder; a later task sweeps UI copy to string
+                    // resources.
+                    time = event.time?.format(EventTimeFormatter) ?: "All day",
                     title = event.title,
                     isPrimary = index == 0,
                 )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -75,6 +75,7 @@ internal fun DashboardScaffold(
         InfoPane(
             uiState = uiState,
             temperatureUnit = temperatureUnit,
+            speedUnit = speedUnit,
             onAction = onAction,
             modifier = Modifier.weight(1f).fillMaxHeight(),
         )
@@ -122,6 +123,7 @@ private fun MapPane(
 private fun InfoPane(
     uiState: HomeUiState,
     temperatureUnit: TemperatureUnit,
+    speedUnit: SpeedUnit,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(
@@ -143,6 +145,7 @@ private fun InfoPane(
             snapshot = uiState.weather,
             city = uiState.address?.locality,
             temperatureUnit = temperatureUnit,
+            speedUnit = speedUnit,
             modifier = Modifier.weight(1f).fillMaxHeight(),
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -35,9 +35,11 @@ import com.composables.icons.lucide.Sun
 import io.github.seijikohara.femto.data.HourlyForecast
 import io.github.seijikohara.femto.data.WeatherCode
 import io.github.seijikohara.femto.data.WeatherSnapshot
+import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 import io.github.seijikohara.femto.ui.locale.fromCelsius
 import io.github.seijikohara.femto.ui.locale.label
+import io.github.seijikohara.femto.ui.locale.windLabel
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
@@ -70,6 +72,7 @@ internal fun WeatherCard(
     snapshot: WeatherSnapshot?,
     city: String?,
     temperatureUnit: TemperatureUnit,
+    speedUnit: SpeedUnit,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
@@ -86,7 +89,7 @@ internal fun WeatherCard(
     ) {
         if (snapshot != null) {
             Head(snapshot, city, temperatureUnit)
-            Metrics(snapshot, temperatureUnit)
+            Metrics(snapshot, temperatureUnit, speedUnit)
             Forecast(snapshot.hourly, temperatureUnit)
         } else {
             EmptyState()
@@ -174,13 +177,13 @@ private fun Head(
 private fun Metrics(
     snapshot: WeatherSnapshot,
     temperatureUnit: TemperatureUnit,
+    speedUnit: SpeedUnit,
 ) = Row(
     modifier = Modifier.fillMaxWidth(),
     horizontalArrangement = Arrangement.spacedBy(16.dp),
 ) {
     Metric(label = "FEELS", value = "${temperatureUnit.fromCelsius(snapshot.apparentTempC).roundToInt()}°")
-    val windMs = (snapshot.windKmh / 3.6).roundToInt()
-    Metric(label = "WIND", value = "$windMs m/s")
+    Metric(label = "WIND", value = windLabel(snapshot.windKmh, speedUnit))
     val humidityLabel = snapshot.humidityPercent?.let { "$it%" } ?: "—"
     Metric(label = "HUMID.", value = humidityLabel)
 }
@@ -365,6 +368,7 @@ private fun WeatherCardPreview() {
                 ),
             city = "Košice",
             temperatureUnit = TemperatureUnit.CELSIUS,
+            speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/locale/SystemUnits.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/locale/SystemUnits.kt
@@ -1,8 +1,12 @@
 package io.github.seijikohara.femto.ui.locale
 
+import androidx.core.text.util.LocalePreferences
 import java.util.Locale
+import kotlin.math.roundToInt
 
 private const val METERS_PER_MILE = 1609.344
+
+private const val SECONDS_PER_HOUR = 3.6
 
 internal enum class SpeedUnit { KILOMETERS_PER_HOUR, MILES_PER_HOUR }
 
@@ -13,11 +17,21 @@ internal enum class TemperatureUnit { CELSIUS, FAHRENHEIT }
 private val ImperialCountries = setOf("US", "GB", "MM")
 
 /**
- * Countries that use Fahrenheit for everyday weather. Deliberately separate
- * from [ImperialCountries]: the UK (GB) reads road distances in miles but
- * reports weather in Celsius, so it must not appear here.
+ * Fallback set of countries that use Fahrenheit for everyday weather, used when
+ * [LocalePreferences] does not resolve Fahrenheit. Deliberately separate from
+ * [ImperialCountries]: the UK (GB) reads road distances in miles but reports
+ * weather in Celsius, so it must not appear here.
+ *
+ * Includes the US territories GU, VI, AS, and MP. They follow US weather
+ * conventions but are absent from the country table that backs
+ * [LocalePreferences.getTemperatureUnit] on the JVM (where `Build.VERSION` is
+ * the unit-test stub), so this set is what carries them under the test runner.
  */
-private val FahrenheitCountries = setOf("US", "BS", "BZ", "KY", "FM", "MH", "PW", "LR")
+private val FahrenheitCountries =
+    setOf("US", "BS", "BZ", "KY", "FM", "MH", "PW", "LR", "GU", "VI", "AS", "MP")
+
+/** CLDR Unicode extension key for the measurement-unit (`-u-mu-`) override. */
+private const val TEMPERATURE_OVERRIDE_KEY = "mu"
 
 internal fun speedUnitFor(locale: Locale = Locale.getDefault()): SpeedUnit =
     if (locale.country in ImperialCountries) {
@@ -33,11 +47,39 @@ internal fun distanceUnitFor(locale: Locale = Locale.getDefault()): DistanceUnit
         DistanceUnit.METERS
     }
 
+/**
+ * Resolve the temperature unit from CLDR via [LocalePreferences] first, then
+ * fall back to [FahrenheitCountries].
+ *
+ * [LocalePreferences.getTemperatureUnit] returns a CLDR token; only
+ * `FAHRENHEIT` ("fahrenhe") maps to Fahrenheit here, and `KELVIN` collapses to
+ * Celsius for this two-value enum. The token honours an explicit `-u-mu-`
+ * override (e.g. `en-US-u-mu-celsius`) on any platform and resolves US
+ * territories via ICU on-device (API 33+).
+ *
+ * The country-set fallback only applies when no explicit `-u-mu-` override is
+ * present: an override is the user's deliberate choice and must win over the
+ * country default. Without an override, the fallback catches markets the
+ * platform country table misses — notably US territories under the JVM test
+ * runner, where the table that backs [LocalePreferences] lacks them.
+ */
 internal fun temperatureUnitFor(locale: Locale = Locale.getDefault()): TemperatureUnit =
-    if (locale.country in FahrenheitCountries) {
-        TemperatureUnit.FAHRENHEIT
-    } else {
-        TemperatureUnit.CELSIUS
+    when {
+        LocalePreferences.getTemperatureUnit(locale) == LocalePreferences.TemperatureUnit.FAHRENHEIT -> {
+            TemperatureUnit.FAHRENHEIT
+        }
+
+        locale.getUnicodeLocaleType(TEMPERATURE_OVERRIDE_KEY) != null -> {
+            TemperatureUnit.CELSIUS
+        }
+
+        locale.country in FahrenheitCountries -> {
+            TemperatureUnit.FAHRENHEIT
+        }
+
+        else -> {
+            TemperatureUnit.CELSIUS
+        }
     }
 
 internal fun SpeedUnit.fromMetersPerSecond(mps: Float): Float =
@@ -76,6 +118,22 @@ internal fun SpeedUnit.label(): String =
     when (this) {
         SpeedUnit.KILOMETERS_PER_HOUR -> "km/h"
         SpeedUnit.MILES_PER_HOUR -> "mph"
+    }
+
+/**
+ * Format a wind speed (supplied in km/h by the weather provider) for the
+ * dashboard, matching the speed unit the rest of the launcher shows. Imperial
+ * locales read wind as mph (paired with the [SpeedOverlay] reading); metric
+ * locales keep m/s per `docs/design/dashboard-v2-mockup.html`, which specs m/s
+ * as the conventional meteorological wind unit outside imperial markets.
+ */
+internal fun windLabel(
+    windKmh: Double,
+    speedUnit: SpeedUnit,
+): String =
+    when (speedUnit) {
+        SpeedUnit.MILES_PER_HOUR -> "${speedUnit.fromKilometersPerHour(windKmh).roundToInt()} mph"
+        SpeedUnit.KILOMETERS_PER_HOUR -> "${(windKmh / SECONDS_PER_HOUR).roundToInt()} m/s"
     }
 
 internal fun DistanceUnit.label(): String =

--- a/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
@@ -5,8 +5,10 @@ import android.app.Application
 import android.content.ContentProvider
 import android.content.ContentValues
 import android.database.Cursor
+import android.database.MatrixCursor
 import android.net.Uri
 import android.provider.CalendarContract
+import android.text.format.DateFormat
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -19,8 +21,13 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
@@ -71,6 +78,158 @@ class CalendarRepositoryTest {
             assertTrue(snapshot.events.isEmpty())
             assertEquals(6, snapshot.dayStrip.size)
         }
+
+    @Test
+    fun `places an all-day event on the correct local day in a negative-offset zone`() =
+        runTest {
+            // An all-day Instances row stores BEGIN as UTC midnight of the event
+            // day. Read with the system zone, an event at 2099-06-15T00:00Z
+            // lands a day early (2099-06-14) west of UTC. Reading all-day rows
+            // in UTC keeps the dot on the real local day.
+            shadowOf(application).grantPermissions(Manifest.permission.READ_CALENDAR)
+            Robolectric
+                .buildContentProvider(AllDayCalendarProvider::class.java)
+                .create(CalendarContract.AUTHORITY)
+
+            val newYork = ZoneId.of("America/New_York")
+            val repository =
+                CalendarRepository(
+                    application,
+                    clockFlow = flowOf(ClockTick(LocalTime.NOON, AllDayCalendarProvider.TODAY)),
+                    zone = newYork,
+                )
+
+            val snapshot = repository.snapshotFlow().first()
+            assertNotNull(snapshot)
+
+            // The event day is one day after today, so a correct read dots the
+            // second strip cell and leaves today (cell 0) undotted; a system-zone
+            // read would shift the dot to today.
+            val eventDay = AllDayCalendarProvider.EVENT_DATE
+            val dottedDays = snapshot.dayStrip.filter { it.hasEvent }.map { it.date }
+            assertEquals(listOf(eventDay), dottedDays)
+            assertTrue(snapshot.dayStrip.first { it.date == eventDay }.hasEvent)
+            assertTrue(
+                snapshot.dayStrip
+                    .first { it.date == AllDayCalendarProvider.TODAY }
+                    .hasEvent
+                    .not(),
+            )
+
+            // The all-day event carries no clock time.
+            assertEquals(1, snapshot.events.size)
+            assertNull(snapshot.events.single().time)
+        }
+
+    @Test
+    fun `month label follows the locale field order`() =
+        runTest {
+            // The label is produced from getBestDateTimePattern(locale, "yMMMM").
+            // en places the month first; ja / ko place the year first. Asserting
+            // against the same pattern-derived expectation (rather than a
+            // hardcoded English string) proves the formatter is locale-aware
+            // without baking a brittle literal per locale.
+            val today = LocalDate.of(2026, 3, 30)
+            listOf(Locale.ENGLISH, Locale.JAPANESE, Locale.KOREAN).forEach { locale ->
+                val repository =
+                    CalendarRepository(
+                        application,
+                        clockFlow = flowOf(ClockTick(LocalTime.NOON, today)),
+                        locale = locale,
+                    )
+
+                val snapshot = repository.snapshotFlow().first()
+                assertNotNull(snapshot)
+
+                val expected =
+                    today.format(
+                        DateTimeFormatter.ofPattern(
+                            DateFormat.getBestDateTimePattern(locale, "yMMMM"),
+                            locale,
+                        ),
+                    )
+                assertEquals(expected, snapshot.monthLabel)
+            }
+
+            // The English and Japanese labels must differ: ja leads with the
+            // year, en leads with the month name. This guards against a
+            // regression to the old hand-joined "Month Year" ordering.
+            val enLabel =
+                CalendarRepository(
+                    application,
+                    clockFlow = flowOf(ClockTick(LocalTime.NOON, today)),
+                    locale = Locale.ENGLISH,
+                ).snapshotFlow().first()!!.monthLabel
+            val jaLabel =
+                CalendarRepository(
+                    application,
+                    clockFlow = flowOf(ClockTick(LocalTime.NOON, today)),
+                    locale = Locale.JAPANESE,
+                ).snapshotFlow().first()!!.monthLabel
+            assertTrue(enLabel != jaLabel)
+        }
+
+    /**
+     * Stand-in calendar provider returning a single all-day Instances row whose
+     * BEGIN is UTC midnight of [EVENT_DATE]. The cursor mirrors the requested
+     * projection so both the events query and the dot-dates query read the same
+     * row regardless of column order.
+     */
+    class AllDayCalendarProvider : ContentProvider() {
+        override fun onCreate(): Boolean = true
+
+        override fun query(
+            uri: Uri,
+            projection: Array<out String>?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+            sortOrder: String?,
+        ): Cursor {
+            val columns: Array<out String> =
+                projection ?: arrayOf(CalendarContract.Instances.BEGIN)
+            val cursor = MatrixCursor(columns)
+            cursor.addRow(
+                columns.map { column ->
+                    when (column) {
+                        CalendarContract.Instances.BEGIN -> EVENT_BEGIN_MS
+                        CalendarContract.Instances.ALL_DAY -> 1
+                        CalendarContract.Instances.TITLE -> "Holiday"
+                        else -> null
+                    }
+                },
+            )
+            return cursor
+        }
+
+        override fun getType(uri: Uri): String? = null
+
+        override fun insert(
+            uri: Uri,
+            values: ContentValues?,
+        ): Uri? = null
+
+        override fun delete(
+            uri: Uri,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        override fun update(
+            uri: Uri,
+            values: ContentValues?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        companion object {
+            // Far-future so the event stays ahead of the real `Instant.now()`
+            // floor the events query applies, keeping the test stable over time.
+            val EVENT_DATE: LocalDate = LocalDate.of(2099, 6, 15)
+            val TODAY: LocalDate = EVENT_DATE.minusDays(1)
+            val EVENT_BEGIN_MS: Long =
+                EVENT_DATE.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+        }
+    }
 
     /**
      * Stand-in calendar provider whose [query] throws [SecurityException], the

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -7,6 +7,7 @@ import io.github.seijikohara.femto.data.ClockTick
 import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.testfixtures.fakeAddress
 import io.github.seijikohara.femto.testfixtures.fakeCalendarSnapshot
+import io.github.seijikohara.femto.testfixtures.fakeLocation
 import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
 import io.github.seijikohara.femto.testfixtures.fakeSystemStatus
 import io.github.seijikohara.femto.testfixtures.fakeTripState
@@ -100,6 +101,37 @@ class HomeViewModelTest {
                 action = HomeAction.OpenMaps,
                 expected = HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_MAPS),
             )
+        }
+
+    @Test
+    fun `onAction OpenMaps emits LaunchGeo at the latest location when present`() =
+        runTest {
+            val location = fakeLocation()
+            val viewModel =
+                HomeViewModel(
+                    clockFlow = flowOf(ClockTick(LocalTime.of(14, 32), LocalDate.of(2026, 5, 1))),
+                    locationFlow = flowOf(location),
+                    addressFlow = flowOf(fakeAddress()),
+                    weatherFlow = flowOf(fakeWeatherSnapshot()),
+                    musicStateFlow = flowOf(MusicCardState.Playing(fakeNowPlaying())),
+                    calendarFlow = flowOf(fakeCalendarSnapshot()),
+                    systemStatusFlow = flowOf(fakeSystemStatus()),
+                    tripStateFlow = flowOf(fakeTripState()),
+                )
+            // uiState uses WhileSubscribed, so collect it first to make the
+            // StateFlow value live before onAction reads uiState.value.location.
+            viewModel.uiState.test {
+                assertNotNull(awaitItem().location)
+                viewModel.events.test {
+                    viewModel.onAction(HomeAction.OpenMaps)
+                    assertEquals(
+                        HomeEvent.LaunchGeo(location.latitude, location.longitude),
+                        awaitItem(),
+                    )
+                    cancelAndIgnoreRemainingEvents()
+                }
+                cancelAndIgnoreRemainingEvents()
+            }
         }
 
     @Test

--- a/app/src/test/java/io/github/seijikohara/femto/ui/locale/SystemUnitsTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/locale/SystemUnitsTest.kt
@@ -97,6 +97,34 @@ class SystemUnitsTest {
     }
 
     @Test
+    fun `temperatureUnitFor returns fahrenheit for us territory guam`() {
+        // GU follows US weather conventions but is absent from the platform
+        // country table on the JVM; the expanded fallback set must carry it.
+        val guam = Locale
+            .Builder()
+            .setLanguage("en")
+            .setRegion("GU")
+            .build()
+        assertEquals(TemperatureUnit.FAHRENHEIT, temperatureUnitFor(guam))
+    }
+
+    @Test
+    fun `temperatureUnitFor honors u-mu-celsius override against fahrenheit country`() {
+        // A US locale that explicitly requests Celsius via CLDR must win over
+        // the country default.
+        val usCelsius = Locale.forLanguageTag("en-US-u-mu-celsius")
+        assertEquals(TemperatureUnit.CELSIUS, temperatureUnitFor(usCelsius))
+    }
+
+    @Test
+    fun `temperatureUnitFor honors u-mu-fahrenhe override against celsius country`() {
+        // A metric locale that explicitly requests Fahrenheit via CLDR must win
+        // over the country default.
+        val deFahrenheit = Locale.forLanguageTag("de-DE-u-mu-fahrenhe")
+        assertEquals(TemperatureUnit.FAHRENHEIT, temperatureUnitFor(deFahrenheit))
+    }
+
+    @Test
     fun `fromCelsius returns 32 when zero celsius in fahrenheit`() {
         assertEquals(32.0, TemperatureUnit.FAHRENHEIT.fromCelsius(0.0), 1e-6)
     }
@@ -119,5 +147,17 @@ class SystemUnitsTest {
     @Test
     fun `label returns degrees fahrenheit when fahrenheit`() {
         assertEquals("°F", TemperatureUnit.FAHRENHEIT.label())
+    }
+
+    @Test
+    fun `windLabel returns metres per second when speed unit is metric`() {
+        // 36 km/h is 10 m/s; the metric branch keeps m/s per the mockup.
+        assertEquals("10 m/s", windLabel(36.0, SpeedUnit.KILOMETERS_PER_HOUR))
+    }
+
+    @Test
+    fun `windLabel returns miles per hour when speed unit is imperial`() {
+        // 100 km/h rounds to 62 mph, matching the SpeedOverlay reading.
+        assertEquals("62 mph", windLabel(100.0, SpeedUnit.MILES_PER_HOUR))
     }
 }


### PR DESCRIPTION
## Summary

Phase 3 (logic) of the completeness roadmap — **multi-region correctness**. A
cluster of single-market conventions baked into the dashboard, each visibly wrong
in some locale. (The hardcoded-English-string sweep is a separate follow-up PR.)

## Changes

- **`uses-feature` (3.1)**: declare `android.hardware.location.gps` / `.network`
  with `required="false"` so requesting location doesn't implicitly hard-require the
  hardware on Play (which would hide the launcher from units/regions lacking it).
- **Wind unit (3.2)**: a shared `windLabel(windKmh, speedUnit)` helper formats wind
  as mph for imperial locales and m/s for metric (per the mockup); the single
  locale-derived `speedUnit` now drives both the speed overlay and the wind metric.
- **All-day events (3.3)**: read all-day `Instances` in `ZoneOffset.UTC` (not the
  system zone) so dots/events land on the correct local day west of UTC;
  `EventItem.time` is nullable and the card renders "All day".
- **Month label (3.4)**: `DateFormat.getBestDateTimePattern(locale, "yMMMM")` so
  ja/ko field order (year first) is correct.
- **Maps handoff (3.6)**: `OpenMaps` hands the user position to the maps app via a
  package-agnostic `geo:lat,lon?z=` URI, falling back to the category selector when
  there's no fix.
- **Temperature unit (3.7)**: derive from CLDR (`LocalePreferences`) with `-u-mu`
  override support; keep an expanded country-set fallback (incl. US territories).

## Tests

75 JVM tests pass, including: all-day in a negative-offset zone, locale month label
(en/ja/ko), temperature CLDR + Guam + `-u-mu` overrides, the wind helper (mph/m·s⁻¹),
and `OpenMaps → LaunchGeo` at the latest location.

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green.