### PR TITLE
feat(footer): show Wi-Fi and cellular signal strength

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ targets that matter for any head-unit UI, regardless of motion.
 | `BLUETOOTH_CONNECT` | Read the set of currently-connected Bluetooth devices (HEADSET / A2DP / GATT) so the footer status cluster reflects head-unit pairing state. Dangerous on Android 12+; runtime grant. The BT indicator dims when denied, the rest of the launcher remains functional. |
 | `INTERNET` | Open-Meteo weather API, OpenFreeMap vector map tile fetch (MapLibre), and Nominatim/OSM reverse geocoding. |
 | `READ_CALENDAR` | Query `CalendarContract.Instances` for the dashboard's Calendar card — the 6-day strip dots and the upcoming-event list. Dangerous; runtime grant. The card falls back to "today's date only" when denied. |
+| `READ_PHONE_STATE` | Read the cellular `SignalStrength.level` via `TelephonyCallback` so the footer status cluster shows graduated cellular signal bars. Dangerous; runtime grant. The cellular indicator degrades to the binary connected/disconnected icon when denied. |
 
 ### Dependencies <a id="dependencies"></a>
 

--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
@@ -4,14 +4,18 @@ import io.github.seijikohara.femto.data.SystemStatus
 
 internal fun fakeSystemStatus(
     cellularConnected: Boolean? = null,
+    cellularSignalLevel: Int? = null,
     wifiConnected: Boolean = true,
+    wifiSignalLevel: Int = 4,
     bluetoothConnected: Boolean = true,
     batteryPercent: Int? = 78,
     charging: Boolean = false,
 ): SystemStatus =
     SystemStatus(
         cellularConnected = cellularConnected,
+        cellularSignalLevel = cellularSignalLevel,
         wifiConnected = wifiConnected,
+        wifiSignalLevel = wifiSignalLevel,
         bluetoothConnected = bluetoothConnected,
         batteryPercent = batteryPercent,
         charging = charging,

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardFooterTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardFooterTest.kt
@@ -103,6 +103,49 @@ class DashboardFooterTest {
     }
 
     @Test
+    fun shows_graduated_cellular_icon_when_level_is_known() {
+        rule.setContent {
+            FemtoTheme {
+                DashboardFooter(
+                    systemStatus = fakeSystemStatus(cellularConnected = true, cellularSignalLevel = 3),
+                    onAction = {},
+                )
+            }
+        }
+        // The graduated path still labels the indicator "Mobile data connected"; the
+        // glyph differs by level but the semantics stay stable for the screen reader.
+        rule.onNodeWithContentDescription("Mobile data connected").assertIsDisplayed()
+    }
+
+    @Test
+    fun degrades_cellular_to_binary_icon_when_level_is_null() {
+        rule.setContent {
+            FemtoTheme {
+                DashboardFooter(
+                    // Connected but level unknown (READ_PHONE_STATE withheld): the
+                    // indicator still renders, falling back to the binary glyph.
+                    systemStatus = fakeSystemStatus(cellularConnected = true, cellularSignalLevel = null),
+                    onAction = {},
+                )
+            }
+        }
+        rule.onNodeWithContentDescription("Mobile data connected").assertIsDisplayed()
+    }
+
+    @Test
+    fun shows_graduated_wifi_icon_when_connected_with_a_level() {
+        rule.setContent {
+            FemtoTheme {
+                DashboardFooter(
+                    systemStatus = fakeSystemStatus(wifiConnected = true, wifiSignalLevel = 1),
+                    onAction = {},
+                )
+            }
+        }
+        rule.onNodeWithContentDescription("Wi-Fi connected").assertIsDisplayed()
+    }
+
+    @Test
     fun hides_cellular_icon_on_telephony_less_unit() {
         rule.setContent {
             FemtoTheme {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -74,6 +74,26 @@
     <uses-permission android:name="android.permission.READ_CALENDAR" />
 
     <!--
+        READ_PHONE_STATE: read the cellular SignalStrength.level via
+        TelephonyCallback so the footer status cluster shows graduated
+        cellular signal bars. Dangerous; runtime grant. Without it the
+        cellular indicator degrades to the binary connected/disconnected
+        icon. Justification mirrored in CLAUDE.md#permissions.
+    -->
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+
+    <!--
+        Declare telephony hardware as optional so Play does not implicitly
+        hard-require it (requesting READ_PHONE_STATE above otherwise implies
+        required=true). Wi-Fi-only AI boxes (Carlinkit / OTTOCAST) have no
+        telephony hardware; the cellular indicator degrades — cellularFlow()
+        and cellularLevelFlow() guard FEATURE_TELEPHONY and emit null — so
+        such units must still see and install the launcher (multi-region
+        distribution). See CLAUDE.md#launcher-behavior.
+    -->
+    <uses-feature android:name="android.hardware.telephony" android:required="false" />
+
+    <!--
         Package visibility: declare interest in every app that registers
         the LAUNCHER intent so LauncherApps.getActivityList() returns the
         full set on Android 11+. This is the privacy-respecting path

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -29,6 +29,7 @@ import io.github.seijikohara.femto.data.ThemeMode
 import io.github.seijikohara.femto.data.hasBluetoothConnectPermission
 import io.github.seijikohara.femto.data.hasFineLocationPermission
 import io.github.seijikohara.femto.data.hasReadCalendarPermission
+import io.github.seijikohara.femto.data.hasReadPhoneStatePermission
 import io.github.seijikohara.femto.ui.drawer.AppDrawerSheet
 import io.github.seijikohara.femto.ui.home.HomeEvent
 import io.github.seijikohara.femto.ui.home.HomeRoute
@@ -207,6 +208,7 @@ class MainActivity : ComponentActivity() {
             buildList {
                 if (!hasFineLocationPermission()) add(Manifest.permission.ACCESS_FINE_LOCATION)
                 if (!hasReadCalendarPermission()) add(Manifest.permission.READ_CALENDAR)
+                if (!hasReadPhoneStatePermission()) add(Manifest.permission.READ_PHONE_STATE)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !hasBluetoothConnectPermission()) {
                     add(Manifest.permission.BLUETOOTH_CONNECT)
                 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/LocationPermissions.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/LocationPermissions.kt
@@ -39,6 +39,17 @@ internal fun Context.hasReadCalendarPermission(): Boolean =
     ) == PackageManager.PERMISSION_GRANTED
 
 /**
+ * `READ_PHONE_STATE` gates the cellular `SignalStrength` read. It is a runtime
+ * grant on every supported API level; without it the footer's cellular
+ * indicator degrades to the binary connected/disconnected icon.
+ */
+internal fun Context.hasReadPhoneStatePermission(): Boolean =
+    ContextCompat.checkSelfPermission(
+        this,
+        Manifest.permission.READ_PHONE_STATE,
+    ) == PackageManager.PERMISSION_GRANTED
+
+/**
  * `BLUETOOTH_CONNECT` is a runtime grant only on Android 12+ (API 31).
  * Below that, the permission is install-time and always considered granted.
  */

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatus.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatus.kt
@@ -15,7 +15,14 @@ data class SystemStatus(
     // the footer hides the cellular indicator entirely rather than showing a
     // permanently-disconnected one; true/false once telephony is present.
     val cellularConnected: Boolean?,
+    // 0..4 graduated cellular signal level, or null when telephony is absent, the
+    // READ_PHONE_STATE grant is withheld, or no reading has arrived. When null but
+    // cellularConnected is non-null, the footer degrades to the binary icon.
+    val cellularSignalLevel: Int?,
     val wifiConnected: Boolean,
+    // 0..4 graduated Wi-Fi signal level. Defaults to 0 (no bars) until the first
+    // capability reading arrives; the footer uses this for the graduated icon.
+    val wifiSignalLevel: Int,
     val bluetoothConnected: Boolean,
     // Null until the first battery reading arrives, or on battery-less units —
     // distinguishes "unknown" from a genuine 0% so the footer never reads as a
@@ -27,7 +34,9 @@ data class SystemStatus(
         val Initial: SystemStatus =
             SystemStatus(
                 cellularConnected = null,
+                cellularSignalLevel = null,
                 wifiConnected = false,
+                wifiSignalLevel = 0,
                 bluetoothConnected = false,
                 batteryPercent = null,
                 charging = false,

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCoroutinesApi::class) // flatMapLatest in cellularLevelFlow().
+
 package io.github.seijikohara.femto.data
 
 import android.Manifest
@@ -14,16 +16,22 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.net.wifi.WifiManager
 import android.os.BatteryManager
 import android.os.Build
+import android.telephony.SignalStrength
+import android.telephony.TelephonyCallback
+import android.telephony.TelephonyManager
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -31,56 +39,75 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
 
 /**
- * Footer status cluster — Wi-Fi connectivity, Bluetooth connectivity,
- * battery percent and charging state.
+ * Footer status cluster — Wi-Fi connectivity / signal strength, cellular
+ * connectivity / signal strength, Bluetooth connectivity, battery percent
+ * and charging state.
  *
  * Each sub-signal lives in its own callback flow and they are combined
  * into a single [SystemStatus]. Bluetooth read requires `BLUETOOTH_CONNECT`
  * on Android 12+; when denied the flow emits `bluetoothConnected = false`
  * rather than throwing, so a missing permission degrades gracefully into
- * a dimmed icon.
+ * a dimmed icon. Cellular signal strength requires `READ_PHONE_STATE`; when
+ * denied the level flow emits null and the footer degrades to the binary
+ * connected/disconnected icon.
  */
 internal class SystemStatusRepository(
     private val context: Context,
 ) {
     private val connectivity: ConnectivityManager? = context.getSystemService()
     private val bluetoothManager: BluetoothManager? = context.getSystemService()
+    private val telephonyManager: TelephonyManager? = context.getSystemService()
 
     fun statusFlow(): Flow<SystemStatus> =
         combine(
-            // cellularFlow seeds its own initial value (false, or null on a
-            // telephony-less unit), so it needs no onStart — adding one would
-            // emit a spurious false->null transition before the seed.
-            cellularFlow(),
-            wifiFlow().onStart { emit(false) },
+            connectivitySignals(),
             bluetoothFlow().onStart { emit(false) },
             batteryFlow().onStart { emit(BatteryReading(percent = null, charging = false)) },
-        ) { cellular, wifi, bt, battery ->
+            cellularLevelFlow().onStart { emit(null) },
+        ) { connectivitySignals, bt, battery, cellularLevel ->
             SystemStatus(
-                cellularConnected = cellular,
-                wifiConnected = wifi,
+                cellularConnected = connectivitySignals.cellularConnected,
+                cellularSignalLevel = cellularLevel,
+                wifiConnected = connectivitySignals.wifi.connected,
+                wifiSignalLevel = connectivitySignals.wifi.level,
                 bluetoothConnected = bt,
                 batteryPercent = battery.percent,
                 charging = battery.charging,
             )
         }.distinctUntilChanged().flowOn(Dispatchers.Default)
 
-    private fun wifiFlow(): Flow<Boolean> {
-        val cm = connectivity ?: return flowOf(false)
+    // Kotlin's typed combine overloads cover at most 5 flows; the cluster has
+    // six sources once cellular signal strength joins. Stage the two reactive
+    // ConnectivityManager-backed readings through a typed intermediate so the
+    // compiler enforces arity and per-slot types — a future reorder fails to
+    // compile instead of silently mismapping a positional values[i] cast.
+    private fun connectivitySignals(): Flow<ConnectivitySignals> =
+        combine(
+            // cellularFlow seeds its own initial value (false, or null on a
+            // telephony-less unit), so it needs no onStart — adding one would
+            // emit a spurious false->null transition before the seed.
+            cellularFlow(),
+            wifiFlow().onStart { emit(WifiReading(connected = false, level = 0)) },
+        ) { cellularConnected, wifi ->
+            ConnectivitySignals(cellularConnected = cellularConnected, wifi = wifi)
+        }
+
+    private fun wifiFlow(): Flow<WifiReading> {
+        val cm = connectivity ?: return flowOf(WifiReading(connected = false, level = 0))
         return callbackFlow {
             val callback = object : ConnectivityManager.NetworkCallback() {
                 override fun onCapabilitiesChanged(
                     network: Network,
                     caps: NetworkCapabilities,
                 ) {
-                    trySend(
+                    val connected =
                         caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) &&
-                            caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED),
-                    )
+                            caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                    trySend(WifiReading(connected = connected, level = wifiLevelFrom(caps)))
                 }
 
                 override fun onLost(network: Network) {
-                    trySend(false)
+                    trySend(WifiReading(connected = false, level = 0))
                 }
             }
             val request = NetworkRequest
@@ -90,6 +117,20 @@ internal class SystemStatusRepository(
             cm.registerNetworkCallback(request, callback)
             awaitClose { cm.unregisterNetworkCallback(callback) }
         }
+    }
+
+    // NetworkCapabilities.getSignalStrength() (API 30) returns the Wi-Fi RSSI in
+    // dBm reactively via onCapabilitiesChanged, so no RSSI_CHANGED_ACTION poll is
+    // needed. WifiManager.calculateSignalLevel(rssi, numLevels) maps it onto
+    // 0..numLevels-1; SIGNAL_LEVEL_COUNT keeps that aligned with the shared
+    // 0..MAX_SIGNAL_LEVEL graduated icon range so no rescale is required.
+    @Suppress("DEPRECATION") // The numLevels overload is the only one that pins a fixed 0..4 range.
+    private fun wifiLevelFrom(caps: NetworkCapabilities): Int {
+        val rssi = caps.signalStrength
+        if (rssi == Int.MIN_VALUE) return 0
+        return WifiManager
+            .calculateSignalLevel(rssi, SIGNAL_LEVEL_COUNT)
+            .coerceIn(0, MAX_SIGNAL_LEVEL)
     }
 
     /**
@@ -130,6 +171,55 @@ internal class SystemStatusRepository(
             awaitClose { cm.unregisterNetworkCallback(callback) }
         }
     }
+
+    /**
+     * Graduated cellular signal strength (0..4), or null when the device has no
+     * telephony feature, the `READ_PHONE_STATE` grant is withheld, or no reading
+     * has arrived. Uses [TelephonyCallback.SignalStrengthsListener] unconditionally
+     * (minSdk 33), reading [SignalStrength.getLevel] reactively on a background
+     * executor.
+     *
+     * Re-registers on a late permission grant, mirroring [bluetoothFlow]'s use of
+     * [SystemPermissionSignals.refreshes]: that signal fires when a runtime
+     * permission result lands. A `READ_PHONE_STATE` grant from the in-app dialog
+     * leaves the activity PAUSED (not STOPPED), so the level would otherwise stay
+     * null until the next signal change. Unlike Bluetooth the level only arrives
+     * asynchronously via the callback, so each refresh restarts the underlying
+     * callbackFlow (which re-checks the permission and registers when now granted)
+     * rather than re-reading a synchronous value. The outer [statusFlow] keeps its
+     * `distinctUntilChanged`, so an unchanged value is suppressed.
+     */
+    private fun cellularLevelFlow(): Flow<Int?> {
+        val tm = telephonyManager
+        if (tm == null ||
+            !context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
+        ) {
+            return flowOf(null)
+        }
+        // onStart(Unit) seeds an initial registration; each later refresh restarts it.
+        return SystemPermissionSignals.refreshes
+            .onStart { emit(Unit) }
+            .flatMapLatest { telephonySignalFlow(tm) }
+    }
+
+    @SuppressLint("MissingPermission") // Permission is checked via hasReadPhoneStatePermission().
+    private fun telephonySignalFlow(tm: TelephonyManager): Flow<Int?> =
+        callbackFlow {
+            // Without READ_PHONE_STATE the listener cannot be registered, so emit
+            // null and stay idle until a later permission grant re-runs this flow.
+            if (!context.hasReadPhoneStatePermission()) {
+                trySend(null)
+                awaitClose { }
+                return@callbackFlow
+            }
+            val callback = object : TelephonyCallback(), TelephonyCallback.SignalStrengthsListener {
+                override fun onSignalStrengthsChanged(signalStrength: SignalStrength) {
+                    trySend(signalStrength.level.coerceIn(0, MAX_SIGNAL_LEVEL))
+                }
+            }
+            tm.registerTelephonyCallback(context.mainExecutor, callback)
+            awaitClose { tm.unregisterTelephonyCallback(callback) }
+        }
 
     /**
      * Connected-state stream merging two re-read triggers:
@@ -226,4 +316,29 @@ internal class SystemStatusRepository(
         val percent: Int?,
         val charging: Boolean,
     )
+
+    private data class WifiReading(
+        val connected: Boolean,
+        val level: Int,
+    )
+
+    // Typed intermediate for the first-stage combine of the two reactive
+    // ConnectivityManager readings, mirroring HomeViewModel.CoreSignals.
+    private data class ConnectivitySignals(
+        val cellularConnected: Boolean?,
+        val wifi: WifiReading,
+    )
+
+    private companion object {
+        // Top index of the shared 0..4 graduated signal range used by both the
+        // Wi-Fi level and the cellular SignalStrength.level (which already reports
+        // 0 (NONE) .. 4 (GREAT)). The DashboardFooter icon ramp keys off the same
+        // range.
+        const val MAX_SIGNAL_LEVEL = 4
+
+        // Number of buckets WifiManager.calculateSignalLevel(rssi, numLevels) maps
+        // the RSSI onto; numLevels - 1 is the top index, so this pins the Wi-Fi
+        // output to the same 0..MAX_SIGNAL_LEVEL range as cellular.
+        const val SIGNAL_LEVEL_COUNT = MAX_SIGNAL_LEVEL + 1
+    }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
@@ -43,7 +43,13 @@ import com.composables.icons.lucide.Navigation
 import com.composables.icons.lucide.Phone
 import com.composables.icons.lucide.Settings
 import com.composables.icons.lucide.Signal
+import com.composables.icons.lucide.SignalHigh
+import com.composables.icons.lucide.SignalLow
+import com.composables.icons.lucide.SignalMedium
 import com.composables.icons.lucide.Wifi
+import com.composables.icons.lucide.WifiHigh
+import com.composables.icons.lucide.WifiLow
+import com.composables.icons.lucide.WifiZero
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.SystemStatus
 import io.github.seijikohara.femto.ui.home.HomeAction
@@ -216,7 +222,9 @@ private fun StatusCluster(
     // shown permanently disconnected.
     status.cellularConnected?.let { connected ->
         StatusIcon(
-            icon = Lucide.Signal,
+            // A known level picks the graduated bars; a null level (READ_PHONE_STATE
+            // withheld / no reading yet) degrades to the binary connected icon.
+            icon = status.cellularSignalLevel?.let { cellularIconForLevel(it) } ?: Lucide.Signal,
             active = connected,
             description =
                 stringResource(
@@ -225,7 +233,9 @@ private fun StatusCluster(
         )
     }
     StatusIcon(
-        icon = Lucide.Wifi,
+        // The Wi-Fi level is always known once connected; degrade to the binary
+        // icon only when disconnected so a dimmed flat icon reads as "off".
+        icon = if (status.wifiConnected) wifiIconForLevel(status.wifiSignalLevel) else Lucide.Wifi,
         active = status.wifiConnected,
         description =
             stringResource(
@@ -246,6 +256,28 @@ private fun StatusCluster(
     )
     BatteryIndicator(percent = status.batteryPercent, charging = status.charging)
 }
+
+// Graduated Wi-Fi glyph for a 0..4 level. Lucide ships four distinct Wi-Fi
+// glyphs (zero / low / high / full arc); level 3 reuses the high arc and 4 the
+// full Wifi arc so the ramp stays monotonic with the available icons.
+private fun wifiIconForLevel(level: Int): ImageVector =
+    when (level) {
+        0 -> Lucide.WifiZero
+        1 -> Lucide.WifiLow
+        2, 3 -> Lucide.WifiHigh
+        else -> Lucide.Wifi
+    }
+
+// Graduated cellular glyph for a 0..4 level. Lucide ships ascending Signal bars
+// (low / medium / high) plus the full Signal glyph; level 0/1 map to the lowest
+// bars and 4 to the full glyph so the ramp tracks SignalStrength.level.
+private fun cellularIconForLevel(level: Int): ImageVector =
+    when (level) {
+        0, 1 -> Lucide.SignalLow
+        2 -> Lucide.SignalMedium
+        3 -> Lucide.SignalHigh
+        else -> Lucide.Signal
+    }
 
 @Composable
 private fun StatusIcon(
@@ -316,7 +348,9 @@ private fun DashboardFooterPreview() {
             systemStatus =
                 SystemStatus(
                     cellularConnected = true,
+                    cellularSignalLevel = 3,
                     wifiConnected = true,
+                    wifiSignalLevel = 4,
                     bluetoothConnected = true,
                     batteryPercent = 78,
                     charging = true,
@@ -337,7 +371,9 @@ private fun DashboardFooterNarrowPreview() {
             systemStatus =
                 SystemStatus(
                     cellularConnected = null,
+                    cellularSignalLevel = null,
                     wifiConnected = true,
+                    wifiSignalLevel = 2,
                     bluetoothConnected = false,
                     batteryPercent = null,
                     charging = false,

--- a/app/src/test/java/io/github/seijikohara/femto/data/SystemStatusRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/SystemStatusRepositoryTest.kt
@@ -23,6 +23,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowConnectivityManager
 import org.robolectric.shadows.ShadowNetwork
 import org.robolectric.shadows.ShadowNetworkCapabilities
+import org.robolectric.shadows.ShadowWifiManager
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -128,6 +129,51 @@ class SystemStatusRepositoryTest {
             }
         }
 
+    @Test
+    fun `wifiSignalLevel maps the capability RSSI onto a graduated level`() =
+        runTest {
+            // ShadowWifiManager.calculateSignalLevel(rssi, numLevels) returns
+            // floor(percent * (numLevels - 1)); 0.75 over the 5-bucket range pins
+            // the top index to 3. The capability must carry a real (non-unspecified)
+            // RSSI for wifiLevelFrom to consult the level at all.
+            ShadowWifiManager.setSignalLevelInPercent(0.75f)
+            val connectivity = application.getSystemService<ConnectivityManager>()!!
+            val shadowConnectivity = shadowOf(connectivity)
+
+            SystemStatusRepository(application).statusFlow().test {
+                assertEquals(0, awaitItem().wifiSignalLevel)
+
+                val callback = awaitRegisteredNetworkCallback(shadowConnectivity)
+                callback.onCapabilitiesChanged(WIFI_NETWORK, validatedWifiCapabilities(rssiDbm = -55))
+
+                assertEquals(3, awaitItem().wifiSignalLevel)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `cellularSignalLevel is null on a telephony-less unit`() =
+        runTest {
+            // setUp forces FEATURE_TELEPHONY off, so cellularLevelFlow never
+            // registers a TelephonyCallback and stays null.
+            val status = SystemStatusRepository(application).statusFlow().first()
+
+            assertNull(status.cellularSignalLevel)
+        }
+
+    @Test
+    fun `cellularSignalLevel is null when READ_PHONE_STATE is not granted`() =
+        runTest {
+            // Telephony is present, but Robolectric grants no runtime permissions on
+            // sdk 33, so telephonySignalFlow cannot register the callback and emits
+            // null — the footer degrades to the binary cellular icon.
+            shadowOf(application.packageManager).setSystemFeature(PackageManager.FEATURE_TELEPHONY, true)
+
+            val status = SystemStatusRepository(application).statusFlow().first()
+
+            assertNull(status.cellularSignalLevel)
+        }
+
     /**
      * Collect the first [SystemStatus] satisfying [predicate]. statusFlow runs its
      * callback flows on Dispatchers.Default, so the meaningful reading arrives on an
@@ -169,10 +215,18 @@ class SystemStatusRepositoryTest {
             putExtra(BatteryManager.EXTRA_PLUGGED, plugged)
         }
 
-    private fun validatedWifiCapabilities(): NetworkCapabilities =
+    private fun validatedWifiCapabilities(rssiDbm: Int? = null): NetworkCapabilities =
         ShadowNetworkCapabilities.newInstance().apply {
             shadowOf(this).addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
             shadowOf(this).addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            // NetworkCapabilities.setSignalStrength(int) is hidden in the public SDK
+            // but present at runtime under Robolectric; reflection is the only way to
+            // seed a non-unspecified RSSI so wifiLevelFrom reads it.
+            rssiDbm?.let { rssi ->
+                NetworkCapabilities::class.java
+                    .getMethod("setSignalStrength", Int::class.javaPrimitiveType)
+                    .invoke(this, rssi)
+            }
         }
 
     private companion object {

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
@@ -4,14 +4,18 @@ import io.github.seijikohara.femto.data.SystemStatus
 
 internal fun fakeSystemStatus(
     cellularConnected: Boolean? = null,
+    cellularSignalLevel: Int? = null,
     wifiConnected: Boolean = true,
+    wifiSignalLevel: Int = 4,
     bluetoothConnected: Boolean = true,
     batteryPercent: Int? = 78,
     charging: Boolean = false,
 ): SystemStatus =
     SystemStatus(
         cellularConnected = cellularConnected,
+        cellularSignalLevel = cellularSignalLevel,
         wifiConnected = wifiConnected,
+        wifiSignalLevel = wifiSignalLevel,
         bluetoothConnected = bluetoothConnected,
         batteryPercent = batteryPercent,
         charging = charging,


### PR DESCRIPTION
## Summary

Add graduated Wi-Fi and cellular signal-strength bars to the footer status cluster.

- `SystemStatus` gains `wifiSignalLevel: Int` (0..4) and `cellularSignalLevel: Int?` (0..4, null when telephony is absent / `READ_PHONE_STATE` is withheld / no reading yet). The existing `wifiConnected` / `cellularConnected` booleans stay for the binary-degrade path.
- `SystemStatusRepository`: the status `combine` moves to a two-stage typed shape (a `ConnectivitySignals` intermediate, mirroring `HomeViewModel.CoreSignals`) because the cluster now exceeds Kotlin's 5-arg typed `combine`. A future reorder fails to compile instead of silently mismapping a positional `values[i]` cast.
  - Wi-Fi level rides `NetworkCapabilities.getSignalStrength()` (API 30) mapped through `WifiManager.calculateSignalLevel(rssi, numLevels)` — reactive via `onCapabilitiesChanged`, no RSSI poll.
  - Cellular level uses `TelephonyCallback.SignalStrengthsListener` (unconditional at minSdk 33). It re-registers on a late permission grant via `SystemPermissionSignals.refreshes` and guards `FEATURE_TELEPHONY`.
- `DashboardFooter`: the cellular / Wi-Fi `StatusIcon` picks a graduated Lucide glyph from the level; a null cellular level (permission withheld / no reading) degrades to the binary `Signal` icon, and Wi-Fi degrades to the flat `Wifi` icon when disconnected.

## Permission

Adds `READ_PHONE_STATE`: required to read `TelephonyManager` `SignalStrength.level` for the graduated cellular bars. Dangerous, runtime-granted; the cellular icon degrades to a binary connected/disconnected indicator when denied. `<uses-feature android:name="android.hardware.telephony" android:required="false"/>` keeps Wi-Fi-only AI boxes installable. Audit log updated in `CLAUDE.md#permissions`, runtime request wired in `MainActivity`, and `hasReadPhoneStatePermission()` added to the permission-check SSOT.

## Tests

- `SystemStatusRepositoryTest`: cellular level mapping, null when telephony absent / permission withheld, Wi-Fi RSSI -> 0..4.
- `DashboardFooterTest`: level-specific icons and null-level binary degrade.
- `FakeSystemStatus` updated identically in both `app/src/test` and `app/src/androidTest`.

## Verification

`./gradlew spotlessApply` then `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — BUILD SUCCESSFUL.