### PR TITLE
ci: PR validation + rolling nightly signed-APK release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,118 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel superseded PR runs; never cancel an in-flight main/nightly publish.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          # setup-gradle writes the cache only on the default branch; make the
+          # read-only fallback explicit so feature branches never pollute it.
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Run checks
+        run: ./gradlew spotlessCheck test lint assembleDebug --stacktrace
+
+  nightly:
+    name: Publish nightly
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name != 'pull_request'
+    permissions:
+      # gh release create/delete + tag manipulation require write access to repo
+      # contents. The default GITHUB_TOKEN satisfies this for the same repo.
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history so the rolling "nightly" tag can be deleted and re-pointed.
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Verify signing secrets are present
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          # Fail fast (and clearly) if any signing secret is missing, so the job
+          # never reaches Gradle half-configured and never publishes an unsigned APK.
+          missing=""
+          [ -z "$RELEASE_KEYSTORE_BASE64" ] && missing="$missing RELEASE_KEYSTORE_BASE64"
+          [ -z "$RELEASE_KEYSTORE_PASSWORD" ] && missing="$missing RELEASE_KEYSTORE_PASSWORD"
+          [ -z "$RELEASE_KEY_ALIAS" ] && missing="$missing RELEASE_KEY_ALIAS"
+          [ -z "$RELEASE_KEY_PASSWORD" ] && missing="$missing RELEASE_KEY_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing signing secret(s):$missing. Add all four (RELEASE_KEYSTORE_BASE64, RELEASE_KEYSTORE_PASSWORD, RELEASE_KEY_ALIAS, RELEASE_KEY_PASSWORD) so the nightly APK can be release-signed. Refusing to publish an unsigned APK."
+            exit 1
+          fi
+
+      - name: Decode keystore
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          # Write outside the checked-out tree; $RUNNER_TEMP is auto-cleaned.
+          echo "$RELEASE_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
+
+      - name: Build signed release APK
+        env:
+          RELEASE_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          NIGHTLY_VERSION_CODE: ${{ github.run_number }}
+          NIGHTLY_VERSION_NAME: nightly-${{ github.run_number }}-${{ github.sha }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Stage APK with a meaningful asset name
+        run: cp app/build/outputs/apk/release/app-release.apk "$RUNNER_TEMP/femto-car-launcher-nightly.apk"
+
+      - name: Publish rolling nightly prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # `gh release edit --target` cannot move an existing tag (cli/cli#8669),
+          # so delete the old rolling release and tag, then recreate against the
+          # exact built commit. `|| true` keeps the first-ever run idempotent.
+          gh release delete nightly --yes --cleanup-tag || true
+          gh release create nightly \
+            "$RUNNER_TEMP/femto-car-launcher-nightly.apk" \
+            --target "$GITHUB_SHA" \
+            --title "Nightly ${{ github.run_number }}" \
+            --notes "Automated nightly build from ${GITHUB_SHA:0:7} (run #${{ github.run_number }}) on $(date -u +%Y-%m-%d)." \
+            --prerelease \
+            --latest=false

--- a/README.md
+++ b/README.md
@@ -40,6 +40,61 @@ placeholder until a location fix is available. Light mode uses the
 Positron style; dark mode uses a bundled style under
 `app/src/main/assets/map/`.
 
+## Continuous integration
+
+The [`CI`](.github/workflows/ci.yml) workflow runs on every pull request and on
+pushes to `main`:
+
+- **Validate** (all triggers): runs
+  `./gradlew spotlessCheck test lint assembleDebug` on a Temurin JDK 21 runner.
+- **Publish nightly** (`main` pushes and manual `workflow_dispatch` only): builds a
+  release-signed APK and republishes a rolling prerelease.
+
+### Nightly build
+
+On every merge to `main`, CI builds a release-signed APK and republishes it as a
+rolling prerelease tagged `nightly`. The tag is re-pointed to the built commit each
+run, so the release always reflects the latest `main`. Download the latest APK from
+the [`nightly` release](../../releases/tag/nightly).
+
+The nightly APK is **release-signed**; local and contributor `./gradlew
+assembleRelease` builds stay **unsigned** because no keystore environment variables
+are present. The signing config is registered only when `RELEASE_KEYSTORE_PATH` is
+set, so local release builds keep working.
+
+### Signing secrets
+
+A maintainer must add four repository secrets (Settings -> Secrets and variables ->
+Actions) before the nightly job can sign:
+
+| Secret | Contents |
+| --- | --- |
+| `RELEASE_KEYSTORE_BASE64` | Base64 of the upload keystore (`.jks`) |
+| `RELEASE_KEYSTORE_PASSWORD` | Keystore (store) password |
+| `RELEASE_KEY_ALIAS` | Key alias inside the keystore |
+| `RELEASE_KEY_PASSWORD` | Password for that key |
+
+Generate an upload keystore once:
+
+```bash
+keytool -genkeypair -v \
+  -keystore release.jks \
+  -alias femto-upload \
+  -keyalg RSA -keysize 2048 -validity 10000
+```
+
+Base64-encode it for the `RELEASE_KEYSTORE_BASE64` secret:
+
+```bash
+# macOS
+base64 -i release.jks | pbcopy
+# Linux
+base64 -w0 release.jks
+```
+
+Keep `release.jks` out of version control. If `RELEASE_KEYSTORE_BASE64` is missing,
+the nightly job fails with an explicit message instead of publishing an unsigned APK.
+
 ## Conventions
 
 Project rules, code style, and design system policies live in

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,11 @@ val localProperties =
 val geocoderBaseUrl = localProperties.getProperty("GEOCODER_BASE_URL", "https://nominatim.openstreetmap.org/")
 val geocoderApiKey = localProperties.getProperty("GEOCODER_API_KEY", "")
 
+// Release signing is driven entirely by environment variables so CI can sign the
+// nightly APK without committing a keystore, while local `assembleRelease` stays
+// unsigned (no signing config attached) when the variables are absent.
+val releaseKeystorePath: String? = System.getenv("RELEASE_KEYSTORE_PATH")
+
 spotless {
     val ktlintVersion = libs.versions.ktlint.get()
     val composeRulesVersion = libs.versions.ktlintComposeRules.get()
@@ -48,8 +53,10 @@ android {
         applicationId = "io.github.seijikohara.femto"
         minSdk = 33
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        // CI injects a monotonically increasing versionCode/versionName for the
+        // nightly channel; local builds fall back to the committed 1 / "1.0".
+        versionCode = System.getenv("NIGHTLY_VERSION_CODE")?.toIntOrNull() ?: 1
+        versionName = System.getenv("NIGHTLY_VERSION_NAME") ?: "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -57,8 +64,25 @@ android {
         buildConfigField("String", "GEOCODER_API_KEY", "\"${geocoderApiKey}\"")
     }
 
+    signingConfigs {
+        // Only register the release signing config when CI supplies a keystore path
+        // via env; absent it, `signingConfigs.findByName("release")` returns null and
+        // the release build stays unsigned so local `assembleRelease` still works.
+        releaseKeystorePath?.let { keystorePath ->
+            create("release") {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("RELEASE_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("RELEASE_KEY_ALIAS")
+                keyPassword = System.getenv("RELEASE_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
+            // Null when no env-driven keystore is present, leaving the release build
+            // unsigned for local contributors; CI attaches the "release" config above.
+            signingConfig = signingConfigs.findByName("release")
             // Intentionally unminified: the launcher is a small, reflection-light app
             // and keeping R8 off removes a class of release-only stripping bugs. The
             // keep rules in proguard-rules.pro stay R8-ready so this flag can flip to


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI (the repo had none): validate PRs/main, and publish a rolling
**nightly** signed-APK GitHub Release on every merge to `main`.

## Workflow (`.github/workflows/ci.yml`)

- **validate** (PRs + main pushes + manual): JDK 21 (Temurin) + Gradle cache →
  `spotlessCheck test lint assembleDebug`.
- **nightly** (main pushes + manual, `needs: validate`, `contents: write`): build a
  **release-signed** APK and publish it to a rolling `nightly` prerelease re-pointed to
  the built commit (`gh release delete --cleanup-tag` then `create --target $SHA`, since
  `gh` cannot move an existing tag). A guard **fails fast** if any signing secret is
  missing, so an unsigned APK is never published.

## Gradle (`app/build.gradle.kts`)

- Conditional, env-driven release signing: the `release` `signingConfig` is registered
  only when `RELEASE_KEYSTORE_PATH` is set, so CI signs while local/contributor
  `assembleRelease` stays unsigned but buildable.
- `versionCode`/`versionName` injected from `NIGHTLY_VERSION_CODE`/`NIGHTLY_VERSION_NAME`
  (`github.run_number`), falling back to `1` / `1.0` locally.

## Maintainer setup (required for nightly to publish)

Add four repository secrets (commands + table in the README): `RELEASE_KEYSTORE_BASE64`,
`RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`. Until they
exist, the nightly job intentionally fails at the guard (validate stays green).

## Verification

Locally: `spotlessCheck test lint assembleDebug assembleRelease` green (release unsigned
without env); a throwaway-keystore signed build verified with `apksigner` (v2 scheme);
version injection confirmed (`versionCode=42`); the YAML parses; action version tags
(checkout v6, setup-java v5, setup-gradle v6) confirmed to exist. GitHub Actions itself
runs on merge.