### PR TITLE
feat(trip): add a trip reset and reject impossible speed readings

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayTest.kt
@@ -4,7 +4,9 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import io.github.seijikohara.femto.testfixtures.fakeAddress
 import io.github.seijikohara.femto.testfixtures.fakeLocation
 import io.github.seijikohara.femto.testfixtures.fakeTripState
@@ -12,6 +14,7 @@ import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Rule
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class SpeedOverlayTest {
     @get:Rule
@@ -26,6 +29,7 @@ class SpeedOverlayTest {
                     address = fakeAddress(),
                     tripState = fakeTripState(currentSpeedMs = 18.0),
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    onReset = {},
                 )
             }
         }
@@ -43,6 +47,7 @@ class SpeedOverlayTest {
                     address = fakeAddress(),
                     tripState = fakeTripState(currentSpeedMs = 18.0),
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    onReset = {},
                 )
             }
         }
@@ -64,6 +69,7 @@ class SpeedOverlayTest {
                     address = fakeAddress(),
                     tripState = fakeTripState(currentSpeedMs = 18.0),
                     speedUnit = SpeedUnit.MILES_PER_HOUR,
+                    onReset = {},
                 )
             }
         }
@@ -73,5 +79,25 @@ class SpeedOverlayTest {
         rule.onAllNodesWithText("mph", substring = true).assertCountEquals(2)
         rule.onAllNodesWithText("mi", substring = true).assertCountEquals(1)
         rule.onAllNodesWithText("km", substring = true).assertCountEquals(0)
+    }
+
+    @Test
+    fun reset_button_invokes_on_reset_callback() {
+        var resetCount = 0
+        rule.setContent {
+            FemtoTheme {
+                SpeedOverlay(
+                    location = fakeLocation(),
+                    address = fakeAddress(),
+                    tripState = fakeTripState(currentSpeedMs = 18.0),
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    onReset = { resetCount++ },
+                )
+            }
+        }
+        // The trip-reset control is labelled by its content description (see
+        // R.string.speed_reset_trip) and tapping it raises the reset callback.
+        rule.onNodeWithContentDescription("Reset trip").performClick()
+        assertEquals(1, resetCount)
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/TripRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/TripRepository.kt
@@ -1,22 +1,40 @@
 package io.github.seijikohara.femto.data
 
 import android.location.Location
+import android.location.LocationManager
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 
 /**
  * In-memory trip aggregator.
  *
  * Subscribes to the shared location flow, walks the sequence of fixes,
- * and emits a running [TripState] each time a new fix lands. Three
+ * and emits a running [TripState] each time a new fix lands. Several
  * filters guard against the worst of GPS noise:
  *
- *  - Fixes whose *effective* speed (see below) is below
- *    `MIN_MOVING_SPEED_MS` (≈ 1.8 km/h) are treated as "not moving" —
- *    distance and time both stop accruing. This stops the average from
- *    collapsing toward zero at long stops.
+ *  - Only `GPS_PROVIDER` (and test) fixes feed the trip math.
+ *    `NETWORK_PROVIDER` fixes (cell-tower / Wi-Fi) are accurate enough
+ *    for map centring but jump tens-to-hundreds of metres between
+ *    updates; mixing them in injected phantom distance and the
+ *    impossible average speeds reported on-device, so they are filtered
+ *    out before the accrual sequence (the GPS anchor is never advanced
+ *    by a network fix).
+ *  - A fix whose *effective* speed (see below) exceeds
+ *    `MAX_PLAUSIBLE_SPEED_MS` (≈ 396 km/h) is treated as noise and
+ *    dropped entirely — neither published as the current speed nor
+ *    accrued — so one glitch can never poison the running totals.
+ *  - Fixes whose *effective* speed is below `MIN_MOVING_SPEED_MS`
+ *    (≈ 1.8 km/h) are treated as "not moving": distance and time both
+ *    stop accruing, so the average does not collapse toward zero at long
+ *    stops.
  *  - Fixes whose elapsed-time delta is non-positive or larger than
  *    `MAX_GAP_SECONDS` (a missing-fix gap, e.g. a tunnel) are skipped —
  *    we do not interpolate across them.
@@ -24,15 +42,19 @@ import kotlinx.coroutines.flow.flowOn
  *    clock, not `Location.time`. AI boxes routinely apply an NTP /
  *    system-clock correction mid-trip; the wall clock can jump
  *    backward or forward, but the boot clock keeps ticking, so it is
- *    the only safe basis for a delta. (Task 5.8.)
+ *    the only safe basis for a delta.
  *
  * "Effective speed" decouples accrual from the GPS chip's speed report.
  * Cheap chips and raw `GPS_PROVIDER` HALs leave `Location.speed` at
  * `0.0` and `Location.hasSpeed() == false`. Gating on the reported
  * speed would then freeze distance/average at zero for the whole trip.
  * Instead, when the fix carries no speed we derive one from the
- * position delta (`previous.distanceTo(current) / deltaSeconds`).
- * (Task 2.3.)
+ * position delta (`previous.distanceTo(current) / deltaSeconds`) — but
+ * only when `deltaSeconds` is at least `MIN_TRUSTWORTHY_DELTA_SECONDS`.
+ * A sub-second gap (two near-simultaneous fixes) would divide a real
+ * position delta into an absurd speed, so below that floor the
+ * position-derived path yields no reading and the fix contributes
+ * nothing.
  *
  * The accumulators ([lastLocation], [totalMeters], [totalSeconds]) live
  * on the instance, not inside the cold `flow {}`. Under
@@ -42,16 +64,24 @@ import kotlinx.coroutines.flow.flowOn
  * lived in the flow body they would reset to zero on every restart,
  * silently breaking the "since process start" contract. Hoisting them
  * makes the subscription window gate only *UI delivery*, never the
- * accumulated total. WhileSubscribed guarantees a single live upstream
- * collection at a time, so the plain (non-atomic) fields are safe.
+ * accumulated total.
+ *
+ * Location fixes and explicit [reset] requests are merged into a single
+ * stream consumed by one sequential `collect`, so the plain (non-atomic)
+ * accumulator fields are only ever read and written from that one
+ * sequence — a reset can never interleave with an accrual.
  *
  * Accrual still *pauses* while fully backgrounded — there is no eager
  * always-on GPS scope here — but the running total survives the gap and
- * resumes on the next fix. This composes with the later location
- * `shareIn` work. Trip resets are out of scope for this pass.
+ * resumes on the next fix.
  */
 internal class TripRepository(
     private val locationFlow: Flow<Location?>,
+    // The accrual sequence runs here. Production uses the default compute pool;
+    // tests inject a TestDispatcher so an explicit [reset] (a non-suspending
+    // tryEmit) and the resulting emission are observed deterministically under
+    // runTest's virtual clock.
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
     // Hoisted out of the cold flow {} so the running total survives a
     // WhileSubscribed stop/restart; see the class KDoc.
@@ -60,48 +90,108 @@ internal class TripRepository(
     private var totalSeconds = 0.0
     private var currentSpeedMs = 0.0
 
+    // Push channel for an explicit trip reset. extraBufferCapacity = 1 lets a
+    // single tryEmit from the UI thread land without a suspended collector. The
+    // reset is applied inside the merged collect (below), on the same single
+    // sequence as accrual, so the accumulators are never mutated concurrently.
+    private val resetSignals = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     fun stateFlow(): Flow<TripState> =
         flow {
             // Replay the running total to a (re)subscriber instead of a
             // hardcoded Initial, so distance does not appear to reset to
             // zero when the window reopens.
             emit(snapshot())
-            locationFlow.collect { current ->
-                if (current == null) return@collect
-                accrue(current)
-                emit(snapshot())
-            }
-        }.flowOn(Dispatchers.Default)
+            // Trip math is GPS-only: drop null fixes and NETWORK_PROVIDER fixes
+            // (cell-tower / Wi-Fi) before they reach the accrual sequence, so the
+            // GPS anchor is never advanced by a network jump and a dropped fix
+            // never produces a redundant emission.
+            val fixes: Flow<TripSignal> =
+                locationFlow
+                    .filterNotNull()
+                    .filterNot { it.provider == LocationManager.NETWORK_PROVIDER }
+                    .map { TripSignal.Fix(it) }
+            val resets: Flow<TripSignal> = resetSignals.map { TripSignal.Reset }
+            merge(fixes, resets).collect { signal ->
+                when (signal) {
+                    is TripSignal.Fix -> {
+                        accrue(signal.location)
+                        emit(snapshot())
+                    }
 
+                    TripSignal.Reset -> {
+                        resetAccumulators()
+                        emit(snapshot())
+                    }
+                }
+            }
+        }.flowOn(dispatcher)
+
+    /**
+     * Clear the running trip totals (Distance, Avg, and the current speed).
+     *
+     * Pushes a reset through [resetSignals] so the cleared [TripState] reaches
+     * collectors immediately, rather than waiting for the next location fix
+     * (the device may be parked for minutes after the user taps reset).
+     */
+    fun reset() {
+        resetSignals.tryEmit(Unit)
+    }
+
+    // Receives only GPS (non-network, non-null) fixes; network fixes are filtered
+    // upstream in stateFlow so they never advance the anchor.
     private fun accrue(current: Location) {
         val previous = lastLocation
         if (previous != null) {
             val deltaSeconds =
                 (current.elapsedRealtimeNanos - previous.elapsedRealtimeNanos) / NANOS_PER_SECOND
             if (deltaSeconds in MIN_DELTA_SECONDS..MAX_GAP_SECONDS) {
-                val effectiveSpeed = effectiveSpeed(previous, current, deltaSeconds)
-                currentSpeedMs = effectiveSpeed
-                if (effectiveSpeed >= MIN_MOVING_SPEED_MS) {
-                    totalMeters += previous.distanceTo(current).toDouble()
-                    totalSeconds += deltaSeconds
+                val speed = effectiveSpeed(previous, current, deltaSeconds)
+                // Drop implausible speeds (teleport jumps, bad chip reports,
+                // sub-second gaps): do not publish or accrue them.
+                if (speed != null && speed <= MAX_PLAUSIBLE_SPEED_MS) {
+                    currentSpeedMs = speed
+                    if (speed >= MIN_MOVING_SPEED_MS) {
+                        totalMeters += previous.distanceTo(current).toDouble()
+                        totalSeconds += deltaSeconds
+                    }
                 }
             }
         }
         lastLocation = current
     }
 
-    // The chip's reported speed when it has one; otherwise the
-    // position-derived speed so speed-less HALs still register motion.
+    // The chip's reported speed when it has one; otherwise the position-derived
+    // speed, but only when the elapsed-time base is long enough to trust.
+    // Returns null when a speed-less fix arrives too soon after the previous one
+    // for the derived speed to be meaningful.
     private fun effectiveSpeed(
         previous: Location,
         current: Location,
         deltaSeconds: Double,
-    ): Double =
-        if (current.hasSpeed()) {
-            current.speed.toDouble()
-        } else {
-            previous.distanceTo(current).toDouble() / deltaSeconds
+    ): Double? =
+        when {
+            current.hasSpeed() -> {
+                current.speed.toDouble()
+            }
+
+            deltaSeconds >= MIN_TRUSTWORTHY_DELTA_SECONDS -> {
+                previous.distanceTo(current).toDouble() / deltaSeconds
+            }
+
+            else -> {
+                null
+            }
         }
+
+    private fun resetAccumulators() {
+        // Drop the anchor too so the trip restarts cleanly from the next fix
+        // rather than charging the gap between the reset and that fix.
+        lastLocation = null
+        totalMeters = 0.0
+        totalSeconds = 0.0
+        currentSpeedMs = 0.0
+    }
 
     private fun snapshot(): TripState =
         TripState(
@@ -109,6 +199,15 @@ internal class TripRepository(
             avgSpeedMs = if (totalSeconds > 0.0) totalMeters / totalSeconds else 0.0,
             currentSpeedMs = currentSpeedMs,
         )
+
+    // Merged input to the single accrual sequence: a GPS location fix or a reset.
+    private sealed interface TripSignal {
+        data class Fix(
+            val location: Location,
+        ) : TripSignal
+
+        data object Reset : TripSignal
+    }
 
     private companion object {
         // ~1.8 km/h — below this the device is treated as stationary.
@@ -122,5 +221,14 @@ internal class TripRepository(
 
         // Drop pairs separated by a long gap (parked, lost fix, tunnel).
         const val MAX_GAP_SECONDS = 60.0
+
+        // Minimum elapsed time before a position-derived speed is trusted.
+        // Below this a sub-second inter-fix gap manufactures an impossible
+        // speed from a real position delta.
+        const val MIN_TRUSTWORTHY_DELTA_SECONDS = 0.5
+
+        // Plausible vehicle-speed ceiling (~396 km/h). Any effective speed
+        // above this is GPS noise and is dropped from all three metrics.
+        const val MAX_PLAUSIBLE_SPEED_MS = 110.0
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
@@ -26,4 +26,6 @@ internal sealed interface HomeAction {
     data object OpenBrowser : HomeAction
 
     data object OpenSettings : HomeAction
+
+    data object ResetTrip : HomeAction
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -47,6 +47,7 @@ internal class HomeViewModel(
     private val systemStatusFlow: Flow<SystemStatus>,
     private val tripStateFlow: Flow<TripState>,
     private val sendMusicCommand: (MusicCommand) -> Unit = {},
+    private val resetTrip: () -> Unit = {},
 ) : ViewModel() {
     // Kotlin's typed combine overloads cover at most 5 flows. Stage the eight
     // sources through a typed intermediate (CoreSignals) so the compiler enforces
@@ -128,6 +129,10 @@ internal class HomeViewModel(
             HomeAction.OpenSettings -> {
                 mutableEvents.tryEmit(HomeEvent.OpenSystemSettings)
             }
+
+            HomeAction.ResetTrip -> {
+                resetTrip()
+            }
         }
     }
 }
@@ -188,6 +193,7 @@ internal class HomeViewModelFactory(
             systemStatusFlow = systemStatus.statusFlow(),
             tripStateFlow = trip.stateFlow(),
             sendMusicCommand = music::send,
+            resetTrip = trip::reset,
         ) as T
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -112,6 +112,7 @@ private fun MapPane(
         address = uiState.address,
         tripState = uiState.tripState,
         speedUnit = speedUnit,
+        onReset = { onAction(HomeAction.ResetTrip) },
         modifier =
             Modifier
                 .align(Alignment.BottomCenter)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -3,6 +3,7 @@ package io.github.seijikohara.femto.ui.home.components
 import android.location.Location
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,6 +14,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -26,13 +29,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.MapPin
+import com.composables.icons.lucide.RotateCcw
+import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.ShortAddress
 import io.github.seijikohara.femto.data.TripState
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
@@ -51,16 +58,18 @@ import kotlin.math.roundToInt
  * Glass overlay anchored to the map pane's bottom-centre, per
  * `docs/design/dashboard-v2-mockup.html` `.speed-overlay`:
  *
- *  - Three-cell grid: hero current speed | 1 dp × 36 dp separator |
- *    distance | separator | average speed.
+ *  - Metric row: hero current speed | separator | distance | separator |
+ *    average speed | separator | reset-trip button (top-right).
  *  - Below: a 1 dp top border, then a MapPin · short-address row.
  *  - 20 dp corner radius and a 1 dp outline border. The Column wraps its
  *    content rather than claiming a fixed width, so the metric cells sit
  *    tight with a consistent 16 dp gap and the overlay never stretches to
  *    fill the map pane. The call site centres it via
  *    `Alignment.BottomCenter`, so a content-width Column stays compact and
- *    centred. Tabular figures keep digit widths stable, so the overlay
- *    barely changes width as the values tick.
+ *    centred. Tabular figures plus reserved per-cell widths
+ *    ([FemtoDimens.SpeedHeroValueMinWidth] / [FemtoDimens.SpeedMetricMinWidth])
+ *    keep the overlay's width stable as the values tick, so it no longer grows
+ *    and shrinks with the digit count.
  *
  * The 40 sp speed numeral is the only saturated value here; the
  * supporting metrics use `onSurface` / `onSurfaceVariant` so the hero
@@ -79,6 +88,7 @@ internal fun SpeedOverlay(
     address: ShortAddress?,
     tripState: TripState,
     speedUnit: SpeedUnit,
+    onReset: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // Source the hero numeral from the trip's effective speed, not
@@ -125,6 +135,7 @@ internal fun SpeedOverlay(
             distance = distance,
             distanceUnitLabel = speedUnit.distanceLabel(),
             avgSpeed = avgSpeed,
+            onReset = onReset,
         )
         if (shortAddress.isNotBlank()) {
             Box(modifier = Modifier.height(12.dp))
@@ -142,6 +153,7 @@ private fun MetricRow(
     distance: Double,
     distanceUnitLabel: String,
     avgSpeed: Int,
+    onReset: () -> Unit,
 ) = Row(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -151,9 +163,16 @@ private fun MetricRow(
     SecondaryMetric(
         key = "DISTANCE",
         value = "%.1f %s".format(distance, distanceUnitLabel),
+        modifier = Modifier.widthIn(min = FemtoDimens.SpeedMetricMinWidth),
     )
     Separator()
-    SecondaryMetric(key = "AVG.", value = "$avgSpeed $speedUnitLabel")
+    SecondaryMetric(
+        key = "AVG.",
+        value = "$avgSpeed $speedUnitLabel",
+        modifier = Modifier.widthIn(min = FemtoDimens.SpeedMetricMinWidth),
+    )
+    Separator()
+    ResetButton(onReset = onReset)
 }
 
 @Composable
@@ -176,6 +195,11 @@ private fun NowMetric(
             ),
         color = MaterialTheme.colorScheme.onSurface,
         maxLines = 1,
+        // Reserve a stable width sized for the clamped 3-digit range and
+        // right-align within it, so the hero numeral does not reflow the
+        // overlay as the speed's digit count changes.
+        textAlign = TextAlign.End,
+        modifier = Modifier.widthIn(min = FemtoDimens.SpeedHeroValueMinWidth),
     )
     Text(
         text = unit,
@@ -251,6 +275,30 @@ private fun AddressRow(text: String) =
         )
     }
 
+// Trailing reset control for the trip metrics, anchored to the overlay's
+// top-right (the end of the metric row). A 64 dp hit area
+// (CLAUDE.md#automotive-overrides) wraps a small glyph; the box also sets the
+// metric row height, so the tap target is met without a separate overlay.
+@Composable
+private fun ResetButton(
+    onReset: () -> Unit,
+    modifier: Modifier = Modifier,
+) = Box(
+    modifier =
+        modifier
+            .size(FemtoDimens.MinTouchTarget)
+            .clip(CircleShape)
+            .clickable(onClick = onReset),
+    contentAlignment = Alignment.Center,
+) {
+    Icon(
+        imageVector = Lucide.RotateCcw,
+        contentDescription = stringResource(R.string.speed_reset_trip),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(FemtoDimens.InlineIconSize),
+    )
+}
+
 /**
  * Advance an exponential moving average (EMA) by one sample.
  *
@@ -280,7 +328,7 @@ private const val SPEED_OVERLAY_EMA_ALPHA = 0.33f
 private const val NO_SPEED_PLACEHOLDER = "—"
 
 @PreviewLightDark
-@Preview(name = "Speed overlay", widthDp = 520, heightDp = 140)
+@Preview(name = "Speed overlay", widthDp = 560, heightDp = 160)
 @Composable
 private fun SpeedOverlayPreview() {
     FemtoTheme {
@@ -291,12 +339,30 @@ private fun SpeedOverlayPreview() {
             address = ShortAddress(locality = "Minato-ku", region = "Tokyo"),
             tripState = TripState(distanceMeters = 24_400.0, avgSpeedMs = 11.7, currentSpeedMs = 13.2),
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            onReset = {},
         )
     }
 }
 
 @PreviewLightDark
-@Preview(name = "Speed overlay (no fix)", widthDp = 520, heightDp = 140)
+@Preview(name = "Speed overlay (wide values)", widthDp = 560, heightDp = 160)
+@Composable
+private fun SpeedOverlayWideValuesPreview() {
+    FemtoTheme {
+        // Large 3-digit speed and a long distance verify the reserved metric
+        // widths hold the overlay's width stable instead of reflowing.
+        SpeedOverlay(
+            location = Location("preview").apply { speed = 30.5f },
+            address = ShortAddress(locality = "Minato-ku", region = "Tokyo"),
+            tripState = TripState(distanceMeters = 188_400.0, avgSpeedMs = 30.5, currentSpeedMs = 30.5),
+            speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            onReset = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Preview(name = "Speed overlay (no fix)", widthDp = 560, heightDp = 160)
 @Composable
 private fun SpeedOverlayNoFixPreview() {
     FemtoTheme {
@@ -307,6 +373,7 @@ private fun SpeedOverlayNoFixPreview() {
             address = ShortAddress(locality = "Minato-ku", region = "Tokyo"),
             tripState = TripState.Initial,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            onReset = {},
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -60,6 +60,21 @@ object FemtoDimens {
      */
     val SpeedOverlayCorner = 20.dp
 
+    /**
+     * Minimum width reserved for the speed overlay's hero numeral so the card
+     * does not reflow as the speed's digit count changes (e.g. 9 -> 120 km/h).
+     * Sized for the 3-digit range left after [TripRepository]'s plausibility
+     * clamp; the value is right-aligned within it.
+     */
+    val SpeedHeroValueMinWidth = 72.dp
+
+    /**
+     * Minimum width reserved for each secondary speed-metric cell (distance,
+     * average) so digit-count changes do not reflow the overlay across the
+     * common driving range.
+     */
+    val SpeedMetricMinWidth = 76.dp
+
     /** Weather glyph beside the city name in the weather card head row. */
     val WeatherGlyphLarge = 20.dp
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,9 @@
     <string name="map_unavailable">Map unavailable</string>
     <string name="map_permission_cta">Grant location access to enable the map and overlays.</string>
 
+    <!-- Speed overlay -->
+    <string name="speed_reset_trip">Reset trip</string>
+
     <!-- Calendar card -->
     <string name="calendar_no_events">No upcoming events</string>
     <string name="calendar_permission_denied">Calendar access not granted</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/TripRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/TripRepositoryTest.kt
@@ -1,10 +1,13 @@
 package io.github.seijikohara.femto.data
 
 import android.location.Location
+import android.location.LocationManager
 import app.cash.turbine.test
 import io.github.seijikohara.femto.testfixtures.fakeLocation
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,6 +19,7 @@ import kotlin.test.assertTrue
 // Location is an Android type that Robolectric supplies; distanceTo() uses
 // the WGS84 model, so assertions check inequalities / deltas rather than
 // hardcoded metre counts.
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
 class TripRepositoryTest {
@@ -192,6 +196,161 @@ class TripRepositoryTest {
                 skipItems(2) // initial snapshot + first fix
                 // Reported speed wins when the fix has one (hasSpeed default true).
                 assertEquals(9.5, awaitItem().currentSpeedMs, 0.0001)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `rejects an impossible speed above the plausible ceiling`() =
+        runTest {
+            // A reported speed far beyond any vehicle (a bad chip report) must be
+            // dropped, not published or accrued, so it cannot poison the totals.
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 5_000f, elapsedRealtimeNanos = tenSeconds(1)),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix
+                // The first fix has no previous, so currentSpeedMs is never set
+                // (stays 0.0); the second fix is over the ceiling and is dropped,
+                // so both metrics remain zero.
+                val afterSpike = awaitItem()
+                assertEquals(0.0, afterSpike.distanceMeters, 0.0)
+                assertEquals(0.0, afterSpike.currentSpeedMs, 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `rejects an impossible speed from a sub-second gap between position fixes`() =
+        runTest {
+            // Two speed-less fixes far apart in position but ~20 ms apart on the
+            // boot clock (the dual-provider interleave that produced the reported
+            // tens-of-thousands km/h). The position-derived speed must be distrusted.
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, hasSpeed = false, elapsedRealtimeNanos = 0L),
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, hasSpeed = false, elapsedRealtimeNanos = 20_000_000L),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix
+                val afterGlitch = awaitItem()
+                assertEquals(0.0, afterGlitch.distanceMeters, 0.0)
+                assertEquals(0.0, afterGlitch.currentSpeedMs, 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `ignores network-provider fixes for trip distance`() =
+        runTest {
+            // A GPS pair accrues; a following NETWORK fix that jumps position must
+            // be ignored — it must emit nothing and must not advance the GPS
+            // anchor (network fixes are tower / Wi-Fi, not for trip math).
+            val source = MutableSharedFlow<Location?>(replay = 0)
+            val repository = TripRepository(source, UnconfinedTestDispatcher(testScheduler))
+
+            repository.stateFlow().test {
+                awaitItem() // initial snapshot
+                source.emit(fakeLocation(latitude = ORIGIN_LAT, speedMps = 11f, elapsedRealtimeNanos = 0L))
+                awaitItem() // first GPS fix, no previous
+                source.emit(
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 11f, elapsedRealtimeNanos = tenSeconds(1)),
+                )
+                val afterGps = awaitItem()
+                assertTrue(afterGps.distanceMeters > 0.0)
+
+                // The far NETWORK jump is filtered out: no emission at all.
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 10 * STEP,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(2),
+                        provider = LocationManager.NETWORK_PROVIDER,
+                    ),
+                )
+                expectNoEvents()
+
+                // The next GPS fix accrues a normal step from the last GPS anchor
+                // (ORIGIN + STEP), not from the discarded network jump.
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 2 * STEP,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(3),
+                    ),
+                )
+                assertTrue(awaitItem().distanceMeters > afterGps.distanceMeters)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `reset clears distance avg and current speed`() =
+        runTest {
+            val source = MutableSharedFlow<Location?>(replay = 0)
+            // Test dispatcher so the non-suspending reset() and its emission are
+            // observed deterministically under the virtual clock.
+            val repository = TripRepository(source, UnconfinedTestDispatcher(testScheduler))
+
+            repository.stateFlow().test {
+                assertEquals(0.0, awaitItem().distanceMeters, 0.0) // initial snapshot
+                source.emit(fakeLocation(latitude = ORIGIN_LAT, speedMps = 11f, elapsedRealtimeNanos = 0L))
+                awaitItem() // first fix, no previous
+                source.emit(
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 11f, elapsedRealtimeNanos = tenSeconds(1)),
+                )
+                assertTrue(awaitItem().distanceMeters > 0.0)
+
+                repository.reset()
+
+                val cleared = awaitItem()
+                assertEquals(0.0, cleared.distanceMeters, 0.0)
+                assertEquals(0.0, cleared.avgSpeedMs, 0.0)
+                assertEquals(0.0, cleared.currentSpeedMs, 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `accrual resumes after a reset`() =
+        runTest {
+            val source = MutableSharedFlow<Location?>(replay = 0)
+            val repository = TripRepository(source, UnconfinedTestDispatcher(testScheduler))
+
+            repository.stateFlow().test {
+                awaitItem() // initial snapshot
+                source.emit(fakeLocation(latitude = ORIGIN_LAT, speedMps = 11f, elapsedRealtimeNanos = 0L))
+                awaitItem()
+                source.emit(
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 11f, elapsedRealtimeNanos = tenSeconds(1)),
+                )
+                awaitItem()
+
+                repository.reset()
+                assertEquals(0.0, awaitItem().distanceMeters, 0.0)
+
+                // The reset drops the anchor: the first post-reset fix re-anchors
+                // (no accrual), the second accrues from there.
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 2 * STEP,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(3),
+                    ),
+                )
+                assertEquals(0.0, awaitItem().distanceMeters, 0.0)
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 3 * STEP,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(4),
+                    ),
+                )
+                assertTrue(awaitItem().distanceMeters > 0.0)
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeLocation.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeLocation.kt
@@ -12,8 +12,11 @@ internal fun fakeLocation(
     // When false, the fix carries no speed (Location.hasSpeed() == false),
     // mirroring cheap GPS chips and raw GPS_PROVIDER HALs.
     hasSpeed: Boolean = true,
+    // Defaults to a neutral test provider; pass LocationManager.NETWORK_PROVIDER
+    // to exercise the GPS-only trip-accrual path.
+    provider: String = "test",
 ): Location =
-    Location("test").apply {
+    Location(provider).apply {
         this.latitude = latitude
         this.longitude = longitude
         this.altitude = altitudeM

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -180,6 +180,19 @@ class HomeViewModelTest {
         }
 
     @Test
+    fun `onAction ResetTrip invokes resetTrip and emits no event`() =
+        runTest {
+            var resetCount = 0
+            val viewModel = stubViewModel(resetTrip = { resetCount++ })
+            viewModel.events.test {
+                viewModel.onAction(HomeAction.ResetTrip)
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertEquals(1, resetCount)
+        }
+
+    @Test
     fun `onAction Music forwards the command to sendMusicCommand and emits no event`() =
         runTest {
             val received = mutableListOf<MusicCommand>()
@@ -208,7 +221,10 @@ class HomeViewModelTest {
         }
     }
 
-    private fun stubViewModel(sendMusicCommand: (MusicCommand) -> Unit = {}): HomeViewModel =
+    private fun stubViewModel(
+        sendMusicCommand: (MusicCommand) -> Unit = {},
+        resetTrip: () -> Unit = {},
+    ): HomeViewModel =
         HomeViewModel(
             clockFlow = emptyFlow(),
             locationFlow = emptyFlow(),
@@ -219,5 +235,6 @@ class HomeViewModelTest {
             systemStatusFlow = emptyFlow(),
             tripStateFlow = emptyFlow(),
             sendMusicCommand = sendMusicCommand,
+            resetTrip = resetTrip,
         )
 }


### PR DESCRIPTION
PR1 of the dashboard device-feedback redesign (spec:
`docs/superpowers/specs/2026-06-04-dashboard-device-feedback-design.md`).
Addresses the trip/speed cluster: feedback items 8, 6, 19.

## Item 8 (bug): impossible speed corrupting Distance/Avg

The speed overlay periodically showed impossible values (tens of
thousands of km/h) that also corrupted Distance and Average. The shared
GPS+NETWORK location stream delivered two near-simultaneous fixes whose
sub-second elapsed-time delta divided a real position delta into an
absurd speed, which was then accrued into the running totals.

`TripRepository` is hardened with defence-in-depth:
- **GPS-only**: `NETWORK_PROVIDER` fixes are filtered out before the
  accrual sequence (they jump tens-to-hundreds of metres and are for map
  centring, not distance), so they never advance the anchor or emit.
- **Trustworthy dt**: a position-derived speed is trusted only when the
  elapsed-time base is at least `MIN_TRUSTWORTHY_DELTA_SECONDS`, so a
  sub-second gap can no longer manufacture a huge speed.
- **Plausibility clamp**: any effective speed above
  `MAX_PLAUSIBLE_SPEED_MS` (~396 km/h) is dropped from all three metrics.

## Item 6 (fix): speed panel width fluctuated with content

Reserve per-cell widths (`SpeedHeroValueMinWidth` / `SpeedMetricMinWidth`)
and right-align the hero numeral so the overlay no longer reflows as the
digit count changes.

## Item 19 (feature): Distance/Avg reset button

`TripRepository.reset()` zeroes the totals and pushes the cleared state
immediately via a reset signal merged into the accrual flow (the cold
flow otherwise emits only on the next fix). Wired through
`HomeAction.ResetTrip` to a top-right reset button on the overlay with a
64 dp tap target (`Lucide.RotateCcw`). The accrual dispatcher is injected
so the reset path is deterministic under `runTest`.

## Tests

JVM: reject over-ceiling speed, reject sub-second-gap derived speed,
ignore network fixes (asserts no emission), reset clears all three
metrics, accrual resumes after reset. Plus an androidTest that the reset
button raises its callback, and a wide-value preview to lock the stable
width.

Reviewed by the compose-launcher-reviewer agent (no blockers; should-fix
items addressed).

## Verification

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — all green (101 unit tests).