### PR TITLE
feat(footer): add a voice-assistant nav button

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardFooterTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardFooterTest.kt
@@ -49,6 +49,21 @@ class DashboardFooterTest {
     }
 
     @Test
+    fun tapping_assistant_dispatches_open_assistant() {
+        var lastAction: HomeAction? = null
+        rule.setContent {
+            FemtoTheme {
+                DashboardFooter(
+                    systemStatus = fakeSystemStatus(),
+                    onAction = { lastAction = it },
+                )
+            }
+        }
+        rule.onNodeWithContentDescription("Assistant").performClick()
+        assertEquals(HomeAction.OpenAssistant, lastAction)
+    }
+
+    @Test
     fun shows_wifi_connected_description_when_wifi_connected() {
         rule.setContent {
             FemtoTheme {

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -138,8 +138,20 @@ class MainActivity : ComponentActivity() {
                 setShowDrawer(false)
                 setShowSettings(true)
             }
+
+            HomeEvent.OpenAssistant -> {
+                openAssistant()
+            }
         }
     }
+
+    // Defer to whichever assistant the user has elected (ACTION_ASSIST),
+    // falling back to the generic voice-command intent. No package is
+    // hard-coded, so it works across markets and OEM assistants. `||`
+    // short-circuits: the fallback fires only when no assistant resolves.
+    private fun openAssistant() =
+        tryStartActivity(Intent(Intent.ACTION_ASSIST).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) ||
+            tryStartActivity(Intent(Intent.ACTION_VOICE_COMMAND).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
 
     private fun resolveIs24Hour(clock: ClockSetting): Boolean =
         when (clock) {
@@ -152,7 +164,7 @@ class MainActivity : ComponentActivity() {
         val intent =
             Intent(Settings.ACTION_SETTINGS)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        startActivityIfResolved(intent)
+        tryStartActivity(intent)
     }
 
     private fun launchAppCategory(category: String) {
@@ -163,7 +175,7 @@ class MainActivity : ComponentActivity() {
             Intent
                 .makeMainSelectorActivity(Intent.ACTION_MAIN, category)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        startActivityIfResolved(intent)
+        tryStartActivity(intent)
     }
 
     private fun launchGeo(
@@ -175,14 +187,14 @@ class MainActivity : ComponentActivity() {
         val intent =
             Intent(Intent.ACTION_VIEW, Uri.parse("geo:$latitude,$longitude?z=$MAPS_ZOOM_LEVEL"))
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        startActivityIfResolved(intent)
+        tryStartActivity(intent)
     }
 
     private fun openNotificationListenerSettings() {
         val intent =
             Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        startActivityIfResolved(intent)
+        tryStartActivity(intent)
     }
 
     /**
@@ -203,17 +215,19 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Start [intent] but no-op if no activity resolves. Other failures (e.g.
-     * `SecurityException`) propagate so they surface as crashes rather than
-     * silent dead clicks during development.
+     * Start [intent], returning whether an activity handled it. Callers that
+     * chain alternatives consume the result (the assistant fallback); fire-and-
+     * forget callers ignore it. [ActivityNotFoundException] means the head unit
+     * has no app for the target — a silent no-op rather than a dead-click crash;
+     * any other failure (e.g. `SecurityException`) propagates.
      */
-    private fun startActivityIfResolved(intent: Intent) {
+    private fun tryStartActivity(intent: Intent): Boolean =
         try {
             startActivity(intent)
+            true
         } catch (_: ActivityNotFoundException) {
-            // Head-unit has no app for this category / settings target.
+            false
         }
-    }
 
     /**
      * Nudge MapLibre's OpenGL `EGLConfigChooser` onto its emulator-safe config

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
@@ -27,5 +27,7 @@ internal sealed interface HomeAction {
 
     data object OpenSettings : HomeAction
 
+    data object OpenAssistant : HomeAction
+
     data object ResetTrip : HomeAction
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
@@ -44,4 +44,7 @@ internal sealed interface HomeEvent {
 
     /** Open the in-app settings screen (units, theme, font, system links). */
     data object OpenInAppSettings : HomeEvent
+
+    /** Invoke the device's voice assistant (ACTION_ASSIST, falling back to voice command). */
+    data object OpenAssistant : HomeEvent
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -130,6 +130,10 @@ internal class HomeViewModel(
                 mutableEvents.tryEmit(HomeEvent.OpenInAppSettings)
             }
 
+            HomeAction.OpenAssistant -> {
+                mutableEvents.tryEmit(HomeEvent.OpenAssistant)
+            }
+
             HomeAction.ResetTrip -> {
                 resetTrip()
             }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
@@ -37,6 +37,7 @@ import com.composables.icons.lucide.Bluetooth
 import com.composables.icons.lucide.Globe
 import com.composables.icons.lucide.LayoutGrid
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Mic
 import com.composables.icons.lucide.Music
 import com.composables.icons.lucide.Navigation
 import com.composables.icons.lucide.Phone
@@ -51,10 +52,13 @@ import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.TabularFigures
 
-// Below this footer width the read-only status cluster is dropped so the six
+// Below this footer width the read-only status cluster is dropped so the seven
 // nav buttons keep room to render at >= FemtoDimens.MinTouchTarget without
-// clipping on portrait / narrow head units.
-private val CompactFooterWidth: Dp = 640.dp
+// clipping on portrait / narrow head units. Derived from the layout, not tuned
+// to a device: 7 buttons * 64 dp floor (448 dp) + the status cluster (~140 dp)
+// + dividers and horizontal padding (~70 dp) ~= 660 dp, rounded up for headroom.
+// Adding an eighth button raises the button term by one MinTouchTarget.
+private val CompactFooterWidth: Dp = 700.dp
 
 /**
  * Bottom dock. Originally derived from `docs/design/dashboard-v2-mockup.html`
@@ -63,8 +67,8 @@ private val CompactFooterWidth: Dp = 640.dp
  * the mockup, is now the authoritative footer spec.
  *
  *  - [FemtoDimens.FooterHeight] surface with a 1 dp top divider (`outlineVariant`).
- *  - Six equal-weight nav buttons (Phone / Apps / Music / Navigation / Browser /
- *    Settings). This app IS the launcher, so there is no Home button.
+ *  - Seven equal-weight nav buttons (Phone / Apps / Music / Navigation /
+ *    Browser / Assistant / Settings). This app IS the launcher, so no Home button.
  *  - A 1 dp vertical divider separates the actionable nav from a read-only
  *    status cluster: cellular (hidden on telephony-less units), Wi-Fi,
  *    Bluetooth, and a battery indicator (icon over percent, with a "Charging"
@@ -89,7 +93,7 @@ internal fun DashboardFooter(
                     .fillMaxSize()
                     .padding(horizontal = 24.dp),
         ) {
-            // The six nav buttons plus the cluster cannot both fit on a narrow
+            // The seven nav buttons plus the cluster cannot both fit on a narrow
             // portrait head unit; below the threshold the read-only status
             // cluster yields so the actionable nav stays uncut.
             val showStatusCluster = maxWidth >= CompactFooterWidth
@@ -128,7 +132,7 @@ private fun NavRow(
     horizontalArrangement = Arrangement.SpaceBetween,
     verticalAlignment = Alignment.CenterVertically,
 ) {
-    // Each button takes an equal weight so the six buttons share the width and
+    // Each button takes an equal weight so the seven buttons share the width and
     // shrink toward FemtoDimens.MinTouchTarget instead of clipping when the row
     // is narrow. The widthIn floor in NavButton keeps every tap target legal.
     NavButton(
@@ -159,6 +163,12 @@ private fun NavRow(
         icon = Lucide.Globe,
         description = stringResource(R.string.nav_browser),
         onClick = { onAction(HomeAction.OpenBrowser) },
+        modifier = Modifier.weight(1f),
+    )
+    NavButton(
+        icon = Lucide.Mic,
+        description = stringResource(R.string.nav_assistant),
+        onClick = { onAction(HomeAction.OpenAssistant) },
         modifier = Modifier.weight(1f),
     )
     NavButton(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="nav_music">Music</string>
     <string name="nav_navigation">Navigation</string>
     <string name="nav_browser">Browser</string>
+    <string name="nav_assistant">Assistant</string>
     <string name="nav_settings">Settings</string>
 
     <!-- Dashboard footer: status cluster -->

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -171,6 +171,15 @@ class HomeViewModelTest {
         }
 
     @Test
+    fun `onAction OpenAssistant emits OpenAssistant`() =
+        runTest {
+            stubViewModel().assertEvent(
+                action = HomeAction.OpenAssistant,
+                expected = HomeEvent.OpenAssistant,
+            )
+        }
+
+    @Test
     fun `onAction ConnectMusicPlayer emits OpenNotificationListenerSettings`() =
         runTest {
             stubViewModel().assertEvent(


### PR DESCRIPTION
## Summary

Adds a voice-assistant nav button to the dashboard footer (device-feedback item 12). Tapping the Mic button invokes the device's elected voice assistant.

Part of the on-device feedback series; see `docs/superpowers/specs/2026-06-04-dashboard-device-feedback-design.md`.

## Changes

- **Mic nav button** between Browser and Settings (`Lucide.Mic`, `nav_assistant`), wired as `HomeAction.OpenAssistant` → `HomeEvent.OpenAssistant`.
- **Package-agnostic dispatch**: `openAssistant()` tries `ACTION_ASSIST` (the user's elected assistant), falling back to `ACTION_VOICE_COMMAND`. No package is hard-coded, so it works across markets and OEM assistants.
- **Refactor**: `startActivityIfResolved` becomes `tryStartActivity` returning whether an activity handled the intent, letting `openAssistant` chain the two intents with `||`. The redundant wrapper is removed; fire-and-forget callers ignore the result.
- **Responsive threshold**: the status-cluster drop point rises 640 → 700 dp so all seven nav buttons stay above the 64 dp touch-target floor on narrow head units. The value is derived from the button count (7 × 64 dp + cluster + padding), not tuned to a device.

## Tests

- `HomeViewModelTest`: `OpenAssistant` action emits `OpenAssistant` event.
- `DashboardFooterTest`: tapping Assistant dispatches `OpenAssistant`.

## Verification

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.