### PR TITLE
refactor: tech-debt cleanup & docs accuracy (Phase 8)

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
@@ -70,19 +70,17 @@ internal class CalendarRepository(
             )
         }
         val granted = hasPermission()
-        val events = if (granted) readEvents(today) else emptyList()
-        // readEventDates runs its own full-window query (earlier-today events
-        // dot days the future-only readEvents window misses), so it must run
-        // whenever the permission is granted — not only when readEvents found
-        // future events.
-        val datesWithEvents = if (granted) readEventDates(today) else emptySet()
-        val stripWithDots = strip.map { it.copy(hasEvent = it.date in datesWithEvents) }
+        // One window scan yields both signals: the full set of dotted days
+        // (every event in the window, including earlier-today) and the next
+        // up-to-EVENT_LIST_LIMIT future events.
+        val window = if (granted) readWindow(today) else CalendarWindow.EMPTY
+        val stripWithDots = strip.map { it.copy(hasEvent = it.date in window.datesWithEvents) }
         return CalendarSnapshot(
             today = today,
             weekday = today.dayOfWeek.getDisplayName(TextStyle.FULL, locale),
             monthLabel = monthLabelOf(today),
             dayStrip = stripWithDots,
-            events = events.take(EVENT_LIST_LIMIT),
+            events = window.events,
             hasCalendarAccess = granted,
         )
     }
@@ -107,32 +105,50 @@ internal class CalendarRepository(
             PackageManager.PERMISSION_GRANTED
 
     /**
-     * Map each event to its start date so the day-strip can render a dot.
-     * Kept separate from [readEvents] so the events list itself only carries
-     * the time-of-day for display.
+     * Build the `Instances` content URI for the `today .. today + DAY_STRIP_LENGTH`
+     * window. `Instances` requires the begin / end millis embedded as path ids
+     * rather than passed as a selection.
+     */
+    private fun windowUri(today: LocalDate) =
+        CalendarContract.Instances.CONTENT_URI
+            .buildUpon()
+            .let {
+                ContentUris.appendId(it, today.atStartOfDay(zone).toInstant().toEpochMilli())
+            }.let {
+                ContentUris.appendId(
+                    it,
+                    today
+                        .plusDays(DAY_STRIP_LENGTH.toLong())
+                        .atStartOfDay(zone)
+                        .toInstant()
+                        .toEpochMilli(),
+                )
+            }.build()
+
+    /**
+     * Scan the strip window once and accumulate both card signals in a single
+     * pass: every event's local day (for the strip dots, including
+     * earlier-today rows) and the next up-to-[EVENT_LIST_LIMIT] future events
+     * (`BEGIN >= now`). A single query replaces the former two byte-identical
+     * window queries. The loop keeps scanning after the event list fills so the
+     * dot set still covers the full window.
+     *
+     * A mid-stream permission revoke (SecurityException) or an OEM provider
+     * fault (SQLiteException) must not tear down the dashboard StateFlow, so the
+     * whole scan is guarded.
      */
     @SuppressLint("MissingPermission") // Caller checks READ_CALENDAR before subscribing.
-    private fun readEventDates(today: LocalDate): Set<LocalDate> {
-        val begin = today.atStartOfDay(zone).toInstant().toEpochMilli()
-        val end = today
-            .plusDays(DAY_STRIP_LENGTH.toLong())
-            .atStartOfDay(zone)
-            .toInstant()
-            .toEpochMilli()
-        val uri = CalendarContract.Instances.CONTENT_URI
-            .buildUpon()
-            .let { ContentUris.appendId(it, begin) }
-            .let { ContentUris.appendId(it, end) }
-            .build()
-        // A mid-stream permission revoke (SecurityException) or an OEM provider
-        // fault (SQLiteException) must not tear down the dashboard StateFlow.
+    private fun readWindow(today: LocalDate): CalendarWindow {
+        val now = Instant.now().toEpochMilli()
         return runCatching {
             val dates = mutableSetOf<LocalDate>()
+            val events = mutableListOf<EventItem>()
             context.contentResolver
                 .query(
-                    uri,
+                    windowUri(today),
                     arrayOf(
                         CalendarContract.Instances.BEGIN,
+                        CalendarContract.Instances.TITLE,
                         CalendarContract.Instances.ALL_DAY,
                     ),
                     null,
@@ -141,61 +157,25 @@ internal class CalendarRepository(
                 )?.use { cursor ->
                     while (cursor.moveToNext()) {
                         val startMs = cursor.getLong(0)
-                        val allDay = cursor.getInt(1) != 0
-                        dates += localDateOf(startMs, allDay)
-                    }
-                }
-            dates.toSet()
-        }.getOrDefault(emptySet())
-    }
-
-    @SuppressLint("MissingPermission") // Caller checks READ_CALENDAR before subscribing.
-    private fun readEvents(today: LocalDate): List<EventItem> {
-        val begin = today.atStartOfDay(zone).toInstant().toEpochMilli()
-        val end = today
-            .plusDays(DAY_STRIP_LENGTH.toLong())
-            .atStartOfDay(zone)
-            .toInstant()
-            .toEpochMilli()
-        val uri = CalendarContract.Instances.CONTENT_URI
-            .buildUpon()
-            .let { ContentUris.appendId(it, begin) }
-            .let { ContentUris.appendId(it, end) }
-            .build()
-        val now = Instant
-            .now()
-            .toEpochMilli()
-        // A mid-stream permission revoke (SecurityException) or an OEM provider
-        // fault (SQLiteException) must not tear down the dashboard StateFlow.
-        return runCatching {
-            val items = mutableListOf<EventItem>()
-            context.contentResolver
-                .query(
-                    uri,
-                    arrayOf(
-                        CalendarContract.Instances.BEGIN,
-                        CalendarContract.Instances.TITLE,
-                        CalendarContract.Instances.ALL_DAY,
-                    ),
-                    "${CalendarContract.Instances.BEGIN} >= ?",
-                    arrayOf(now.toString()),
-                    "${CalendarContract.Instances.BEGIN} ASC",
-                )?.use { cursor ->
-                    while (cursor.moveToNext() && items.size < EVENT_LIST_LIMIT) {
-                        val startMs = cursor.getLong(0)
-                        val title = cursor.getString(1) ?: continue
+                        val title = cursor.getString(1)
                         val allDay = cursor.getInt(2) != 0
-                        items += EventItem(
-                            // All-day rows carry no clock time; surface null so
-                            // the card renders an "all day" label instead of a
-                            // spurious 00:00 derived from the system zone.
-                            time = if (allDay) null else LocalTime.ofInstant(Instant.ofEpochMilli(startMs), zone),
-                            title = title,
-                        )
+                        dates += localDateOf(startMs, allDay)
+                        // Future top-N list mirrors the former `BEGIN >= now`
+                        // selection and the null-title skip; a null-title row
+                        // still dots its day above but never enters the list.
+                        if (title != null && startMs >= now && events.size < EVENT_LIST_LIMIT) {
+                            events += EventItem(
+                                // All-day rows carry no clock time; surface null
+                                // so the card renders an "all day" label instead
+                                // of a spurious 00:00 derived from the system zone.
+                                time = if (allDay) null else LocalTime.ofInstant(Instant.ofEpochMilli(startMs), zone),
+                                title = title,
+                            )
+                        }
                     }
                 }
-            items.toList()
-        }.getOrDefault(emptyList())
+            CalendarWindow(datesWithEvents = dates.toSet(), events = events.toList())
+        }.getOrDefault(CalendarWindow.EMPTY)
     }
 
     /**
@@ -235,6 +215,19 @@ internal class CalendarRepository(
             )
             awaitClose { context.contentResolver.unregisterContentObserver(observer) }
         }.debounce(CHANGE_DEBOUNCE_MS)
+
+    /**
+     * Result of a single window scan: the days carrying any event (strip dots)
+     * and the next few future events (the card's event list).
+     */
+    private data class CalendarWindow(
+        val datesWithEvents: Set<LocalDate>,
+        val events: List<EventItem>,
+    ) {
+        companion object {
+            val EMPTY = CalendarWindow(datesWithEvents = emptySet(), events = emptyList())
+        }
+    }
 
     private companion object {
         const val DAY_STRIP_LENGTH = 6

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -48,46 +48,34 @@ internal class HomeViewModel(
     private val tripStateFlow: Flow<TripState>,
     private val sendMusicCommand: (MusicCommand) -> Unit = {},
 ) : ViewModel() {
-    val uiState: StateFlow<HomeUiState> =
+    // Kotlin's typed combine overloads cover at most 5 flows. Stage the eight
+    // sources through a typed intermediate (CoreSignals) so the compiler enforces
+    // arity and per-slot types end-to-end: a future reorder fails to compile
+    // instead of silently mismapping a positional values[i] cast.
+    private val coreSignals: Flow<CoreSignals> =
         combine(
             clockFlow,
             locationFlow,
             addressFlow,
             weatherFlow,
             musicStateFlow,
+        ) { clock, location, address, weather, music ->
+            CoreSignals(clock, location, address, weather, music)
+        }
+
+    val uiState: StateFlow<HomeUiState> =
+        combine(
+            coreSignals,
             calendarFlow,
             systemStatusFlow,
             tripStateFlow,
-        ) { values ->
-            @Suppress("UNCHECKED_CAST")
-            val clock = values[0] as ClockTick
-
-            @Suppress("UNCHECKED_CAST")
-            val location = values[1] as Location?
-
-            @Suppress("UNCHECKED_CAST")
-            val address = values[2] as ShortAddress?
-
-            @Suppress("UNCHECKED_CAST")
-            val weather = values[3] as WeatherSnapshot?
-
-            @Suppress("UNCHECKED_CAST")
-            val music = values[4] as MusicCardState
-
-            @Suppress("UNCHECKED_CAST")
-            val calendar = values[5] as CalendarSnapshot?
-
-            @Suppress("UNCHECKED_CAST")
-            val systemStatus = values[6] as SystemStatus
-
-            @Suppress("UNCHECKED_CAST")
-            val tripState = values[7] as TripState
+        ) { core, calendar, systemStatus, tripState ->
             HomeUiState(
-                clock = clock,
-                location = location,
-                address = address,
-                weather = weather,
-                musicState = music,
+                clock = core.clock,
+                location = core.location,
+                address = core.address,
+                weather = core.weather,
+                musicState = core.music,
                 calendar = calendar,
                 systemStatus = systemStatus,
                 tripState = tripState,
@@ -143,6 +131,16 @@ internal class HomeViewModel(
         }
     }
 }
+
+// File-private holder that groups the first five sources so the two-stage
+// combine stays within Kotlin's typed (max-arity-5) combine overloads.
+private data class CoreSignals(
+    val clock: ClockTick,
+    val location: Location?,
+    val address: ShortAddress?,
+    val weather: WeatherSnapshot?,
+    val music: MusicCardState,
+)
 
 internal class HomeViewModelFactory(
     private val application: Application,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppsBarShortcut.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppsBarShortcut.kt
@@ -1,29 +1,19 @@
 package io.github.seijikohara.femto.ui.home.components
 
-import androidx.compose.ui.graphics.vector.ImageVector
-import com.composables.icons.lucide.Camera
-import com.composables.icons.lucide.Compass
-import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.Map
-import com.composables.icons.lucide.Music
-import com.composables.icons.lucide.Phone
-
 /**
  * Apps shortcut category referenced by [io.github.seijikohara.femto.ui.home.HomeAction.Shortcut].
  *
  * `intentCategory` matches the value the launcher dispatches via
  * `HomeEvent.LaunchAppCategory`, deferring the actual app pick to whichever
- * app the user has elected as the default for that category. The icon /
- * label are only used by previews; the production footer renders bespoke
- * navigation buttons in [DashboardFooter] rather than the generic tile.
+ * app the user has elected as the default for that category. The production
+ * footer renders bespoke navigation buttons in [DashboardFooter] rather than
+ * the generic tile.
  */
 internal enum class AppsBarShortcut(
-    val icon: ImageVector,
     val intentCategory: String,
 ) {
-    Phone(Lucide.Phone, "android.intent.category.APP_CONTACTS"),
-    Music(Lucide.Music, "android.intent.category.APP_MUSIC"),
-    Maps(Lucide.Map, "android.intent.category.APP_MAPS"),
-    Camera(Lucide.Camera, "android.intent.category.APP_GALLERY"),
-    Navigation(Lucide.Compass, "android.intent.category.APP_MAPS"),
+    // TODO: Phone maps to APP_CONTACTS, not a dialer. A proper dialer entry
+    //  needs ACTION_DIAL plumbing; align the category and footer label then.
+    Phone("android.intent.category.APP_CONTACTS"),
+    Music("android.intent.category.APP_MUSIC"),
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -30,12 +30,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.MapPinOff
 import io.github.seijikohara.femto.R
@@ -245,6 +245,10 @@ private fun ForwardLowMemory(mapView: MapView) {
             object : ComponentCallbacks2 {
                 override fun onLowMemory() = mapView.onLowMemory()
 
+                // onTrimMemory(level) is the live callback; only the TRIM_MEMORY_RUNNING_LOW
+                // level constant is deprecated on API 34+. Suppress narrowly here so the
+                // low-memory forwarding keeps firing across API levels without warnings.
+                @Suppress("DEPRECATION")
                 override fun onTrimMemory(level: Int) {
                     if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
                         mapView.onLowMemory()

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -111,12 +111,12 @@ internal fun SpeedOverlay(
                 // defaults to fillMaxWidth) would stretch the card to the full
                 // map pane. The address-row divider then spans the same width.
                 .width(IntrinsicSize.Max)
-                .clip(RoundedCornerShape(20.dp))
+                .clip(RoundedCornerShape(FemtoDimens.SpeedOverlayCorner))
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = glassAlpha))
                 .border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = FemtoDimens.GlassBorderAlpha),
-                    shape = RoundedCornerShape(20.dp),
+                    shape = RoundedCornerShape(FemtoDimens.SpeedOverlayCorner),
                 ).padding(horizontal = 24.dp, vertical = 16.dp),
     ) {
         MetricRow(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -93,7 +93,7 @@ internal fun WeatherCard(
         if (snapshot != null) {
             Head(snapshot, city, temperatureUnit)
             Metrics(snapshot, temperatureUnit, speedUnit)
-            Forecast(snapshot.hourly, temperatureUnit)
+            Forecast(snapshot.hourly, snapshot.sunrise, snapshot.sunset, temperatureUnit)
         } else {
             EmptyState()
         }
@@ -222,6 +222,8 @@ private fun Metric(
 @Composable
 private fun Forecast(
     hourly: List<HourlyForecast>,
+    sunrise: LocalTime?,
+    sunset: LocalTime?,
     temperatureUnit: TemperatureUnit,
 ) {
     val next = hourly.take(3)
@@ -233,7 +235,7 @@ private fun Forecast(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             next.forEach { hour ->
-                ForecastChip(hour, temperatureUnit, modifier = Modifier.weight(1f))
+                ForecastChip(hour, sunrise, sunset, temperatureUnit, modifier = Modifier.weight(1f))
             }
         }
     }
@@ -242,10 +244,13 @@ private fun Forecast(
 @Composable
 private fun ForecastChip(
     forecast: HourlyForecast,
+    sunrise: LocalTime?,
+    sunset: LocalTime?,
     temperatureUnit: TemperatureUnit,
     modifier: Modifier = Modifier,
 ) {
     val glyphs = weatherGlyphs()
+    val isDay = isDaylight(forecast.time, sunrise, sunset)
     Column(
         modifier =
             modifier
@@ -262,9 +267,9 @@ private fun ForecastChip(
             maxLines = 1,
         )
         Icon(
-            imageVector = glyphIconFor(forecast.code, isDay = forecast.time.hour in 6..18),
+            imageVector = glyphIconFor(forecast.code, isDay),
             contentDescription = null,
-            tint = glyphTintFor(forecast.code, isDay = forecast.time.hour in 6..18, glyphs),
+            tint = glyphTintFor(forecast.code, isDay, glyphs),
             modifier = Modifier.size(FemtoDimens.WeatherGlyphSmall),
         )
         Text(
@@ -298,6 +303,20 @@ private fun EmptyState() =
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(48.dp),
         )
+    }
+
+// Day/night drives the sun-vs-moon glyph for CLEAR. Use the snapshot's real
+// sunrise/sunset when present; fall back to a fixed 6..18 window only when either
+// bound is missing, so a forecast hour past sunset reads as night.
+private fun isDaylight(
+    time: LocalTime,
+    sunrise: LocalTime?,
+    sunset: LocalTime?,
+): Boolean =
+    if (sunrise != null && sunset != null) {
+        time >= sunrise && time < sunset
+    } else {
+        time.hour in 6..18
     }
 
 private fun glyphIconFor(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/locale/SystemUnits.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/locale/SystemUnits.kt
@@ -10,8 +10,6 @@ private const val SECONDS_PER_HOUR = 3.6
 
 internal enum class SpeedUnit { KILOMETERS_PER_HOUR, MILES_PER_HOUR }
 
-internal enum class DistanceUnit { METERS, FEET }
-
 internal enum class TemperatureUnit { CELSIUS, FAHRENHEIT }
 
 private val ImperialCountries = setOf("US", "GB", "MM")
@@ -38,13 +36,6 @@ internal fun speedUnitFor(locale: Locale = Locale.getDefault()): SpeedUnit =
         SpeedUnit.MILES_PER_HOUR
     } else {
         SpeedUnit.KILOMETERS_PER_HOUR
-    }
-
-internal fun distanceUnitFor(locale: Locale = Locale.getDefault()): DistanceUnit =
-    if (locale.country in ImperialCountries) {
-        DistanceUnit.FEET
-    } else {
-        DistanceUnit.METERS
     }
 
 /**
@@ -108,12 +99,6 @@ internal fun SpeedUnit.distanceLabel(): String =
         SpeedUnit.MILES_PER_HOUR -> "mi"
     }
 
-internal fun DistanceUnit.fromMeters(meters: Double): Double =
-    when (this) {
-        DistanceUnit.METERS -> meters
-        DistanceUnit.FEET -> meters * 3.2808399
-    }
-
 internal fun SpeedUnit.label(): String =
     when (this) {
         SpeedUnit.KILOMETERS_PER_HOUR -> "km/h"
@@ -134,12 +119,6 @@ internal fun windLabel(
     when (speedUnit) {
         SpeedUnit.MILES_PER_HOUR -> "${speedUnit.fromKilometersPerHour(windKmh).roundToInt()} mph"
         SpeedUnit.KILOMETERS_PER_HOUR -> "${(windKmh / SECONDS_PER_HOUR).roundToInt()} m/s"
-    }
-
-internal fun DistanceUnit.label(): String =
-    when (this) {
-        DistanceUnit.METERS -> "m"
-        DistanceUnit.FEET -> "ft"
     }
 
 internal fun TemperatureUnit.fromCelsius(celsius: Double): Double =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/Color.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/Color.kt
@@ -17,22 +17,58 @@ private val Night = Color(0xFF050505)
 private val NightSurface = Color(0xFF0A0A0A)
 private val Bone = Color.White
 
+// Muted monochrome roles derived from the Ink/Paper and Bone/Night anchors.
+// The dashboard reads onSurfaceVariant, outlineVariant, surfaceContainer,
+// surfaceContainerHigh, primaryContainer, onPrimaryContainer, outline, and
+// tertiary; left unset they fall back to the M3 baseline purple/teal, which
+// contradicts the Bold Minimal monochrome aesthetic in previews. Deriving
+// them here as greys keeps the preview fallback in the same palette family as
+// the production dynamic-color path.
+
+// Light: greys stepping from Ink towards Paper.
+private val InkMuted = Color(0xFF5A5A5A) // secondary ink for variant text
+private val InkHairline = Color(0xFFD9D9D9) // hairline outlines on paper
+private val PaperRaised = Color(0xFFF0F0F0) // first container tier above surface
+private val PaperRaisedHigh = Color(0xFFE8E8E8) // second container tier
+
+// Dark: greys stepping from Bone towards Night.
+private val BoneMuted = Color(0xFFB0B0B0) // secondary bone text for variant roles
+private val BoneHairline = Color(0xFF2E2E2E) // hairline outlines on night
+private val NightRaised = Color(0xFF161616) // first container tier above surface
+private val NightRaisedHigh = Color(0xFF1F1F1F) // second container tier
+
 internal val LightFallback =
     lightColorScheme(
         primary = Ink,
         onPrimary = PaperPure,
+        primaryContainer = PaperRaisedHigh,
+        onPrimaryContainer = Ink,
+        tertiary = Ink,
         background = Paper,
         onBackground = Ink,
         surface = PaperPure,
         onSurface = Ink,
+        onSurfaceVariant = InkMuted,
+        surfaceContainer = PaperRaised,
+        surfaceContainerHigh = PaperRaisedHigh,
+        outline = InkMuted,
+        outlineVariant = InkHairline,
     )
 
 internal val DarkFallback =
     darkColorScheme(
         primary = Bone,
         onPrimary = Night,
+        primaryContainer = NightRaisedHigh,
+        onPrimaryContainer = Bone,
+        tertiary = Bone,
         background = Night,
         onBackground = Bone,
         surface = NightSurface,
         onSurface = Bone,
+        onSurfaceVariant = BoneMuted,
+        surfaceContainer = NightRaised,
+        surfaceContainerHigh = NightRaisedHigh,
+        outline = BoneMuted,
+        outlineVariant = BoneHairline,
     )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -51,6 +51,15 @@ object FemtoDimens {
     /** Corner radius for glass overlays on the map pane. */
     val OverlayCorner = 16.dp
 
+    /**
+     * Corner radius for the speed overlay on the map pane. Deliberately
+     * distinct from [OverlayCorner] (16 dp): the speed overlay carries a
+     * larger 20 dp corner per `docs/design/dashboard-v2-mockup.html`
+     * `.speed-overlay`, so the two tokens stay separate rather than reusing
+     * [OverlayCorner].
+     */
+    val SpeedOverlayCorner = 20.dp
+
     /** Weather glyph beside the city name in the weather card head row. */
     val WeatherGlyphLarge = 20.dp
 

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -32,7 +32,6 @@ import java.time.LocalDate
 import java.time.LocalTime
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
@@ -51,26 +50,36 @@ class HomeViewModelTest {
     @Test
     fun `combines all flows into one HomeUiState`() =
         runTest {
+            // Each source carries a distinct, identity-checkable value so the
+            // assertions below pin every field to its own flow. A future reorder
+            // of the two-stage combine (or its CoreSignals holder) that swaps two
+            // same-typed slots is caught here rather than slipping through.
+            val clock = ClockTick(LocalTime.of(14, 32), LocalDate.of(2026, 5, 1))
+            val location = fakeLocation()
+            val address = fakeAddress()
+            val weather = fakeWeatherSnapshot()
+            val musicState = MusicCardState.Playing(fakeNowPlaying())
             val calendar = fakeCalendarSnapshot()
             val systemStatus = fakeSystemStatus()
             val tripState = fakeTripState()
             val viewModel =
                 HomeViewModel(
-                    clockFlow = flowOf(ClockTick(LocalTime.of(14, 32), LocalDate.of(2026, 5, 1))),
-                    locationFlow = flowOf(null),
-                    addressFlow = flowOf(fakeAddress()),
-                    weatherFlow = flowOf(fakeWeatherSnapshot()),
-                    musicStateFlow = flowOf(MusicCardState.Playing(fakeNowPlaying())),
+                    clockFlow = flowOf(clock),
+                    locationFlow = flowOf(location),
+                    addressFlow = flowOf(address),
+                    weatherFlow = flowOf(weather),
+                    musicStateFlow = flowOf(musicState),
                     calendarFlow = flowOf(calendar),
                     systemStatusFlow = flowOf(systemStatus),
                     tripStateFlow = flowOf(tripState),
                 )
             viewModel.uiState.test {
                 val state = awaitItem()
-                assertEquals(LocalTime.of(14, 32), state.clock.time)
-                assertNotNull(state.address)
-                assertNotNull(state.weather)
-                assertTrue(state.musicState is MusicCardState.Playing)
+                assertEquals(clock, state.clock)
+                assertEquals(location, state.location)
+                assertEquals(address, state.address)
+                assertEquals(weather, state.weather)
+                assertEquals(musicState, state.musicState)
                 assertEquals(calendar, state.calendar)
                 assertEquals(systemStatus, state.systemStatus)
                 assertEquals(tripState, state.tripState)

--- a/app/src/test/java/io/github/seijikohara/femto/ui/locale/SystemUnitsTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/locale/SystemUnitsTest.kt
@@ -6,43 +6,38 @@ import java.util.Locale
 
 class SystemUnitsTest {
     @Test
-    fun `us country defaults to imperial speed and distance`() {
+    fun `us country defaults to imperial speed`() {
         assertEquals(SpeedUnit.MILES_PER_HOUR, speedUnitFor(Locale.US))
-        assertEquals(DistanceUnit.FEET, distanceUnitFor(Locale.US))
     }
 
     @Test
-    fun `gb country defaults to imperial speed and distance`() {
+    fun `gb country defaults to imperial speed`() {
         val gb = Locale
             .Builder()
             .setLanguage("en")
             .setRegion("GB")
             .build()
         assertEquals(SpeedUnit.MILES_PER_HOUR, speedUnitFor(gb))
-        assertEquals(DistanceUnit.FEET, distanceUnitFor(gb))
     }
 
     @Test
-    fun `mm country defaults to imperial speed and distance`() {
+    fun `mm country defaults to imperial speed`() {
         val mm = Locale
             .Builder()
             .setLanguage("my")
             .setRegion("MM")
             .build()
         assertEquals(SpeedUnit.MILES_PER_HOUR, speedUnitFor(mm))
-        assertEquals(DistanceUnit.FEET, distanceUnitFor(mm))
     }
 
     @Test
-    fun `jp country defaults to metric speed and distance`() {
+    fun `jp country defaults to metric speed`() {
         assertEquals(SpeedUnit.KILOMETERS_PER_HOUR, speedUnitFor(Locale.JAPAN))
-        assertEquals(DistanceUnit.METERS, distanceUnitFor(Locale.JAPAN))
     }
 
     @Test
-    fun `de country defaults to metric speed and distance`() {
+    fun `de country defaults to metric speed`() {
         assertEquals(SpeedUnit.KILOMETERS_PER_HOUR, speedUnitFor(Locale.GERMANY))
-        assertEquals(DistanceUnit.METERS, distanceUnitFor(Locale.GERMANY))
     }
 
     @Test
@@ -53,7 +48,6 @@ class SystemUnitsTest {
             .setRegion("XX")
             .build()
         assertEquals(SpeedUnit.KILOMETERS_PER_HOUR, speedUnitFor(xx))
-        assertEquals(DistanceUnit.METERS, distanceUnitFor(xx))
     }
 
     @Test

--- a/docs/superpowers/plans/2026-05-01-home-dashboard-plan.md
+++ b/docs/superpowers/plans/2026-05-01-home-dashboard-plan.md
@@ -1,3 +1,7 @@
+> **SUPERSEDED (2026-06-03).** This document is historical. The shipped architecture
+> replaced Google Maps with MapLibre + OpenFreeMap and the AOSP Geocoder with OSM
+> Nominatim; CLAUDE.md is the authoritative SSOT. Do not implement from this doc.
+
 # Home Dashboard (Plan B) Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-05-01-home-dashboard-pr.md
+++ b/docs/superpowers/plans/2026-05-01-home-dashboard-pr.md
@@ -1,3 +1,7 @@
+> **SUPERSEDED (2026-06-03).** This document is historical. The shipped architecture
+> replaced Google Maps with MapLibre + OpenFreeMap and the AOSP Geocoder with OSM
+> Nominatim; CLAUDE.md is the authoritative SSOT. Do not implement from this doc.
+
 # Pull request: home dashboard (Plan B)
 
 ## Title (≤70 chars)

--- a/docs/superpowers/specs/2026-05-01-home-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-01-home-dashboard-design.md
@@ -1,10 +1,14 @@
+> **SUPERSEDED (2026-06-03).** This document is historical. The shipped architecture
+> replaced Google Maps with MapLibre + OpenFreeMap and the AOSP Geocoder with OSM
+> Nominatim; CLAUDE.md is the authoritative SSOT. Do not implement from this doc.
+
 # Home Dashboard (Plan B) — Design Spec
 
 | | |
 | --- | --- |
 | Date | 2026-05-01 |
 | Owner | Seiji Kohara |
-| Status | Draft, awaiting review |
+| Status | Superseded |
 | Targets | `app/src/main/java/io/github/seijikohara/femto/ui/home/`, new `ui/drawer/`, expanded `data/` |
 
 ## 1. Goal


### PR DESCRIPTION
## Summary

Phase 8 (final) of the completeness roadmap — lower-stakes cleanups and docs accuracy.

## Changes

- **Type-safe combine (8.1)**: `HomeViewModel`'s 8-arity index-cast combine becomes a
  two-stage typed combine (`CoreSignals` holder); all `UNCHECKED_CAST`/`values[i]` are
  gone, so a future flow reorder fails to compile instead of silently mismapping. The VM
  test now pins each source to its field.
- **Superseded docs (8.2)**: the 2026-05-01 spec/plan/PR docs get a "SUPERSEDED" banner +
  status so a re-run can't re-introduce the removed Google Maps / Geocoder stack.
- **Dead code (8.3)**: drop the callerless `Maps`/`Camera`/`Navigation` `AppsBarShortcut`
  entries and the unread `icon` field; remove the orphan `DistanceUnit` enum + helpers (and
  their self-referential tests).
- **Design tokens (8.4)**: hoist the SpeedOverlay 20dp corner to
  `FemtoDimens.SpeedOverlayCorner`; extend the `Color.kt` preview fallback to all consumed
  roles (no more M3 baseline purple/teal in previews).
- **Calendar single-window (8.5)**: collapse the duplicate two-query window into one
  guarded scan accumulating dots + the future top-2 in a single pass.
- **Deprecation cleanup**: `MapPanel` uses the non-deprecated
  `androidx.lifecycle.compose.LocalLifecycleOwner` and narrowly suppresses the
  `TRIM_MEMORY_RUNNING_LOW` constant — production sources build warning-free.
- **Forecast day/night**: `WeatherCard` drives the forecast-chip day/night from the real
  `sunrise`/`sunset` on the snapshot (was a fixed 6..18 window), consuming previously
  orphaned data.

## Deferred (P3, noted for follow-up)

Phone→dialer `ACTION_DIAL`, distinct precipitation glyphs (needs a mockup SSOT update),
non-JP East-Asian ISO region recovery, and the drawer A–Z fast-scroll — pure
enhancements with no correctness impact.

## Verification

`./gradlew spotlessCheck test lint compileDebugAndroidTestKotlin assembleDebug`
— all green.