### PR TITLE
feat(settings): add an in-app settings screen (theme, units, font, system links)

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -7,27 +7,40 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
+import android.text.format.DateFormat
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.seijikohara.femto.data.AppsRepository
+import io.github.seijikohara.femto.data.ClockSetting
+import io.github.seijikohara.femto.data.DisplayPreferences
+import io.github.seijikohara.femto.data.DisplaySettings
+import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.SystemPermissionSignals
+import io.github.seijikohara.femto.data.ThemeMode
 import io.github.seijikohara.femto.data.hasBluetoothConnectPermission
 import io.github.seijikohara.femto.data.hasFineLocationPermission
 import io.github.seijikohara.femto.data.hasReadCalendarPermission
 import io.github.seijikohara.femto.ui.drawer.AppDrawerSheet
 import io.github.seijikohara.femto.ui.home.HomeEvent
 import io.github.seijikohara.femto.ui.home.HomeRoute
+import io.github.seijikohara.femto.ui.locale.resolved
+import io.github.seijikohara.femto.ui.settings.SettingsRoute
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.FontTheme
 
 class MainActivity : ComponentActivity() {
     private val appsRepository by lazy { AppsRepository(this) }
+    private val displayPreferences by lazy { DisplayPreferences(this) }
+    private val fontPreferences by lazy { FontPreferences(this) }
 
     // Emit on the process-wide refresh signal so permission-gated flows (e.g.
     // the Bluetooth footer indicator) re-read after a late runtime grant.
@@ -43,23 +56,51 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         requestRuntimePermissions()
         setContent {
-            FemtoTheme {
+            // User display settings override the locale/system defaults; the
+            // theme + font feed FemtoTheme, the units + clock feed the dashboard.
+            val display by displayPreferences.settings.collectAsStateWithLifecycle(
+                initialValue = DisplaySettings.Default,
+            )
+            val fontTheme by fontPreferences.fontTheme.collectAsStateWithLifecycle(initialValue = FontTheme.INTER)
+            val darkTheme =
+                when (display.themeMode) {
+                    ThemeMode.SYSTEM -> isSystemInDarkTheme()
+                    ThemeMode.LIGHT -> false
+                    ThemeMode.DARK -> true
+                }
+            FemtoTheme(fontTheme = fontTheme, darkTheme = darkTheme) {
                 // The dashboard stays composed; the app drawer is a bottom-sheet
-                // overlay on top of it rather than a full-screen swap.
+                // overlay and settings is a full destination over it.
                 var showDrawer by rememberSaveable { mutableStateOf(false) }
-                HomeRoute(
-                    onEvent = { event ->
-                        handleHomeEvent(event) { showDrawer = it }
-                    },
-                )
-                if (showDrawer) {
-                    AppDrawerSheet(
-                        onLaunch = { component ->
-                            appsRepository.launch(component)
-                            showDrawer = false
-                        },
-                        onDismiss = { showDrawer = false },
+                var showSettings by rememberSaveable { mutableStateOf(false) }
+                if (showSettings) {
+                    SettingsRoute(
+                        onBack = { showSettings = false },
+                        onOpenNotificationAccess = ::openNotificationListenerSettings,
+                        onOpenSystemSettings = ::openSystemSettings,
                     )
+                } else {
+                    HomeRoute(
+                        is24Hour = resolveIs24Hour(display.clock),
+                        speedUnit = display.speedUnit.resolved(),
+                        temperatureUnit = display.temperatureUnit.resolved(),
+                        onEvent = { event ->
+                            handleHomeEvent(
+                                event = event,
+                                setShowDrawer = { showDrawer = it },
+                                setShowSettings = { showSettings = it },
+                            )
+                        },
+                    )
+                    if (showDrawer) {
+                        AppDrawerSheet(
+                            onLaunch = { component ->
+                                appsRepository.launch(component)
+                                showDrawer = false
+                            },
+                            onDismiss = { showDrawer = false },
+                        )
+                    }
                 }
             }
         }
@@ -68,16 +109,44 @@ class MainActivity : ComponentActivity() {
     private fun handleHomeEvent(
         event: HomeEvent,
         setShowDrawer: (Boolean) -> Unit,
+        setShowSettings: (Boolean) -> Unit,
     ) {
         when (event) {
-            HomeEvent.OpenDrawer -> setShowDrawer(true)
-            is HomeEvent.LaunchComponent -> appsRepository.launch(event.component)
-            is HomeEvent.LaunchAppCategory -> launchAppCategory(event.intentCategory)
-            is HomeEvent.LaunchGeo -> launchGeo(event.latitude, event.longitude)
-            HomeEvent.OpenNotificationListenerSettings -> openNotificationListenerSettings()
-            HomeEvent.OpenSystemSettings -> openSystemSettings()
+            HomeEvent.OpenDrawer -> {
+                setShowDrawer(true)
+            }
+
+            is HomeEvent.LaunchComponent -> {
+                appsRepository.launch(event.component)
+            }
+
+            is HomeEvent.LaunchAppCategory -> {
+                launchAppCategory(event.intentCategory)
+            }
+
+            is HomeEvent.LaunchGeo -> {
+                launchGeo(event.latitude, event.longitude)
+            }
+
+            HomeEvent.OpenNotificationListenerSettings -> {
+                openNotificationListenerSettings()
+            }
+
+            HomeEvent.OpenInAppSettings -> {
+                // Close the drawer overlay so it does not re-appear behind settings
+                // when the user navigates back.
+                setShowDrawer(false)
+                setShowSettings(true)
+            }
         }
     }
+
+    private fun resolveIs24Hour(clock: ClockSetting): Boolean =
+        when (clock) {
+            ClockSetting.AUTO -> DateFormat.is24HourFormat(this)
+            ClockSetting.TWELVE_HOUR -> false
+            ClockSetting.TWENTY_FOUR_HOUR -> true
+        }
 
     private fun openSystemSettings() {
         val intent =

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -1,0 +1,89 @@
+package io.github.seijikohara.femto.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlin.enums.enumEntries
+
+/** Light / dark / follow-system theme choice. */
+internal enum class ThemeMode { SYSTEM, LIGHT, DARK }
+
+/** Speed/distance unit: follow the locale, or force metric / imperial. */
+internal enum class SpeedUnitSetting { AUTO, KILOMETERS, MILES }
+
+/** Temperature unit: follow the locale, or force Celsius / Fahrenheit. */
+internal enum class TemperatureUnitSetting { AUTO, CELSIUS, FAHRENHEIT }
+
+/** Clock: follow the system 12/24h setting, or force 12h / 24h. */
+internal enum class ClockSetting { AUTO, TWELVE_HOUR, TWENTY_FOUR_HOUR }
+
+/**
+ * User display settings that override the locale / system defaults. Every value
+ * defaults to the auto / system choice so a fresh install behaves exactly as
+ * before the settings screen existed.
+ */
+internal data class DisplaySettings(
+    val themeMode: ThemeMode,
+    val speedUnit: SpeedUnitSetting,
+    val temperatureUnit: TemperatureUnitSetting,
+    val clock: ClockSetting,
+) {
+    companion object {
+        val Default =
+            DisplaySettings(
+                themeMode = ThemeMode.SYSTEM,
+                speedUnit = SpeedUnitSetting.AUTO,
+                temperatureUnit = TemperatureUnitSetting.AUTO,
+                clock = ClockSetting.AUTO,
+            )
+    }
+}
+
+private val Context.displayDataStore: DataStore<Preferences> by preferencesDataStore(name = "display_preferences")
+
+/**
+ * DataStore-backed accessor for [DisplaySettings].
+ *
+ * Each enum is stored by name and decoded defensively (an unknown / renamed
+ * value falls back to the auto default) so a downgrade or a renamed entry never
+ * crashes the read path. Modelled on [FontPreferences].
+ */
+internal class DisplayPreferences(
+    private val context: Context,
+) {
+    val settings: Flow<DisplaySettings> =
+        context.displayDataStore.data.map { prefs ->
+            DisplaySettings(
+                themeMode = prefs[THEME_KEY].toEnumOr(ThemeMode.SYSTEM),
+                speedUnit = prefs[SPEED_KEY].toEnumOr(SpeedUnitSetting.AUTO),
+                temperatureUnit = prefs[TEMPERATURE_KEY].toEnumOr(TemperatureUnitSetting.AUTO),
+                clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
+            )
+        }
+
+    suspend fun setThemeMode(value: ThemeMode) = context.displayDataStore.edit { it[THEME_KEY] = value.name }
+
+    suspend fun setSpeedUnit(value: SpeedUnitSetting) = context.displayDataStore.edit { it[SPEED_KEY] = value.name }
+
+    suspend fun setTemperatureUnit(value: TemperatureUnitSetting) =
+        context.displayDataStore.edit { it[TEMPERATURE_KEY] = value.name }
+
+    suspend fun setClock(value: ClockSetting) = context.displayDataStore.edit { it[CLOCK_KEY] = value.name }
+
+    private companion object {
+        val THEME_KEY = stringPreferencesKey("theme_mode")
+        val SPEED_KEY = stringPreferencesKey("speed_unit")
+        val TEMPERATURE_KEY = stringPreferencesKey("temperature_unit")
+        val CLOCK_KEY = stringPreferencesKey("clock")
+    }
+}
+
+// Decode a stored enum name to [T], falling back to [fallback] for a missing or
+// unrecognised value so the read never throws on a downgrade / renamed entry.
+private inline fun <reified T : Enum<T>> String?.toEnumOr(fallback: T): T =
+    this?.let { name -> enumEntries<T>().firstOrNull { it.name == name } } ?: fallback

--- a/app/src/main/java/io/github/seijikohara/femto/data/FontPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/FontPreferences.kt
@@ -19,7 +19,7 @@ private val Context.fontDataStore: DataStore<Preferences> by preferencesDataStor
  * default. The setter exists so future settings code can flip the choice
  * without introducing the persistence layer separately.
  */
-class FontPreferences(
+internal class FontPreferences(
     private val context: Context,
 ) {
     val fontTheme: Flow<FontTheme> =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
@@ -42,6 +42,6 @@ internal sealed interface HomeEvent {
     /** Open the system "Notification listener access" settings so the user can grant our NLS. */
     data object OpenNotificationListenerSettings : HomeEvent
 
-    /** Open the system Settings root (`Settings.ACTION_SETTINGS`). */
-    data object OpenSystemSettings : HomeEvent
+    /** Open the in-app settings screen (units, theme, font, system links). */
+    data object OpenInAppSettings : HomeEvent
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -13,9 +13,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.seijikohara.femto.data.hasFineLocationPermission
+import io.github.seijikohara.femto.ui.locale.SpeedUnit
+import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 
 @Composable
 internal fun HomeRoute(
+    is24Hour: Boolean,
+    speedUnit: SpeedUnit,
+    temperatureUnit: TemperatureUnit,
     onEvent: (HomeEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -30,6 +35,9 @@ internal fun HomeRoute(
     }
     HomeScreen(
         uiState = uiState,
+        is24Hour = is24Hour,
+        speedUnit = speedUnit,
+        temperatureUnit = temperatureUnit,
         onAction = viewModel::onAction,
         modifier = modifier,
     )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -1,21 +1,22 @@
 package io.github.seijikohara.femto.ui.home
 
-import android.text.format.DateFormat
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import io.github.seijikohara.femto.ui.home.components.DashboardScaffold
-import io.github.seijikohara.femto.ui.locale.speedUnitFor
-import io.github.seijikohara.femto.ui.locale.temperatureUnitFor
+import io.github.seijikohara.femto.ui.locale.SpeedUnit
+import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 
 @Composable
 internal fun HomeScreen(
     uiState: HomeUiState,
+    is24Hour: Boolean,
+    speedUnit: SpeedUnit,
+    temperatureUnit: TemperatureUnit,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
@@ -24,9 +25,9 @@ internal fun HomeScreen(
 ) {
     DashboardScaffold(
         uiState = uiState,
-        is24Hour = DateFormat.is24HourFormat(LocalContext.current),
-        speedUnit = speedUnitFor(),
-        temperatureUnit = temperatureUnitFor(),
+        is24Hour = is24Hour,
+        speedUnit = speedUnit,
+        temperatureUnit = temperatureUnit,
         onAction = onAction,
         modifier = Modifier.fillMaxSize(),
     )
@@ -34,4 +35,13 @@ internal fun HomeScreen(
 
 @PreviewLightDark
 @Composable
-private fun HomeScreenPreview() = FemtoTheme { HomeScreen(uiState = HomeUiState.Initial, onAction = {}) }
+private fun HomeScreenPreview() =
+    FemtoTheme {
+        HomeScreen(
+            uiState = HomeUiState.Initial,
+            is24Hour = true,
+            speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            temperatureUnit = TemperatureUnit.CELSIUS,
+            onAction = {},
+        )
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -127,7 +127,7 @@ internal class HomeViewModel(
             }
 
             HomeAction.OpenSettings -> {
-                mutableEvents.tryEmit(HomeEvent.OpenSystemSettings)
+                mutableEvents.tryEmit(HomeEvent.OpenInAppSettings)
             }
 
             HomeAction.ResetTrip -> {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/locale/SystemUnits.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/locale/SystemUnits.kt
@@ -1,6 +1,8 @@
 package io.github.seijikohara.femto.ui.locale
 
 import androidx.core.text.util.LocalePreferences
+import io.github.seijikohara.femto.data.SpeedUnitSetting
+import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -71,6 +73,22 @@ internal fun temperatureUnitFor(locale: Locale = Locale.getDefault()): Temperatu
         else -> {
             TemperatureUnit.CELSIUS
         }
+    }
+
+/** Resolve a user speed-unit setting to a concrete unit; AUTO follows [locale]. */
+internal fun SpeedUnitSetting.resolved(locale: Locale = Locale.getDefault()): SpeedUnit =
+    when (this) {
+        SpeedUnitSetting.AUTO -> speedUnitFor(locale)
+        SpeedUnitSetting.KILOMETERS -> SpeedUnit.KILOMETERS_PER_HOUR
+        SpeedUnitSetting.MILES -> SpeedUnit.MILES_PER_HOUR
+    }
+
+/** Resolve a user temperature-unit setting to a concrete unit; AUTO follows [locale]. */
+internal fun TemperatureUnitSetting.resolved(locale: Locale = Locale.getDefault()): TemperatureUnit =
+    when (this) {
+        TemperatureUnitSetting.AUTO -> temperatureUnitFor(locale)
+        TemperatureUnitSetting.CELSIUS -> TemperatureUnit.CELSIUS
+        TemperatureUnitSetting.FAHRENHEIT -> TemperatureUnit.FAHRENHEIT
     }
 
 internal fun SpeedUnit.fromMetersPerSecond(mps: Float): Float =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsRoute.kt
@@ -1,0 +1,38 @@
+package io.github.seijikohara.femto.ui.settings
+
+import android.app.Application
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+/**
+ * Settings entry point: binds [SettingsViewModel], collects its state, and
+ * forwards persisted changes to the VM. Host-level navigation / system intents (back, the
+ * notification-access screen, the OS settings root) flow up to [MainActivity] via
+ * the callbacks so this route owns no Activity concerns.
+ */
+@Composable
+internal fun SettingsRoute(
+    onBack: () -> Unit,
+    onOpenNotificationAccess: () -> Unit,
+    onOpenSystemSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val viewModel: SettingsViewModel =
+        viewModel(factory = SettingsViewModelFactory(context.applicationContext as Application))
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    BackHandler(onBack = onBack)
+    SettingsScreen(
+        uiState = uiState,
+        onAction = viewModel::onAction,
+        onBack = onBack,
+        onOpenNotificationAccess = onOpenNotificationAccess,
+        onOpenSystemSettings = onOpenSystemSettings,
+        modifier = modifier,
+    )
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -1,0 +1,270 @@
+package io.github.seijikohara.femto.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.Lucide
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.ClockSetting
+import io.github.seijikohara.femto.data.SpeedUnitSetting
+import io.github.seijikohara.femto.data.TemperatureUnitSetting
+import io.github.seijikohara.femto.data.ThemeMode
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.FontTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+
+/**
+ * In-app settings: theme, units, clock, font, and links out to the relevant
+ * system screens. Pure UI — persisted changes flow up via [onAction]; the
+ * host-level navigation / system intents flow up via the dedicated callbacks so
+ * the screen stays previewable and testable in isolation.
+ */
+@Composable
+internal fun SettingsScreen(
+    uiState: SettingsUiState,
+    onAction: (SettingsAction) -> Unit,
+    onBack: () -> Unit,
+    onOpenNotificationAccess: () -> Unit,
+    onOpenSystemSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) = Surface(
+    modifier = modifier.fillMaxSize(),
+    color = MaterialTheme.colorScheme.background,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(FemtoDimens.ScreenPadding),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        Header(onBack = onBack)
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_theme),
+            options =
+                listOf(
+                    ThemeMode.SYSTEM to stringResource(R.string.settings_option_auto),
+                    ThemeMode.LIGHT to stringResource(R.string.settings_theme_light),
+                    ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
+                ),
+            selected = uiState.themeMode,
+            onSelect = { onAction(SettingsAction.SetThemeMode(it)) },
+        )
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_speed),
+            options =
+                listOf(
+                    SpeedUnitSetting.AUTO to stringResource(R.string.settings_option_auto),
+                    SpeedUnitSetting.KILOMETERS to stringResource(R.string.settings_speed_km),
+                    SpeedUnitSetting.MILES to stringResource(R.string.settings_speed_mi),
+                ),
+            selected = uiState.speedUnit,
+            onSelect = { onAction(SettingsAction.SetSpeedUnit(it)) },
+        )
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_temperature),
+            options =
+                listOf(
+                    TemperatureUnitSetting.AUTO to stringResource(R.string.settings_option_auto),
+                    TemperatureUnitSetting.CELSIUS to stringResource(R.string.settings_temp_celsius),
+                    TemperatureUnitSetting.FAHRENHEIT to stringResource(R.string.settings_temp_fahrenheit),
+                ),
+            selected = uiState.temperatureUnit,
+            onSelect = { onAction(SettingsAction.SetTemperatureUnit(it)) },
+        )
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_clock),
+            options =
+                listOf(
+                    ClockSetting.AUTO to stringResource(R.string.settings_option_auto),
+                    ClockSetting.TWELVE_HOUR to stringResource(R.string.settings_clock_12),
+                    ClockSetting.TWENTY_FOUR_HOUR to stringResource(R.string.settings_clock_24),
+                ),
+            selected = uiState.clock,
+            onSelect = { onAction(SettingsAction.SetClock(it)) },
+        )
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_font),
+            options = FontTheme.entries.map { it to it.displayName() },
+            selected = uiState.fontTheme,
+            onSelect = { onAction(SettingsAction.SetFontTheme(it)) },
+        )
+
+        SystemGroup(
+            onOpenNotificationAccess = onOpenNotificationAccess,
+            onOpenSystemSettings = onOpenSystemSettings,
+        )
+    }
+}
+
+@Composable
+private fun Header(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) = Row(
+    modifier = modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+) {
+    Box(
+        modifier =
+            Modifier
+                .size(FemtoDimens.MinTouchTarget)
+                .clipClickable(onBack),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Lucide.ArrowLeft,
+            contentDescription = stringResource(R.string.settings_back),
+            tint = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.size(28.dp),
+        )
+    }
+    Text(
+        text = stringResource(R.string.settings_title),
+        style = MaterialTheme.typography.headlineMedium,
+        color = MaterialTheme.colorScheme.onBackground,
+    )
+}
+
+@Composable
+private fun <T> SettingGroup(
+    title: String,
+    options: List<Pair<T, String>>,
+    selected: T,
+    onSelect: (T) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier = modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        options.forEach { (value, label) ->
+            OptionChip(
+                label = label,
+                selected = value == selected,
+                onClick = { onSelect(value) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun OptionChip(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val container =
+        if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainerHigh
+    val content =
+        if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
+    Surface(
+        onClick = onClick,
+        modifier = modifier.heightIn(min = FemtoDimens.MinTouchTarget),
+        shape = RoundedCornerShape(14.dp),
+        color = container,
+    ) {
+        Box(
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+                color = content,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SystemGroup(
+    onOpenNotificationAccess: () -> Unit,
+    onOpenSystemSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier = modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+) {
+    Text(
+        text = stringResource(R.string.settings_group_system),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    FilledTonalButton(
+        onClick = onOpenNotificationAccess,
+        modifier = Modifier.fillMaxWidth().heightIn(min = FemtoDimens.MinTouchTarget),
+    ) {
+        Text(text = stringResource(R.string.settings_open_notification_access))
+    }
+    FilledTonalButton(
+        onClick = onOpenSystemSettings,
+        modifier = Modifier.fillMaxWidth().heightIn(min = FemtoDimens.MinTouchTarget),
+    ) {
+        Text(text = stringResource(R.string.settings_open_system_settings))
+    }
+}
+
+// A human-readable label for a font theme (e.g. INTER -> "Inter").
+private fun FontTheme.displayName(): String = name.lowercase().replaceFirstChar(Char::uppercaseChar)
+
+// Small modifier helper: clip to a circle and make clickable, for the back box.
+private fun Modifier.clipClickable(onClick: () -> Unit): Modifier =
+    this
+        .clip(RoundedCornerShape(percent = 50))
+        .clickable(onClick = onClick)
+
+@PreviewLightDark
+@Composable
+private fun SettingsScreenPreview() {
+    FemtoTheme {
+        SettingsScreen(
+            uiState = SettingsUiState.Initial,
+            onAction = {},
+            onBack = {},
+            onOpenNotificationAccess = {},
+            onOpenSystemSettings = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -1,0 +1,53 @@
+package io.github.seijikohara.femto.ui.settings
+
+import io.github.seijikohara.femto.data.ClockSetting
+import io.github.seijikohara.femto.data.DisplaySettings
+import io.github.seijikohara.femto.data.SpeedUnitSetting
+import io.github.seijikohara.femto.data.TemperatureUnitSetting
+import io.github.seijikohara.femto.data.ThemeMode
+import io.github.seijikohara.femto.ui.theme.FontTheme
+
+/** State for the in-app settings screen: the persisted display + font choices. */
+internal data class SettingsUiState(
+    val themeMode: ThemeMode,
+    val speedUnit: SpeedUnitSetting,
+    val temperatureUnit: TemperatureUnitSetting,
+    val clock: ClockSetting,
+    val fontTheme: FontTheme,
+) {
+    companion object {
+        // Seeded from the persistence defaults so the default values live in one
+        // place (DisplaySettings.Default + the FontTheme MVP default).
+        val Initial =
+            SettingsUiState(
+                themeMode = DisplaySettings.Default.themeMode,
+                speedUnit = DisplaySettings.Default.speedUnit,
+                temperatureUnit = DisplaySettings.Default.temperatureUnit,
+                clock = DisplaySettings.Default.clock,
+                fontTheme = FontTheme.INTER,
+            )
+    }
+}
+
+/** Persisted-preference changes the settings screen reports up. */
+internal sealed interface SettingsAction {
+    data class SetThemeMode(
+        val value: ThemeMode,
+    ) : SettingsAction
+
+    data class SetSpeedUnit(
+        val value: SpeedUnitSetting,
+    ) : SettingsAction
+
+    data class SetTemperatureUnit(
+        val value: TemperatureUnitSetting,
+    ) : SettingsAction
+
+    data class SetClock(
+        val value: ClockSetting,
+    ) : SettingsAction
+
+    data class SetFontTheme(
+        val value: FontTheme,
+    ) : SettingsAction
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,58 @@
+package io.github.seijikohara.femto.ui.settings
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import io.github.seijikohara.femto.data.DisplayPreferences
+import io.github.seijikohara.femto.data.FontPreferences
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+internal class SettingsViewModel(
+    private val displayPreferences: DisplayPreferences,
+    private val fontPreferences: FontPreferences,
+) : ViewModel() {
+    val uiState: StateFlow<SettingsUiState> =
+        combine(displayPreferences.settings, fontPreferences.fontTheme) { display, font ->
+            SettingsUiState(
+                themeMode = display.themeMode,
+                speedUnit = display.speedUnit,
+                temperatureUnit = display.temperatureUnit,
+                clock = display.clock,
+                fontTheme = font,
+            )
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState.Initial)
+
+    fun onAction(action: SettingsAction) {
+        // Each branch is a single suspending write; launch once and dispatch.
+        viewModelScope.launch {
+            when (action) {
+                is SettingsAction.SetThemeMode -> displayPreferences.setThemeMode(action.value)
+                is SettingsAction.SetSpeedUnit -> displayPreferences.setSpeedUnit(action.value)
+                is SettingsAction.SetTemperatureUnit -> displayPreferences.setTemperatureUnit(action.value)
+                is SettingsAction.SetClock -> displayPreferences.setClock(action.value)
+                is SettingsAction.SetFontTheme -> fontPreferences.setFontTheme(action.value)
+            }
+        }
+    }
+}
+
+internal class SettingsViewModelFactory(
+    private val application: Application,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(
+        modelClass: Class<T>,
+        extras: CreationExtras,
+    ): T {
+        @Suppress("UNCHECKED_CAST")
+        return SettingsViewModel(
+            displayPreferences = DisplayPreferences(application),
+            fontPreferences = FontPreferences(application),
+        ) as T
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,4 +65,25 @@
     <string name="drawer_no_apps">No apps installed</string>
     <string name="drawer_load_error">Couldn\'t load apps</string>
     <string name="drawer_retry">Retry</string>
+
+    <!-- Settings -->
+    <string name="settings_title">Settings</string>
+    <string name="settings_back">Back</string>
+    <string name="settings_group_theme">Theme</string>
+    <string name="settings_group_speed">Speed &amp; distance</string>
+    <string name="settings_group_temperature">Temperature</string>
+    <string name="settings_group_clock">Clock</string>
+    <string name="settings_group_font">Font</string>
+    <string name="settings_group_system">System</string>
+    <string name="settings_option_auto">Auto</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
+    <string name="settings_speed_km">km/h</string>
+    <string name="settings_speed_mi">mph</string>
+    <string name="settings_temp_celsius">°C</string>
+    <string name="settings_temp_fahrenheit">°F</string>
+    <string name="settings_clock_12">12-hour</string>
+    <string name="settings_clock_24">24-hour</string>
+    <string name="settings_open_notification_access">Notification access</string>
+    <string name="settings_open_system_settings">System settings</string>
 </resources>

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -162,11 +162,11 @@ class HomeViewModelTest {
         }
 
     @Test
-    fun `onAction OpenSettings emits OpenSystemSettings`() =
+    fun `onAction OpenSettings emits OpenInAppSettings`() =
         runTest {
             stubViewModel().assertEvent(
                 action = HomeAction.OpenSettings,
-                expected = HomeEvent.OpenSystemSettings,
+                expected = HomeEvent.OpenInAppSettings,
             )
         }
 


### PR DESCRIPTION
PR7 of the dashboard device-feedback redesign (item 13): the gear opened the OS
Settings; route it to a new in-app settings screen and make the choices stick.

## Changes

- New `ui/settings/` UDF screen (Route + Screen + ViewModel + UiState): grouped
  64 dp option chips for theme (System/Light/Dark), speed & distance, temperature,
  clock (each Auto / explicit), and font; a System group links out to notification
  access and the OS settings root. Chips use FlowRow so they wrap on narrow units.
- New `DisplayPreferences` DataStore (theme mode, speed/temperature unit, clock),
  modelled on `FontPreferences`; all values default to Auto/System so a fresh
  install behaves exactly as before. `SystemUnits.resolved()` maps a setting to a
  concrete unit (Auto follows the locale).
- `MainActivity` collects DisplayPreferences + FontPreferences, feeds
  `fontTheme` + `darkTheme` into the single `FemtoTheme` wrap and the resolved
  units + clock into the dashboard, and shows `SettingsRoute` as a destination
  over Home (gear → `OpenInAppSettings`; the `OpenSystemSettings` event is gone,
  OS settings now reached from inside the screen). `HomeRoute`/`HomeScreen` take
  the units/clock as params, so the override genuinely takes effect.

No new permission; dynamic color stays on (theme is light/dark/system only).

Reviewed by compose-launcher-reviewer (blockers fixed: `enumEntries` over the
deprecated `enumValues`, `internal` visibility on the new data types; should-fix
items — Default-derived initial state, drawer reset on settings open, FlowRow
wrapping, dropped speculative `@Immutable` — all addressed).

## Verification

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.

⚠️ On-device confirmation welcome: theme/unit/font changes applying live, and the
settings layout on the 9-inch unit.