### PR TITLE
fix(map): relax the MapLibre EGL config so tiles render on head-unit GPUs

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -108,16 +108,24 @@ private fun VectorMap(
             // textureMode(true) renders the map into a TextureView (drawn inline
             // in the view hierarchy), so it is clipped by the parent Surface's
             // rounded corners and the Compose overlays (clock / speed) sit cleanly
-            // on top. translucentTextureSurface(false) forces the buffer opaque so
-            // the surfaceContainer behind it cannot bleed through, and saves a
-            // blend pass on real GPUs. (On software-GL emulators the emulator
-            // cannot composite this surface into a screencap, but it renders on
-            // real head-unit GPUs — see MainActivity.enableEmulatorMapRendering.)
+            // on top. This is why we cannot use a SurfaceView (the MapLibre
+            // default): a SurfaceView is a separate window layer that ignores the
+            // rounded-corner clip and would hide the Compose overlays.
+            //
+            // translucentTextureSurface(true) requests an RGBA EGL config. The
+            // earlier opaque-RGB config (false) was rejected by the head-unit GL
+            // driver, so the GL surface was created but never produced frames —
+            // the map showed as a blank grey/black rectangle on-device while the
+            // location gate and style load both succeeded. RGBA is the widely
+            // supported config; the tiles are fully opaque so the surfaceContainer
+            // behind does not visibly bleed through, and the extra blend pass is a
+            // negligible cost for broad GPU compatibility. (Verify on-device:
+            // local/emulator software GL cannot reproduce the driver's rejection.)
             val options =
                 MapLibreMapOptions
                     .createFromAttributes(context)
                     .textureMode(true)
-                    .translucentTextureSurface(false)
+                    .translucentTextureSurface(true)
             // onCreate(null) is mandatory before getMapAsync; without it the
             // ready callback never fires and the map silently stays blank.
             MapView(context, options).apply { onCreate(null) }


### PR DESCRIPTION
PR2 of the dashboard device-feedback redesign (feedback item 7).

## Symptom

On the real head unit (Carlinkit TBox Ambient + factory 9-inch display)
the map area showed a blank **grey/black rectangle**. Crucially it was
the rectangle, not the "Map unavailable" fallback — so `location != null`
(the map composable rendered `VectorMap`) and the style load did not fail
(no fallback overlay). The GL surface was created but never produced
frames.

## Root cause

`translucentTextureSurface(false)` requests an **opaque RGB** EGL config.
Cheap head-unit GL drivers commonly reject that config, so MapLibre's GL
context cannot produce frames and the TextureView stays blank, revealing
the grey `surfaceContainer` behind it.

Ruled out by the symptom: the location gate (would show the fallback),
the network/style path (would show the fallback after retries), R8
(minify is off), and lifecycle wiring (forwarded correctly).

## Fix

Switch to `translucentTextureSurface(true)` (an **RGBA** config, the
widely supported one), keeping `textureMode(true)`.

A `SurfaceView` (the MapLibre default) is **not** an option here: it is a
separate window layer that ignores the parent's rounded-corner clip and
would hide the Compose clock/speed overlays. TextureView is required for
the overlay design, so the fix targets the EGL config rather than the
view type.

## Verification

`./gradlew spotlessCheck test lint assembleDebug` — green.

⚠️ This is a GPU-driver behavior change that **cannot be reproduced on
local/emulator software GL**. It needs **on-device confirmation**: please
install the nightly APK and check whether the map now renders tiles. If
the rectangle persists, the next step is swapping the MapLibre backend to
the Vulkan-capable default artifact (a version-catalog change).