### PR TITLE
feat(music): source app icon + tap-to-open, clearer connect CTA

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicCardTest.kt
@@ -10,6 +10,8 @@ import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Rule
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class MusicCardTest {
     @get:Rule
@@ -23,6 +25,7 @@ class MusicCardTest {
                     state = MusicCardState.Playing(fakeNowPlaying()),
                     onCommand = {},
                     onConnect = {},
+                    onLaunchSource = {},
                 )
             }
         }
@@ -39,11 +42,31 @@ class MusicCardTest {
                     state = MusicCardState.Playing(fakeNowPlaying(isPlaying = false)),
                     onCommand = {},
                     onConnect = {},
+                    onLaunchSource = {},
                 )
             }
         }
         rule.onNodeWithText("Strobe").assertIsDisplayed()
         rule.onNodeWithContentDescription("Play / pause").assertIsDisplayed()
+    }
+
+    @Test
+    fun tapping_source_icon_dispatches_launch_with_the_source_package() {
+        var launched: String? = null
+        rule.setContent {
+            FemtoTheme {
+                MusicCard(
+                    state = MusicCardState.Playing(fakeNowPlaying()),
+                    onCommand = {},
+                    onConnect = {},
+                    onLaunchSource = { launched = it },
+                )
+            }
+        }
+        // The fixture's package (com.spotify.music) resolves to the "Spotify"
+        // source label, so the open-app button is described "Open Spotify".
+        rule.onNodeWithContentDescription("Open Spotify").assertIsDisplayed().performClick()
+        assertEquals("com.spotify.music", launched)
     }
 
     @Test
@@ -55,11 +78,12 @@ class MusicCardTest {
                     state = MusicCardState.NeedsPermission,
                     onCommand = {},
                     onConnect = { tapped = true },
+                    onLaunchSource = {},
                 )
             }
         }
-        rule.onNodeWithText("Connect a player").assertIsDisplayed().performClick()
-        assert(tapped)
+        rule.onNodeWithText("Tap to connect a player").assertIsDisplayed().performClick()
+        assertTrue(tapped)
     }
 
     @Test
@@ -70,6 +94,7 @@ class MusicCardTest {
                     state = MusicCardState.NoActiveSession,
                     onCommand = {},
                     onConnect = {},
+                    onLaunchSource = {},
                 )
             }
         }

--- a/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.withContext
  * model. Adding new permissions for this feature is therefore not
  * required.
  */
-class AppsRepository(
+internal class AppsRepository(
     private val context: Context,
     launcher: ((ComponentName) -> Unit)? = null,
 ) {
@@ -64,6 +64,20 @@ class AppsRepository(
                     if (error is ActivityNotFoundException) false else throw error
                 },
             )
+
+    /**
+     * Resolve a package to its primary launcher activity, or null when the
+     * package exposes no launchable activity (e.g. a background-only media
+     * service). Used to open the app behind the current media session, reusing
+     * the same [LauncherApps] launch path as the home grid.
+     */
+    fun launcherComponentFor(packageName: String): ComponentName? =
+        runCatching {
+            launcherApps
+                .getActivityList(packageName, Process.myUserHandle())
+                .firstOrNull()
+                ?.componentName
+        }.getOrNull()
 }
 
 private const val ICON_PIXELS = 192

--- a/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
@@ -10,9 +10,11 @@ import android.media.session.PlaybackState
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
+import androidx.core.graphics.drawable.toBitmap
 import io.github.seijikohara.femto.ui.home.components.MusicCommand
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
@@ -20,12 +22,20 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 
 internal class MusicSessionRepository(
     private val context: Context,
 ) {
     private val sessionManager: MediaSessionManager = checkNotNull(context.getSystemService())
     private val componentName = ComponentName(context, MusicSessionListenerService::class.java)
+
+    // Source-app icons keyed by package. Resolved once per package: the icon is
+    // stable for the process lifetime, while the session flow re-emits on every
+    // playback tick. Touched only from the single sequential icon-resolution map
+    // (see stateFlow); coroutine dispatch provides the happens-before, so a plain
+    // map is safe even though the resolution runs on the Default pool.
+    private val sourceIconCache = mutableMapOf<String, ImageBitmap?>()
 
     fun stateFlow(): Flow<MusicCardState> =
         combine(permissionFlow(), activeControllersFlow()) { hasPermission, controllers ->
@@ -42,6 +52,12 @@ internal class MusicSessionRepository(
                 }
             }
         }.flowOn(Dispatchers.Main.immediate)
+            // Resolve the source-app icon off Main: the PackageManager icon decode
+            // is too heavy for the frame thread. The session logic stays on Main
+            // (where MediaController callbacks arrive); the icon resolves on
+            // Default, cached per package so it runs at most once per source.
+            .map { it.withSourceIcon() }
+            .flowOn(Dispatchers.Default)
 
     /**
      * Forward a transport command to the active media session. The
@@ -156,6 +172,9 @@ internal class MusicSessionRepository(
     private fun List<MediaController>.toNowPlaying(): NowPlaying? =
         selectPrimaryController(this)
             ?.let { controller ->
+                // A granted session can briefly expose no metadata (just connected,
+                // or a metadata-less stream). Degrade to NoActiveSession upstream
+                // rather than render a blank, broken-looking card.
                 val metadata = controller.metadata ?: return@let null
                 val playbackState = controller.playbackState
                 NowPlaying(
@@ -168,6 +187,7 @@ internal class MusicSessionRepository(
                             ?: sourceLabel(controller.packageName),
                     artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST),
                     albumArt = metadata.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)?.asImageBitmap(),
+                    // sourceIcon is resolved downstream off Main (see stateFlow).
                     // A paused controller renders with isPlaying=false (Play icon,
                     // resumable), but stays on screen via selectPrimaryController.
                     isPlaying = playbackState?.state == PlaybackState.STATE_PLAYING,
@@ -179,8 +199,37 @@ internal class MusicSessionRepository(
                 )
             }
 
+    // Attach the source-app icon to a Playing state, leaving the other variants
+    // untouched. Runs on Default (see stateFlow) so the icon decode is off Main.
+    private fun MusicCardState.withSourceIcon(): MusicCardState =
+        if (this is MusicCardState.Playing) {
+            MusicCardState.Playing(nowPlaying.copy(sourceIcon = sourceIconOf(nowPlaying.packageName)))
+        } else {
+            this
+        }
+
+    /**
+     * Resolve a source package's launcher icon, cached because it is stable for
+     * the process lifetime and the session flow re-emits on every playback tick.
+     * Returns null when the package has no resolvable icon (uninstalled /
+     * restricted), in which case the card shows a generic launch glyph.
+     */
+    private fun sourceIconOf(packageName: String): ImageBitmap? =
+        sourceIconCache.getOrPut(packageName) {
+            runCatching {
+                context.packageManager
+                    .getApplicationIcon(packageName)
+                    .toBitmap(width = SOURCE_ICON_PIXELS, height = SOURCE_ICON_PIXELS)
+                    .asImageBitmap()
+            }.getOrNull()
+        }
+
     private companion object {
         const val ENABLED_NOTIFICATION_LISTENERS = "enabled_notification_listeners"
+
+        // The card draws the source icon small (~28 dp); 96 px keeps it crisp on
+        // high-density head units without decoding a full-size adaptive icon.
+        const val SOURCE_ICON_PIXELS = 96
 
         /**
          * Return `true` when the state is PLAYING or PAUSED. A paused session is

--- a/app/src/main/java/io/github/seijikohara/femto/data/NowPlaying.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/NowPlaying.kt
@@ -18,6 +18,12 @@ internal data class NowPlaying(
      * this basis (scaled by [playbackSpeed]) to [positionMs] while playing.
      */
     val positionUpdateTimeMs: Long = 0L,
+    /**
+     * The source app's launcher icon, resolved from [packageName]; null when it
+     * cannot be resolved (uninstalled / restricted). The card shows it top-right
+     * as a tap-to-open affordance.
+     */
+    val sourceIcon: ImageBitmap? = null,
 )
 
 /**

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
@@ -15,6 +15,11 @@ internal sealed interface HomeAction {
 
     data object ConnectMusicPlayer : HomeAction
 
+    /** Open the app behind the current media session (the music card's source icon). */
+    data class LaunchMusicSource(
+        val packageName: String,
+    ) : HomeAction
+
     data class Shortcut(
         val target: AppsBarShortcut,
     ) : HomeAction

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package io.github.seijikohara.femto.ui.home
 
 import android.app.Application
+import android.content.ComponentName
 import android.content.Intent
 import android.location.Location
 import androidx.lifecycle.ViewModel
@@ -8,6 +9,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import io.github.seijikohara.femto.BuildConfig
+import io.github.seijikohara.femto.data.AppsRepository
 import io.github.seijikohara.femto.data.CalendarRepository
 import io.github.seijikohara.femto.data.CalendarSnapshot
 import io.github.seijikohara.femto.data.ClockRepository
@@ -48,6 +50,7 @@ internal class HomeViewModel(
     private val tripStateFlow: Flow<TripState>,
     private val sendMusicCommand: (MusicCommand) -> Unit = {},
     private val resetTrip: () -> Unit = {},
+    private val resolveMusicSourceComponent: (String) -> ComponentName? = { null },
 ) : ViewModel() {
     // Kotlin's typed combine overloads cover at most 5 flows. Stage the eight
     // sources through a typed intermediate (CoreSignals) so the compiler enforces
@@ -118,6 +121,14 @@ internal class HomeViewModel(
                 mutableEvents.tryEmit(HomeEvent.OpenNotificationListenerSettings)
             }
 
+            is HomeAction.LaunchMusicSource -> {
+                // Resolve to the source app's launcher activity and reuse the app
+                // grid's launch path. A package with no launchable activity (a
+                // background-only media service) resolves to null and no-ops.
+                resolveMusicSourceComponent(action.packageName)
+                    ?.let { mutableEvents.tryEmit(HomeEvent.LaunchComponent(it)) }
+            }
+
             is HomeAction.Music -> {
                 sendMusicCommand(action.command)
             }
@@ -185,6 +196,7 @@ internal class HomeViewModelFactory(
         val calendar = CalendarRepository(application, clockFlow)
         val systemStatus = SystemStatusRepository(application)
         val trip = TripRepository(locationFlow)
+        val apps = AppsRepository(application)
 
         @Suppress("UNCHECKED_CAST")
         return HomeViewModel(
@@ -198,6 +210,7 @@ internal class HomeViewModelFactory(
             tripStateFlow = trip.stateFlow(),
             sendMusicCommand = music::send,
             resetTrip = trip::reset,
+            resolveMusicSourceComponent = apps::launcherComponentFor,
         ) as T
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -208,6 +208,7 @@ private fun InfoPane(
         state = uiState.musicState,
         onCommand = { command -> onAction(HomeAction.Music(command)) },
         onConnect = { onAction(HomeAction.ConnectMusicPlayer) },
+        onLaunchSource = { packageName -> onAction(HomeAction.LaunchMusicSource(packageName)) },
         modifier = Modifier.weight(MUSIC_CARD_WEIGHT).fillMaxWidth(),
     )
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -41,6 +42,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import com.composables.icons.lucide.ExternalLink
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Music
 import com.composables.icons.lucide.Pause
@@ -87,6 +89,7 @@ internal fun MusicCard(
     state: MusicCardState,
     onCommand: (MusicCommand) -> Unit,
     onConnect: () -> Unit,
+    onLaunchSource: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
@@ -97,7 +100,7 @@ internal fun MusicCard(
     when (state) {
         MusicCardState.NeedsPermission -> ConnectState(onConnect = onConnect)
         MusicCardState.NoActiveSession -> EmptyState()
-        is MusicCardState.Playing -> PlayingState(state.nowPlaying, onCommand)
+        is MusicCardState.Playing -> PlayingState(state.nowPlaying, onCommand, onLaunchSource)
     }
 }
 
@@ -105,28 +108,76 @@ internal fun MusicCard(
 private fun PlayingState(
     nowPlaying: NowPlaying,
     onCommand: (MusicCommand) -> Unit,
-) = Column(
-    modifier =
-        Modifier
-            .fillMaxSize()
-            .padding(FemtoDimens.CardPadding),
-    horizontalAlignment = Alignment.CenterHorizontally,
-    verticalArrangement = Arrangement.SpaceBetween,
+    onLaunchSource: (String) -> Unit,
+) = Box(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(FemtoDimens.CardPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceBetween,
+    ) {
+        AlbumArt(nowPlaying = nowPlaying)
+        Meta(
+            source = sourceLabel(nowPlaying.packageName),
+            title = nowPlaying.title,
+            artist = nowPlaying.artist,
+        )
+        Progress(
+            positionMs = nowPlaying.positionMs,
+            durationMs = nowPlaying.durationMs,
+            positionUpdateTimeMs = nowPlaying.positionUpdateTimeMs,
+            isPlaying = nowPlaying.isPlaying,
+            playbackSpeed = nowPlaying.playbackSpeed,
+        )
+        TransportRow(isPlaying = nowPlaying.isPlaying, onCommand = onCommand)
+    }
+    SourceAppButton(
+        sourceIcon = nowPlaying.sourceIcon,
+        sourceLabel = sourceLabel(nowPlaying.packageName),
+        onClick = { onLaunchSource(nowPlaying.packageName) },
+        modifier = Modifier.align(Alignment.TopEnd),
+    )
+}
+
+@Composable
+private fun SourceAppButton(
+    sourceIcon: ImageBitmap?,
+    sourceLabel: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    AlbumArt(nowPlaying = nowPlaying)
-    Meta(
-        source = sourceLabel(nowPlaying.packageName),
-        title = nowPlaying.title,
-        artist = nowPlaying.artist,
-    )
-    Progress(
-        positionMs = nowPlaying.positionMs,
-        durationMs = nowPlaying.durationMs,
-        positionUpdateTimeMs = nowPlaying.positionUpdateTimeMs,
-        isPlaying = nowPlaying.isPlaying,
-        playbackSpeed = nowPlaying.playbackSpeed,
-    )
-    TransportRow(isPlaying = nowPlaying.isPlaying, onCommand = onCommand)
+    val description = stringResource(R.string.music_open_source, sourceLabel)
+    Box(
+        modifier =
+            modifier
+                .size(FemtoDimens.MinTouchTarget)
+                .clip(RoundedCornerShape(14.dp))
+                .clickable(onClick = onClick)
+                .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        if (sourceIcon != null) {
+            Image(
+                bitmap = sourceIcon,
+                contentDescription = null,
+                modifier =
+                    Modifier
+                        .size(28.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+            )
+        } else {
+            // Fallback when the source icon could not be resolved: a generic
+            // launch glyph keeps the open-app affordance tappable.
+            Icon(
+                imageVector = Lucide.ExternalLink,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+    }
 }
 
 @Composable
@@ -502,6 +553,7 @@ private fun MusicCardPlayingPreview() {
                 ),
             onCommand = {},
             onConnect = {},
+            onLaunchSource = {},
         )
     }
 }
@@ -515,6 +567,7 @@ private fun MusicCardEmptyPreview() {
             state = MusicCardState.NoActiveSession,
             onCommand = {},
             onConnect = {},
+            onLaunchSource = {},
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,13 +34,14 @@
     <string name="weather_cond_unknown"></string>
 
     <!-- Music card -->
-    <string name="music_connect_cta">Connect a player</string>
-    <string name="music_connect_hint">Allow notification access to control playback from the dashboard.</string>
+    <string name="music_connect_cta">Tap to connect a player</string>
+    <string name="music_connect_hint">Grant notification access and your music appears here, controllable from the dashboard.</string>
     <string name="music_nothing_playing">Nothing is playing</string>
     <string name="music_nothing_hint">Open a music app to start, or say \"Hey Google, play something\".</string>
     <string name="music_skip_previous">Skip previous</string>
     <string name="music_play_pause">Play / pause</string>
     <string name="music_skip_next">Skip next</string>
+    <string name="music_open_source">Open %1$s</string>
 
     <!-- Dashboard footer: navigation -->
     <string name="nav_phone">Phone</string>

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -189,6 +189,28 @@ class HomeViewModelTest {
         }
 
     @Test
+    fun `onAction LaunchMusicSource emits LaunchComponent for the resolved package`() =
+        runTest {
+            val component = ComponentName("com.spotify.music", "com.spotify.music.MainActivity")
+            stubViewModel(resolveMusicSourceComponent = { pkg -> component.takeIf { pkg == "com.spotify.music" } })
+                .assertEvent(
+                    action = HomeAction.LaunchMusicSource("com.spotify.music"),
+                    expected = HomeEvent.LaunchComponent(component),
+                )
+        }
+
+    @Test
+    fun `onAction LaunchMusicSource emits no event when the package has no launcher activity`() =
+        runTest {
+            val viewModel = stubViewModel(resolveMusicSourceComponent = { null })
+            viewModel.events.test {
+                viewModel.onAction(HomeAction.LaunchMusicSource("com.example.headless"))
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `onAction ResetTrip invokes resetTrip and emits no event`() =
         runTest {
             var resetCount = 0
@@ -233,6 +255,7 @@ class HomeViewModelTest {
     private fun stubViewModel(
         sendMusicCommand: (MusicCommand) -> Unit = {},
         resetTrip: () -> Unit = {},
+        resolveMusicSourceComponent: (String) -> ComponentName? = { null },
     ): HomeViewModel =
         HomeViewModel(
             clockFlow = emptyFlow(),
@@ -245,5 +268,6 @@ class HomeViewModelTest {
             tripStateFlow = emptyFlow(),
             sendMusicCommand = sendMusicCommand,
             resetTrip = resetTrip,
+            resolveMusicSourceComponent = resolveMusicSourceComponent,
         )
 }


### PR DESCRIPTION
## Summary

Final PR of the on-device feedback series — music card UX (items 17 and 18). See `docs/superpowers/specs/2026-06-04-dashboard-device-feedback-design.md` (section "Music").

## Item 18 — source app icon + tap to launch

- `NowPlaying.sourceIcon: ImageBitmap?` (mirrors `albumArt`), resolved from `packageName` in `MusicSessionRepository`, cached per package.
- The playing card gains a **top-right app-icon button** (64 dp = `FemtoDimens.MinTouchTarget` hit area, ~28 dp visible icon, `ExternalLink` fallback glyph when the icon can't be resolved).
- Tapping it dispatches `HomeAction.LaunchMusicSource(packageName)` → `HomeViewModel` resolves the package to its launcher `ComponentName` via `AppsRepository.launcherComponentFor` (LauncherApps) → reuses the existing `HomeEvent.LaunchComponent` → `AppsRepository.launch` path. **Package-agnostic** — no hard-coded apps; a background-only media service (no launcher activity) resolves to null and no-ops.

### Off-Main icon decode

The PackageManager icon decode is too heavy for the frame thread, so the session-state combine stays on `Main.immediate` (where `MediaController` callbacks arrive) while the icon resolves in a downstream `map` on `Dispatchers.Default`. The per-package cache means it runs at most once per source.

## Item 17 — music not showing while playing

Root cause was notification-listener access not granted (no runtime prompt exists for it — it's a Settings toggle the card opens on tap). Clarified the connect CTA copy ("Tap to connect a player" + a hint that granting access surfaces the music here). The `metadata == null` edge already degrades to the `NoActiveSession` "nothing playing" state; comment clarified.

## Also

- `AppsRepository` tightened to `internal` (module-internal; now wired into the music path).

## Tests

- `HomeViewModelTest`: `LaunchMusicSource` emits `LaunchComponent` for a resolved package; emits nothing when the package has no launcher activity.
- `MusicCardTest`: tapping the source icon dispatches launch with the source package; updated CTA copy; `assert()` → `assertTrue` (the former is a no-op without `-ea`); all `MusicCard` call sites pass `onLaunchSource`.

## Verification

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.