### PR TITLE
fix: Phase 5 resilience follow-ups (map retry/low-memory, weather decode/heartbeat, BT recovery, shared GPS)

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import io.github.seijikohara.femto.data.AppsRepository
+import io.github.seijikohara.femto.data.SystemPermissionSignals
 import io.github.seijikohara.femto.data.hasBluetoothConnectPermission
 import io.github.seijikohara.femto.data.hasFineLocationPermission
 import io.github.seijikohara.femto.data.hasReadCalendarPermission
@@ -28,10 +29,12 @@ import io.github.seijikohara.femto.ui.theme.FemtoTheme
 class MainActivity : ComponentActivity() {
     private val appsRepository by lazy { AppsRepository(this) }
 
-    // Permission results are not consumed here — each repository self-checks
-    // on every emit, so a late grant flows through naturally.
+    // Emit on the process-wide refresh signal so permission-gated flows (e.g.
+    // the Bluetooth footer indicator) re-read after a late runtime grant.
     private val permissionsLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { /* no-op */ }
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+            SystemPermissionSignals.refreshes.tryEmit(Unit)
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()

--- a/app/src/main/java/io/github/seijikohara/femto/data/LocationRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/LocationRepository.kt
@@ -9,19 +9,29 @@ import androidx.core.content.getSystemService
 import androidx.core.location.LocationListenerCompat
 import androidx.core.location.LocationManagerCompat
 import androidx.core.location.LocationRequestCompat
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.shareIn
 
 internal class LocationRepository(
     private val context: Context,
+    // Repository-scoped scope owns the single shared GPS subscription. The default keeps
+    // production wiring trivial; tests inject their own scope to drive shareIn deterministically.
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
     private val locationManager: LocationManager = checkNotNull(context.getSystemService())
 
+    // Cold per-collector flow: each terminal collection registers its own GPS updates and
+    // getLastKnownLocation. Never expose this directly; it is the upstream for the shared flow.
     @SuppressLint("MissingPermission") // Caller checks ACCESS_FINE_LOCATION before subscribing.
-    fun locationFlow(): Flow<Location?> =
+    private fun rawLocationFlow(): Flow<Location?> =
         callbackFlow {
             val listener = LocationListenerCompat { location -> trySend(location) }
 
@@ -41,6 +51,20 @@ internal class LocationRepository(
 
             awaitClose { locationManager.removeUpdates(listener) }
         }.flowOn(Dispatchers.Main.immediate)
+
+    // Single hot fan-out of the cold raw flow. On an always-on head unit the four consumers
+    // (ViewModel combine, ReverseGeocoder, Weather, Trip) collect the same instance, so they
+    // share one platform GPS registration + one getLastKnownLocation instead of four each.
+    // WhileSubscribed(5_000) gates that single registration: it starts on the first collector,
+    // and stops ~5s after the last collector leaves (the grace window avoids tearing down and
+    // re-registering GPS across brief recomposition / config-change gaps). replay = 1 hands a
+    // late subscriber the most recent fix immediately rather than waiting for the next update.
+    private val shared: SharedFlow<Location?> =
+        rawLocationFlow().shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 1)
+
+    // The repository factory already builds one LocationRepository and passes the single flow
+    // instance to all consumers, so returning the shared flow makes that sharing real.
+    fun locationFlow(): Flow<Location?> = shared
 
     private companion object {
         const val LOCATION_INTERVAL_MS = 1_000L

--- a/app/src/main/java/io/github/seijikohara/femto/data/OpenMeteoApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/OpenMeteoApi.kt
@@ -53,12 +53,15 @@ internal class OpenMeteoApi(
     data class Current(
         val time: String,
         val temperature_2m: Double,
-        val apparent_temperature: Double,
         val weathercode: Int,
-        val windspeed_10m: Double,
+        // Secondary fields are nullable: a payload that drops them must still
+        // yield a usable temperature + code reading instead of failing decoding
+        // with MissingFieldException and discarding the whole snapshot.
+        val apparent_temperature: Double? = null,
+        val windspeed_10m: Double? = null,
         val relative_humidity_2m: Double? = null,
         val uv_index: Double? = null,
-        val is_day: Int,
+        val is_day: Int? = null,
     )
 
     @Serializable

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemPermissionSignals.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemPermissionSignals.kt
@@ -1,0 +1,20 @@
+package io.github.seijikohara.femto.data
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+/**
+ * Process-wide nudge for permission-gated flows.
+ *
+ * A dangerous runtime permission (e.g. `BLUETOOTH_CONNECT`) has no
+ * ContentObserver to watch, unlike the notification-listener setting that
+ * [MusicSessionRepository] observes. The in-app permission dialog keeps the
+ * activity merely PAUSED (not STOPPED), so a grant does not restart the
+ * permission-gated collectors. This lightweight signal lets `MainActivity`
+ * re-trigger a re-read once a permission result lands, without waiting for a
+ * domain broadcast or an app restart.
+ */
+internal object SystemPermissionSignals {
+    // Emitted when a runtime permission result lands so permission-gated flows
+    // can re-read without waiting for a domain event or an app restart.
+    val refreshes: MutableSharedFlow<Unit> = MutableSharedFlow(extraBufferCapacity = 1)
+}

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
@@ -26,6 +26,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
 
 /**
@@ -85,7 +87,23 @@ internal class SystemStatusRepository(
         }
     }
 
+    /**
+     * Connected-state stream merging two re-read triggers:
+     * - [bluetoothBroadcastFlow] fires on BT adapter / connection broadcasts.
+     * - [SystemPermissionSignals.refreshes] fires when a runtime permission
+     *   result lands. A `BLUETOOTH_CONNECT` grant from the in-app dialog leaves
+     *   the activity PAUSED (not STOPPED), so without this nudge the indicator
+     *   would stay dimmed until the next BT broadcast. The outer
+     *   [statusFlow] keeps its `distinctUntilChanged`, so an unchanged value is
+     *   suppressed.
+     */
     private fun bluetoothFlow(): Flow<Boolean> =
+        merge(
+            bluetoothBroadcastFlow(),
+            SystemPermissionSignals.refreshes.map { readBluetoothConnected(bluetoothManager?.adapter) },
+        )
+
+    private fun bluetoothBroadcastFlow(): Flow<Boolean> =
         callbackFlow {
             val adapter: BluetoothAdapter? = bluetoothManager?.adapter
             trySend(readBluetoothConnected(adapter))

--- a/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
@@ -3,8 +3,11 @@ package io.github.seijikohara.femto.data
 import android.location.Location
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -17,6 +20,7 @@ import kotlin.math.roundToInt
 internal class WeatherRepository(
     private val api: OpenMeteoApi,
     private val locationFlow: Flow<Location?>,
+    private val clockFlow: Flow<ClockTick>,
     private val clock: Clock = Clock.systemUTC(),
 ) {
     private var cached: WeatherSnapshot? = null
@@ -27,12 +31,19 @@ internal class WeatherRepository(
     // the public Open-Meteo endpoint, which would risk a ban.
     private var lastAttemptAt: Instant? = null
 
+    // Last-seen fix, updated by the location path and re-read on every clock tick.
+    // The clock heartbeat lets weather re-evaluate refresh while parked indoors or
+    // underground, where GPS stops emitting but the network is still reachable.
+    private val latest = MutableStateFlow<Location?>(null)
+
     fun snapshotFlow(): Flow<WeatherSnapshot?> =
-        flow {
-            locationFlow.collect { location ->
-                emit(refresh(location) ?: cached)
-            }
-        }.flowOn(Dispatchers.IO)
+        merge(
+            locationFlow.onEach { latest.value = it },
+            // merge (not combine) keeps the location path working when clockFlow
+            // is empty; combine would stall until the clock emitted at least once.
+            clockFlow.map { latest.value },
+        ).map { location -> refresh(location) ?: cached }
+            .flowOn(Dispatchers.IO)
 
     private suspend fun refresh(location: Location?): WeatherSnapshot? {
         location ?: return null
@@ -45,12 +56,14 @@ internal class WeatherRepository(
         cached =
             WeatherSnapshot(
                 tempC = current.temperature_2m,
-                apparentTempC = current.apparent_temperature,
+                // Fall back to the air temperature when "feels like" is absent so a
+                // dropped secondary field never discards the usable reading.
+                apparentTempC = current.apparent_temperature ?: current.temperature_2m,
                 code = WeatherCode.fromWmo(current.weathercode),
-                windKmh = current.windspeed_10m,
+                windKmh = current.windspeed_10m ?: 0.0,
                 humidityPercent = current.relative_humidity_2m?.roundToInt(),
                 uvIndex = current.uv_index,
-                isDay = current.is_day == 1,
+                isDay = (current.is_day ?: 1) == 1,
                 sunrise = response.daily
                     ?.sunrise
                     ?.firstOrNull()

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -171,7 +171,7 @@ internal class HomeViewModelFactory(
             )
         val geocoder = ReverseGeocoderRepository(locationFlow, nominatimApi)
         val weatherApi = OpenMeteoApi(client = httpClient)
-        val weather = WeatherRepository(weatherApi, locationFlow)
+        val weather = WeatherRepository(weatherApi, locationFlow, clockFlow)
         val music = MusicSessionRepository(application)
         val calendar = CalendarRepository(application, clockFlow)
         val systemStatus = SystemStatusRepository(application)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -1,8 +1,11 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import android.annotation.SuppressLint
+import android.content.ComponentCallbacks2
 import android.content.Context
+import android.content.res.Configuration
 import android.location.Location
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -36,6 +40,7 @@ import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.MapPinOff
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import kotlinx.coroutines.delay
 import org.maplibre.android.MapLibre
 import org.maplibre.android.camera.CameraUpdateFactory
 import org.maplibre.android.location.LocationComponentActivationOptions
@@ -120,8 +125,15 @@ private fun VectorMap(
 
     var map by remember { mutableStateOf<MapLibreMap?>(null) }
     var loadFailed by remember { mutableStateOf(false) }
+    // OpenFreeMap is a no-SLA host: a single transient style/tile failure must
+    // not strand the fallback forever. retryTick re-keys the style effect to
+    // re-run setStyle; retryAttempt bounds the automatic retries so a hard
+    // outage settles on the fallback instead of looping indefinitely.
+    var retryTick by remember { mutableIntStateOf(0) }
+    var retryAttempt by remember { mutableIntStateOf(0) }
 
     ForwardLifecycle(mapView)
+    ForwardLowMemory(mapView)
 
     LaunchedEffect(mapView) {
         mapView.addOnDidFailLoadingMapListener { loadFailed = true }
@@ -143,13 +155,28 @@ private fun VectorMap(
     }
 
     // Re-apply the style (and re-activate the location layer it owns) whenever
-    // the map becomes ready or the system theme flips between light and dark.
-    LaunchedEffect(map, isDark) {
+    // the map becomes ready, the system theme flips, or a retry is scheduled.
+    // retryTick is in the key so a bumped tick re-runs setStyle.
+    LaunchedEffect(map, isDark, retryTick) {
         val ready = map ?: return@LaunchedEffect
         loadFailed = false
         ready.setStyle(styleFor(context, isDark)) { style ->
+            // A completed style load means the host answered: clear the attempt
+            // budget so a later, unrelated failure starts its backoff fresh.
+            retryAttempt = 0
             activateHeadingUp(context, ready, style)
             ready.locationComponent.forceLocationUpdate(location.withCarriedBearing(bearingHolder))
+        }
+    }
+
+    // When a load fails, schedule a bounded, exponentially backed-off retry by
+    // bumping retryTick. The delay grows 2s, 4s, 8s so a flapping host is given
+    // room to recover without hammering it; after MAX_RETRIES the fallback stays.
+    LaunchedEffect(loadFailed) {
+        if (loadFailed && retryAttempt < MAX_RETRIES) {
+            delay(RETRY_BASE_DELAY_MS shl retryAttempt)
+            retryAttempt += 1
+            retryTick += 1
         }
     }
 
@@ -168,9 +195,17 @@ private fun VectorMap(
             factory = { mapView },
         )
         // OpenFreeMap is a free, no-SLA service; a failed style/tile load shows
-        // the static fallback rather than a blank or black rectangle.
+        // the static fallback rather than a blank or black rectangle. A tap
+        // forces an immediate retry: reset the budget so the user gets a fresh
+        // round of backed-off attempts even after the automatic ones are spent.
         if (loadFailed) {
-            Fallback()
+            Fallback(
+                modifier =
+                    Modifier.clickable {
+                        retryAttempt = 0
+                        retryTick += 1
+                    },
+            )
         }
     }
 }
@@ -195,6 +230,31 @@ private fun ForwardLifecycle(mapView: MapView) {
             mapView.onStop()
             mapView.onDestroy()
         }
+    }
+}
+
+// MapView needs onLowMemory() to release its GL tile / glyph caches under
+// pressure; lifecycle events alone never deliver it. Head units are RAM-tight,
+// so forward both the explicit onLowMemory callback and onTrimMemory once the
+// system reaches RUNNING_LOW, before the OS starts killing background apps.
+@Composable
+private fun ForwardLowMemory(mapView: MapView) {
+    val context = LocalContext.current
+    DisposableEffect(context, mapView) {
+        val callbacks =
+            object : ComponentCallbacks2 {
+                override fun onLowMemory() = mapView.onLowMemory()
+
+                override fun onTrimMemory(level: Int) {
+                    if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
+                        mapView.onLowMemory()
+                    }
+                }
+
+                override fun onConfigurationChanged(newConfig: Configuration) = Unit
+            }
+        context.registerComponentCallbacks(callbacks)
+        onDispose { context.unregisterComponentCallbacks(callbacks) }
     }
 }
 
@@ -241,9 +301,9 @@ private fun Location.withCarriedBearing(holder: FloatArray): Location =
     }
 
 @Composable
-private fun Fallback() =
+private fun Fallback(modifier: Modifier = Modifier) =
     Column(
-        modifier = Modifier.fillMaxSize().padding(32.dp),
+        modifier = modifier.fillMaxSize().padding(32.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -270,3 +330,8 @@ private fun Fallback() =
 private const val MAP_ZOOM = 15.0
 private const val POSITRON_STYLE_URL = "https://tiles.openfreemap.org/styles/positron"
 private const val DARK_STYLE_ASSET = "map/dark.json"
+
+// Automatic style-reload budget after a load failure. The delay is
+// RETRY_BASE_DELAY_MS shifted left by the attempt index, yielding 2s, 4s, 8s.
+private const val MAX_RETRIES = 3
+private const val RETRY_BASE_DELAY_MS = 2_000L

--- a/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.data
 
 import app.cash.turbine.test
 import io.github.seijikohara.femto.testfixtures.fakeLocation
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -51,6 +52,7 @@ class WeatherRepositoryTest {
                 WeatherRepository(
                     api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
                     locationFlow = flowOf(fakeLocation()),
+                    clockFlow = emptyFlow(),
                     clock = Clock.fixed(Instant.parse("2026-05-01T05:32:00Z"), ZoneOffset.UTC),
                 )
 
@@ -78,6 +80,7 @@ class WeatherRepositoryTest {
                 WeatherRepository(
                     api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
                     locationFlow = flowOf(fakeLocation()),
+                    clockFlow = emptyFlow(),
                     clock = Clock.fixed(Instant.parse("2026-05-01T05:32:00Z"), ZoneOffset.UTC),
                 )
 
@@ -101,6 +104,7 @@ class WeatherRepositoryTest {
                 WeatherRepository(
                     api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
                     locationFlow = flowOf(fakeLocation()),
+                    clockFlow = emptyFlow(),
                     clock = Clock.fixed(Instant.parse("2026-05-01T05:32:00Z"), ZoneOffset.UTC),
                 )
 
@@ -125,6 +129,7 @@ class WeatherRepositoryTest {
                 WeatherRepository(
                     api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
                     locationFlow = flowOf(fakeLocation()),
+                    clockFlow = emptyFlow(),
                     clock = Clock.systemUTC(),
                 )
 
@@ -141,6 +146,7 @@ class WeatherRepositoryTest {
                 WeatherRepository(
                     api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
                     locationFlow = flowOf(null),
+                    clockFlow = emptyFlow(),
                     clock = Clock.systemUTC(),
                 )
 
@@ -167,6 +173,7 @@ class WeatherRepositoryTest {
                         clock.advanceBy(Duration.ofSeconds(10))
                         emit(fakeLocation())
                     },
+                    clockFlow = emptyFlow(),
                     clock = clock,
                 )
 
@@ -197,6 +204,7 @@ class WeatherRepositoryTest {
                         clock.advanceBy(Duration.ofSeconds(61))
                         emit(fakeLocation())
                     },
+                    clockFlow = emptyFlow(),
                     clock = clock,
                 )
 
@@ -207,6 +215,33 @@ class WeatherRepositoryTest {
             }
 
             assertEquals(2, server.requestCount)
+        }
+
+    @Test
+    fun `yields a snapshot from temperature and code when secondary current fields are missing`() =
+        runTest {
+            // A current block lacking apparent_temperature, windspeed_10m, and is_day
+            // must still decode (no MissingFieldException) and fall back to the air
+            // temperature and sensible defaults instead of discarding the reading.
+            server.enqueue(MockResponse().setBody(CURRENT_MINIMAL_BODY))
+
+            val repo =
+                WeatherRepository(
+                    api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
+                    locationFlow = flowOf(fakeLocation()),
+                    clockFlow = emptyFlow(),
+                    clock = Clock.fixed(Instant.parse("2026-05-01T05:32:00Z"), ZoneOffset.UTC),
+                )
+
+            repo.snapshotFlow().test {
+                val snapshot = assertNotNull(awaitItem())
+                assertEquals(18.5, snapshot.tempC, 0.0)
+                assertEquals(18.5, snapshot.apparentTempC, 0.0)
+                assertEquals(WeatherCode.CLEAR, snapshot.code)
+                assertEquals(0.0, snapshot.windKmh, 0.0)
+                assertTrue(snapshot.isDay)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
 
     // Mutable clock whose instant the test advances explicitly to exercise the
@@ -261,6 +296,19 @@ class WeatherRepositoryTest {
                 "weathercode": [0, 2, 61],
                 "temperature_2m_max": [22.0, 23.0, 21.0],
                 "temperature_2m_min": [14.0, 15.0, 14.0]
+              }
+            }
+        """
+
+        // A current block carrying only the required temperature_2m + weathercode,
+        // with all secondary fields absent.
+        const val CURRENT_MINIMAL_BODY = """
+            {
+              "timezone": "Asia/Tokyo",
+              "current": {
+                "time": "2026-05-01T11:00",
+                "temperature_2m": 18.5,
+                "weathercode": 0
               }
             }
         """


### PR DESCRIPTION
## Summary

Phase 5 of the completeness roadmap — resilience follow-ups for the long-lived HOME
process. (5.8 monotonic trip clock shipped in the trip PR; 5.7 is obsolete — the home
no longer holds an app list after the dashboard-render PR, and the drawer queries on
open.)

## Changes

- **MapPanel (5.1/5.2)**: retry a failed MapLibre style load with bounded exponential
  backoff (3 attempts at 2s/4s/8s, plus tap-to-retry) instead of latching "Map
  unavailable" forever; forward `onLowMemory`/`onTrimMemory(RUNNING_LOW)` to the
  `MapView` via a `ComponentCallbacks2` so the GL tile/glyph caches release under
  pressure.
- **WeatherRepository / OpenMeteoApi (5.3/5.4)**: the secondary `current` fields
  (`apparent_temperature`, `windspeed_10m`, `is_day`) are nullable with fallbacks, so a
  dropped field no longer discards a usable temperature/code reading; a **clock
  heartbeat** (`merge` of location + clock) refreshes weather when GPS stops emitting
  (parked indoors) — with no happy-path request increase (gating unchanged).
- **SystemStatusRepository (5.5)**: recover the Bluetooth footer indicator after a
  runtime `BLUETOOTH_CONNECT` grant via a lightweight process-wide
  `SystemPermissionSignals` nudge emitted from `MainActivity`'s permission result (a
  dangerous permission has no setting observer, unlike the music NLS).
- **LocationRepository (5.6)**: `shareIn` the GPS flow (`WhileSubscribed`, `replay=1`)
  so the four consumers share one platform registration instead of four.

## Tests

81 JVM tests pass, incl. a new missing-secondary-field decode case and the `clockFlow`
wiring across the WeatherRepository suite.

## Notes

Two non-fatal deprecation warnings remain in MapPanel (`LocalLifecycleOwner` import,
`TRIM_MEMORY_RUNNING_LOW`) — folded into the Phase 8 cleanup.

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green.