### PR TITLE
refactor: extract user-facing UI strings to string resources

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -21,8 +21,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.ui.home.components.AppTile
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
@@ -62,7 +64,7 @@ private fun ContentState(
     onLaunch: (ComponentName) -> Unit,
     modifier: Modifier = Modifier,
 ) = if (apps.isEmpty()) {
-    CenteredMessage(text = "No apps installed", modifier = modifier)
+    CenteredMessage(text = stringResource(R.string.drawer_no_apps), modifier = modifier)
 } else {
     LazyVerticalGrid(
         modifier = modifier,
@@ -87,7 +89,7 @@ private fun ErrorState(
     verticalArrangement = Arrangement.Center,
 ) {
     Text(
-        text = "Couldn't load apps",
+        text = stringResource(R.string.drawer_load_error),
         style = MaterialTheme.typography.bodyLarge,
         color = MaterialTheme.colorScheme.onBackground,
         textAlign = TextAlign.Center,
@@ -103,7 +105,7 @@ private fun ErrorState(
                     minHeight = FemtoDimens.MinTouchTarget,
                 ),
     ) {
-        Text(text = "Retry", fontSize = FemtoDimens.MinBodyTextSize)
+        Text(text = stringResource(R.string.drawer_retry), fontSize = FemtoDimens.MinBodyTextSize)
     }
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -19,12 +19,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.CalendarSnapshot
 import io.github.seijikohara.femto.data.DayCell
 import io.github.seijikohara.femto.data.EventItem
@@ -189,7 +191,7 @@ private fun Events(events: List<EventItem>) =
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
         if (events.isEmpty()) {
             Text(
-                text = "No upcoming events",
+                text = stringResource(R.string.calendar_no_events),
                 style =
                     MaterialTheme.typography.bodyMedium.copy(
                         fontSize = 13.sp,
@@ -201,10 +203,8 @@ private fun Events(events: List<EventItem>) =
         } else {
             events.forEachIndexed { index, event ->
                 EventRow(
-                    // A null time marks an all-day event. The plain string is a
-                    // placeholder; a later task sweeps UI copy to string
-                    // resources.
-                    time = event.time?.format(EventTimeFormatter) ?: "All day",
+                    // A null time marks an all-day event.
+                    time = event.time?.format(EventTimeFormatter) ?: stringResource(R.string.calendar_all_day),
                     title = event.title,
                     isPrimary = index == 0,
                 )
@@ -267,7 +267,7 @@ private fun EmptyState() =
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
-            text = "Calendar access not granted",
+            text = stringResource(R.string.calendar_permission_denied),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -42,6 +43,7 @@ import com.composables.icons.lucide.Navigation
 import com.composables.icons.lucide.Phone
 import com.composables.icons.lucide.Settings
 import com.composables.icons.lucide.Wifi
+import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.SystemStatus
 import io.github.seijikohara.femto.ui.home.HomeAction
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
@@ -112,43 +114,43 @@ private fun NavRow(
 ) {
     NavButton(
         icon = Lucide.House,
-        description = "Home",
+        description = stringResource(R.string.nav_home),
         active = true,
         onClick = { /* already on home */ },
     )
     NavButton(
         icon = Lucide.Phone,
-        description = "Phone",
+        description = stringResource(R.string.nav_phone),
         active = false,
         onClick = { onAction(HomeAction.Shortcut(AppsBarShortcut.Phone)) },
     )
     NavButton(
         icon = Lucide.LayoutGrid,
-        description = "Apps",
+        description = stringResource(R.string.nav_apps),
         active = false,
         onClick = { onAction(HomeAction.OpenAppDrawer) },
     )
     NavButton(
         icon = Lucide.Music,
-        description = "Music",
+        description = stringResource(R.string.nav_music),
         active = false,
         onClick = { onAction(HomeAction.Shortcut(AppsBarShortcut.Music)) },
     )
     NavButton(
         icon = Lucide.Navigation,
-        description = "Navigation",
+        description = stringResource(R.string.nav_navigation),
         active = false,
         onClick = { onAction(HomeAction.OpenMaps) },
     )
     NavButton(
         icon = Lucide.Globe,
-        description = "Browser",
+        description = stringResource(R.string.nav_browser),
         active = false,
         onClick = { onAction(HomeAction.OpenBrowser) },
     )
     NavButton(
         icon = Lucide.Settings,
-        description = "Settings",
+        description = stringResource(R.string.nav_settings),
         active = false,
         onClick = { onAction(HomeAction.OpenSettings) },
     )
@@ -212,12 +214,22 @@ private fun StatusCluster(
     StatusIcon(
         icon = Lucide.Wifi,
         active = status.wifiConnected,
-        description = if (status.wifiConnected) "Wi-Fi connected" else "Wi-Fi disconnected",
+        description =
+            stringResource(
+                if (status.wifiConnected) R.string.status_wifi_connected else R.string.status_wifi_disconnected,
+            ),
     )
     StatusIcon(
         icon = Lucide.Bluetooth,
         active = status.bluetoothConnected,
-        description = if (status.bluetoothConnected) "Bluetooth connected" else "Bluetooth disconnected",
+        description =
+            stringResource(
+                if (status.bluetoothConnected) {
+                    R.string.status_bluetooth_connected
+                } else {
+                    R.string.status_bluetooth_disconnected
+                },
+            ),
     )
     BatteryIndicator(percent = status.batteryPercent, charging = status.charging)
 }
@@ -248,12 +260,16 @@ private fun BatteryIndicator(
 ) {
     Icon(
         imageVector = Lucide.Battery,
-        contentDescription = "Battery",
+        contentDescription = stringResource(R.string.status_battery),
         tint = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.size(20.dp),
     )
     Text(
-        text = if (charging) "$percent% ⚡" else "$percent%",
+        text =
+            stringResource(
+                if (charging) R.string.battery_percent_charging else R.string.battery_percent,
+                percent,
+            ),
         style =
             MaterialTheme.typography.labelLarge.copy(
                 fontSize = 13.sp,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -27,12 +27,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.MapPinOff
+import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import org.maplibre.android.MapLibre
 import org.maplibre.android.camera.CameraUpdateFactory
@@ -252,13 +254,13 @@ private fun Fallback() =
             modifier = Modifier.size(40.dp),
         )
         Text(
-            text = "Map unavailable",
+            text = stringResource(R.string.map_unavailable),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(top = 8.dp),
         )
         Text(
-            text = "Grant location access to enable the map and overlays.",
+            text = stringResource(R.string.map_permission_cta),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(top = 4.dp),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -46,6 +47,7 @@ import com.composables.icons.lucide.Pause
 import com.composables.icons.lucide.Play
 import com.composables.icons.lucide.SkipBack
 import com.composables.icons.lucide.SkipForward
+import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.data.NowPlaying
 import io.github.seijikohara.femto.data.sourceLabel
@@ -324,19 +326,19 @@ private fun TransportRow(
 ) {
     TransportButton(
         icon = Lucide.SkipBack,
-        description = "Skip previous",
+        description = stringResource(R.string.music_skip_previous),
         primary = false,
         onClick = { onCommand(MusicCommand.SkipPrevious) },
     )
     TransportButton(
         icon = if (isPlaying) Lucide.Pause else Lucide.Play,
-        description = "Play / pause",
+        description = stringResource(R.string.music_play_pause),
         primary = true,
         onClick = { onCommand(MusicCommand.PlayPause) },
     )
     TransportButton(
         icon = Lucide.SkipForward,
-        description = "Skip next",
+        description = stringResource(R.string.music_skip_next),
         primary = false,
         onClick = { onCommand(MusicCommand.SkipNext) },
     )
@@ -395,7 +397,7 @@ private fun ConnectState(onConnect: () -> Unit) =
             )
             Box(modifier = Modifier.height(12.dp))
             Text(
-                text = "Connect a player",
+                text = stringResource(R.string.music_connect_cta),
                 style =
                     MaterialTheme.typography.titleMedium.copy(
                         fontSize = 18.sp,
@@ -406,7 +408,7 @@ private fun ConnectState(onConnect: () -> Unit) =
             )
             Box(modifier = Modifier.height(4.dp))
             Text(
-                text = "Allow notification access to control playback from the dashboard.",
+                text = stringResource(R.string.music_connect_hint),
                 style =
                     MaterialTheme.typography.bodySmall.copy(
                         fontSize = 13.sp,
@@ -440,7 +442,7 @@ private fun EmptyState() =
         )
         Box(modifier = Modifier.height(4.dp))
         Text(
-            text = "Nothing is playing",
+            text = stringResource(R.string.music_nothing_playing),
             style =
                 MaterialTheme.typography.titleMedium.copy(
                     fontSize = 18.sp,
@@ -451,7 +453,7 @@ private fun EmptyState() =
         )
         Box(modifier = Modifier.height(4.dp))
         Text(
-            text = "Open a music app to start, or say \"Hey Google, play something\".",
+            text = stringResource(R.string.music_nothing_hint),
             style =
                 MaterialTheme.typography.bodySmall.copy(
                     fontSize = 13.sp,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.ui.home.components
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,6 +34,7 @@ import com.composables.icons.lucide.CloudSun
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Moon
 import com.composables.icons.lucide.Sun
+import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.HourlyForecast
 import io.github.seijikohara.femto.data.WeatherCode
 import io.github.seijikohara.femto.data.WeatherSnapshot
@@ -164,7 +167,7 @@ private fun Head(
                 )
             }
             Text(
-                text = labelFor(snapshot.code).uppercase(),
+                text = stringResource(labelResFor(snapshot.code)).uppercase(),
                 style = MaterialTheme.typography.sectionLabel(11, 0.14f),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
@@ -182,10 +185,13 @@ private fun Metrics(
     modifier = Modifier.fillMaxWidth(),
     horizontalArrangement = Arrangement.spacedBy(16.dp),
 ) {
-    Metric(label = "FEELS", value = "${temperatureUnit.fromCelsius(snapshot.apparentTempC).roundToInt()}°")
-    Metric(label = "WIND", value = windLabel(snapshot.windKmh, speedUnit))
+    Metric(
+        label = stringResource(R.string.weather_metric_feels),
+        value = "${temperatureUnit.fromCelsius(snapshot.apparentTempC).roundToInt()}°",
+    )
+    Metric(label = stringResource(R.string.weather_metric_wind), value = windLabel(snapshot.windKmh, speedUnit))
     val humidityLabel = snapshot.humidityPercent?.let { "$it%" } ?: "—"
-    Metric(label = "HUMID.", value = humidityLabel)
+    Metric(label = stringResource(R.string.weather_metric_humidity), value = humidityLabel)
 }
 
 @Composable
@@ -283,7 +289,7 @@ private fun EmptyState() =
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = "Weather unavailable",
+            text = stringResource(R.string.weather_unavailable),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -323,21 +329,22 @@ private fun glyphTintFor(
         else -> glyphs.cloud
     }
 
-private fun labelFor(code: WeatherCode): String =
+@StringRes
+private fun labelResFor(code: WeatherCode): Int =
     when (code) {
-        WeatherCode.CLEAR -> "Sunny"
-        WeatherCode.PARTLY_CLOUDY -> "Partly cloudy"
-        WeatherCode.CLOUDY -> "Cloudy"
-        WeatherCode.FOG -> "Fog"
-        WeatherCode.DRIZZLE -> "Drizzle"
-        WeatherCode.RAIN -> "Rain"
-        WeatherCode.FREEZING_RAIN -> "Freezing rain"
-        WeatherCode.SNOW -> "Snow"
-        WeatherCode.SNOW_GRAINS -> "Snow grains"
-        WeatherCode.RAIN_SHOWERS -> "Rain showers"
-        WeatherCode.SNOW_SHOWERS -> "Snow showers"
-        WeatherCode.THUNDERSTORM -> "Thunderstorm"
-        WeatherCode.UNKNOWN -> ""
+        WeatherCode.CLEAR -> R.string.weather_cond_sunny
+        WeatherCode.PARTLY_CLOUDY -> R.string.weather_cond_partly_cloudy
+        WeatherCode.CLOUDY -> R.string.weather_cond_cloudy
+        WeatherCode.FOG -> R.string.weather_cond_fog
+        WeatherCode.DRIZZLE -> R.string.weather_cond_drizzle
+        WeatherCode.RAIN -> R.string.weather_cond_rain
+        WeatherCode.FREEZING_RAIN -> R.string.weather_cond_freezing_rain
+        WeatherCode.SNOW -> R.string.weather_cond_snow
+        WeatherCode.SNOW_GRAINS -> R.string.weather_cond_snow_grains
+        WeatherCode.RAIN_SHOWERS -> R.string.weather_cond_rain_showers
+        WeatherCode.SNOW_SHOWERS -> R.string.weather_cond_snow_showers
+        WeatherCode.THUNDERSTORM -> R.string.weather_cond_thunderstorm
+        WeatherCode.UNKNOWN -> R.string.weather_cond_unknown
     }
 
 @PreviewLightDark

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,64 @@
 <resources>
     <string name="app_name">Femto Car Launcher</string>
     <string name="music_listener_label">Femto music session listener</string>
+
+    <!-- Map panel -->
+    <string name="map_unavailable">Map unavailable</string>
+    <string name="map_permission_cta">Grant location access to enable the map and overlays.</string>
+
+    <!-- Calendar card -->
+    <string name="calendar_no_events">No upcoming events</string>
+    <string name="calendar_permission_denied">Calendar access not granted</string>
+    <string name="calendar_all_day">All day</string>
+
+    <!-- Weather card -->
+    <string name="weather_unavailable">Weather unavailable</string>
+    <string name="weather_metric_feels">FEELS</string>
+    <string name="weather_metric_wind">WIND</string>
+    <string name="weather_metric_humidity">HUMID.</string>
+    <string name="weather_cond_sunny">Sunny</string>
+    <string name="weather_cond_partly_cloudy">Partly cloudy</string>
+    <string name="weather_cond_cloudy">Cloudy</string>
+    <string name="weather_cond_fog">Fog</string>
+    <string name="weather_cond_drizzle">Drizzle</string>
+    <string name="weather_cond_rain">Rain</string>
+    <string name="weather_cond_freezing_rain">Freezing rain</string>
+    <string name="weather_cond_snow">Snow</string>
+    <string name="weather_cond_snow_grains">Snow grains</string>
+    <string name="weather_cond_rain_showers">Rain showers</string>
+    <string name="weather_cond_snow_showers">Snow showers</string>
+    <string name="weather_cond_thunderstorm">Thunderstorm</string>
+    <string name="weather_cond_unknown"></string>
+
+    <!-- Music card -->
+    <string name="music_connect_cta">Connect a player</string>
+    <string name="music_connect_hint">Allow notification access to control playback from the dashboard.</string>
+    <string name="music_nothing_playing">Nothing is playing</string>
+    <string name="music_nothing_hint">Open a music app to start, or say \"Hey Google, play something\".</string>
+    <string name="music_skip_previous">Skip previous</string>
+    <string name="music_play_pause">Play / pause</string>
+    <string name="music_skip_next">Skip next</string>
+
+    <!-- Dashboard footer: navigation -->
+    <string name="nav_home">Home</string>
+    <string name="nav_phone">Phone</string>
+    <string name="nav_apps">Apps</string>
+    <string name="nav_music">Music</string>
+    <string name="nav_navigation">Navigation</string>
+    <string name="nav_browser">Browser</string>
+    <string name="nav_settings">Settings</string>
+
+    <!-- Dashboard footer: status cluster -->
+    <string name="status_wifi_connected">Wi-Fi connected</string>
+    <string name="status_wifi_disconnected">Wi-Fi disconnected</string>
+    <string name="status_bluetooth_connected">Bluetooth connected</string>
+    <string name="status_bluetooth_disconnected">Bluetooth disconnected</string>
+    <string name="status_battery">Battery</string>
+    <string name="battery_percent">%1$d%%</string>
+    <string name="battery_percent_charging">%1$d%% ⚡</string>
+
+    <!-- App drawer -->
+    <string name="drawer_no_apps">No apps installed</string>
+    <string name="drawer_load_error">Couldn\'t load apps</string>
+    <string name="drawer_retry">Retry</string>
 </resources>


### PR DESCRIPTION
## Summary

Phase 3.5 of the completeness roadmap — establish the **localization extension
point** the multi-region rule requires. ~47 inline English UI literals across the
dashboard now resolve via `stringResource(R.string.*)` from
`res/values/strings.xml`.

## Covered

- **MapPanel** — "Map unavailable", permission CTA.
- **CalendarCard** — "No upcoming events", "Calendar access not granted", "All day".
- **WeatherCard** — "Weather unavailable", metric labels (FEELS/WIND/HUMID.), and the
  weather **condition names** (converted to a `@StringRes` mapping resolved in
  composition; head still uppercases).
- **MusicCard** — connect CTA + hint, "Nothing is playing" + hint, transport content
  descriptions.
- **DashboardFooter** — nav / Wi-Fi / Bluetooth / battery content descriptions and the
  battery percent **format strings** (`%1$d%%`, charging variant with " ⚡").
- **AppDrawerScreen** — "No apps installed", "Couldn't load apps", "Retry".

## Notes

- Wording is byte-identical, so the instrumented assertions
  (`onNodeWithText`/`onNodeWithContentDescription`) still match.
- Brand names (`sourceLabel`) and dynamic/locale-derived values (temperatures,
  `%02dh`, time) stay in code.
- The Hardcoded-text lint check is left disabled (intentional literals remain).

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green.