### PR TITLE
test: backfill repository, card & view-model coverage (Phase 7)

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
@@ -1,0 +1,36 @@
+package io.github.seijikohara.femto.testfixtures
+
+import io.github.seijikohara.femto.data.CalendarSnapshot
+import io.github.seijikohara.femto.data.DayCell
+import io.github.seijikohara.femto.data.EventItem
+import java.time.LocalDate
+import java.time.LocalTime
+
+internal fun fakeCalendarSnapshot(
+    today: LocalDate = LocalDate.of(2026, 5, 1),
+    weekday: String = "Friday",
+    monthLabel: String = "May 2026",
+    dayStrip: List<DayCell> =
+        listOf(
+            DayCell(LocalDate.of(2026, 5, 1), "Fri", true),
+            DayCell(LocalDate.of(2026, 5, 2), "Sat", false),
+            DayCell(LocalDate.of(2026, 5, 3), "Sun", true),
+            DayCell(LocalDate.of(2026, 5, 4), "Mon", false),
+            DayCell(LocalDate.of(2026, 5, 5), "Tue", false),
+            DayCell(LocalDate.of(2026, 5, 6), "Wed", true),
+        ),
+    events: List<EventItem> =
+        listOf(
+            EventItem(LocalTime.of(10, 30), "Team standup"),
+            EventItem(LocalTime.of(14, 0), "Pick up kids"),
+        ),
+    hasCalendarAccess: Boolean = true,
+): CalendarSnapshot =
+    CalendarSnapshot(
+        today = today,
+        weekday = weekday,
+        monthLabel = monthLabel,
+        dayStrip = dayStrip,
+        events = events,
+        hasCalendarAccess = hasCalendarAccess,
+    )

--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeLocation.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeLocation.kt
@@ -1,0 +1,26 @@
+package io.github.seijikohara.femto.testfixtures
+
+import android.location.Location
+
+internal fun fakeLocation(
+    latitude: Double = 35.6580,
+    longitude: Double = 139.7016,
+    speedMps: Float = 0f,
+    altitudeM: Double = 47.0,
+    timeMs: Long = 0L,
+    elapsedRealtimeNanos: Long = 0L,
+    // When false, the fix carries no speed (Location.hasSpeed() == false),
+    // mirroring cheap GPS chips and raw GPS_PROVIDER HALs.
+    hasSpeed: Boolean = true,
+): Location =
+    Location("test").apply {
+        this.latitude = latitude
+        this.longitude = longitude
+        this.altitude = altitudeM
+        this.time = timeMs
+        this.elapsedRealtimeNanos = elapsedRealtimeNanos
+        // setSpeed flips hasSpeed() to true; removeSpeed() clears it. Only
+        // set a speed when the caller asks for one so the speed-less path
+        // stays exercisable.
+        if (hasSpeed) this.speed = speedMps else removeSpeed()
+    }

--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeTripState.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeTripState.kt
@@ -1,0 +1,14 @@
+package io.github.seijikohara.femto.testfixtures
+
+import io.github.seijikohara.femto.data.TripState
+
+internal fun fakeTripState(
+    distanceMeters: Double = 24_400.0,
+    avgSpeedMs: Double = 11.7,
+    currentSpeedMs: Double = 0.0,
+): TripState =
+    TripState(
+        distanceMeters = distanceMeters,
+        avgSpeedMs = avgSpeedMs,
+        currentSpeedMs = currentSpeedMs,
+    )

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
@@ -1,0 +1,60 @@
+package io.github.seijikohara.femto.ui.home.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.testfixtures.fakeCalendarSnapshot
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import org.junit.Rule
+import org.junit.Test
+
+class CalendarCardTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun renders_upcoming_event_title_for_granted_snapshot() {
+        rule.setContent {
+            FemtoTheme {
+                CalendarCard(snapshot = fakeCalendarSnapshot())
+            }
+        }
+        // The fixture's first event title appears in the events section.
+        rule.onNodeWithText("Team standup").assertIsDisplayed()
+    }
+
+    @Test
+    fun shows_today_number_for_granted_snapshot() {
+        rule.setContent {
+            FemtoTheme {
+                CalendarCard(snapshot = fakeCalendarSnapshot())
+            }
+        }
+        // The hero head renders the day-of-month of the fixture's `today`
+        // (2026-05-01); the strip also leads with the same "1" cell. Compose has
+        // no assertCountIsAtLeast, so fetch the matching nodes and assert the
+        // day-of-month rendered at least once.
+        val dayNodes = rule.onAllNodesWithText("1").fetchSemanticsNodes()
+        assert(dayNodes.isNotEmpty()) { "expected the day-of-month '1' to render at least once" }
+    }
+
+    @Test
+    fun shows_permission_denied_message_when_access_is_denied() {
+        rule.setContent {
+            FemtoTheme {
+                CalendarCard(snapshot = fakeCalendarSnapshot(hasCalendarAccess = false))
+            }
+        }
+        // Resolve the copy from resources so the literal stays the SSOT in
+        // strings.xml ("Calendar access not granted").
+        val denied =
+            InstrumentationRegistry
+                .getInstrumentation()
+                .targetContext
+                .getString(R.string.calendar_permission_denied)
+        rule.onNodeWithText(denied).assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayTest.kt
@@ -1,0 +1,77 @@
+package io.github.seijikohara.femto.ui.home.components
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import io.github.seijikohara.femto.testfixtures.fakeAddress
+import io.github.seijikohara.femto.testfixtures.fakeLocation
+import io.github.seijikohara.femto.testfixtures.fakeTripState
+import io.github.seijikohara.femto.ui.locale.SpeedUnit
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import org.junit.Rule
+import org.junit.Test
+
+class SpeedOverlayTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun renders_em_dash_for_live_speed_when_no_fix() {
+        rule.setContent {
+            FemtoTheme {
+                SpeedOverlay(
+                    location = null,
+                    address = fakeAddress(),
+                    tripState = fakeTripState(currentSpeedMs = 18.0),
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                )
+            }
+        }
+        // With no fix the hero cell shows the em-dash placeholder instead of "0",
+        // so a denied/missing location reads as "unknown", not "standstill".
+        rule.onNodeWithText("—").assertIsDisplayed()
+    }
+
+    @Test
+    fun renders_metric_distance_and_speed_labels_for_metric_unit() {
+        rule.setContent {
+            FemtoTheme {
+                SpeedOverlay(
+                    location = fakeLocation(),
+                    address = fakeAddress(),
+                    tripState = fakeTripState(currentSpeedMs = 18.0),
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                )
+            }
+        }
+        // Assert the unit labels rather than the rounded numerals so the test
+        // stays robust against EMA smoothing and rounding. The metric set is
+        // "km/h" on the hero + avg cells and "km" on the distance cell, with no
+        // imperial "mi" / "mph" labels present.
+        rule.onAllNodesWithText("km/h", substring = true).assertCountEquals(2)
+        rule.onAllNodesWithText("mi", substring = true).assertCountEquals(0)
+        rule.onAllNodesWithText("mph", substring = true).assertCountEquals(0)
+    }
+
+    @Test
+    fun renders_imperial_distance_and_speed_labels_for_imperial_unit() {
+        rule.setContent {
+            FemtoTheme {
+                SpeedOverlay(
+                    location = fakeLocation(),
+                    address = fakeAddress(),
+                    tripState = fakeTripState(currentSpeedMs = 18.0),
+                    speedUnit = SpeedUnit.MILES_PER_HOUR,
+                )
+            }
+        }
+        // The imperial set is "mph" on the hero + avg cells and "mi" on the
+        // distance cell, with no metric "km" label present. "mi" matches only
+        // the distance cell ("mph" does not contain "mi").
+        rule.onAllNodesWithText("mph", substring = true).assertCountEquals(2)
+        rule.onAllNodesWithText("mi", substring = true).assertCountEquals(1)
+        rule.onAllNodesWithText("km", substring = true).assertCountEquals(0)
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/AddressComposerTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/AddressComposerTest.kt
@@ -152,6 +152,57 @@ class AddressComposerTest {
     }
 
     @Test
+    fun `composes non-japanese east-asian line large-to-small with no separator for seoul`() {
+        val address =
+            NominatimAddress(
+                suburb = "Myeong-dong",
+                city = "Jung-gu",
+                province = "Seoul",
+                countryCode = "kr",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("SeoulJung-guMyeong-dong", result.line)
+        assertEquals("Jung-gu", result.locality)
+        assertEquals("Seoul", result.region)
+    }
+
+    @Test
+    fun `derives western region from the state fallback when no iso suffix is present`() {
+        val address =
+            NominatimAddress(
+                houseNumber = "221B",
+                road = "Baker Street",
+                city = "London",
+                state = "England",
+                countryCode = "gb",
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("221B Baker Street, London, England", result.line)
+        assertEquals("London", result.locality)
+        assertEquals("England", result.region)
+    }
+
+    @Test
+    fun `falls back to the western branch when the country is null`() {
+        val address =
+            NominatimAddress(
+                city = "Toronto",
+                province = "Ontario",
+                countryCode = null,
+            )
+
+        val result = assertNotNull(AddressComposer.composeAddress(address))
+
+        assertEquals("Toronto, Ontario", result.line)
+        assertEquals("Toronto", result.locality)
+        assertEquals("Ontario", result.region)
+    }
+
+    @Test
     fun `returns null when neither municipality nor prefecture resolves`() {
         val address =
             NominatimAddress(

--- a/app/src/test/java/io/github/seijikohara/femto/data/NominatimApiTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/NominatimApiTest.kt
@@ -62,6 +62,22 @@ class NominatimApiTest {
         }
 
     @Test
+    fun `reflects a non-default language in the accept-language parameter`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+
+            NominatimApi(
+                client = client,
+                baseUrl = server.url("/").toString(),
+                userAgent = USER_AGENT,
+                language = "en",
+            ).reverse(LAT, LON)
+            val requestUrl = server.takeRequest().requestUrl
+
+            assertEquals("en", requestUrl?.queryParameter("accept-language"))
+        }
+
+    @Test
     fun `sends the configured user-agent header`() =
         runTest {
             server.enqueue(MockResponse().setBody(SHINJUKU_BODY))

--- a/app/src/test/java/io/github/seijikohara/femto/data/SystemStatusRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/SystemStatusRepositoryTest.kt
@@ -1,0 +1,172 @@
+package io.github.seijikohara.femto.data
+
+import android.app.Application
+import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.BatteryManager
+import androidx.core.content.getSystemService
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowConnectivityManager
+import org.robolectric.shadows.ShadowNetwork
+import org.robolectric.shadows.ShadowNetworkCapabilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class SystemStatusRepositoryTest {
+    private val application: Application = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `bluetoothConnected is false when BLUETOOTH_CONNECT is not granted`() =
+        runTest {
+            // Robolectric grants no runtime permissions by default on sdk 33, so
+            // readBluetoothConnected short-circuits to false rather than touching
+            // the adapter. The footer renders a dimmed BT icon instead of throwing.
+            val status = SystemStatusRepository(application).statusFlow().first()
+
+            assertFalse(status.bluetoothConnected)
+        }
+
+    @Test
+    fun `batteryPercent is the level over scale ratio from the sticky broadcast`() =
+        runTest {
+            // The sticky ACTION_BATTERY_CHANGED is the only place a battery reading
+            // arrives; registerReceiver replays it. statusFlow seeds a null default
+            // via onStart and runs the receiver on Dispatchers.Default, so the
+            // sticky-derived percent lands on the emission after the seed.
+            application.sendStickyBroadcast(batteryIntent(level = 50, scale = 100))
+
+            val status = firstStatusMatching(SystemStatusRepository(application)) { it.batteryPercent != null }
+
+            assertEquals(50, status.batteryPercent)
+        }
+
+    @Test
+    fun `batteryPercent clamps a level above scale to 100`() =
+        runTest {
+            // A malformed reading where level exceeds scale must not exceed 100;
+            // the coerceIn(0, 100) in batteryFlow is the single clamp SSOT.
+            application.sendStickyBroadcast(batteryIntent(level = 150, scale = 100))
+
+            val status = firstStatusMatching(SystemStatusRepository(application)) { it.batteryPercent != null }
+
+            assertEquals(100, status.batteryPercent)
+        }
+
+    @Test
+    fun `batteryPercent is null when the sticky reports an unknown level`() =
+        runTest {
+            // level = -1 / scale = -1 is the framework's "unknown" sentinel; the
+            // flow maps it to null so the footer never reads it as a dead 0%. The
+            // seeded default is also null, so collecting the first emission is
+            // sufficient and there is no later non-null reading to wait for.
+            application.sendStickyBroadcast(batteryIntent(level = -1, scale = -1))
+
+            val status = SystemStatusRepository(application).statusFlow().first()
+
+            assertNull(status.batteryPercent)
+        }
+
+    @Test
+    fun `charging is true when the sticky reports a non-zero plugged source`() =
+        runTest {
+            application.sendStickyBroadcast(
+                batteryIntent(level = 50, scale = 100, plugged = BatteryManager.BATTERY_PLUGGED_AC),
+            )
+
+            val status = firstStatusMatching(SystemStatusRepository(application)) { it.charging }
+
+            assertTrue(status.charging)
+        }
+
+    @Test
+    fun `wifiConnected becomes true when the registered callback reports a validated wifi network`() =
+        runTest {
+            val connectivity = application.getSystemService<ConnectivityManager>()!!
+            val shadowConnectivity = shadowOf(connectivity)
+
+            SystemStatusRepository(application).statusFlow().test {
+                // The combine seeds wifi via onStart(false), so the first emission
+                // is the default before any network capability arrives.
+                assertFalse(awaitItem().wifiConnected)
+
+                // statusFlow runs on Dispatchers.Default, so the repository's own
+                // NetworkCallback is registered on another thread; wait for it to
+                // appear before driving it the way the framework would, with a real
+                // validated WIFI capability set.
+                val callback = awaitRegisteredNetworkCallback(shadowConnectivity)
+                callback.onCapabilitiesChanged(WIFI_NETWORK, validatedWifiCapabilities())
+
+                assertTrue(awaitItem().wifiConnected)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    /**
+     * Collect the first [SystemStatus] satisfying [predicate]. statusFlow runs its
+     * callback flows on Dispatchers.Default, so the meaningful reading arrives on an
+     * emission after the onStart-seeded default; [Flow.first] with a predicate skips
+     * the seed without weakening the assertion that follows.
+     */
+    private suspend fun firstStatusMatching(
+        repository: SystemStatusRepository,
+        predicate: (SystemStatus) -> Boolean,
+    ): SystemStatus = repository.statusFlow().first(predicate)
+
+    /**
+     * Wait until statusFlow has registered its [ConnectivityManager.NetworkCallback]
+     * on the Default dispatcher. The poll uses real wall-clock time on a real
+     * dispatcher so it advances independently of the runTest virtual scheduler, which
+     * skips delays. Polling avoids a flaky [List.single] race against the off-thread
+     * registration.
+     */
+    private suspend fun awaitRegisteredNetworkCallback(
+        shadowConnectivity: ShadowConnectivityManager,
+    ): ConnectivityManager.NetworkCallback =
+        withContext(Dispatchers.Default) {
+            val deadline = System.nanoTime() + CALLBACK_POLL_TIMEOUT_NANOS
+            while (System.nanoTime() < deadline) {
+                shadowConnectivity.networkCallbacks.firstOrNull()?.let { return@withContext it }
+                Thread.sleep(CALLBACK_POLL_INTERVAL_MS)
+            }
+            shadowConnectivity.networkCallbacks.single()
+        }
+
+    private fun batteryIntent(
+        level: Int,
+        scale: Int,
+        plugged: Int = 0,
+    ): Intent =
+        Intent(Intent.ACTION_BATTERY_CHANGED).apply {
+            putExtra(BatteryManager.EXTRA_LEVEL, level)
+            putExtra(BatteryManager.EXTRA_SCALE, scale)
+            putExtra(BatteryManager.EXTRA_PLUGGED, plugged)
+        }
+
+    private fun validatedWifiCapabilities(): NetworkCapabilities =
+        ShadowNetworkCapabilities.newInstance().apply {
+            shadowOf(this).addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            shadowOf(this).addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        }
+
+    private companion object {
+        val WIFI_NETWORK: Network = ShadowNetwork.newInstance(1)
+        const val CALLBACK_POLL_INTERVAL_MS = 5L
+        val CALLBACK_POLL_TIMEOUT_NANOS = 2_000_000_000L // 2 s real-time ceiling.
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -144,6 +144,24 @@ class HomeViewModelTest {
         }
 
     @Test
+    fun `onAction OpenBrowser emits LaunchAppCategory APP_BROWSER`() =
+        runTest {
+            stubViewModel().assertEvent(
+                action = HomeAction.OpenBrowser,
+                expected = HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_BROWSER),
+            )
+        }
+
+    @Test
+    fun `onAction OpenSettings emits OpenSystemSettings`() =
+        runTest {
+            stubViewModel().assertEvent(
+                action = HomeAction.OpenSettings,
+                expected = HomeEvent.OpenSystemSettings,
+            )
+        }
+
+    @Test
     fun `onAction ConnectMusicPlayer emits OpenNotificationListenerSettings`() =
         runTest {
             stubViewModel().assertEvent(


### PR DESCRIPTION
## Summary

Phase 7 of the completeness roadmap — close the remaining coverage gaps now that the
androidTest source set compiles and the data layer is hardened. (Trip / Calendar /
Weather repo tests, the music-card and footer UI tests, and most VM cases landed with
their respective feature PRs; this PR fills what was left.)

## Added

- **`SystemStatusRepositoryTest`** (the last untested `data/` repo, Robolectric):
  Bluetooth-denied → `false`; battery level/scale math + `coerceIn(0,100)` clamp +
  unknown(`null`) + charging, driven through the real sticky `ACTION_BATTERY_CHANGED`;
  the Wi-Fi `VALIDATED`+`WIFI` predicate driven through the registered `NetworkCallback`.
- **`CalendarCardTest` + `SpeedOverlayTest`** (Compose): granted events / today number /
  permission-denied copy; the no-fix em-dash and metric-vs-imperial unit labels. New
  androidTest `fakeCalendarSnapshot` / `fakeTripState` / `fakeLocation` fixtures mirror
  the JVM builders.
- **JVM backfill**: `HomeViewModel` `OpenBrowser` / `OpenSettings` actions;
  `AddressComposer` non-JP East-Asian / no-ISO Western / null-country cases;
  `NominatimApi` accept-language reflects a non-`ja` language.

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green (95 JVM tests; instrumented suites compile, execution needs a device).