### PR TITLE
feat: glance readability, accessibility & empty states

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
@@ -5,7 +5,7 @@ import io.github.seijikohara.femto.data.SystemStatus
 internal fun fakeSystemStatus(
     wifiConnected: Boolean = true,
     bluetoothConnected: Boolean = true,
-    batteryPercent: Int = 78,
+    batteryPercent: Int? = 78,
     charging: Boolean = false,
 ): SystemStatus =
     SystemStatus(

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import io.github.seijikohara.femto.data.WeatherCode
 import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
@@ -43,7 +44,9 @@ class WeatherCardTest {
                 )
             }
         }
-        rule.onNodeWithText("Weather unavailable").assertIsDisplayed()
+        // The empty state is now an icon-only placeholder; the unavailable
+        // string is its contentDescription so TalkBack still announces it.
+        rule.onNodeWithContentDescription("Weather unavailable").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
@@ -40,10 +40,11 @@ import java.util.Locale
  * event). The events query window is `today + 5 days` to match the 6-cell
  * strip on the calendar card.
  *
- * When `READ_CALENDAR` is denied the events list is empty; the day strip
- * and head still render from the clock alone. The calling UI treats a
- * null snapshot as "loading"; an empty events list with non-null snapshot
- * means "granted but nothing scheduled".
+ * When `READ_CALENDAR` is denied the snapshot still emits from the clock
+ * alone, but with `hasCalendarAccess = false` so the card renders the denial
+ * message rather than a hollow strip. The calling UI treats a null snapshot
+ * as "loading"; a non-null snapshot with `hasCalendarAccess = true` and an
+ * empty events list means "granted but nothing scheduled".
  */
 internal class CalendarRepository(
     private val context: Context,
@@ -82,6 +83,7 @@ internal class CalendarRepository(
             monthLabel = monthLabelOf(today),
             dayStrip = stripWithDots,
             events = events.take(EVENT_LIST_LIMIT),
+            hasCalendarAccess = granted,
         )
     }
 

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarSnapshot.kt
@@ -12,8 +12,10 @@ import java.time.LocalTime
  * the next few events. The strip is always six entries starting at [today]
  * so the card can iterate without size guards.
  *
- * `null` is used at the [HomeUiState] level to denote "not loaded yet or
- * permission denied"; the card renders an empty state in that case.
+ * `null` denotes "not loaded yet" only. Permission denial is carried
+ * in-band by [hasCalendarAccess]: a non-null snapshot with
+ * [hasCalendarAccess] == false tells the card to render the denial message
+ * instead of an empty strip plus a misleading "no upcoming events".
  */
 @Immutable
 data class CalendarSnapshot(
@@ -22,6 +24,9 @@ data class CalendarSnapshot(
     val monthLabel: String,
     val dayStrip: List<DayCell>,
     val events: List<EventItem>,
+    // false means READ_CALENDAR is denied, so the strip / event sections carry
+    // no real data and the card shows the denial message instead.
+    val hasCalendarAccess: Boolean,
 )
 
 @Immutable

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatus.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatus.kt
@@ -13,7 +13,10 @@ import androidx.compose.runtime.Immutable
 data class SystemStatus(
     val wifiConnected: Boolean,
     val bluetoothConnected: Boolean,
-    val batteryPercent: Int,
+    // Null until the first battery reading arrives, or on battery-less units —
+    // distinguishes "unknown" from a genuine 0% so the footer never reads as a
+    // dead battery during cold start.
+    val batteryPercent: Int?,
     val charging: Boolean,
 ) {
     companion object {
@@ -21,7 +24,7 @@ data class SystemStatus(
             SystemStatus(
                 wifiConnected = false,
                 bluetoothConnected = false,
-                batteryPercent = 0,
+                batteryPercent = null,
                 charging = false,
             )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
@@ -48,7 +48,7 @@ internal class SystemStatusRepository(
         combine(
             wifiFlow().onStart { emit(false) },
             bluetoothFlow().onStart { emit(false) },
-            batteryFlow().onStart { emit(BatteryReading(0, false)) },
+            batteryFlow().onStart { emit(BatteryReading(percent = null, charging = false)) },
         ) { wifi, bt, battery ->
             SystemStatus(
                 wifiConnected = wifi,
@@ -137,7 +137,9 @@ internal class SystemStatusRepository(
                 if (intent != null) {
                     val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
                     val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
-                    val percent = if (level >= 0 && scale > 0) level * 100 / scale else 0
+                    // Null when the reading is unavailable; clamp the valid value here
+                    // so this SSOT is the only place the 0..100 range is enforced.
+                    val percent = if (level >= 0 && scale > 0) (level * 100 / scale).coerceIn(0, 100) else null
                     val plugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0)
                     trySend(BatteryReading(percent = percent, charging = plugged != 0))
                 }
@@ -159,7 +161,7 @@ internal class SystemStatusRepository(
         }
 
     private data class BatteryReading(
-        val percent: Int,
+        val percent: Int?,
         val charging: Boolean,
     )
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -72,12 +72,25 @@ internal fun CalendarCard(
                 .padding(FemtoDimens.CardPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        if (snapshot != null) {
-            Head(snapshot)
-            Strip(snapshot.dayStrip)
-            Events(snapshot.events)
-        } else {
-            EmptyState()
+        when {
+            // null is the loading frame: render nothing rather than a denial
+            // message the user has not earned yet.
+            snapshot == null -> {
+                Unit
+            }
+
+            // A non-null snapshot with access denied carries no real strip /
+            // event data, so show the denial message instead of a hollow strip
+            // plus a misleading "no upcoming events".
+            !snapshot.hasCalendarAccess -> {
+                PermissionDenied()
+            }
+
+            else -> {
+                Head(snapshot)
+                Strip(snapshot.dayStrip)
+                Events(snapshot.events)
+            }
         }
     }
 }
@@ -260,7 +273,7 @@ private fun EventRow(
 }
 
 @Composable
-private fun EmptyState() =
+private fun PermissionDenied() =
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
@@ -298,6 +311,7 @@ private fun CalendarCardPreview() {
                             EventItem(LocalTime.of(10, 30), "Team standup"),
                             EventItem(LocalTime.of(14, 0), "Pick up kids"),
                         ),
+                    hasCalendarAccess = true,
                 ),
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -30,6 +32,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.composables.icons.lucide.Battery
@@ -50,6 +53,11 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.TabularFigures
+
+// Below this footer width the read-only status cluster is dropped so the seven
+// nav buttons keep room to render at >= FemtoDimens.MinTouchTarget without
+// clipping on portrait / narrow head units.
+private val CompactFooterWidth: Dp = 640.dp
 
 /**
  * Bottom dock per `docs/design/dashboard-v2-mockup.html` `.footer`:
@@ -77,28 +85,38 @@ internal fun DashboardFooter(
 ) {
     Column {
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-        Row(
+        BoxWithConstraints(
             modifier =
                 Modifier
                     .fillMaxSize()
                     .padding(horizontal = 24.dp),
-            verticalAlignment = Alignment.CenterVertically,
         ) {
-            NavRow(
-                onAction = onAction,
-                modifier = Modifier.weight(1f),
-            )
-            VerticalDivider(
-                modifier =
-                    Modifier
-                        .padding(start = 4.dp)
-                        .height(48.dp),
-                color = MaterialTheme.colorScheme.outlineVariant,
-            )
-            StatusCluster(
-                status = systemStatus,
-                modifier = Modifier.padding(start = 20.dp),
-            )
+            // Seven 64 dp buttons plus the cluster need ~707 dp with zero slack;
+            // narrow portrait head units cannot fit both. Below the threshold the
+            // read-only status cluster yields so the actionable nav stays uncut.
+            val showStatusCluster = maxWidth >= CompactFooterWidth
+            Row(
+                modifier = Modifier.fillMaxSize(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                NavRow(
+                    onAction = onAction,
+                    modifier = Modifier.weight(1f),
+                )
+                if (showStatusCluster) {
+                    VerticalDivider(
+                        modifier =
+                            Modifier
+                                .padding(start = 4.dp)
+                                .height(48.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                    )
+                    StatusCluster(
+                        status = systemStatus,
+                        modifier = Modifier.padding(start = 20.dp),
+                    )
+                }
+            }
         }
     }
 }
@@ -112,47 +130,57 @@ private fun NavRow(
     horizontalArrangement = Arrangement.SpaceBetween,
     verticalAlignment = Alignment.CenterVertically,
 ) {
+    // Each button takes an equal weight so seven buttons share the width and
+    // shrink toward FemtoDimens.MinTouchTarget instead of clipping when the row
+    // is narrow. The widthIn floor in NavButton keeps every tap target legal.
     NavButton(
         icon = Lucide.House,
         description = stringResource(R.string.nav_home),
         active = true,
         onClick = { /* already on home */ },
+        modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.Phone,
         description = stringResource(R.string.nav_phone),
         active = false,
         onClick = { onAction(HomeAction.Shortcut(AppsBarShortcut.Phone)) },
+        modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.LayoutGrid,
         description = stringResource(R.string.nav_apps),
         active = false,
         onClick = { onAction(HomeAction.OpenAppDrawer) },
+        modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.Music,
         description = stringResource(R.string.nav_music),
         active = false,
         onClick = { onAction(HomeAction.Shortcut(AppsBarShortcut.Music)) },
+        modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.Navigation,
         description = stringResource(R.string.nav_navigation),
         active = false,
         onClick = { onAction(HomeAction.OpenMaps) },
+        modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.Globe,
         description = stringResource(R.string.nav_browser),
         active = false,
         onClick = { onAction(HomeAction.OpenBrowser) },
+        modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.Settings,
         description = stringResource(R.string.nav_settings),
         active = false,
         onClick = { onAction(HomeAction.OpenSettings) },
+        modifier = Modifier.weight(1f),
     )
 }
 
@@ -162,6 +190,7 @@ private fun NavButton(
     description: String,
     active: Boolean,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val background =
         if (active) MaterialTheme.colorScheme.primaryContainer else Color.Transparent
@@ -169,12 +198,14 @@ private fun NavButton(
         if (active) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
     Box(
         modifier =
-            Modifier
+            modifier
                 .height(FemtoDimens.MinTouchTarget)
-                .width(72.dp)
+                .widthIn(min = FemtoDimens.MinTouchTarget)
                 .clip(RoundedCornerShape(14.dp))
                 .background(background)
-                .clickable(onClick = onClick)
+                // The active Home button is the current surface — skip clickable so
+                // it shows no dead-tap ripple.
+                .then(if (active) Modifier else Modifier.clickable(onClick = onClick))
                 .semantics { contentDescription = description },
         contentAlignment = Alignment.Center,
     ) {
@@ -239,6 +270,7 @@ private fun StatusIcon(
     icon: ImageVector,
     active: Boolean,
     description: String,
+    modifier: Modifier = Modifier,
 ) {
     val tint =
         if (active) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outline
@@ -246,15 +278,17 @@ private fun StatusIcon(
         imageVector = icon,
         contentDescription = description,
         tint = tint,
-        modifier = Modifier.size(20.dp),
+        modifier = modifier.size(20.dp),
     )
 }
 
 @Composable
 private fun BatteryIndicator(
-    percent: Int,
+    percent: Int?,
     charging: Boolean,
+    modifier: Modifier = Modifier,
 ) = Row(
+    modifier = modifier,
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(6.dp),
 ) {
@@ -265,11 +299,17 @@ private fun BatteryIndicator(
         modifier = Modifier.size(20.dp),
     )
     Text(
+        // Render an em-dash while the percent is unknown (cold start / battery-less
+        // unit) so the cluster never reads as a dead 0% battery.
         text =
-            stringResource(
-                if (charging) R.string.battery_percent_charging else R.string.battery_percent,
-                percent,
-            ),
+            if (percent == null) {
+                "—"
+            } else {
+                stringResource(
+                    if (charging) R.string.battery_percent_charging else R.string.battery_percent,
+                    percent,
+                )
+            },
         style =
             MaterialTheme.typography.labelLarge.copy(
                 fontSize = 13.sp,
@@ -292,6 +332,25 @@ private fun DashboardFooterPreview() {
                     wifiConnected = true,
                     bluetoothConnected = true,
                     batteryPercent = 78,
+                    charging = false,
+                ),
+            onAction = {},
+        )
+    }
+}
+
+// Narrow portrait head unit: the status cluster drops and the nav buttons share
+// the width down toward FemtoDimens.MinTouchTarget rather than clipping.
+@Preview(name = "Dashboard footer (narrow)", widthDp = 520, heightDp = 80)
+@Composable
+private fun DashboardFooterNarrowPreview() {
+    FemtoTheme {
+        DashboardFooter(
+            systemStatus =
+                SystemStatus(
+                    wifiConnected = true,
+                    bluetoothConnected = false,
+                    batteryPercent = null,
                     charging = false,
                 ),
             onAction = {},

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -408,11 +408,14 @@ private fun ConnectState(onConnect: () -> Unit) =
             )
             Box(modifier = Modifier.height(4.dp))
             Text(
+                // Actionable copy the user must read to unlock the card: clear
+                // the head-unit glance floor (CLAUDE.md#automotive-overrides),
+                // unlike the sanctioned 13sp NoActiveSession EmptyState hint.
                 text = stringResource(R.string.music_connect_hint),
                 style =
-                    MaterialTheme.typography.bodySmall.copy(
-                        fontSize = 13.sp,
-                        lineHeight = 18.sp,
+                    MaterialTheme.typography.bodyMedium.copy(
+                        fontSize = FemtoDimens.MinBodyTextSize,
+                        lineHeight = FemtoDimens.MinBodyTextSize * 1.33f,
                     ),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -19,6 +19,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -61,6 +65,13 @@ import kotlin.math.roundToInt
  * The 40 sp speed numeral is the only saturated value here; the
  * supporting metrics use `onSurface` / `onSurfaceVariant` so the hero
  * number reads as the "thing you glance at" on the move.
+ *
+ * Live speed honours the permissions contract: with no fix
+ * (`location == null`) the hero cell shows an em-dash rather than "0",
+ * so a missing/denied location reads as "unknown", not "standstill". A
+ * 5-sample exponential moving average ([SPEED_OVERLAY_EMA_ALPHA])
+ * smooths the raw 1 Hz speed so the numeral stops flickering between
+ * adjacent integers on a steady cruise.
  */
 @Composable
 internal fun SpeedOverlay(
@@ -74,7 +85,20 @@ internal fun SpeedOverlay(
     // location.speed: cheap GPS chips leave Location.speed at 0.0
     // (hasSpeed() == false) while moving, which would pin the numeral to
     // zero. currentSpeedMs falls back to the position-derived speed.
-    val currentSpeed = speedUnit.fromMetersPerSecond(tripState.currentSpeedMs.toFloat()).roundToInt()
+    //
+    // The EMA accumulator is keyed off the latest fix so a new sample
+    // advances the average and a null fix (no location) resets it; the
+    // first non-null sample seeds the accumulator with itself.
+    val smoothedSpeedMs = remember { mutableStateOf<Float?>(null) }
+    smoothedSpeedMs.value =
+        location?.let { emaStep(smoothedSpeedMs.value, tripState.currentSpeedMs.toFloat(), SPEED_OVERLAY_EMA_ALPHA) }
+    val currentSpeedText by remember(speedUnit) {
+        derivedStateOf {
+            smoothedSpeedMs.value
+                ?.let { "${speedUnit.fromMetersPerSecond(it).roundToInt()}" }
+                ?: NO_SPEED_PLACEHOLDER
+        }
+    }
     val distance = speedUnit.tripDistanceFromMeters(tripState.distanceMeters)
     val avgSpeed = speedUnit.fromMetersPerSecond(tripState.avgSpeedMs.toFloat()).roundToInt()
     val shortAddress = address?.displayString().orEmpty()
@@ -96,7 +120,7 @@ internal fun SpeedOverlay(
                 ).padding(horizontal = 24.dp, vertical = 16.dp),
     ) {
         MetricRow(
-            currentSpeed = currentSpeed,
+            currentSpeed = currentSpeedText,
             speedUnitLabel = speedUnit.label(),
             distance = distance,
             distanceUnitLabel = speedUnit.distanceLabel(),
@@ -113,7 +137,7 @@ internal fun SpeedOverlay(
 
 @Composable
 private fun MetricRow(
-    currentSpeed: Int,
+    currentSpeed: String,
     speedUnitLabel: String,
     distance: Double,
     distanceUnitLabel: String,
@@ -134,14 +158,14 @@ private fun MetricRow(
 
 @Composable
 private fun NowMetric(
-    value: Int,
+    value: String,
     unit: String,
 ) = Row(
     verticalAlignment = Alignment.Bottom,
     horizontalArrangement = Arrangement.spacedBy(4.dp),
 ) {
     Text(
-        text = "$value",
+        text = value,
         style =
             MaterialTheme.typography.displayMedium.copy(
                 fontSize = 40.sp,
@@ -227,15 +251,61 @@ private fun AddressRow(text: String) =
         )
     }
 
+/**
+ * Advance an exponential moving average (EMA) by one sample.
+ *
+ * Return [sample] when [previous] is null so the first reading seeds the
+ * accumulator with itself; otherwise return the standard EMA update
+ * `previous + alpha * (sample - previous)`. A larger [alpha] weights the
+ * newest sample more heavily (faster response, less smoothing). The
+ * function is pure so the smoothing math is JVM-unit-testable in
+ * isolation from Compose.
+ */
+internal fun emaStep(
+    previous: Float?,
+    sample: Float,
+    alpha: Float,
+): Float = previous?.let { it + alpha * (sample - it) } ?: sample
+
+/**
+ * Roughly a 5-sample window: each sample retains `(1 - alpha)` of the
+ * prior estimate, so 0.33 settles a steady reading within ~5 ticks of
+ * the 1 Hz speed stream.
+ */
+private const val SPEED_OVERLAY_EMA_ALPHA = 0.33f
+
+// Em-dash stands in for the live speed when there is no fix, mirroring
+// the WeatherCard convention and the permissions contract (location
+// panels read empty until granted). It avoids the ambiguous "0".
+private const val NO_SPEED_PLACEHOLDER = "—"
+
 @PreviewLightDark
 @Preview(name = "Speed overlay", widthDp = 520, heightDp = 140)
 @Composable
 private fun SpeedOverlayPreview() {
     FemtoTheme {
+        // A non-null fix exercises the live-speed path so the hero numeral
+        // renders the smoothed value rather than the no-fix em-dash.
+        SpeedOverlay(
+            location = Location("preview").apply { speed = 13.2f },
+            address = ShortAddress(locality = "Minato-ku", region = "Tokyo"),
+            tripState = TripState(distanceMeters = 24_400.0, avgSpeedMs = 11.7, currentSpeedMs = 13.2),
+            speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+        )
+    }
+}
+
+@PreviewLightDark
+@Preview(name = "Speed overlay (no fix)", widthDp = 520, heightDp = 140)
+@Composable
+private fun SpeedOverlayNoFixPreview() {
+    FemtoTheme {
+        // No fix: the hero cell shows the em-dash placeholder while the
+        // distance stays "0.0" for a fresh trip.
         SpeedOverlay(
             location = null,
             address = ShortAddress(locality = "Minato-ku", region = "Tokyo"),
-            tripState = TripState(distanceMeters = 24_400.0, avgSpeedMs = 11.7, currentSpeedMs = 13.2),
+            tripState = TripState.Initial,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -288,10 +288,15 @@ private fun EmptyState() =
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = stringResource(R.string.weather_unavailable),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        // The cold-start window reads as an error when shown as text. Per the
+        // spec the empty state is an icon-only placeholder with no error copy;
+        // the unavailable string moves to contentDescription so TalkBack still
+        // announces the state.
+        Icon(
+            imageVector = Lucide.Cloud,
+            contentDescription = stringResource(R.string.weather_unavailable),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(48.dp),
         )
     }
 

--- a/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
@@ -26,6 +26,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -49,6 +50,9 @@ class CalendarRepositoryTest {
             val snapshot = repository.snapshotFlow().first()
 
             assertNotNull(snapshot)
+            // The snapshot must mark access denied in-band so the card can
+            // render the denial message rather than a hollow strip.
+            assertFalse(snapshot.hasCalendarAccess)
             assertTrue(snapshot.events.isEmpty())
             assertEquals(6, snapshot.dayStrip.size)
         }
@@ -101,6 +105,9 @@ class CalendarRepositoryTest {
 
             val snapshot = repository.snapshotFlow().first()
             assertNotNull(snapshot)
+            // The permission is granted here, so the snapshot must report
+            // access true (the mirror of the denied-path assertion above).
+            assertTrue(snapshot.hasCalendarAccess)
 
             // The event day is one day after today, so a correct read dots the
             // second strip cell and leaves today (cell 0) undotted; a system-zone

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
@@ -24,6 +24,7 @@ internal fun fakeCalendarSnapshot(
             EventItem(LocalTime.of(10, 30), "Team standup"),
             EventItem(LocalTime.of(14, 0), "Pick up kids"),
         ),
+    hasCalendarAccess: Boolean = true,
 ): CalendarSnapshot =
     CalendarSnapshot(
         today = today,
@@ -31,4 +32,5 @@ internal fun fakeCalendarSnapshot(
         monthLabel = monthLabel,
         dayStrip = dayStrip,
         events = events,
+        hasCalendarAccess = hasCalendarAccess,
     )

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
@@ -5,7 +5,7 @@ import io.github.seijikohara.femto.data.SystemStatus
 internal fun fakeSystemStatus(
     wifiConnected: Boolean = true,
     bluetoothConnected: Boolean = true,
-    batteryPercent: Int = 78,
+    batteryPercent: Int? = 78,
     charging: Boolean = false,
 ): SystemStatus =
     SystemStatus(

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayEmaTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayEmaTest.kt
@@ -1,0 +1,43 @@
+package io.github.seijikohara.femto.ui.home.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpeedOverlayEmaTest {
+    @Test
+    fun `null previous seeds the accumulator with the sample`() {
+        assertEquals(12.5f, emaStep(previous = null, sample = 12.5f, alpha = 0.33f), 0f)
+    }
+
+    @Test
+    fun `single step moves toward the sample by alpha`() {
+        // previous + alpha * (sample - previous) = 10 + 0.5 * (20 - 10) = 15.
+        assertEquals(15f, emaStep(previous = 10f, sample = 20f, alpha = 0.5f), 1e-4f)
+    }
+
+    @Test
+    fun `repeated steps converge toward a steady sample`() {
+        val target = 30f
+        val converged =
+            (1..10).fold(0f) { estimate, _ ->
+                emaStep(previous = estimate, sample = target, alpha = 0.33f)
+            }
+        assertTrue(
+            "estimate $converged should be within 1 of the steady sample $target",
+            kotlin.math.abs(converged - target) < 1f,
+        )
+    }
+
+    @Test
+    fun `larger alpha takes a bigger step toward the same sample`() {
+        val slow = emaStep(previous = 0f, sample = 100f, alpha = 0.2f)
+        val fast = emaStep(previous = 0f, sample = 100f, alpha = 0.8f)
+        assertTrue("higher alpha must respond faster: slow=$slow fast=$fast", fast > slow)
+    }
+
+    @Test
+    fun `zero alpha holds the previous estimate`() {
+        assertEquals(42f, emaStep(previous = 42f, sample = 100f, alpha = 0f), 0f)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4 of the completeness roadmap — fabricated zeros, blank rows, and
below-floor CTA copy that degrade the at-a-glance read on a head unit.

## Changes

- **Calendar denial (4.1)**: `CalendarSnapshot.hasCalendarAccess` carries permission
  state in-band; `null` now means loading only. A denied user sees the denial copy
  instead of a full date strip + a misleading "No upcoming events".
- **SpeedOverlay (4.2/4.3)**: an em-dash for the live-speed cell when there is no fix
  (distinct from a real standstill, per the permissions contract), plus a 5-sample
  EMA on the hero numeral (extracted, unit-tested `emaStep`).
- **Battery + footer (4.5/4.6)**: `SystemStatus.batteryPercent` is nullable, computed
  and `coerceIn(0,100)`-clamped at the repository SSOT, rendered as an em-dash when
  unknown instead of "0%". `NavRow` is width-aware (drops the status cluster at compact
  widths so it never clips on portrait/narrow units); private footer composables take a
  `modifier`; the active Home button is no longer clickable.
- **Weather empty (4.7)**: a dimmed icon placeholder (unavailable copy → contentDescription)
  instead of error-like text.
- **Music CTA (4.8)**: the actionable notification-access instruction now clears the
  18 sp glance floor.

## Tests

80 JVM tests pass (new `emaStep` suite + `hasCalendarAccess` assertions); the
WeatherCard empty-state instrumented assertion moved to the icon contentDescription.

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green.