### PR TITLE
feat(footer): shrink the footer to the touch-target floor

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
@@ -308,7 +308,7 @@ private fun BatteryIndicator(
 }
 
 @PreviewLightDark
-@Preview(name = "Dashboard footer", widthDp = 1280, heightDp = 72)
+@Preview(name = "Dashboard footer", widthDp = 1280, heightDp = 64)
 @Composable
 private fun DashboardFooterPreview() {
     FemtoTheme {
@@ -329,7 +329,7 @@ private fun DashboardFooterPreview() {
 // Narrow portrait head unit: the status cluster drops and the nav buttons share
 // the width down toward FemtoDimens.MinTouchTarget rather than clipping.
 @PreviewLightDark
-@Preview(name = "Dashboard footer (narrow)", widthDp = 520, heightDp = 72)
+@Preview(name = "Dashboard footer (narrow)", widthDp = 520, heightDp = 64)
 @Composable
 private fun DashboardFooterNarrowPreview() {
     FemtoTheme {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -33,8 +33,12 @@ object FemtoDimens {
     /** Album art thumbnail size in the music panel's playing state. */
     val AlbumArtSize = 72.dp
 
-    /** Footer dock height (64.dp tap target + 8.dp top/bottom breathing room). */
-    val FooterHeight = 72.dp
+    /**
+     * Footer dock height. Set to exactly [MinTouchTarget] (64.dp): the dock
+     * holds full-height nav buttons, so it cannot go lower without breaching the
+     * tap-target floor (CLAUDE.md#automotive-overrides).
+     */
+    val FooterHeight = 64.dp
 
     /** Album art size inside the music card's vertical playing layout. */
     val MusicArtSize = 140.dp


### PR DESCRIPTION
## Summary

Reduce `FemtoDimens.FooterHeight` from 72 to 64 dp — exactly the
`MinTouchTarget` floor, the densest legal footer
(CLAUDE.md#automotive-overrides). The dock holds full-height nav
buttons that already render at 64 dp, so nothing clips. The two
`DashboardFooter` previews drop their `heightDp` from 72 to 64 to
match, and `FemtoDimens.FooterHeight` gains a comment documenting that
64 dp is the floor.

## How verified

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin`
— BUILD SUCCESSFUL. The existing `DashboardFooterTest` is green at 64
dp; the 64 dp previews show the battery/charge-caption cluster without
clipping.