### PR TITLE
fix(theme): lighten Bold Minimal typography one weight notch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,11 @@ with automotive overrides on top.
   `MaterialTheme.colorScheme.*`; never hardcode hex outside
   `Color.kt`.
 - Shape: M3 default `Shapes` (squircles). Do not customise.
-- Typography: Bold Minimal weights on M3 roles. Use
+- Typography: Bold Minimal on M3 roles, tuned **one weight notch
+  lighter** than the original scale after on-device review found the
+  heavy display/headline weights too dense on the head unit (display
+  ExtraBold/Bold, headline SemiBold, title Medium; body Normal, label
+  Medium — `ui/theme/Type.kt` is the SSOT). Use
   `MaterialTheme.typography.*` styles; never construct ad-hoc
   `TextStyle` literals.
 - Sizing: read from `FemtoDimens` (e.g. `FemtoDimens.MinTouchTarget`).

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -113,7 +113,7 @@ private fun Head(snapshot: CalendarSnapshot) =
                 style =
                     MaterialTheme.typography.titleLarge.copy(
                         fontSize = 20.sp,
-                        fontWeight = FontWeight.Bold,
+                        fontWeight = FontWeight.SemiBold,
                         letterSpacing = (-0.01f).em,
                         lineHeight = 20.sp,
                     ),
@@ -178,7 +178,7 @@ private fun DayCellView(
             style =
                 MaterialTheme.typography.titleSmall.copy(
                     fontSize = 14.sp,
-                    fontWeight = FontWeight.Bold,
+                    fontWeight = FontWeight.SemiBold,
                     lineHeight = 16.sp,
                     fontFeatureSettings = TabularFigures,
                 ),
@@ -251,7 +251,7 @@ private fun EventRow(
             style =
                 MaterialTheme.typography.labelLarge.copy(
                     fontSize = 13.sp,
-                    fontWeight = FontWeight.Bold,
+                    fontWeight = FontWeight.SemiBold,
                     lineHeight = 17.sp,
                     fontFeatureSettings = TabularFigures,
                 ),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
@@ -62,7 +62,7 @@ internal fun ClockOverlay(
         style =
             MaterialTheme.typography.displayMedium.copy(
                 fontSize = 40.sp,
-                fontWeight = FontWeight.ExtraBold,
+                fontWeight = FontWeight.Bold,
                 letterSpacing = (-0.04f).em,
                 lineHeight = 40.sp,
                 fontFeatureSettings = TabularFigures,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
@@ -313,7 +313,7 @@ private fun BatteryIndicator(
         style =
             MaterialTheme.typography.labelLarge.copy(
                 fontSize = 13.sp,
-                fontWeight = FontWeight.Bold,
+                fontWeight = FontWeight.SemiBold,
                 fontFeatureSettings = TabularFigures,
             ),
         color = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -205,7 +205,7 @@ private fun Meta(
         style =
             MaterialTheme.typography.titleLarge.copy(
                 fontSize = 20.sp,
-                fontWeight = FontWeight.ExtraBold,
+                fontWeight = FontWeight.Bold,
                 letterSpacing = (-0.02f).em,
                 lineHeight = 23.sp,
             ),
@@ -219,7 +219,7 @@ private fun Meta(
             style =
                 MaterialTheme.typography.bodyMedium.copy(
                     fontSize = 14.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    fontWeight = FontWeight.Medium,
                     lineHeight = 16.sp,
                 ),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -279,7 +279,7 @@ private fun Progress(
             style =
                 MaterialTheme.typography.labelSmall.copy(
                     fontSize = 11.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    fontWeight = FontWeight.Medium,
                     fontFeatureSettings = TabularFigures,
                 ),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -307,7 +307,7 @@ private fun Progress(
             style =
                 MaterialTheme.typography.labelSmall.copy(
                     fontSize = 11.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    fontWeight = FontWeight.Medium,
                     fontFeatureSettings = TabularFigures,
                 ),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -401,7 +401,7 @@ private fun ConnectState(onConnect: () -> Unit) =
                 style =
                     MaterialTheme.typography.titleMedium.copy(
                         fontSize = 18.sp,
-                        fontWeight = FontWeight.Bold,
+                        fontWeight = FontWeight.SemiBold,
                     ),
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
@@ -449,7 +449,7 @@ private fun EmptyState() =
             style =
                 MaterialTheme.typography.titleMedium.copy(
                     fontSize = 18.sp,
-                    fontWeight = FontWeight.Bold,
+                    fontWeight = FontWeight.SemiBold,
                 ),
             color = MaterialTheme.colorScheme.onSurface,
             maxLines = 1,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -188,7 +188,7 @@ private fun NowMetric(
         style =
             MaterialTheme.typography.displayMedium.copy(
                 fontSize = 40.sp,
-                fontWeight = FontWeight.ExtraBold,
+                fontWeight = FontWeight.Bold,
                 letterSpacing = (-0.03f).em,
                 lineHeight = 40.sp,
                 fontFeatureSettings = TabularFigures,
@@ -241,7 +241,7 @@ private fun SecondaryMetric(
         style =
             MaterialTheme.typography.titleSmall.copy(
                 fontSize = 16.sp,
-                fontWeight = FontWeight.Bold,
+                fontWeight = FontWeight.SemiBold,
                 letterSpacing = (-0.01f).em,
                 fontFeatureSettings = TabularFigures,
             ),
@@ -267,7 +267,7 @@ private fun AddressRow(text: String) =
             style =
                 MaterialTheme.typography.bodyMedium.copy(
                     fontSize = 13.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    fontWeight = FontWeight.Medium,
                     lineHeight = 16.sp,
                 ),
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.86f),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -124,7 +124,7 @@ private fun Head(
                 style =
                     MaterialTheme.typography.titleMedium.copy(
                         fontSize = 20.sp,
-                        fontWeight = FontWeight.Bold,
+                        fontWeight = FontWeight.SemiBold,
                         lineHeight = 20.sp,
                     ),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -157,7 +157,7 @@ private fun Head(
                     style =
                         MaterialTheme.typography.titleMedium.copy(
                             fontSize = 16.sp,
-                            fontWeight = FontWeight.Bold,
+                            fontWeight = FontWeight.SemiBold,
                             letterSpacing = (-0.01f).em,
                             lineHeight = 16.sp,
                         ),
@@ -210,7 +210,7 @@ private fun Metric(
         style =
             MaterialTheme.typography.bodyMedium.copy(
                 fontSize = 14.sp,
-                fontWeight = FontWeight.Bold,
+                fontWeight = FontWeight.SemiBold,
                 lineHeight = 16.sp,
                 fontFeatureSettings = TabularFigures,
             ),
@@ -277,7 +277,7 @@ private fun ForecastChip(
             style =
                 MaterialTheme.typography.bodyMedium.copy(
                     fontSize = 13.sp,
-                    fontWeight = FontWeight.Bold,
+                    fontWeight = FontWeight.SemiBold,
                     lineHeight = 15.sp,
                     fontFeatureSettings = TabularFigures,
                 ),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
@@ -62,21 +62,29 @@ internal object FemtoFonts {
 }
 
 /**
- * Bold Minimal typography on top of M3 roles.
+ * Bold Minimal typography on top of M3 roles, tuned one weight notch lighter
+ * than the original scale after on-device review found the heavy display/headline
+ * weights too dense on the head unit.
  *
- * Display sizes lean heavier (Black/ExtraBold) for editorial impact;
- * body sizes are bumped up to clear the 18sp automotive minimum.
+ * Display anchors stay confident (ExtraBold/Bold) for editorial impact but no
+ * longer reach Black; headlines drop to SemiBold and titles to Medium. Body and
+ * label roles are unchanged (already Normal/Medium) and body sizes still clear
+ * the 18sp automotive minimum. See `CLAUDE.md#design-system`.
  */
 internal fun femtoTypography(latin: FontFamily): Typography =
     Typography().run {
         copy(
-            displayLarge = displayLarge.copy(fontFamily = latin, fontWeight = FontWeight.Black, fontSize = 96.sp),
-            displayMedium = displayMedium.copy(fontFamily = latin, fontWeight = FontWeight.ExtraBold, fontSize = 72.sp),
-            displaySmall = displaySmall.copy(fontFamily = latin, fontWeight = FontWeight.ExtraBold, fontSize = 56.sp),
-            headlineLarge = headlineLarge.copy(fontFamily = latin, fontWeight = FontWeight.Bold, fontSize = 40.sp),
-            headlineMedium = headlineMedium.copy(fontFamily = latin, fontWeight = FontWeight.Bold, fontSize = 32.sp),
-            headlineSmall = headlineSmall.copy(fontFamily = latin, fontWeight = FontWeight.SemiBold, fontSize = 26.sp),
-            titleLarge = titleLarge.copy(fontFamily = latin, fontWeight = FontWeight.SemiBold, fontSize = 24.sp),
+            displayLarge = displayLarge.copy(fontFamily = latin, fontWeight = FontWeight.ExtraBold, fontSize = 96.sp),
+            displayMedium = displayMedium.copy(fontFamily = latin, fontWeight = FontWeight.Bold, fontSize = 72.sp),
+            displaySmall = displaySmall.copy(fontFamily = latin, fontWeight = FontWeight.Bold, fontSize = 56.sp),
+            headlineLarge = headlineLarge.copy(fontFamily = latin, fontWeight = FontWeight.SemiBold, fontSize = 40.sp),
+            headlineMedium = headlineMedium.copy(
+                fontFamily = latin,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 32.sp,
+            ),
+            headlineSmall = headlineSmall.copy(fontFamily = latin, fontWeight = FontWeight.Medium, fontSize = 26.sp),
+            titleLarge = titleLarge.copy(fontFamily = latin, fontWeight = FontWeight.Medium, fontSize = 24.sp),
             titleMedium = titleMedium.copy(fontFamily = latin, fontWeight = FontWeight.Medium, fontSize = 20.sp),
             titleSmall = titleSmall.copy(fontFamily = latin, fontWeight = FontWeight.Medium, fontSize = 18.sp),
             bodyLarge = bodyLarge.copy(fontFamily = latin, fontWeight = FontWeight.Normal, fontSize = 20.sp),
@@ -108,7 +116,7 @@ internal const val TabularFigures = "tnum"
 internal fun Typography.bigNumber(): TextStyle =
     displayLarge.copy(
         fontSize = FemtoDimens.BigNumberFontSize,
-        fontWeight = FontWeight.ExtraBold,
+        fontWeight = FontWeight.Bold,
         letterSpacing = (-0.045f).em,
         lineHeight = (FemtoDimens.BigNumberFontSize.value * 0.92f).sp,
         fontFeatureSettings = TabularFigures,
@@ -128,7 +136,7 @@ internal fun Typography.sectionLabel(
 ): TextStyle =
     labelSmall.copy(
         fontSize = sizeSp.sp,
-        fontWeight = FontWeight.Bold,
+        fontWeight = FontWeight.SemiBold,
         letterSpacing = trackingEm.em,
         fontFeatureSettings = TabularFigures,
     )

--- a/docs/design/dashboard-v2-mockup.html
+++ b/docs/design/dashboard-v2-mockup.html
@@ -22,7 +22,7 @@
     padding: 32px;
     min-height: 100vh;
   }
-  h1 { font-size: 22px; font-weight: 800; letter-spacing: -0.02em; margin-bottom: 6px; }
+  h1 { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 6px; }
   .subtitle { font-size: 14px; color: #8a8f95; margin-bottom: 24px; max-width: 1280px; }
   .legend {
     display: grid; grid-template-columns: repeat(4, 1fr);
@@ -39,7 +39,7 @@
   .variant { margin-bottom: 40px; max-width: 1280px; }
   .variant-title {
     font-size: 14px; text-transform: uppercase; letter-spacing: 0.12em;
-    color: #8a8f95; margin-bottom: 8px; font-weight: 700;
+    color: #8a8f95; margin-bottom: 8px; font-weight: 600;
   }
   .variant-note { font-size: 13px; color: #6b7079; margin-top: 8px; line-height: 1.5; }
 
@@ -163,7 +163,7 @@
   }
   .frame.dark .clock-overlay { color: #f5f7fa; }
   .clock-overlay .time {
-    font-size: 40px; font-weight: 800;
+    font-size: 40px; font-weight: 700;
     letter-spacing: -0.04em; line-height: 1;
     font-feature-settings: "tnum" 1;
   }
@@ -193,17 +193,17 @@
   }
   .speed-overlay .now { display: flex; align-items: baseline; gap: 4px; }
   .speed-overlay .now .v {
-    font-size: 40px; font-weight: 800; letter-spacing: -0.03em; line-height: 1;
+    font-size: 40px; font-weight: 700; letter-spacing: -0.03em; line-height: 1;
   }
   .speed-overlay .now .u {
-    font-size: 12px; font-weight: 700; letter-spacing: 0.12em; opacity: 0.7;
+    font-size: 12px; font-weight: 600; letter-spacing: 0.12em; opacity: 0.7;
   }
   .speed-overlay .k {
-    font-size: 10px; font-weight: 700; letter-spacing: 0.14em; opacity: 0.62;
+    font-size: 10px; font-weight: 600; letter-spacing: 0.14em; opacity: 0.62;
     text-transform: uppercase; margin-bottom: 2px;
   }
   .speed-overlay .v-secondary {
-    font-size: 16px; font-weight: 700; letter-spacing: -0.01em;
+    font-size: 16px; font-weight: 600; letter-spacing: -0.01em;
   }
   .speed-overlay .address-row {
     grid-column: 1 / -1;
@@ -212,7 +212,7 @@
     border-top: 1px solid currentColor;
     border-top-color: rgba(255,255,255,0.16);
     display: flex; align-items: center; gap: 8px;
-    font-size: 13px; font-weight: 600; opacity: 0.86;
+    font-size: 13px; font-weight: 500; opacity: 0.86;
   }
   .frame.light .speed-overlay .address-row { border-top-color: rgba(0,0,0,0.10); }
 
@@ -225,13 +225,13 @@
     color: var(--on-surface-variant);
   }
   .map-fallback .icon { width: 48px; height: 48px; stroke-width: 1.5; margin: 0 auto 16px; color: var(--on-surface-dim); }
-  .map-fallback .title { font-size: 22px; font-weight: 700; color: var(--on-surface); margin-bottom: 8px; letter-spacing: -0.01em; }
+  .map-fallback .title { font-size: 22px; font-weight: 600; color: var(--on-surface); margin-bottom: 8px; letter-spacing: -0.01em; }
   .map-fallback .desc { font-size: 16px; line-height: 1.5; max-width: 360px; margin: 0 auto 24px; }
   .map-fallback .cta {
     height: 56px; padding: 0 28px;
     border-radius: 28px;
     background: var(--primary); color: var(--on-primary);
-    font-size: 16px; font-weight: 700;
+    font-size: 16px; font-weight: 600;
     display: inline-flex; align-items: center; gap: 10px;
   }
 
@@ -258,7 +258,7 @@
   }
   .eyebrow {
     display: flex; align-items: center; gap: 6px;
-    font-size: 11px; font-weight: 700; letter-spacing: 0.14em;
+    font-size: 11px; font-weight: 600; letter-spacing: 0.14em;
     text-transform: uppercase; color: var(--on-surface-dim);
   }
   .eyebrow .icon { width: 14px; height: 14px; stroke-width: 2; }
@@ -275,7 +275,7 @@
     align-items: center;
   }
   .calendar-card .big-day {
-    font-size: 56px; font-weight: 800;
+    font-size: 56px; font-weight: 700;
     line-height: 0.92; letter-spacing: -0.045em;
     color: var(--primary);
   }
@@ -283,12 +283,12 @@
     display: grid; row-gap: 4px; min-width: 0;
   }
   .calendar-card .head .weekday {
-    font-size: 20px; font-weight: 700;
+    font-size: 20px; font-weight: 600;
     color: var(--on-surface);
     letter-spacing: -0.01em; line-height: 1;
   }
   .calendar-card .head .month {
-    font-size: 11px; font-weight: 700;
+    font-size: 11px; font-weight: 600;
     color: var(--on-surface-variant);
     letter-spacing: 0.14em; text-transform: uppercase;
   }
@@ -306,12 +306,12 @@
     align-content: center;
   }
   .calendar-card .day .w {
-    font-size: 9px; font-weight: 700;
+    font-size: 9px; font-weight: 600;
     letter-spacing: 0.08em; text-transform: uppercase;
     opacity: 0.78;
   }
   .calendar-card .day .n {
-    font-size: 14px; font-weight: 700;
+    font-size: 14px; font-weight: 600;
     line-height: 1.1;
   }
   .calendar-card .day .marker {
@@ -345,7 +345,7 @@
     background: var(--outline);
   }
   .calendar-card .events .row .time {
-    font-weight: 700; color: var(--on-surface);
+    font-weight: 600; color: var(--on-surface);
     font-size: 13px;
   }
   .calendar-card .events .row .label {
@@ -364,12 +364,12 @@
     align-items: center;
   }
   .weather-card .big-temp {
-    font-size: 56px; font-weight: 800;
+    font-size: 56px; font-weight: 700;
     line-height: 0.92; letter-spacing: -0.045em;
     color: var(--on-surface);
   }
   .weather-card .big-temp .deg {
-    font-size: 20px; font-weight: 700;
+    font-size: 20px; font-weight: 600;
     color: var(--on-surface-variant);
     vertical-align: top; margin-left: 2px;
   }
@@ -392,13 +392,13 @@
   .weather-card .glyph:has(use[href="#i-cloud-sun"]) { color: var(--w-cloud-sun); }
   .weather-card .glyph:has(use[href="#i-cloud"])     { color: var(--w-cloud); }
   .weather-card .head .city {
-    font-size: 18px; font-weight: 700;
+    font-size: 18px; font-weight: 600;
     color: var(--on-surface);
     letter-spacing: -0.01em; line-height: 1;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .weather-card .head .conditions {
-    font-size: 11px; font-weight: 700;
+    font-size: 11px; font-weight: 600;
     color: var(--on-surface-variant);
     letter-spacing: 0.14em; text-transform: uppercase;
   }
@@ -410,12 +410,12 @@
     display: inline-flex; align-items: baseline; gap: 8px;
   }
   .weather-card .metrics .m .k {
-    font-size: 10px; font-weight: 700;
+    font-size: 10px; font-weight: 600;
     letter-spacing: 0.1em; text-transform: uppercase;
     color: var(--on-surface-dim);
   }
   .weather-card .metrics .m .v {
-    font-size: 14px; font-weight: 700;
+    font-size: 14px; font-weight: 600;
     color: var(--on-surface);
     font-feature-settings: "tnum" 1;
   }
@@ -433,9 +433,9 @@
     align-items: center;
     justify-items: center;
   }
-  .weather-card .forecast .h .hr { font-size: 10px; font-weight: 700; letter-spacing: 0.08em; color: var(--on-surface-dim); }
+  .weather-card .forecast .h .hr { font-size: 10px; font-weight: 600; letter-spacing: 0.08em; color: var(--on-surface-dim); }
   .weather-card .forecast .h .glyph { width: 18px; height: 18px; stroke-width: 1.75; }
-  .weather-card .forecast .h .tt { font-size: 13px; font-weight: 700; color: var(--on-surface); }
+  .weather-card .forecast .h .tt { font-size: 13px; font-weight: 600; color: var(--on-surface); }
 
   /* ---- Music ----
      Sections (art / meta / progress / controls) distributed by
@@ -454,7 +454,7 @@
     color: var(--on-surface-variant);
   }
   .music-card.empty .empty-icon { color: var(--on-surface-dim); }
-  .music-card.empty .empty-title { font-size: 18px; font-weight: 700; color: var(--on-surface); }
+  .music-card.empty .empty-title { font-size: 18px; font-weight: 600; color: var(--on-surface); }
   .music-card.empty .empty-desc { font-size: 13px; line-height: 1.4; max-width: 280px; }
 
   .music-card .art {
@@ -476,20 +476,20 @@
     align-self: start;
   }
   .music-card .meta .source {
-    font-size: 10px; font-weight: 700; letter-spacing: 0.16em;
+    font-size: 10px; font-weight: 600; letter-spacing: 0.16em;
     text-transform: uppercase; color: var(--on-surface-dim);
     display: inline-flex; align-items: center; gap: 6px; justify-content: center;
   }
   .music-card .meta .source .icon { width: 12px; height: 12px; stroke-width: 2; }
   .music-card .meta .title {
-    font-size: 20px; font-weight: 800;
+    font-size: 20px; font-weight: 700;
     letter-spacing: -0.02em; color: var(--on-surface);
     line-height: 1.15;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     max-width: 100%;
   }
   .music-card .meta .artist {
-    font-size: 14px; font-weight: 600;
+    font-size: 14px; font-weight: 500;
     color: var(--on-surface-variant);
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     max-width: 100%;
@@ -498,7 +498,7 @@
     width: 100%;
     display: grid; grid-template-columns: auto 1fr auto;
     align-items: center; column-gap: 10px;
-    font-size: 11px; color: var(--on-surface-dim); font-weight: 600;
+    font-size: 11px; color: var(--on-surface-dim); font-weight: 500;
   }
   .music-card .bar {
     height: 4px; background: var(--outline-variant);
@@ -560,7 +560,7 @@
     stroke-width: 2;
   }
   .footer .status .pct {
-    font-size: 13px; font-weight: 700;
+    font-size: 13px; font-weight: 600;
     color: var(--on-surface);
     font-feature-settings: "tnum" 1;
   }


### PR DESCRIPTION
PR3 of the dashboard device-feedback redesign (feedback item 1: "text too bold").

On-device review found the documented Bold Minimal weights too dense on
the head unit. Every heavy role drops one notch, consistently across the
theme, the shared helpers, and the call-site overrides.

## Changes

- `Type.kt` roles: displayLarge Black→ExtraBold, displayMedium/Small
  ExtraBold→Bold, headline Bold→SemiBold, headlineSmall/titleLarge
  SemiBold→Medium. Body (Normal) and label (Medium) unchanged; body sizes
  still clear the 18sp automotive floor.
- Helpers: `bigNumber()` ExtraBold→Bold, `sectionLabel()` Bold→SemiBold.
- The ~18 ad-hoc call-site `fontWeight` overrides in ClockOverlay,
  WeatherCard, CalendarCard, MusicCard, SpeedOverlay, DashboardFooter all
  move one notch lighter in lock-step (ExtraBold→Bold, Bold→SemiBold,
  SemiBold→Medium).

## SSOT kept in sync

- `CLAUDE.md#design-system` wording revised to describe the lighter scale.
- `docs/design/dashboard-v2-mockup.html` font-weights lightened one notch
  (800→700, 700→600, 600→500).

## Verification

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green. No tests assert font weights.