### PR TITLE
feat(calendar): select a day to view its events

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
@@ -12,17 +12,19 @@ internal fun fakeCalendarSnapshot(
     monthLabel: String = "May 2026",
     dayStrip: List<DayCell> =
         listOf(
-            DayCell(LocalDate.of(2026, 5, 1), "Fri", true),
-            DayCell(LocalDate.of(2026, 5, 2), "Sat", false),
-            DayCell(LocalDate.of(2026, 5, 3), "Sun", true),
-            DayCell(LocalDate.of(2026, 5, 4), "Mon", false),
-            DayCell(LocalDate.of(2026, 5, 5), "Tue", false),
-            DayCell(LocalDate.of(2026, 5, 6), "Wed", true),
-        ),
-    events: List<EventItem> =
-        listOf(
-            EventItem(LocalTime.of(10, 30), "Team standup"),
-            EventItem(LocalTime.of(14, 0), "Pick up kids"),
+            DayCell(
+                LocalDate.of(2026, 5, 1),
+                "Fri",
+                listOf(
+                    EventItem(LocalTime.of(10, 30), "Team standup"),
+                    EventItem(LocalTime.of(14, 0), "Pick up kids"),
+                ),
+            ),
+            DayCell(LocalDate.of(2026, 5, 2), "Sat", emptyList()),
+            DayCell(LocalDate.of(2026, 5, 3), "Sun", listOf(EventItem(LocalTime.of(9, 0), "Brunch"))),
+            DayCell(LocalDate.of(2026, 5, 4), "Mon", emptyList()),
+            DayCell(LocalDate.of(2026, 5, 5), "Tue", emptyList()),
+            DayCell(LocalDate.of(2026, 5, 6), "Wed", listOf(EventItem(null, "Holiday"))),
         ),
     hasCalendarAccess: Boolean = true,
 ): CalendarSnapshot =
@@ -31,6 +33,5 @@ internal fun fakeCalendarSnapshot(
         weekday = weekday,
         monthLabel = monthLabel,
         dayStrip = dayStrip,
-        events = events,
         hasCalendarAccess = hasCalendarAccess,
     )

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
@@ -1,9 +1,12 @@
 package io.github.seijikohara.femto.ui.home.components
 
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.testfixtures.fakeCalendarSnapshot
@@ -16,14 +19,49 @@ class CalendarCardTest {
     val rule = createComposeRule()
 
     @Test
-    fun renders_upcoming_event_title_for_granted_snapshot() {
+    fun renders_selected_day_event_title_for_granted_snapshot() {
         rule.setContent {
             FemtoTheme {
                 CalendarCard(snapshot = fakeCalendarSnapshot())
             }
         }
-        // The fixture's first event title appears in the events section.
+        // Selection defaults to today (the first strip cell), so today's first
+        // event title appears in the events section.
         rule.onNodeWithText("Team standup").assertIsDisplayed()
+    }
+
+    @Test
+    fun selecting_a_day_shows_that_days_events_and_keeps_the_head_on_today() {
+        rule.setContent {
+            FemtoTheme {
+                CalendarCard(snapshot = fakeCalendarSnapshot())
+            }
+        }
+        // Strip cells expose their ISO date as the content description.
+        rule.onNodeWithContentDescription("2026-05-03").performClick()
+
+        // The events section switches to the selected day; today's events leave.
+        rule.onNodeWithText("Brunch").assertIsDisplayed()
+        rule.onAllNodesWithText("Team standup").assertCountEquals(0)
+        // The hero head stays on today regardless of the selected day.
+        rule.onNodeWithText("Friday").assertIsDisplayed()
+    }
+
+    @Test
+    fun selecting_a_day_without_events_shows_the_empty_message() {
+        rule.setContent {
+            FemtoTheme {
+                CalendarCard(snapshot = fakeCalendarSnapshot())
+            }
+        }
+        rule.onNodeWithContentDescription("2026-05-02").performClick()
+
+        val noEvents =
+            InstrumentationRegistry
+                .getInstrumentation()
+                .targetContext
+                .getString(R.string.calendar_no_events)
+        rule.onNodeWithText(noEvents).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
@@ -36,9 +36,10 @@ import java.util.Locale
  *
  * Combines two upstream signals — the wall clock (so today / weekday /
  * month follow real time without an extra timer) and the events provider
- * (so the strip dots and event list refresh when the user edits a calendar
- * event). The events query window is `today + 5 days` to match the 6-cell
- * strip on the calendar card.
+ * (so the per-day events refresh when the user edits a calendar event). The
+ * events query window is `today + 5 days` to match the 6-cell strip on the
+ * calendar card; each day's events are attached to its strip cell so the card
+ * can switch the shown day from card-local selection without a re-query.
  *
  * When `READ_CALENDAR` is denied the snapshot still emits from the clock
  * alone, but with `hasCalendarAccess = false` so the card renders the denial
@@ -61,26 +62,21 @@ internal class CalendarRepository(
         }.distinctUntilChanged().flowOn(Dispatchers.Default)
 
     private fun buildSnapshot(today: LocalDate): CalendarSnapshot {
+        val granted = hasPermission()
+        val eventsByDay = if (granted) readWindow(today) else emptyMap()
         val strip = (0 until DAY_STRIP_LENGTH).map { offset ->
             val date = today.plusDays(offset.toLong())
             DayCell(
                 date = date,
                 weekdayLetter = date.dayOfWeek.getDisplayName(TextStyle.SHORT, locale),
-                hasEvent = false,
+                events = eventsByDay[date].orEmpty(),
             )
         }
-        val granted = hasPermission()
-        // One window scan yields both signals: the full set of dotted days
-        // (every event in the window, including earlier-today) and the next
-        // up-to-EVENT_LIST_LIMIT future events.
-        val window = if (granted) readWindow(today) else CalendarWindow.EMPTY
-        val stripWithDots = strip.map { it.copy(hasEvent = it.date in window.datesWithEvents) }
         return CalendarSnapshot(
             today = today,
             weekday = today.dayOfWeek.getDisplayName(TextStyle.FULL, locale),
             monthLabel = monthLabelOf(today),
-            dayStrip = stripWithDots,
-            events = window.events,
+            dayStrip = strip,
             hasCalendarAccess = granted,
         )
     }
@@ -126,23 +122,20 @@ internal class CalendarRepository(
             }.build()
 
     /**
-     * Scan the strip window once and accumulate both card signals in a single
-     * pass: every event's local day (for the strip dots, including
-     * earlier-today rows) and the next up-to-[EVENT_LIST_LIMIT] future events
-     * (`BEGIN >= now`). A single query replaces the former two byte-identical
-     * window queries. The loop keeps scanning after the event list fills so the
-     * dot set still covers the full window.
+     * Scan the strip window once and group every event by its local day. The
+     * card shows whichever day the user selects, so the window holds the whole
+     * day (no `BEGIN >= now` future-only filter) capped at [EVENTS_PER_DAY_LIMIT]
+     * per day to bound the card height. Rows arrive `BEGIN ASC`, so each day's
+     * list stays time-ordered and the cap keeps the earliest events.
      *
      * A mid-stream permission revoke (SecurityException) or an OEM provider
      * fault (SQLiteException) must not tear down the dashboard StateFlow, so the
      * whole scan is guarded.
      */
     @SuppressLint("MissingPermission") // Caller checks READ_CALENDAR before subscribing.
-    private fun readWindow(today: LocalDate): CalendarWindow {
-        val now = Instant.now().toEpochMilli()
-        return runCatching {
-            val dates = mutableSetOf<LocalDate>()
-            val events = mutableListOf<EventItem>()
+    private fun readWindow(today: LocalDate): Map<LocalDate, List<EventItem>> =
+        runCatching {
+            val byDay = linkedMapOf<LocalDate, MutableList<EventItem>>()
             context.contentResolver
                 .query(
                     windowUri(today),
@@ -157,14 +150,14 @@ internal class CalendarRepository(
                 )?.use { cursor ->
                     while (cursor.moveToNext()) {
                         val startMs = cursor.getLong(0)
-                        val title = cursor.getString(1)
+                        // Skip null-title rows entirely: with the dot derived from
+                        // the listed events, a row that cannot be shown must not
+                        // dot its day either.
+                        val title = cursor.getString(1) ?: continue
                         val allDay = cursor.getInt(2) != 0
-                        dates += localDateOf(startMs, allDay)
-                        // Future top-N list mirrors the former `BEGIN >= now`
-                        // selection and the null-title skip; a null-title row
-                        // still dots its day above but never enters the list.
-                        if (title != null && startMs >= now && events.size < EVENT_LIST_LIMIT) {
-                            events += EventItem(
+                        val dayEvents = byDay.getOrPut(localDateOf(startMs, allDay)) { mutableListOf() }
+                        if (dayEvents.size < EVENTS_PER_DAY_LIMIT) {
+                            dayEvents += EventItem(
                                 // All-day rows carry no clock time; surface null
                                 // so the card renders an "all day" label instead
                                 // of a spurious 00:00 derived from the system zone.
@@ -174,9 +167,8 @@ internal class CalendarRepository(
                         }
                     }
                 }
-            CalendarWindow(datesWithEvents = dates.toSet(), events = events.toList())
-        }.getOrDefault(CalendarWindow.EMPTY)
-    }
+            byDay.mapValues { (_, events) -> events.toList() }
+        }.getOrDefault(emptyMap())
 
     /**
      * Resolve an Instances.BEGIN epoch-millis to the local calendar day.
@@ -216,22 +208,9 @@ internal class CalendarRepository(
             awaitClose { context.contentResolver.unregisterContentObserver(observer) }
         }.debounce(CHANGE_DEBOUNCE_MS)
 
-    /**
-     * Result of a single window scan: the days carrying any event (strip dots)
-     * and the next few future events (the card's event list).
-     */
-    private data class CalendarWindow(
-        val datesWithEvents: Set<LocalDate>,
-        val events: List<EventItem>,
-    ) {
-        companion object {
-            val EMPTY = CalendarWindow(datesWithEvents = emptySet(), events = emptyList())
-        }
-    }
-
     private companion object {
         const val DAY_STRIP_LENGTH = 6
-        const val EVENT_LIST_LIMIT = 2
+        const val EVENTS_PER_DAY_LIMIT = 3
         const val CHANGE_DEBOUNCE_MS = 500L
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarSnapshot.kt
@@ -8,9 +8,11 @@ import java.time.LocalTime
  * Calendar surface for the dashboard.
  *
  * The shape mirrors the visual hierarchy of the calendar card: a hero
- * "today" anchor on the left, a 6-day strip rolling forward, and a list of
- * the next few events. The strip is always six entries starting at [today]
- * so the card can iterate without size guards.
+ * "today" anchor on the left, a 6-day strip rolling forward, and the events
+ * of whichever day the user has selected. The strip is always six entries
+ * starting at [today] so the card can iterate without size guards, and each
+ * cell carries its own day's events so selecting a cell needs no second
+ * query.
  *
  * `null` denotes "not loaded yet" only. Permission denial is carried
  * in-band by [hasCalendarAccess]: a non-null snapshot with
@@ -23,9 +25,8 @@ data class CalendarSnapshot(
     val weekday: String,
     val monthLabel: String,
     val dayStrip: List<DayCell>,
-    val events: List<EventItem>,
-    // false means READ_CALENDAR is denied, so the strip / event sections carry
-    // no real data and the card shows the denial message instead.
+    // false means READ_CALENDAR is denied, so the strip carries no real data
+    // and the card shows the denial message instead.
     val hasCalendarAccess: Boolean,
 )
 
@@ -33,8 +34,14 @@ data class CalendarSnapshot(
 data class DayCell(
     val date: LocalDate,
     val weekdayLetter: String,
-    val hasEvent: Boolean,
-)
+    // The day's events, ordered by start time and capped per day upstream so a
+    // busy day cannot grow the card without bound.
+    val events: List<EventItem>,
+) {
+    // Derive the strip dot from the listed events so "has an event" and the
+    // shown events can never disagree.
+    val hasEvent: Boolean get() = events.isNotEmpty()
+}
 
 @Immutable
 data class EventItem(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -1,27 +1,35 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -43,18 +51,21 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 /**
- * Calendar card. Three vertical sections stacked on the
- * [FemtoDimens.CardSectionGap] rhythm ([Arrangement.spacedBy]); the content is
- * top-aligned and scrolls if the card is too short to fit all three:
+ * Calendar card. Three vertical sections on the [FemtoDimens.CardSectionGap]
+ * rhythm:
  *
- *  1. Head — big day number (primary tint) + weekday + month label.
- *  2. Strip — 6 future days starting today, each cell carrying a "has event" dot.
- *  3. Events — up to two upcoming events, separated from the strip by a 1dp divider.
+ *  1. Head — big day number (primary tint) + weekday + month label. The head
+ *     always shows **today**; selecting another day in the strip never moves it.
+ *  2. Strip — 6 days starting today, each tappable. The selected cell carries
+ *     the highlight; today keeps a thin ring while another day is previewed.
+ *  3. Events — the selected day's events, bottom-anchored so the per-day-capped
+ *     list grows into the flexible gap rather than pushing the card taller.
  *
- * Typography and spacing follow `docs/design/dashboard-v2-mockup.html`
- * (`.calendar-card` rules) verbatim; the dashboard's wider 18sp body-size
- * floor is intentionally relaxed here so the strip and event list match
- * the design.
+ * Selection is card-local ([rememberSaveable]); the dashboard owns no calendar
+ * selection state. Typography and spacing follow
+ * `docs/design/dashboard-v2-mockup.html` (`.calendar-card` rules); the
+ * dashboard's 18sp body-size floor is intentionally relaxed here so the strip
+ * and event list match the design.
  */
 @Composable
 internal fun CalendarCard(
@@ -67,37 +78,53 @@ internal fun CalendarCard(
     tonalElevation = FemtoDimens.CardElevation,
 ) {
     when {
-        // null is the loading frame: render nothing rather than a denial
-        // message the user has not earned yet.
-        snapshot == null -> {
-            Unit
-        }
+        // null is the loading frame: render nothing rather than a denial the
+        // user has not earned yet.
+        snapshot == null -> Unit
 
-        // A non-null snapshot with access denied carries no real strip /
-        // event data, so show the denial message instead of a hollow strip
-        // plus a misleading "no upcoming events".
-        !snapshot.hasCalendarAccess -> {
-            PermissionDenied()
-        }
+        // A non-null snapshot with access denied carries no real strip data, so
+        // show the denial message instead of a hollow strip.
+        !snapshot.hasCalendarAccess -> PermissionDenied()
 
-        else -> {
-            // verticalScroll is a safety net: fillMaxWidth (not fillMaxSize) lets
-            // the content keep its intrinsic height, so on a card too short for
-            // the head + strip + events it scrolls instead of clipping; on a tall
-            // enough card it simply sits top-aligned.
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(rememberScrollState())
-                        .padding(FemtoDimens.CardPadding),
-                verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGap),
-            ) {
-                Head(snapshot)
-                Strip(snapshot.dayStrip)
-                Events(snapshot.events)
-            }
-        }
+        else -> CalendarContent(snapshot)
+    }
+}
+
+@Composable
+private fun CalendarContent(snapshot: CalendarSnapshot) {
+    // Card-local selection, defaulting to today and surviving configuration
+    // change via the epoch-day saver. The big-day head stays on today.
+    var selectedDate by rememberSaveable(stateSaver = LocalDateSaver) {
+        mutableStateOf(snapshot.today)
+    }
+    val days = snapshot.dayStrip
+    // A selection outside the rolling window — after a midnight rollover, or a
+    // stale restored value — clamps back to today, so the events area never
+    // shows an out-of-window blank. This is the spec's "reset to today on
+    // rollover" without clobbering a config-change-restored selection.
+    val selected = days.firstOrNull { it.date == selectedDate } ?: days.first()
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(FemtoDimens.CardPadding),
+        verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGap),
+    ) {
+        Head(snapshot)
+        Strip(
+            days = days,
+            today = snapshot.today,
+            // Highlight the clamped selection (`selected.date`), not the raw
+            // `selectedDate` state: after a rollover the stored value can point
+            // outside the window, and the clamp keeps exactly one cell lit.
+            selectedDate = selected.date,
+            onSelect = { selectedDate = it },
+        )
+        // Bottom-anchor the events: the per-day cap bounds their count, so they
+        // grow upward into this flexible gap instead of pushing the card taller
+        // — selecting a busy day cannot worsen the clip.
+        Spacer(Modifier.weight(1f))
+        Events(selected.events)
     }
 }
 
@@ -137,37 +164,61 @@ private fun Head(snapshot: CalendarSnapshot) =
     }
 
 @Composable
-private fun Strip(days: List<DayCell>) =
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        days.forEachIndexed { index, day ->
-            DayCellView(
-                day = day,
-                isToday = index == 0,
-                modifier = Modifier.weight(1f),
-            )
-        }
+private fun Strip(
+    days: List<DayCell>,
+    today: LocalDate,
+    selectedDate: LocalDate,
+    onSelect: (LocalDate) -> Unit,
+) = Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.spacedBy(4.dp),
+) {
+    days.forEach { day ->
+        DayCellView(
+            day = day,
+            isToday = day.date == today,
+            isSelected = day.date == selectedDate,
+            onClick = { onSelect(day.date) },
+            modifier = Modifier.weight(1f),
+        )
     }
+}
 
 @Composable
 private fun DayCellView(
     day: DayCell,
     isToday: Boolean,
+    isSelected: Boolean,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val background =
-        if (isToday) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer
+        if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer
     val onBackground =
-        if (isToday) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+        if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
     val numberColor =
-        if (isToday) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
+        if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
+    val shape = RoundedCornerShape(FemtoDimens.DayCellCorner)
     Column(
         modifier =
             modifier
-                .clip(RoundedCornerShape(FemtoDimens.DayCellCorner))
-                .background(background)
+                .clip(shape)
+                // Today keeps a thin ring when it is not the selected cell, so it
+                // stays identifiable while the user previews another day.
+                .then(
+                    if (isToday && !isSelected) {
+                        Modifier.border(1.dp, MaterialTheme.colorScheme.primary, shape)
+                    } else {
+                        Modifier
+                    },
+                ).background(background)
+                .clickable(onClick = onClick)
+                // The day-of-month alone repeats across months; the ISO date is a
+                // stable, unique label for selection and testing.
+                .semantics { contentDescription = day.date.toString() }
+                // Sub-64dp tap target: a deliberate exception for the in-card
+                // mini-calendar grid (CLAUDE.md#automotive-overrides keeps 64dp the
+                // default; the strip relaxes it like the footer status cluster).
                 .padding(vertical = 8.dp, horizontal = 4.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(2.dp),
@@ -232,6 +283,14 @@ private fun Events(events: List<EventItem>) =
     }
 
 private val EventTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+// Store the card-local selection as an epoch day so rememberSaveable can persist
+// it across configuration change without a Parcelable wrapper.
+private val LocalDateSaver: Saver<LocalDate, Long> =
+    Saver(
+        save = { it.toEpochDay() },
+        restore = { LocalDate.ofEpochDay(it) },
+    )
 
 @Composable
 private fun EventRow(
@@ -305,17 +364,27 @@ private fun CalendarCardPreview() {
                     monthLabel = "March 2026",
                     dayStrip =
                         listOf(
-                            DayCell(LocalDate.of(2026, 3, 30), "Mon", true),
-                            DayCell(LocalDate.of(2026, 3, 31), "Tue", false),
-                            DayCell(LocalDate.of(2026, 4, 1), "Wed", true),
-                            DayCell(LocalDate.of(2026, 4, 2), "Thu", false),
-                            DayCell(LocalDate.of(2026, 4, 3), "Fri", true),
-                            DayCell(LocalDate.of(2026, 4, 4), "Sat", false),
-                        ),
-                    events =
-                        listOf(
-                            EventItem(LocalTime.of(10, 30), "Team standup"),
-                            EventItem(LocalTime.of(14, 0), "Pick up kids"),
+                            DayCell(
+                                LocalDate.of(2026, 3, 30),
+                                "Mon",
+                                listOf(
+                                    EventItem(LocalTime.of(10, 30), "Team standup"),
+                                    EventItem(LocalTime.of(14, 0), "Pick up kids"),
+                                ),
+                            ),
+                            DayCell(LocalDate.of(2026, 3, 31), "Tue", emptyList()),
+                            DayCell(
+                                LocalDate.of(2026, 4, 1),
+                                "Wed",
+                                listOf(EventItem(null, "Quarter close")),
+                            ),
+                            DayCell(LocalDate.of(2026, 4, 2), "Thu", emptyList()),
+                            DayCell(
+                                LocalDate.of(2026, 4, 3),
+                                "Fri",
+                                listOf(EventItem(LocalTime.of(9, 0), "Dentist")),
+                            ),
+                            DayCell(LocalDate.of(2026, 4, 4), "Sat", emptyList()),
                         ),
                     hasCalendarAccess = true,
                 ),

--- a/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
@@ -53,7 +53,7 @@ class CalendarRepositoryTest {
             // The snapshot must mark access denied in-band so the card can
             // render the denial message rather than a hollow strip.
             assertFalse(snapshot.hasCalendarAccess)
-            assertTrue(snapshot.events.isEmpty())
+            assertTrue(snapshot.dayStrip.all { it.events.isEmpty() })
             assertEquals(6, snapshot.dayStrip.size)
         }
 
@@ -79,7 +79,7 @@ class CalendarRepositoryTest {
             val snapshot = repository.snapshotFlow().first()
 
             assertNotNull(snapshot)
-            assertTrue(snapshot.events.isEmpty())
+            assertTrue(snapshot.dayStrip.all { it.events.isEmpty() })
             assertEquals(6, snapshot.dayStrip.size)
         }
 
@@ -123,9 +123,46 @@ class CalendarRepositoryTest {
                     .not(),
             )
 
-            // The all-day event carries no clock time.
-            assertEquals(1, snapshot.events.size)
-            assertNull(snapshot.events.single().time)
+            // The all-day event lands on its own day's cell and carries no clock
+            // time.
+            val eventDayEvents = snapshot.dayStrip.first { it.date == eventDay }.events
+            assertEquals(1, eventDayEvents.size)
+            assertNull(eventDayEvents.single().time)
+        }
+
+    @Test
+    fun `groups events onto their own day cells and caps each day`() =
+        runTest {
+            // Four events on today (over the per-day cap) plus one two days out.
+            // Each lands on its day's cell; today keeps only the earliest three
+            // and stays time-ordered; the day between carries nothing.
+            shadowOf(application).grantPermissions(Manifest.permission.READ_CALENDAR)
+            Robolectric
+                .buildContentProvider(MultiDayCalendarProvider::class.java)
+                .create(CalendarContract.AUTHORITY)
+
+            val repository =
+                CalendarRepository(
+                    application,
+                    clockFlow = flowOf(ClockTick(LocalTime.NOON, MultiDayCalendarProvider.TODAY)),
+                    zone = ZoneOffset.UTC,
+                )
+
+            val snapshot = repository.snapshotFlow().first()
+            assertNotNull(snapshot)
+
+            val today = snapshot.dayStrip.first { it.date == MultiDayCalendarProvider.TODAY }
+            assertEquals(listOf("A", "B", "C"), today.events.map { it.title })
+
+            val later = snapshot.dayStrip.first { it.date == MultiDayCalendarProvider.TODAY.plusDays(2) }
+            assertEquals(listOf("E"), later.events.map { it.title })
+
+            assertTrue(
+                snapshot.dayStrip
+                    .first { it.date == MultiDayCalendarProvider.TODAY.plusDays(1) }
+                    .events
+                    .isEmpty(),
+            )
         }
 
     @Test
@@ -235,6 +272,83 @@ class CalendarRepositoryTest {
             val TODAY: LocalDate = EVENT_DATE.minusDays(1)
             val EVENT_BEGIN_MS: Long =
                 EVENT_DATE.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+        }
+    }
+
+    /**
+     * Stand-in calendar provider returning four timed rows on [TODAY] and one on
+     * `TODAY + 2`, all titled, in `BEGIN ASC` order. Exercises per-day grouping
+     * and the per-day cap (today's fourth row must drop).
+     */
+    class MultiDayCalendarProvider : ContentProvider() {
+        override fun onCreate(): Boolean = true
+
+        override fun query(
+            uri: Uri,
+            projection: Array<out String>?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+            sortOrder: String?,
+        ): Cursor {
+            val columns: Array<out String> =
+                projection ?: arrayOf(CalendarContract.Instances.BEGIN)
+            val cursor = MatrixCursor(columns)
+            ROWS.forEach { (beginMs, title) ->
+                cursor.addRow(
+                    columns.map { column ->
+                        when (column) {
+                            CalendarContract.Instances.BEGIN -> beginMs
+                            CalendarContract.Instances.ALL_DAY -> 0
+                            CalendarContract.Instances.TITLE -> title
+                            else -> null
+                        }
+                    },
+                )
+            }
+            return cursor
+        }
+
+        override fun getType(uri: Uri): String? = null
+
+        override fun insert(
+            uri: Uri,
+            values: ContentValues?,
+        ): Uri? = null
+
+        override fun delete(
+            uri: Uri,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        override fun update(
+            uri: Uri,
+            values: ContentValues?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        companion object {
+            val TODAY: LocalDate = LocalDate.of(2099, 7, 1)
+
+            private fun at(
+                date: LocalDate,
+                hour: Int,
+            ): Long =
+                date
+                    .atTime(hour, 0)
+                    .atZone(ZoneOffset.UTC)
+                    .toInstant()
+                    .toEpochMilli()
+
+            val ROWS: List<Pair<Long, String>> =
+                listOf(
+                    at(TODAY, 9) to "A",
+                    at(TODAY, 10) to "B",
+                    at(TODAY, 11) to "C",
+                    at(TODAY, 12) to "D",
+                    at(TODAY.plusDays(2), 14) to "E",
+                )
         }
     }
 

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
@@ -12,17 +12,19 @@ internal fun fakeCalendarSnapshot(
     monthLabel: String = "May 2026",
     dayStrip: List<DayCell> =
         listOf(
-            DayCell(LocalDate.of(2026, 5, 1), "Fri", true),
-            DayCell(LocalDate.of(2026, 5, 2), "Sat", false),
-            DayCell(LocalDate.of(2026, 5, 3), "Sun", true),
-            DayCell(LocalDate.of(2026, 5, 4), "Mon", false),
-            DayCell(LocalDate.of(2026, 5, 5), "Tue", false),
-            DayCell(LocalDate.of(2026, 5, 6), "Wed", true),
-        ),
-    events: List<EventItem> =
-        listOf(
-            EventItem(LocalTime.of(10, 30), "Team standup"),
-            EventItem(LocalTime.of(14, 0), "Pick up kids"),
+            DayCell(
+                LocalDate.of(2026, 5, 1),
+                "Fri",
+                listOf(
+                    EventItem(LocalTime.of(10, 30), "Team standup"),
+                    EventItem(LocalTime.of(14, 0), "Pick up kids"),
+                ),
+            ),
+            DayCell(LocalDate.of(2026, 5, 2), "Sat", emptyList()),
+            DayCell(LocalDate.of(2026, 5, 3), "Sun", listOf(EventItem(LocalTime.of(9, 0), "Brunch"))),
+            DayCell(LocalDate.of(2026, 5, 4), "Mon", emptyList()),
+            DayCell(LocalDate.of(2026, 5, 5), "Tue", emptyList()),
+            DayCell(LocalDate.of(2026, 5, 6), "Wed", listOf(EventItem(null, "Holiday"))),
         ),
     hasCalendarAccess: Boolean = true,
 ): CalendarSnapshot =
@@ -31,6 +33,5 @@ internal fun fakeCalendarSnapshot(
         weekday = weekday,
         monthLabel = monthLabel,
         dayStrip = dayStrip,
-        events = events,
         hasCalendarAccess = hasCalendarAccess,
     )


### PR DESCRIPTION
## Summary

Makes the calendar card's day strip interactive (device-feedback item 5). Tapping a strip cell shows that day's events; the big-day header stays on **today**.

Part of the on-device feedback series; see `docs/superpowers/specs/2026-06-04-dashboard-device-feedback-design.md` (section "Calendar").

## Behaviour

- **Default selection is today**; tapping any strip cell selects it and the events area switches to that day's events.
- **Header stays on today** — the big day number / weekday / month never move with selection.
- **Selected cell is highlighted**; today keeps a thin ring while another day is previewed.
- A selection that falls outside the rolling 6-day window (midnight rollover, or a stale config-change-restored value) **clamps back to today**.

## Model & data

- `DayCell` now carries `events: List<EventItem>` and derives `hasEvent` from it, so the strip dot and the listed events can never disagree.
- `CalendarRepository.readWindow` groups the single window scan by local day, **drops the future-only filter** (a selected day shows its whole schedule), and **caps each day at 3 events** to bound the card height. Null-title rows are skipped (a row that cannot be shown must not dot its day).
- `CalendarSnapshot.events` and `CalendarWindow` are removed.

## Layout / clip-safety

The events section is **bottom-anchored** (a `weight(1f)` spacer) and the per-day cap bounds its height, so selecting a busy day cannot reintroduce the clipping the removed card-wide `verticalScroll` guarded against (feedback item 4). `CalendarCard` renders inside the scaffold's `fillMaxHeight` slot, so the content has a bounded height.

Selection state is **card-local** (`rememberSaveable` with an epoch-day `Saver`); the dashboard / ViewModel own no calendar selection state.

## Tests

- `CalendarRepositoryTest`: per-day grouping + per-day cap (4 events on one day collapse to the earliest 3; an event two days out lands on its own cell; the empty day between stays empty).
- `CalendarCardTest`: selecting a day shows that day's events and hides today's; the head stays on today; selecting an empty day shows the "no events" message.

## Verification

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.