### PR TITLE
feat(footer): trim height, drop the home button, add cellular and charging text

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
@@ -3,12 +3,14 @@ package io.github.seijikohara.femto.testfixtures
 import io.github.seijikohara.femto.data.SystemStatus
 
 internal fun fakeSystemStatus(
+    cellularConnected: Boolean? = null,
     wifiConnected: Boolean = true,
     bluetoothConnected: Boolean = true,
     batteryPercent: Int? = 78,
     charging: Boolean = false,
 ): SystemStatus =
     SystemStatus(
+        cellularConnected = cellularConnected,
         wifiConnected = wifiConnected,
         bluetoothConnected = bluetoothConnected,
         batteryPercent = batteryPercent,

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardFooterTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardFooterTest.kt
@@ -1,7 +1,9 @@
 package io.github.seijikohara.femto.ui.home.components
 
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -17,7 +19,7 @@ class DashboardFooterTest {
     val rule = createComposeRule()
 
     @Test
-    fun renders_home_and_apps_nav_buttons() {
+    fun renders_apps_and_settings_nav_buttons() {
         rule.setContent {
             FemtoTheme {
                 DashboardFooter(
@@ -26,8 +28,9 @@ class DashboardFooterTest {
                 )
             }
         }
-        rule.onNodeWithContentDescription("Home").assertIsDisplayed()
+        // The launcher dashboard IS home, so there is no Home button.
         rule.onNodeWithContentDescription("Apps").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Settings").assertIsDisplayed()
     }
 
     @Test
@@ -72,6 +75,33 @@ class DashboardFooterTest {
     }
 
     @Test
+    fun shows_cellular_connected_description_when_connected() {
+        rule.setContent {
+            FemtoTheme {
+                DashboardFooter(
+                    systemStatus = fakeSystemStatus(cellularConnected = true),
+                    onAction = {},
+                )
+            }
+        }
+        rule.onNodeWithContentDescription("Mobile data connected").assertIsDisplayed()
+    }
+
+    @Test
+    fun hides_cellular_icon_on_telephony_less_unit() {
+        rule.setContent {
+            FemtoTheme {
+                DashboardFooter(
+                    systemStatus = fakeSystemStatus(cellularConnected = null),
+                    onAction = {},
+                )
+            }
+        }
+        rule.onAllNodesWithContentDescription("Mobile data connected").assertCountEquals(0)
+        rule.onAllNodesWithContentDescription("Mobile data disconnected").assertCountEquals(0)
+    }
+
+    @Test
     fun renders_battery_percent_text() {
         rule.setContent {
             FemtoTheme {
@@ -82,5 +112,18 @@ class DashboardFooterTest {
             }
         }
         rule.onNodeWithText("78%").assertIsDisplayed()
+    }
+
+    @Test
+    fun shows_charging_caption_when_charging() {
+        rule.setContent {
+            FemtoTheme {
+                DashboardFooter(
+                    systemStatus = fakeSystemStatus(charging = true),
+                    onAction = {},
+                )
+            }
+        }
+        rule.onNodeWithText("Charging").assertIsDisplayed()
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatus.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatus.kt
@@ -11,6 +11,10 @@ import androidx.compose.runtime.Immutable
  */
 @Immutable
 data class SystemStatus(
+    // Null on a device with no telephony feature (e.g. a Wi-Fi-only AI box), so
+    // the footer hides the cellular indicator entirely rather than showing a
+    // permanently-disconnected one; true/false once telephony is present.
+    val cellularConnected: Boolean?,
     val wifiConnected: Boolean,
     val bluetoothConnected: Boolean,
     // Null until the first battery reading arrives, or on battery-less units —
@@ -22,6 +26,7 @@ data class SystemStatus(
     companion object {
         val Initial: SystemStatus =
             SystemStatus(
+                cellularConnected = null,
                 wifiConnected = false,
                 bluetoothConnected = false,
                 batteryPercent = null,

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
@@ -48,11 +48,16 @@ internal class SystemStatusRepository(
 
     fun statusFlow(): Flow<SystemStatus> =
         combine(
+            // cellularFlow seeds its own initial value (false, or null on a
+            // telephony-less unit), so it needs no onStart — adding one would
+            // emit a spurious false->null transition before the seed.
+            cellularFlow(),
             wifiFlow().onStart { emit(false) },
             bluetoothFlow().onStart { emit(false) },
             batteryFlow().onStart { emit(BatteryReading(percent = null, charging = false)) },
-        ) { wifi, bt, battery ->
+        ) { cellular, wifi, bt, battery ->
             SystemStatus(
+                cellularConnected = cellular,
                 wifiConnected = wifi,
                 bluetoothConnected = bt,
                 batteryPercent = battery.percent,
@@ -81,6 +86,45 @@ internal class SystemStatusRepository(
             val request = NetworkRequest
                 .Builder()
                 .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                .build()
+            cm.registerNetworkCallback(request, callback)
+            awaitClose { cm.unregisterNetworkCallback(callback) }
+        }
+    }
+
+    /**
+     * Mobile-data connectivity, connectivity-only (no SIM / signal-strength
+     * read, so no READ_PHONE_STATE). Emits null on a device with no telephony
+     * feature so the footer hides the indicator rather than showing a
+     * permanently-disconnected one. Mirrors [wifiFlow] for the validated check.
+     */
+    private fun cellularFlow(): Flow<Boolean?> {
+        val cm = connectivity ?: return flowOf(null)
+        if (!context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
+            return flowOf(null)
+        }
+        return callbackFlow {
+            // Seed disconnected so combine has an initial cellular value even when
+            // no cellular network is currently present to fire the callback.
+            trySend(false)
+            val callback = object : ConnectivityManager.NetworkCallback() {
+                override fun onCapabilitiesChanged(
+                    network: Network,
+                    caps: NetworkCapabilities,
+                ) {
+                    trySend(
+                        caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) &&
+                            caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED),
+                    )
+                }
+
+                override fun onLost(network: Network) {
+                    trySend(false)
+                }
+            }
+            val request = NetworkRequest
+                .Builder()
+                .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
                 .build()
             cm.registerNetworkCallback(request, callback)
             awaitClose { cm.unregisterNetworkCallback(callback) }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
@@ -1,6 +1,5 @@
 package io.github.seijikohara.femto.ui.home.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
@@ -25,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -38,13 +35,13 @@ import androidx.compose.ui.unit.sp
 import com.composables.icons.lucide.Battery
 import com.composables.icons.lucide.Bluetooth
 import com.composables.icons.lucide.Globe
-import com.composables.icons.lucide.House
 import com.composables.icons.lucide.LayoutGrid
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Music
 import com.composables.icons.lucide.Navigation
 import com.composables.icons.lucide.Phone
 import com.composables.icons.lucide.Settings
+import com.composables.icons.lucide.Signal
 import com.composables.icons.lucide.Wifi
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.SystemStatus
@@ -54,23 +51,24 @@ import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.TabularFigures
 
-// Below this footer width the read-only status cluster is dropped so the seven
+// Below this footer width the read-only status cluster is dropped so the six
 // nav buttons keep room to render at >= FemtoDimens.MinTouchTarget without
 // clipping on portrait / narrow head units.
 private val CompactFooterWidth: Dp = 640.dp
 
 /**
- * Bottom dock per `docs/design/dashboard-v2-mockup.html` `.footer`:
+ * Bottom dock. Originally derived from `docs/design/dashboard-v2-mockup.html`
+ * `.footer`, since evolved from on-device feedback (shorter height, no Home
+ * button, added cellular indicator and charging caption); this composable, not
+ * the mockup, is now the authoritative footer spec.
  *
- *  - 80 dp surface with a 1 dp top divider (`outlineVariant`).
- *  - Seven 72 × 64 dp nav buttons (Home / Phone / Apps / Music /
- *    Navigation / Browser / Settings) in a 3 + 1 + 3 grouping, evenly
- *    distributed across the left flex region.
- *  - The Home button is the only active state — primaryContainer
- *    background with a 20 × 3 dp underline 4 dp from the bottom.
- *  - A 1 dp vertical divider separates the actionable nav from a
- *    read-only Wi-Fi / Bluetooth / battery cluster at 20 dp icon size,
- *    with the battery percent rendered at 13sp / 700.
+ *  - [FemtoDimens.FooterHeight] surface with a 1 dp top divider (`outlineVariant`).
+ *  - Six equal-weight nav buttons (Phone / Apps / Music / Navigation / Browser /
+ *    Settings). This app IS the launcher, so there is no Home button.
+ *  - A 1 dp vertical divider separates the actionable nav from a read-only
+ *    status cluster: cellular (hidden on telephony-less units), Wi-Fi,
+ *    Bluetooth, and a battery indicator (icon over percent, with a "Charging"
+ *    caption while plugged in).
  *
  * Iconography is Lucide stroke-1.75 for parity with the design SSOT.
  */
@@ -91,9 +89,9 @@ internal fun DashboardFooter(
                     .fillMaxSize()
                     .padding(horizontal = 24.dp),
         ) {
-            // Seven 64 dp buttons plus the cluster need ~707 dp with zero slack;
-            // narrow portrait head units cannot fit both. Below the threshold the
-            // read-only status cluster yields so the actionable nav stays uncut.
+            // The six nav buttons plus the cluster cannot both fit on a narrow
+            // portrait head unit; below the threshold the read-only status
+            // cluster yields so the actionable nav stays uncut.
             val showStatusCluster = maxWidth >= CompactFooterWidth
             Row(
                 modifier = Modifier.fillMaxSize(),
@@ -130,55 +128,42 @@ private fun NavRow(
     horizontalArrangement = Arrangement.SpaceBetween,
     verticalAlignment = Alignment.CenterVertically,
 ) {
-    // Each button takes an equal weight so seven buttons share the width and
+    // Each button takes an equal weight so the six buttons share the width and
     // shrink toward FemtoDimens.MinTouchTarget instead of clipping when the row
     // is narrow. The widthIn floor in NavButton keeps every tap target legal.
     NavButton(
-        icon = Lucide.House,
-        description = stringResource(R.string.nav_home),
-        active = true,
-        onClick = { /* already on home */ },
-        modifier = Modifier.weight(1f),
-    )
-    NavButton(
         icon = Lucide.Phone,
         description = stringResource(R.string.nav_phone),
-        active = false,
         onClick = { onAction(HomeAction.Shortcut(AppsBarShortcut.Phone)) },
         modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.LayoutGrid,
         description = stringResource(R.string.nav_apps),
-        active = false,
         onClick = { onAction(HomeAction.OpenAppDrawer) },
         modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.Music,
         description = stringResource(R.string.nav_music),
-        active = false,
         onClick = { onAction(HomeAction.Shortcut(AppsBarShortcut.Music)) },
         modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.Navigation,
         description = stringResource(R.string.nav_navigation),
-        active = false,
         onClick = { onAction(HomeAction.OpenMaps) },
         modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.Globe,
         description = stringResource(R.string.nav_browser),
-        active = false,
         onClick = { onAction(HomeAction.OpenBrowser) },
         modifier = Modifier.weight(1f),
     )
     NavButton(
         icon = Lucide.Settings,
         description = stringResource(R.string.nav_settings),
-        active = false,
         onClick = { onAction(HomeAction.OpenSettings) },
         modifier = Modifier.weight(1f),
     )
@@ -188,50 +173,25 @@ private fun NavRow(
 private fun NavButton(
     icon: ImageVector,
     description: String,
-    active: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+) = Box(
+    modifier =
+        modifier
+            .height(FemtoDimens.MinTouchTarget)
+            .widthIn(min = FemtoDimens.MinTouchTarget)
+            .clip(RoundedCornerShape(14.dp))
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = description },
+    contentAlignment = Alignment.Center,
 ) {
-    val background =
-        if (active) MaterialTheme.colorScheme.primaryContainer else Color.Transparent
-    val tint =
-        if (active) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
-    Box(
-        modifier =
-            modifier
-                .height(FemtoDimens.MinTouchTarget)
-                .widthIn(min = FemtoDimens.MinTouchTarget)
-                .clip(RoundedCornerShape(14.dp))
-                .background(background)
-                // The active Home button is the current surface — skip clickable so
-                // it shows no dead-tap ripple.
-                .then(if (active) Modifier else Modifier.clickable(onClick = onClick))
-                .semantics { contentDescription = description },
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = tint,
-            modifier = Modifier.size(26.dp),
-        )
-        if (active) {
-            ActiveIndicator(modifier = Modifier.align(Alignment.BottomCenter))
-        }
-    }
-}
-
-@Composable
-private fun ActiveIndicator(modifier: Modifier = Modifier) =
-    Box(
-        modifier =
-            modifier
-                .padding(bottom = 4.dp)
-                .height(3.dp)
-                .width(20.dp)
-                .clip(RoundedCornerShape(2.dp))
-                .background(MaterialTheme.colorScheme.primary),
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(26.dp),
     )
+}
 
 @Composable
 private fun StatusCluster(
@@ -242,6 +202,18 @@ private fun StatusCluster(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(18.dp),
 ) {
+    // Cellular is hidden entirely on telephony-less units (null), rather than
+    // shown permanently disconnected.
+    status.cellularConnected?.let { connected ->
+        StatusIcon(
+            icon = Lucide.Signal,
+            active = connected,
+            description =
+                stringResource(
+                    if (connected) R.string.status_cellular_connected else R.string.status_cellular_disconnected,
+                ),
+        )
+    }
     StatusIcon(
         icon = Lucide.Wifi,
         active = status.wifiConnected,
@@ -282,34 +254,30 @@ private fun StatusIcon(
     )
 }
 
+// Battery icon stacked over its percent, with a "Charging" caption beneath while
+// plugged in. The 13sp percent and 10sp caption sit below the dashboard's 18sp
+// body floor under the same footer glance-metadata allowance the cluster already
+// uses (CLAUDE.md#automotive-overrides).
 @Composable
 private fun BatteryIndicator(
     percent: Int?,
     charging: Boolean,
     modifier: Modifier = Modifier,
-) = Row(
+) = Column(
     modifier = modifier,
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(6.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(1.dp),
 ) {
     Icon(
         imageVector = Lucide.Battery,
         contentDescription = stringResource(R.string.status_battery),
-        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        tint = if (charging) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.size(20.dp),
     )
     Text(
         // Render an em-dash while the percent is unknown (cold start / battery-less
         // unit) so the cluster never reads as a dead 0% battery.
-        text =
-            if (percent == null) {
-                "—"
-            } else {
-                stringResource(
-                    if (charging) R.string.battery_percent_charging else R.string.battery_percent,
-                    percent,
-                )
-            },
+        text = if (percent == null) "—" else stringResource(R.string.battery_percent, percent),
         style =
             MaterialTheme.typography.labelLarge.copy(
                 fontSize = 13.sp,
@@ -319,20 +287,29 @@ private fun BatteryIndicator(
         color = MaterialTheme.colorScheme.onSurface,
         maxLines = 1,
     )
+    if (charging) {
+        Text(
+            text = stringResource(R.string.status_charging),
+            style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+            color = MaterialTheme.colorScheme.primary,
+            maxLines = 1,
+        )
+    }
 }
 
 @PreviewLightDark
-@Preview(name = "Dashboard footer", widthDp = 1280, heightDp = 80)
+@Preview(name = "Dashboard footer", widthDp = 1280, heightDp = 72)
 @Composable
 private fun DashboardFooterPreview() {
     FemtoTheme {
         DashboardFooter(
             systemStatus =
                 SystemStatus(
+                    cellularConnected = true,
                     wifiConnected = true,
                     bluetoothConnected = true,
                     batteryPercent = 78,
-                    charging = false,
+                    charging = true,
                 ),
             onAction = {},
         )
@@ -341,13 +318,15 @@ private fun DashboardFooterPreview() {
 
 // Narrow portrait head unit: the status cluster drops and the nav buttons share
 // the width down toward FemtoDimens.MinTouchTarget rather than clipping.
-@Preview(name = "Dashboard footer (narrow)", widthDp = 520, heightDp = 80)
+@PreviewLightDark
+@Preview(name = "Dashboard footer (narrow)", widthDp = 520, heightDp = 72)
 @Composable
 private fun DashboardFooterNarrowPreview() {
     FemtoTheme {
         DashboardFooter(
             systemStatus =
                 SystemStatus(
+                    cellularConnected = null,
                     wifiConnected = true,
                     bluetoothConnected = false,
                     batteryPercent = null,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -33,8 +33,8 @@ object FemtoDimens {
     /** Album art thumbnail size in the music panel's playing state. */
     val AlbumArtSize = 72.dp
 
-    /** Footer dock height (64.dp tap target + 16.dp top/bottom breathing room). */
-    val FooterHeight = 80.dp
+    /** Footer dock height (64.dp tap target + 8.dp top/bottom breathing room). */
+    val FooterHeight = 72.dp
 
     /** Album art size inside the music card's vertical playing layout. */
     val MusicArtSize = 140.dp

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,6 @@
     <string name="music_skip_next">Skip next</string>
 
     <!-- Dashboard footer: navigation -->
-    <string name="nav_home">Home</string>
     <string name="nav_phone">Phone</string>
     <string name="nav_apps">Apps</string>
     <string name="nav_music">Music</string>
@@ -52,13 +51,15 @@
     <string name="nav_settings">Settings</string>
 
     <!-- Dashboard footer: status cluster -->
+    <string name="status_cellular_connected">Mobile data connected</string>
+    <string name="status_cellular_disconnected">Mobile data disconnected</string>
     <string name="status_wifi_connected">Wi-Fi connected</string>
     <string name="status_wifi_disconnected">Wi-Fi disconnected</string>
     <string name="status_bluetooth_connected">Bluetooth connected</string>
     <string name="status_bluetooth_disconnected">Bluetooth disconnected</string>
     <string name="status_battery">Battery</string>
+    <string name="status_charging">Charging</string>
     <string name="battery_percent">%1$d%%</string>
-    <string name="battery_percent_charging">%1$d%% ⚡</string>
 
     <!-- App drawer -->
     <string name="drawer_no_apps">No apps installed</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/SystemStatusRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/SystemStatusRepositoryTest.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.data
 
 import android.app.Application
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
@@ -13,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -30,6 +32,15 @@ import kotlin.test.assertTrue
 @Config(sdk = [33])
 class SystemStatusRepositoryTest {
     private val application: Application = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setUp() {
+        // statusFlow's cellularFlow registers no NetworkCallback when the device
+        // reports no telephony feature, so forcing it off keeps these tests
+        // deterministic — the only registered callback is the Wi-Fi one, and
+        // [awaitRegisteredNetworkCallback]'s single() invariant holds.
+        shadowOf(application.packageManager).setSystemFeature(PackageManager.FEATURE_TELEPHONY, false)
+    }
 
     @Test
     fun `bluetoothConnected is false when BLUETOOTH_CONNECT is not granted`() =

--- a/app/src/test/java/io/github/seijikohara/femto/data/TripRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/TripRepositoryTest.kt
@@ -149,7 +149,10 @@ class TripRepositoryTest {
     fun `persists distance across re-subscription`() =
         runTest {
             val source = MutableSharedFlow<Location?>(replay = 0)
-            val repository = TripRepository(source)
+            // Test dispatcher so the MutableSharedFlow emit/awaitItem handshake runs
+            // on the virtual clock instead of racing Dispatchers.Default under load
+            // (the source of an intermittent Turbine timeout).
+            val repository = TripRepository(source, UnconfinedTestDispatcher(testScheduler))
 
             // First subscription: feed two moving fixes, capture the running total,
             // then cancel the collection (simulating a WhileSubscribed stop).

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
@@ -3,12 +3,14 @@ package io.github.seijikohara.femto.testfixtures
 import io.github.seijikohara.femto.data.SystemStatus
 
 internal fun fakeSystemStatus(
+    cellularConnected: Boolean? = null,
     wifiConnected: Boolean = true,
     bluetoothConnected: Boolean = true,
     batteryPercent: Int? = 78,
     charging: Boolean = false,
 ): SystemStatus =
     SystemStatus(
+        cellularConnected = cellularConnected,
         wifiConnected = wifiConnected,
         bluetoothConnected = bluetoothConnected,
         batteryPercent = batteryPercent,


### PR DESCRIPTION
PR5 of the dashboard device-feedback redesign. Addresses the bottom-bar items 9
(too tall), 10 (redundant Home button), 14 (cellular indicator), 15 (charging
text under the battery).

## Changes

- **Height (9)**: `FemtoDimens.FooterHeight` 80 -> 72 dp (the 64 dp tap floor is
  untouched; only the breathing room shrinks).
- **Home button (10)**: removed — this app IS the launcher — along with the now
  dead `active` / `ActiveIndicator` machinery. The row is six equal-weight
  buttons (Phone / Apps / Music / Navigation / Browser / Settings).
- **Cellular (14)**: a connectivity-only indicator (`ConnectivityManager`
  `TRANSPORT_CELLULAR` validated check, **no new permission** — covered by the
  existing `ACCESS_NETWORK_STATE`). Auto-hides on telephony-less units
  (`cellularConnected = null` via a `FEATURE_TELEPHONY` check).
- **Charging (15)**: battery restructured into a column — icon over percent with
  a "Charging" caption (and primary tint) while plugged in — replacing the
  inline lightning glyph.

`SystemStatus` gains a nullable `cellularConnected`; `SystemStatusRepository`
adds `cellularFlow` as a 4th combined source (seeds its own initial value, so no
`onStart`, avoiding a spurious transition). Strings: drop `nav_home` and
`battery_percent_charging`; add `status_cellular_*` and `status_charging`.

Drive-by: made `TripRepositoryTest.persists distance across re-subscription`
deterministic (inject the test dispatcher) after it flaked under load — same
determinism fix already applied to the reset/network cases.

Reviewed by compose-launcher-reviewer (no blockers; the test-`single()`
robustness, mockup-citation, and preview-annotation findings were addressed).

## Verification

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.