### PR TITLE
feat(dashboard): make the layout responsive and stop cards clipping

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -41,12 +43,11 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 /**
- * Calendar card. Three vertical sections stacked on a 12dp rhythm
- * ([Arrangement.spacedBy], matching the mockup `.calendar-card`
- * `row-gap: 12px`); content stays top-aligned and any spare height in the
- * fixed-height card falls to the bottom rather than stretching the gaps:
+ * Calendar card. Three vertical sections stacked on the
+ * [FemtoDimens.CardSectionGap] rhythm ([Arrangement.spacedBy]); the content is
+ * top-aligned and scrolls if the card is too short to fit all three:
  *
- *  1. Head — 56sp day number (primary tint) + weekday + month label.
+ *  1. Head — big day number (primary tint) + weekday + month label.
  *  2. Strip — 6 future days starting today, each cell carrying a "has event" dot.
  *  3. Events — up to two upcoming events, separated from the strip by a 1dp divider.
  *
@@ -65,28 +66,33 @@ internal fun CalendarCard(
     color = MaterialTheme.colorScheme.surfaceContainer,
     tonalElevation = FemtoDimens.CardElevation,
 ) {
-    Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(FemtoDimens.CardPadding),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        when {
-            // null is the loading frame: render nothing rather than a denial
-            // message the user has not earned yet.
-            snapshot == null -> {
-                Unit
-            }
+    when {
+        // null is the loading frame: render nothing rather than a denial
+        // message the user has not earned yet.
+        snapshot == null -> {
+            Unit
+        }
 
-            // A non-null snapshot with access denied carries no real strip /
-            // event data, so show the denial message instead of a hollow strip
-            // plus a misleading "no upcoming events".
-            !snapshot.hasCalendarAccess -> {
-                PermissionDenied()
-            }
+        // A non-null snapshot with access denied carries no real strip /
+        // event data, so show the denial message instead of a hollow strip
+        // plus a misleading "no upcoming events".
+        !snapshot.hasCalendarAccess -> {
+            PermissionDenied()
+        }
 
-            else -> {
+        else -> {
+            // verticalScroll is a safety net: fillMaxWidth (not fillMaxSize) lets
+            // the content keep its intrinsic height, so on a card too short for
+            // the head + strip + events it scrolls instead of clipping; on a tall
+            // enough card it simply sits top-aligned.
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .padding(FemtoDimens.CardPadding),
+                verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGap),
+            ) {
                 Head(snapshot)
                 Strip(snapshot.dayStrip)
                 Events(snapshot.events)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -2,46 +2,62 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.ui.home.HomeAction
 import io.github.seijikohara.femto.ui.home.HomeUiState
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 
 /**
- * Top-level dashboard layout. Two horizontal panes plus a fixed footer:
+ * Top-level dashboard layout. Two panes plus a fixed footer, arranged
+ * responsively from the available viewport rather than a fixed canvas:
  *
  * ```
- * +-----------------------------+--------------+
- * | MapPane (weight 1.5)        | InfoPane (1) |
- * | + ClockOverlay (top-right)  |  CalendarCard|
- * | + SpeedOverlay (bottom)     |  + Weather   |
- * |                             |  MusicCard   |
- * +-----------------------------+--------------+
- * | DashboardFooter (height 80) |              |
- * +-----------------------------+--------------+
+ * Landscape (wide)                    Portrait (tall)
+ * +-------------------+-----------+    +-----------------------+
+ * | MapPane (1.5)     | InfoPane  |    | MapPane (1.1)         |
+ * |  + ClockOverlay   |  Calendar |    |  + Clock + Speed      |
+ * |  + SpeedOverlay   |  + Weather|    +-----------------------+
+ * |                   |  MusicCard|    | InfoPane (1)          |
+ * +-------------------+-----------+    |  Calendar + Weather   |
+ * | DashboardFooter               |    |  MusicCard            |
+ * +-------------------------------+    +-----------------------+
+ *                                      | DashboardFooter       |
+ *                                      +-----------------------+
  * ```
+ *
+ * A [BoxWithConstraints] reads the available width/height and (a) tightens the
+ * outer / inter-pane spacing on a compact viewport and (b) stacks the panes
+ * vertically when the screen is taller than wide. The info pane distributes its
+ * height between the calendar/weather row and the music card with **weights**
+ * (no fixed row height), so neither is starved on a short head unit. All of this
+ * keys off geometry, never a specific device — the launcher stays
+ * resolution-agnostic.
  *
  * `enableEdgeToEdge()` lets the activity paint under the system bars; the
- * scaffold itself reserves them back with [windowInsetsPadding] so nothing
- * tap-able (the footer especially) hides behind the navigation bar.
+ * scaffold reserves them back with [windowInsetsPadding] so nothing tap-able
+ * (the footer especially) hides behind the navigation bar.
  *
- * The scaffold owns no state of its own; everything reads from
- * [uiState] and reports back through [onAction].
+ * The scaffold owns no state of its own; everything reads from [uiState] and
+ * reports back through [onAction].
  */
 @Composable
 internal fun DashboardScaffold(
@@ -57,28 +73,65 @@ internal fun DashboardScaffold(
             .fillMaxSize()
             .windowInsetsPadding(WindowInsets.systemBars),
 ) {
-    Row(
+    BoxWithConstraints(
         modifier =
             Modifier
                 .weight(1f)
-                .fillMaxWidth()
-                .padding(FemtoDimens.ScreenPadding),
-        horizontalArrangement = Arrangement.spacedBy(FemtoDimens.PaneGap),
+                .fillMaxWidth(),
     ) {
-        MapPane(
-            uiState = uiState,
-            is24Hour = is24Hour,
-            speedUnit = speedUnit,
-            onAction = onAction,
-            modifier = Modifier.weight(1.5f).fillMaxHeight(),
-        )
-        InfoPane(
-            uiState = uiState,
-            temperatureUnit = temperatureUnit,
-            speedUnit = speedUnit,
-            onAction = onAction,
-            modifier = Modifier.weight(1f).fillMaxHeight(),
-        )
+        val compact = maxHeight < CompactHeightBreakpoint || maxWidth < CompactWidthBreakpoint
+        val portrait = maxHeight > maxWidth
+        val screenPadding = if (compact) CompactScreenPadding else FemtoDimens.ScreenPadding
+        val paneGap = if (compact) CompactPaneGap else FemtoDimens.PaneGap
+        if (portrait) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(screenPadding),
+                verticalArrangement = Arrangement.spacedBy(paneGap),
+            ) {
+                MapPane(
+                    uiState = uiState,
+                    is24Hour = is24Hour,
+                    speedUnit = speedUnit,
+                    onAction = onAction,
+                    modifier = Modifier.weight(MAP_PANE_PORTRAIT_WEIGHT).fillMaxWidth(),
+                )
+                InfoPane(
+                    uiState = uiState,
+                    temperatureUnit = temperatureUnit,
+                    speedUnit = speedUnit,
+                    paneGap = paneGap,
+                    onAction = onAction,
+                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                )
+            }
+        } else {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(screenPadding),
+                horizontalArrangement = Arrangement.spacedBy(paneGap),
+            ) {
+                MapPane(
+                    uiState = uiState,
+                    is24Hour = is24Hour,
+                    speedUnit = speedUnit,
+                    onAction = onAction,
+                    modifier = Modifier.weight(MAP_PANE_LANDSCAPE_WEIGHT).fillMaxHeight(),
+                )
+                InfoPane(
+                    uiState = uiState,
+                    temperatureUnit = temperatureUnit,
+                    speedUnit = speedUnit,
+                    paneGap = paneGap,
+                    onAction = onAction,
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                )
+            }
+        }
     }
     DashboardFooter(
         systemStatus = uiState.systemStatus,
@@ -125,18 +178,19 @@ private fun InfoPane(
     uiState: HomeUiState,
     temperatureUnit: TemperatureUnit,
     speedUnit: SpeedUnit,
+    paneGap: Dp,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(
     modifier = modifier,
-    verticalArrangement = Arrangement.spacedBy(FemtoDimens.PaneGap),
+    verticalArrangement = Arrangement.spacedBy(paneGap),
 ) {
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(FemtoDimens.TopRowHeight),
-        horizontalArrangement = Arrangement.spacedBy(FemtoDimens.PaneGap),
+                .weight(TOP_ROW_WEIGHT),
+        horizontalArrangement = Arrangement.spacedBy(paneGap),
     ) {
         CalendarCard(
             snapshot = uiState.calendar,
@@ -154,6 +208,74 @@ private fun InfoPane(
         state = uiState.musicState,
         onCommand = { command -> onAction(HomeAction.Music(command)) },
         onConnect = { onAction(HomeAction.ConnectMusicPlayer) },
-        modifier = Modifier.weight(1f).fillMaxWidth(),
+        modifier = Modifier.weight(MUSIC_CARD_WEIGHT).fillMaxWidth(),
     )
+}
+
+// Below either breakpoint the dashboard switches to its compact spacing. The
+// thresholds are deliberately coarse: they separate small head units from large
+// in-dash panels without targeting any one resolution.
+private val CompactHeightBreakpoint: Dp = 420.dp
+private val CompactWidthBreakpoint: Dp = 600.dp
+
+// Compact outer / inter-pane spacing; the comfortable values are the FemtoDimens
+// defaults used on large panels.
+private val CompactScreenPadding: Dp = 12.dp
+private val CompactPaneGap: Dp = 10.dp
+
+// Pane weights. The map is the dominant surface in landscape; in portrait it
+// sits a little taller than the info pane. The info pane splits its height
+// roughly 0.43 : 0.57 between the calendar/weather row and the music card,
+// preserving the mockup's top-row-to-music proportion without a fixed height.
+private const val MAP_PANE_LANDSCAPE_WEIGHT = 1.5f
+private const val MAP_PANE_PORTRAIT_WEIGHT = 1.1f
+private const val TOP_ROW_WEIGHT = 1f
+private const val MUSIC_CARD_WEIGHT = 1.35f
+
+// Responsive previews. HomeUiState.Initial renders the empty/loading states (no
+// network/GL in a preview), which is enough to lock the responsive arrangement
+// across head-unit geometries. These dimensions are test cases, not targets.
+@PreviewLightDark
+@Preview(name = "Dashboard - 16:9", widthDp = 640, heightDp = 360)
+@Composable
+private fun DashboardScaffoldLandscapePreview() {
+    FemtoTheme {
+        DashboardScaffold(
+            uiState = HomeUiState.Initial,
+            is24Hour = true,
+            speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            temperatureUnit = TemperatureUnit.CELSIUS,
+            onAction = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Preview(name = "Dashboard - 8:3 ultra-wide", widthDp = 640, heightDp = 240)
+@Composable
+private fun DashboardScaffoldUltraWidePreview() {
+    FemtoTheme {
+        DashboardScaffold(
+            uiState = HomeUiState.Initial,
+            is24Hour = true,
+            speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            temperatureUnit = TemperatureUnit.CELSIUS,
+            onAction = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Preview(name = "Dashboard - portrait", widthDp = 360, heightDp = 640)
+@Composable
+private fun DashboardScaffoldPortraitPreview() {
+    FemtoTheme {
+        DashboardScaffold(
+            uiState = HomeUiState.Initial,
+            is24Hour = true,
+            speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            temperatureUnit = TemperatureUnit.CELSIUS,
+            onAction = {},
+        )
+    }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -419,6 +419,8 @@ private fun ConnectState(onConnect: () -> Unit) =
                     ),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.widthIn(max = 280.dp),
             )
         }
@@ -464,6 +466,8 @@ private fun EmptyState() =
                 ),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.widthIn(max = 280.dp),
         )
         Box(modifier = Modifier.weight(0.9f))

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -56,15 +58,13 @@ import java.time.LocalTime
 import kotlin.math.roundToInt
 
 /**
- * Weather card. Three vertical sections stacked on a 12dp rhythm
- * ([Arrangement.spacedBy], matching the mockup `.weather-card`
- * `row-gap: 12px`); content stays top-aligned and any spare height in the
- * fixed-height card falls to the bottom, so the forecast divider keeps even
- * 12dp breathing room instead of being stretched apart:
+ * Weather card. Three vertical sections stacked on the
+ * [FemtoDimens.CardSectionGap] rhythm ([Arrangement.spacedBy]); the content is
+ * top-aligned and scrolls if the card is too short to fit all three:
  *
- *  1. Head — 56sp temperature + glyph (per-condition colour) + city + short conditions.
- *  2. Metrics — Feels / Wind / Humid row at 14sp / 700 weight.
- *  3. Forecast — three hourly chips at 13sp temperatures.
+ *  1. Head — big temperature + glyph (per-condition colour) + city + short conditions.
+ *  2. Metrics — Feels / Wind / Humid row.
+ *  3. Forecast — three hourly chips.
  *
  * Typography and spacing follow `docs/design/dashboard-v2-mockup.html`
  * (`.weather-card` rules) verbatim — the same intentional relaxation of
@@ -83,20 +83,25 @@ internal fun WeatherCard(
     color = MaterialTheme.colorScheme.surfaceContainer,
     tonalElevation = FemtoDimens.CardElevation,
 ) {
-    Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(FemtoDimens.CardPadding),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        if (snapshot != null) {
+    if (snapshot != null) {
+        // verticalScroll is a safety net: fillMaxWidth (not fillMaxSize) lets the
+        // content keep its intrinsic height, so on a card too short for the full
+        // head + metrics + forecast it scrolls instead of clipping; on a tall
+        // enough card it simply sits top-aligned.
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(FemtoDimens.CardPadding),
+            verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGap),
+        ) {
             Head(snapshot, city, temperatureUnit)
             Metrics(snapshot, temperatureUnit, speedUnit)
             Forecast(snapshot.hourly, snapshot.sunrise, snapshot.sunset, temperatureUnit)
-        } else {
-            EmptyState()
         }
+    } else {
+        EmptyState()
     }
 }
 
@@ -228,7 +233,7 @@ private fun Forecast(
 ) {
     val next = hourly.take(3)
     if (next.isEmpty()) return
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGap)) {
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -36,9 +36,6 @@ object FemtoDimens {
     /** Footer dock height (64.dp tap target + 16.dp top/bottom breathing room). */
     val FooterHeight = 80.dp
 
-    /** Top row of the info pane that houses the calendar and weather cards. */
-    val TopRowHeight = 224.dp
-
     /** Album art size inside the music card's vertical playing layout. */
     val MusicArtSize = 140.dp
 
@@ -87,8 +84,11 @@ object FemtoDimens {
     /** Gap between the two top-level panes. Mockup legend: pane gap 16 dp. */
     val PaneGap = 16.dp
 
-    /** Uniform inner padding for dashboard cards. Mockup legend: card padding 16 dp. */
-    val CardPadding = 16.dp
+    /** Uniform inner padding for dashboard cards. Tightened from the mockup's 16 dp. */
+    val CardPadding = 14.dp
+
+    /** Vertical rhythm between the sections stacked inside a card. */
+    val CardSectionGap = 10.dp
 
     /** Corner radius for dashboard cards. Mockup legend: card radius 16 dp (Shapes.large). */
     val CardCorner = 16.dp


### PR DESCRIPTION
PR4 of the dashboard device-feedback redesign. Addresses items 2 (whitespace
between panels), 3 (whitespace inside panels), 4 (panels clipped), 16
(responsive across resolutions).

The dashboard was a 1:1 dp transcription of a fixed 1280x720 mockup, so on a
real 9-inch head unit the panels floated apart, a fixed 224 dp top row starved
the music card, and content clipped (the "Connect a player" hint was cut off).

## Changes (geometry-driven, never device-specific — multi-region posture)

- **DashboardScaffold**: wraps the panes in `BoxWithConstraints` and
  - tightens outer/inter-pane spacing on a compact viewport
    (`maxHeight < 420dp || maxWidth < 600dp`);
  - **stacks the panes vertically** (map over info) in portrait
    (`maxHeight > maxWidth`), side-by-side in landscape.
- **Weight-based vertical distribution**: the fixed `FemtoDimens.TopRowHeight`
  is removed; the info pane splits its height between the calendar/weather row
  and the music card with weights, so neither is starved on a short panel.
- **Overflow safety net**: calendar and weather card content scrolls
  (`fillMaxWidth` + `verticalScroll`) instead of hard-clipping when the card is
  too short; the music connect/empty hints gain `maxLines = 2` + ellipsis.
- **Tighter card spacing**: `CardPadding` 16->14, `CardSectionGap` 12->10
  (promoted from a repeated literal).
- 3 responsive `@PreviewLightDark` sizes (640x360, 640x240 ultra-wide, 360x640
  portrait) lock the behavior. These are test cases, not targets.

Reviewed by compose-launcher-reviewer (no blockers; the dormant-scroll,
modifier-order, preview-annotation, and stale-KDoc findings were all addressed).

## Verification

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.

⚠️ Layout cannot be pixel-validated in this environment; on-device confirmation
of the portrait stacking and the compact spacing on the 9-inch unit is welcome.