### PR TITLE
chore: build, dependency & manifest hygiene (Phase 6)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,26 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.spotless)
 }
+
+// Production geocoder host is threaded in via gitignored local.properties so the
+// public PoC endpoint is never the implicit production default. Production builds
+// should set GEOCODER_BASE_URL (and GEOCODER_API_KEY when the host requires one)
+// to a non-public host; absent keys fall back to the public Nominatim PoC endpoint.
+val localProperties =
+    Properties().apply {
+        rootProject
+            .file("local.properties")
+            .takeIf { it.exists() }
+            ?.inputStream()
+            ?.use { load(it) }
+    }
+val geocoderBaseUrl = localProperties.getProperty("GEOCODER_BASE_URL", "https://nominatim.openstreetmap.org/")
+val geocoderApiKey = localProperties.getProperty("GEOCODER_API_KEY", "")
 
 spotless {
     val ktlintVersion = libs.versions.ktlint.get()
@@ -35,10 +52,17 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "GEOCODER_BASE_URL", "\"${geocoderBaseUrl}\"")
+        buildConfigField("String", "GEOCODER_API_KEY", "\"${geocoderApiKey}\"")
     }
 
     buildTypes {
         release {
+            // Intentionally unminified: the launcher is a small, reflection-light app
+            // and keeping R8 off removes a class of release-only stripping bugs. The
+            // keep rules in proguard-rules.pro stay R8-ready so this flag can flip to
+            // true later without a separate audit.
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -57,6 +81,10 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
+            // Plain JVM unit tests (NominatimApiTest) reach android.util.Log on
+            // the failure path; without this the stub throws "not mocked".
+            // Returning defaults lets the void Log calls no-op instead.
+            isReturnDefaultValues = true
         }
     }
 }
@@ -75,7 +103,6 @@ dependencies {
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.composables.icons.lucide)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
@@ -87,8 +114,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockito.core)
-    testImplementation(libs.mockito.kotlin)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.robolectric)
     testImplementation(libs.turbine)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,40 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# ---------------------------------------------------------------------------
+# Future-minify guard rules. These are inert while isMinifyEnabled = false in
+# build.gradle.kts, but stay in place so flipping minify on does not regress
+# kotlinx-serialization reflection or MapLibre's native/reflective surface.
+# ---------------------------------------------------------------------------
+
+# kotlinx-serialization: standard keep rules. R8 strips the synthetic
+# serializer companions and @Serializable metadata without these.
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.**
+
+# Keep the @Serializer/@Serializable-generated serializer companions.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    *** Companion;
+}
+
+# Keep the serializer() accessor and named-companion serializers.
+-keepclasseswithmembers class **$$serializer {
+    *** INSTANCE;
+}
+
+# MapLibre: relies on native (JNI) and reflective access; keep its classes and
+# silence warnings for missing optional references.
+-keep class org.maplibre.** { *; }
+-dontwarn org.maplibre.**

--- a/app/src/main/java/io/github/seijikohara/femto/data/LocationPermissions.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/LocationPermissions.kt
@@ -21,6 +21,17 @@ internal fun Context.hasFineLocationPermission(): Boolean =
         Manifest.permission.ACCESS_FINE_LOCATION,
     ) == PackageManager.PERMISSION_GRANTED
 
+/**
+ * A coarse-only grant (the system "Approximate" toggle) lets the launcher
+ * serve location at degraded precision via the network provider, honoring the
+ * manifest's `ACCESS_COARSE_LOCATION` contract when the user withholds fine.
+ */
+internal fun Context.hasCoarseLocationPermission(): Boolean =
+    ContextCompat.checkSelfPermission(
+        this,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED
+
 internal fun Context.hasReadCalendarPermission(): Boolean =
     ContextCompat.checkSelfPermission(
         this,

--- a/app/src/main/java/io/github/seijikohara/femto/data/LocationRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/LocationRepository.kt
@@ -28,26 +28,37 @@ internal class LocationRepository(
 ) {
     private val locationManager: LocationManager = checkNotNull(context.getSystemService())
 
-    // Cold per-collector flow: each terminal collection registers its own GPS updates and
+    // Cold per-collector flow: each terminal collection registers updates and seeds
     // getLastKnownLocation. Never expose this directly; it is the upstream for the shared flow.
-    @SuppressLint("MissingPermission") // Caller checks ACCESS_FINE_LOCATION before subscribing.
+    //
+    // Both GPS_PROVIDER and NETWORK_PROVIDER are registered so the launcher honors the
+    // ACCESS_COARSE_LOCATION manifest contract: a coarse-only ("Approximate") grant makes
+    // GPS_PROVIDER throw SecurityException while NETWORK_PROVIDER still delivers fixes at
+    // degraded precision, and a device without network location still gets GPS. Each provider
+    // is guarded by its own runCatching so a SecurityException or a missing provider on one
+    // never disturbs the other. A per-provider failure is dropped (no null emission) so a
+    // working provider is never blanked by the other's absence.
+    @SuppressLint("MissingPermission") // Caller checks fine or coarse location before subscribing.
     private fun rawLocationFlow(): Flow<Location?> =
         callbackFlow {
+            // One listener shared across both registrations; each fix is forwarded verbatim.
             val listener = LocationListenerCompat { location -> trySend(location) }
 
-            runCatching {
-                locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
-            }.onSuccess { trySend(it) }
+            listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER).forEach { provider ->
+                runCatching {
+                    locationManager.getLastKnownLocation(provider)
+                }.onSuccess { trySend(it) }
 
-            runCatching {
-                LocationManagerCompat.requestLocationUpdates(
-                    locationManager,
-                    LocationManager.GPS_PROVIDER,
-                    LocationRequestCompat.Builder(LOCATION_INTERVAL_MS).build(),
-                    listener,
-                    Looper.getMainLooper(),
-                )
-            }.onFailure { trySend(null) }
+                runCatching {
+                    LocationManagerCompat.requestLocationUpdates(
+                        locationManager,
+                        provider,
+                        LocationRequestCompat.Builder(LOCATION_INTERVAL_MS).build(),
+                        listener,
+                        Looper.getMainLooper(),
+                    )
+                }
+            }
 
             awaitClose { locationManager.removeUpdates(listener) }
         }.flowOn(Dispatchers.Main.immediate)

--- a/app/src/main/java/io/github/seijikohara/femto/data/NominatimApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/NominatimApi.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.data
 
+import android.util.Log
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -9,6 +10,8 @@ import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+
+private const val TAG = "NominatimApi"
 
 /**
  * Reverse-geocode a coordinate through an OSM Nominatim-compatible endpoint.
@@ -59,7 +62,8 @@ internal class NominatimApi(
                         json.decodeFromString<NominatimResponse>(body)
                     }
                 }
-            }.getOrNull()
+            }.onFailure { Log.w(TAG, "reverse geocode failed", it) }
+                .getOrNull()
         }
 
     @Serializable

--- a/app/src/main/java/io/github/seijikohara/femto/data/OpenMeteoApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/OpenMeteoApi.kt
@@ -1,11 +1,14 @@
 package io.github.seijikohara.femto.data
 
+import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
+
+private const val TAG = "OpenMeteoApi"
 
 internal class OpenMeteoApi(
     private val client: OkHttpClient,
@@ -38,7 +41,8 @@ internal class OpenMeteoApi(
                         json.decodeFromString<ForecastResponse>(body)
                     }
                 }
-            }.getOrNull()
+            }.onFailure { Log.w(TAG, "forecast failed", it) }
+                .getOrNull()
         }
 
     @Serializable

--- a/app/src/main/java/io/github/seijikohara/femto/data/ReverseGeocoderRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/ReverseGeocoderRepository.kt
@@ -29,7 +29,17 @@ internal class ReverseGeocoderRepository(
     // Per-bucket cache keyed by the 100 m bucket (lat/lon rounded to 3
     // decimals). A revisited bucket returns the cached address without a
     // network call, and a failed lookup falls back to the most recent value.
-    private val cache = mutableMapOf<String, ShortAddress>()
+    //
+    // Access-order LinkedHashMap so the map doubles as a bounded LRU: the
+    // eldest (least-recently-read-or-written) bucket is evicted once the map
+    // exceeds MAX_ENTRIES. This caps the cache at a few hundred buckets so a
+    // long drive cannot grow it without bound. A pure-JVM LinkedHashMap is
+    // preferred over android.util.LruCache so the cache needs no Robolectric
+    // shadow to exercise.
+    private val cache =
+        object : LinkedHashMap<String, CacheEntry>(MAX_ENTRIES, LOAD_FACTOR, true) {
+            override fun removeEldestEntry(eldest: Map.Entry<String, CacheEntry>): Boolean = size > MAX_ENTRIES
+        }
     private var lastResult: ShortAddress? = null
     private var lastRequestAtMs = 0L
 
@@ -41,7 +51,7 @@ internal class ReverseGeocoderRepository(
 
     private suspend fun resolve(location: Location): ShortAddress? {
         val key = bucketKey(location.latitude, location.longitude)
-        cache[key]?.let { return it }
+        cachedAddress(key)?.let { return it }
 
         // Nominatim's usage policy caps callers at 1 request per second; the
         // 100 m bucket already collapses most calls, and this spacing guards
@@ -54,11 +64,24 @@ internal class ReverseGeocoderRepository(
             }
         }.getOrNull()
             ?.also {
-                cache[key] = it
+                cache[key] = CacheEntry(it, nowMs())
                 lastResult = it
             }
             ?: lastResult
     }
+
+    // Return the cached address only while it is within the TTL window. A
+    // stale entry is dropped so the next visit re-queries and can recover from
+    // a low-quality first geocode.
+    private fun cachedAddress(key: String): ShortAddress? =
+        cache[key]?.let { entry ->
+            if (nowMs() - entry.resolvedAtMs < TTL_MS) {
+                entry.address
+            } else {
+                cache.remove(key)
+                null
+            }
+        }
 
     private suspend fun throttle() {
         val elapsed = nowMs() - lastRequestAtMs
@@ -77,8 +100,25 @@ internal class ReverseGeocoderRepository(
                 (old != null && new != null && old.distanceTo(new) < BUCKET_M)
         }
 
+    // Cached address paired with the wall-clock time it was resolved, so the
+    // TTL check can age out a stale or low-quality bucket.
+    private data class CacheEntry(
+        val address: ShortAddress,
+        val resolvedAtMs: Long,
+    )
+
     private companion object {
         const val BUCKET_M = 100f
         const val MIN_REQUEST_SPACING_MS = 1_000L
+
+        // Cap the per-bucket cache so a long drive cannot grow it without
+        // bound; ~256 buckets covers a large daily travel envelope while
+        // bounding the worst-case memory footprint.
+        const val MAX_ENTRIES = 256
+        const val LOAD_FACTOR = 0.75f
+
+        // Re-resolve a bucket after a day so a stale or low-quality first
+        // geocode recovers without restarting the process.
+        const val TTL_MS = 24L * 60L * 60L * 1_000L
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -166,8 +166,10 @@ internal class HomeViewModelFactory(
         val nominatimApi =
             NominatimApi(
                 client = httpClient,
+                baseUrl = BuildConfig.GEOCODER_BASE_URL,
                 userAgent = userAgent,
                 language = Locale.getDefault().language,
+                apiKey = BuildConfig.GEOCODER_API_KEY.takeIf { it.isNotBlank() },
             )
         val geocoder = ReverseGeocoderRepository(locationFlow, nominatimApi)
         val weatherApi = OpenMeteoApi(client = httpClient)

--- a/app/src/test/java/io/github/seijikohara/femto/data/ReverseGeocoderRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/ReverseGeocoderRepositoryTest.kt
@@ -6,6 +6,7 @@ import android.location.Location
 import app.cash.turbine.test
 import io.github.seijikohara.femto.testfixtures.fakeLocation
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -127,7 +128,78 @@ class ReverseGeocoderRepositoryTest {
             }
         }
 
-    private fun TestScope.newRepo(locationFlow: Flow<Location?>): ReverseGeocoderRepository {
+    @Test
+    fun `evicts the eldest bucket once the cache exceeds its bound`() =
+        runTest {
+            // The eldest fill, MAX_ENTRIES newer fills that push the eldest out,
+            // and the eldest re-query after its eviction each hit the network.
+            val totalRequests = MAX_ENTRIES + 2
+            repeat(totalRequests) { server.enqueue(MockResponse().setBody(SHINJUKU_BODY)) }
+
+            // Distinct buckets spaced well beyond the 100 m bucket so each fix is
+            // its own cache key. The eldest bucket is filled first, never
+            // re-read while the newer buckets arrive, then revisited last to
+            // prove it was evicted rather than served from the cache. Inserting
+            // the eldest plus MAX_ENTRIES newer buckets overflows the cap by one,
+            // so the eldest is the entry that the LRU drops.
+            val eldest = fakeLocation(latitude = BASE_LATITUDE)
+            val newer =
+                (1..MAX_ENTRIES).map { index ->
+                    fakeLocation(latitude = BASE_LATITUDE + index * BUCKET_STEP_DEG)
+                }
+            val fixes = listOf(eldest) + newer + eldest
+
+            newRepo(fixes.asFlow()).addressFlow().test {
+                repeat(fixes.size) { assertEquals("新宿区", awaitItem()?.locality) }
+                awaitComplete()
+            }
+
+            // If the eldest were still cached the revisit would be a cache hit
+            // and the count would be MAX_ENTRIES + 1.
+            assertEquals(totalRequests, server.requestCount)
+        }
+
+    @Test
+    fun `re-queries a bucket once its cached value passes the TTL`() =
+        runTest {
+            // One body per network call: near bucket, far bucket, then the near
+            // bucket again after the TTL expires.
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+
+            // The clock crosses the near entry's TTL once the near and far fills
+            // (the first two network calls) have landed. Tying the clock to the
+            // request count makes the TTL crossing deterministic regardless of
+            // when the eager flow drains, where a variable mutated between
+            // awaitItem() calls would race the buffered emissions.
+            val nowMs = { if (server.requestCount >= 2) TTL_MS + 1 else 0L }
+            // near -> far -> near: the far fix between the two near visits keeps
+            // distinctUntilChangedByBucket from collapsing them, so the second
+            // near visit actually reaches resolve().
+            val near = fakeLocation()
+            val far = fakeLocation(latitude = 35.7000)
+            val repo = newRepo(flowOf(near, far, near), nowMs = nowMs)
+
+            repo.addressFlow().test {
+                assertEquals("新宿区", awaitItem()?.locality)
+                assertEquals("新宿区", awaitItem()?.locality)
+                // Past the TTL: the near bucket re-queries instead of hitting the
+                // now-stale cache entry.
+                assertEquals("新宿区", awaitItem()?.locality)
+                awaitComplete()
+            }
+
+            // Near (fill), far (fill), near (re-query after the TTL): the
+            // sibling cache test asserts this same sequence is two requests when
+            // the clock stays inside the TTL.
+            assertEquals(3, server.requestCount)
+        }
+
+    private fun TestScope.newRepo(
+        locationFlow: Flow<Location?>,
+        nowMs: () -> Long = { testScheduler.currentTime },
+    ): ReverseGeocoderRepository {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         return ReverseGeocoderRepository(
             locationFlow = locationFlow,
@@ -140,12 +212,22 @@ class ReverseGeocoderRepositoryTest {
                 ),
             ioDispatcher = dispatcher,
             // Tie the throttle clock to the scheduler so delay() advances it.
-            nowMs = { testScheduler.currentTime },
+            nowMs = nowMs,
         )
     }
 
     private companion object {
         const val USER_AGENT = "femto-car-launcher/1.0 (test)"
+
+        // Mirrors ReverseGeocoderRepository.MAX_ENTRIES / TTL_MS, which are
+        // private; keep these in sync if the production bounds change.
+        const val MAX_ENTRIES = 256
+        const val TTL_MS = 24L * 60L * 60L * 1_000L
+
+        // A starting latitude and a step large enough that each fix lands in a
+        // distinct 100 m bucket (~0.001 deg ~= 111 m).
+        const val BASE_LATITUDE = 35.0
+        const val BUCKET_STEP_DEG = 0.01
 
         const val SHINJUKU_BODY = """
             {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ espressoCore = "3.5.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 kotlin = "2.2.10"
-kotlinTest = "2.2.10"
 kotlinxCoroutinesTest = "1.10.2"
 kotlinxSerialization = "1.8.0"
 ktlint = "1.8.0"
@@ -19,8 +18,6 @@ ktlintComposeRules = "0.5.8"
 lifecycle = "2.10.0"
 maplibre = "11.11.0"
 material = "1.12.0"
-mockito = "5.14.2"
-mockitoKotlin = "5.4.0"
 mockwebserver = "5.1.0"
 okhttp = "5.1.0"
 robolectric = "4.14.1"
@@ -32,7 +29,6 @@ versionCatalogUpdate = "1.1.0"
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
-androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
@@ -50,13 +46,11 @@ androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "l
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 composables-icons-lucide = { group = "com.composables", name = "icons-lucide", version.ref = "composablesIconsLucide" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlinTest" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 maplibre-android = { group = "org.maplibre.gl", name = "android-sdk-opengl", version.ref = "maplibre" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
-mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockitoKotlin" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }


### PR DESCRIPTION
## Summary

Phase 6 of the completeness roadmap — build/dependency/manifest hygiene and a couple
of resilience-adjacent code fixes. (6.8 battery clamp shipped in the glance PR; the
calendar dot-gate shipped in the resilience-P0 PR.)

## Changes

- **Deps (6.1/6.4)**: remove the unused `material-icons-extended` (UI is Lucide-only)
  and the unused Mockito test deps; **keep** `androidx-test-core` (now used via
  `ApplicationProvider`).
- **Catalog (6.5)**: collapse the duplicate Kotlin version key so `kotlin-test` stays in
  lock-step with the compiler/compose plugin.
- **Production geocoder host (6.2)**: thread `GEOCODER_BASE_URL`/`GEOCODER_API_KEY`
  through gitignored `local.properties` → `buildConfigField` → `NominatimApi`; the public
  Nominatim PoC endpoint is now only the explicit debug default (empty key stays null).
- **R8 posture (6.6)**: document the intentional unminified release, keep R8-ready
  kotlinx-serialization + MapLibre keep rules, and make the `NominatimApi`/`OpenMeteoApi`
  network swallows observable (log on failure).
- **Coarse location (6.3)**: `LocationRepository` registers a `NETWORK_PROVIDER` fallback
  alongside GPS (each guarded independently) so a coarse-only grant yields a
  degraded-precision fix instead of nothing; `hasCoarseLocationPermission` added.
- **Geocode cache (6.7)**: access-order LRU (~256 buckets) + injectable-clock TTL.

## Tests

83 JVM tests pass, incl. new geocode cache eviction + TTL cases.
`isReturnDefaultValues` lets the plain-JVM Nominatim test tolerate the new failure-path
`Log` call.

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green.