### PR TITLE
test(map): verify OpenStreetMap tiles render via MapSnapshotter

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MapSnapshotRenderTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MapSnapshotRenderTest.kt
@@ -1,0 +1,135 @@
+package io.github.seijikohara.femto.ui.home.components
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.maplibre.android.MapLibre
+import org.maplibre.android.camera.CameraPosition
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.Style
+import org.maplibre.android.snapshotter.MapSnapshot
+import org.maplibre.android.snapshotter.MapSnapshotter
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Confirms the dashboard map renders real OpenStreetMap tiles (not a blank
+ * surface) using MapLibre's off-screen [MapSnapshotter].
+ *
+ * Why a snapshotter rather than a screenshot of the live [MapPanel]: on the
+ * Android emulator's GLES translator (software SwiftShader and host-GPU alike)
+ * MapLibre fetches and rasterises tiles correctly but never *presents* the live
+ * TextureView frame to a steady on-screen surface, so `adb screencap` and
+ * `TextureView.getBitmap()` capture only the grey card background even while the
+ * map renders. [MapSnapshotter] renders into its own framebuffer and reads the
+ * pixels back, so it reflects the true render on the emulator and on real head
+ * units. This makes "does OSM render?" answerable on an emulator, where a live
+ * screenshot cannot.
+ *
+ * Run on a connected device/emulator: `./gradlew connectedAndroidTest`. A green
+ * run is the confirmation that OSM renders; the test skips itself when offline
+ * (the OpenFreeMap style and tiles need network). For a visual artefact it also
+ * writes the rendered PNG to the app's external files dir
+ * (`files/map_render_verification.png`); `connectedAndroidTest` uninstalls the
+ * app on cleanup, so pull it from an IDE run or a manual `am instrument` run that
+ * leaves the app installed.
+ */
+class MapSnapshotRenderTest {
+    @Test
+    fun renders_openstreetmap_tiles_offscreen() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        assumeTrue("Skipped: OpenFreeMap tiles require network", context.hasInternet())
+
+        val rendered = AtomicReference<Bitmap?>()
+        val failure = AtomicReference<String?>()
+        val snapshotter = AtomicReference<MapSnapshotter?>()
+        val done = CountDownLatch(1)
+
+        // MapSnapshotter posts its callbacks to the thread that starts it, so
+        // start it on the main looper and await the result on the test thread.
+        // The strong reference in [snapshotter] keeps it alive until the callback.
+        instrumentation.runOnMainSync {
+            MapLibre.getInstance(context)
+            val options =
+                MapSnapshotter
+                    .Options(SNAPSHOT_WIDTH, SNAPSHOT_HEIGHT)
+                    .withStyleBuilder(Style.Builder().fromUri(POSITRON_STYLE_URL))
+                    .withCameraPosition(
+                        CameraPosition
+                            .Builder()
+                            .target(LatLng(LONDON_LAT, LONDON_LON))
+                            .zoom(MAP_ZOOM)
+                            .build(),
+                    )
+            snapshotter.set(
+                MapSnapshotter(context, options).apply {
+                    start(
+                        { snapshot: MapSnapshot ->
+                            rendered.set(snapshot.bitmap)
+                            done.countDown()
+                        },
+                        { error: String ->
+                            failure.set(error)
+                            done.countDown()
+                        },
+                    )
+                },
+            )
+        }
+
+        assertTrue(done.await(SNAPSHOT_TIMEOUT_SECONDS, TimeUnit.SECONDS), "Snapshot timed out")
+        assertNull(failure.get(), "Snapshot failed: ${failure.get()}")
+        val bitmap = rendered.get() ?: error("Snapshot produced no bitmap")
+        writeForInspection(context, bitmap)
+
+        // A blank/uniform surface is ~1 colour; real OSM tiles (roads, water,
+        // labels) yield hundreds (~2000 observed). The threshold sits far above
+        // blank and far below that, so minor style changes never flake it.
+        val distinctColors = bitmap.distinctColorCount()
+        assertTrue(
+            distinctColors > MIN_DISTINCT_COLORS,
+            "Expected rendered OSM tiles but the map is effectively blank ($distinctColors distinct colours)",
+        )
+    }
+
+    private fun Context.hasInternet(): Boolean {
+        val manager = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val capabilities = manager.getNetworkCapabilities(manager.activeNetwork) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+
+    private fun Bitmap.distinctColorCount(): Int {
+        val pixels = IntArray(width * height)
+        getPixels(pixels, 0, width, 0, 0, width, height)
+        return pixels.toHashSet().size
+    }
+
+    // Best-effort visual artefact; never fail the render assertion over file I/O.
+    private fun writeForInspection(
+        context: Context,
+        bitmap: Bitmap,
+    ) = runCatching {
+        File(context.getExternalFilesDir(null), VERIFICATION_FILE_NAME)
+            .outputStream()
+            .use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+    }
+
+    private companion object {
+        const val SNAPSHOT_WIDTH = 700
+        const val SNAPSHOT_HEIGHT = 560
+        const val LONDON_LAT = 51.5074
+        const val LONDON_LON = -0.1278
+        const val SNAPSHOT_TIMEOUT_SECONDS = 45L
+        const val MIN_DISTINCT_COLORS = 50
+        const val VERIFICATION_FILE_NAME = "map_render_verification.png"
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -339,8 +339,11 @@ private fun Fallback(modifier: Modifier = Modifier) =
         )
     }
 
-private const val MAP_ZOOM = 15.0
-private const val POSITRON_STYLE_URL = "https://tiles.openfreemap.org/styles/positron"
+// internal (not private) so the instrumented map-render verification
+// (MapSnapshotRenderTest) renders the SAME style/zoom the panel uses, keeping the
+// OpenFreeMap style URL a single source rather than a literal duplicated in tests.
+internal const val MAP_ZOOM = 15.0
+internal const val POSITRON_STYLE_URL = "https://tiles.openfreemap.org/styles/positron"
 private const val DARK_STYLE_ASSET = "map/dark.json"
 
 // Automatic style-reload budget after a load failure. The delay is


### PR DESCRIPTION
## Why

Investigating the report that OSM tiles don't show on the emulator. **Conclusion: the map renders correctly on the emulator** — the grey pane is an emulator GLES-translator *presentation* limitation (MapLibre #4079 family), not a render/data failure and not an app bug. Real head units (real GPU drivers) are unaffected.

### Evidence gathered on TBox-Mock (Intel Mac, API 33, x86_64)
- `setStyle` succeeds: Positron, **56 layers / 3 sources** (`In emulator: true` — the `ro.kernel.qemu` nudge fires correctly).
- Offline cache fills: **`tiles=16`, `resources=4`** from `tiles.openfreemap.org/planet/.../{z}/{x}/{y}.pbf` — tiles are fetched.
- Off-screen **`MapSnapshotter` renders a real London map** (~2000 distinct colours).
- Grey reproduces under **both** `-gpu swiftshader_indirect` and `-gpu host`; `adb screencap`, host-side `adb emu screenrecord screenshot`, and `TextureView.getBitmap()` (distinctColors=1) all miss the live GL surface — only `MapSnapshotter` captures it.

## What this adds

`MapSnapshotRenderTest` (instrumented): renders the live `POSITRON_STYLE_URL` via `MapSnapshotter` (which reads back its own framebuffer, so it reflects the true render on the emulator) and asserts the bitmap is non-blank. It skips when offline and writes `files/map_render_verification.png` for a visual pull.

This makes **"does OSM render?" answerable on an emulator** — a grey screencap is not proof of a blank map.

`POSITRON_STYLE_URL` and `MAP_ZOOM` become `internal` so the test renders the exact app config (single source for the OpenFreeMap style URL) — no behavioural change to the app.

## How to confirm

```
./gradlew connectedAndroidTest    # green = OSM renders on the emulator
```

(Not run in CI — `connectedAndroidTest` is device-only; CI only compiles it via `compileDebugAndroidTestKotlin`.)

## Verification

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green. `MapSnapshotRenderTest` passes on the TBox-Mock emulator.