### PR TITLE
feat(footer): show GPS reception in the status cluster

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
@@ -10,6 +10,7 @@ internal fun fakeSystemStatus(
     bluetoothConnected: Boolean = true,
     batteryPercent: Int? = 78,
     charging: Boolean = false,
+    gpsFixed: Boolean = false,
 ): SystemStatus =
     SystemStatus(
         cellularConnected = cellularConnected,
@@ -19,4 +20,5 @@ internal fun fakeSystemStatus(
         bluetoothConnected = bluetoothConnected,
         batteryPercent = batteryPercent,
         charging = charging,
+        gpsFixed = gpsFixed,
     )

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardFooterTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardFooterTest.kt
@@ -160,6 +160,32 @@ class DashboardFooterTest {
     }
 
     @Test
+    fun shows_gps_fixed_description_when_gps_is_fixed() {
+        rule.setContent {
+            FemtoTheme {
+                DashboardFooter(
+                    systemStatus = fakeSystemStatus(gpsFixed = true),
+                    onAction = {},
+                )
+            }
+        }
+        rule.onNodeWithContentDescription("GPS fixed").assertIsDisplayed()
+    }
+
+    @Test
+    fun shows_gps_searching_description_when_gps_is_not_fixed() {
+        rule.setContent {
+            FemtoTheme {
+                DashboardFooter(
+                    systemStatus = fakeSystemStatus(gpsFixed = false),
+                    onAction = {},
+                )
+            }
+        }
+        rule.onNodeWithContentDescription("GPS searching").assertIsDisplayed()
+    }
+
+    @Test
     fun renders_battery_percent_text() {
         rule.setContent {
             FemtoTheme {

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatus.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatus.kt
@@ -29,6 +29,10 @@ data class SystemStatus(
     // dead battery during cold start.
     val batteryPercent: Int?,
     val charging: Boolean,
+    // True while a recent GPS_PROVIDER fix is fresh; flips back to false once the
+    // last fix ages past the freshness window so the footer reads "searching"
+    // when GPS reception drops (e.g. a tunnel or a parked cold start).
+    val gpsFixed: Boolean,
 ) {
     companion object {
         val Initial: SystemStatus =
@@ -40,6 +44,7 @@ data class SystemStatus(
                 bluetoothConnected = false,
                 batteryPercent = null,
                 charging = false,
+                gpsFixed = false,
             )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalCoroutinesApi::class) // flatMapLatest in cellularLevelFlow().
+@file:OptIn(ExperimentalCoroutinesApi::class) // flatMapLatest / transformLatest below.
 
 package io.github.seijikohara.femto.data
 
@@ -12,6 +12,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationManager
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
@@ -24,19 +26,25 @@ import android.telephony.TelephonyCallback
 import android.telephony.TelephonyManager
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transformLatest
 
 /**
  * Footer status cluster — Wi-Fi connectivity / signal strength, cellular
@@ -50,9 +58,20 @@ import kotlinx.coroutines.flow.onStart
  * a dimmed icon. Cellular signal strength requires `READ_PHONE_STATE`; when
  * denied the level flow emits null and the footer degrades to the binary
  * connected/disconnected icon.
+ *
+ * GPS reception is derived from the shared [locationFlow]: a fresh GPS_PROVIDER
+ * fix sets `gpsFixed` true, and it flips back to false once the last fix ages
+ * past [GPS_FIX_FRESHNESS_MS]. The default [emptyFlow] keeps callers that do
+ * not wire location (e.g. unit tests for the connectivity signals) compiling
+ * with `gpsFixed` permanently false.
  */
 internal class SystemStatusRepository(
     private val context: Context,
+    private val locationFlow: Flow<Location?> = emptyFlow(),
+    // The combined flow (including gpsFlow's freshness delay) runs here. Production
+    // uses the default compute pool; tests inject a TestDispatcher so the GPS
+    // freshness window is observable under runTest's virtual clock.
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
     private val connectivity: ConnectivityManager? = context.getSystemService()
     private val bluetoothManager: BluetoothManager? = context.getSystemService()
@@ -64,7 +83,8 @@ internal class SystemStatusRepository(
             bluetoothFlow().onStart { emit(false) },
             batteryFlow().onStart { emit(BatteryReading(percent = null, charging = false)) },
             cellularLevelFlow().onStart { emit(null) },
-        ) { connectivitySignals, bt, battery, cellularLevel ->
+            gpsFlow(),
+        ) { connectivitySignals, bt, battery, cellularLevel, gpsFixed ->
             SystemStatus(
                 cellularConnected = connectivitySignals.cellularConnected,
                 cellularSignalLevel = cellularLevel,
@@ -73,8 +93,9 @@ internal class SystemStatusRepository(
                 bluetoothConnected = bt,
                 batteryPercent = battery.percent,
                 charging = battery.charging,
+                gpsFixed = gpsFixed,
             )
-        }.distinctUntilChanged().flowOn(Dispatchers.Default)
+        }.distinctUntilChanged().flowOn(dispatcher)
 
     // Kotlin's typed combine overloads cover at most 5 flows; the cluster has
     // six sources once cellular signal strength joins. Stage the two reactive
@@ -222,6 +243,28 @@ internal class SystemStatusRepository(
         }
 
     /**
+     * GPS reception state. Emits true on each fresh GPS_PROVIDER fix, then false
+     * once that fix ages past [GPS_FIX_FRESHNESS_MS] with no follow-up — so the
+     * footer reads "searching" when reception drops (tunnel, parked cold start).
+     *
+     * The provider predicate mirrors [TripRepository]'s GPS-only gate; NETWORK
+     * fixes (cell-tower / Wi-Fi) centre the map but do not represent a GPS lock,
+     * so they never set this true. [transformLatest] cancels the pending false
+     * timer whenever a newer fix lands, keeping the indicator lit while fixes
+     * keep coming. [onStart] seeds false so combine has an initial value before
+     * the first fix (and the [emptyFlow] default leaves it false forever).
+     */
+    private fun gpsFlow(): Flow<Boolean> =
+        locationFlow
+            .filterNotNull()
+            .filter { it.provider == LocationManager.GPS_PROVIDER }
+            .transformLatest {
+                emit(true)
+                delay(GPS_FIX_FRESHNESS_MS)
+                emit(false)
+            }.onStart { emit(false) }
+
+    /**
      * Connected-state stream merging two re-read triggers:
      * - [bluetoothBroadcastFlow] fires on BT adapter / connection broadcasts.
      * - [SystemPermissionSignals.refreshes] fires when a runtime permission
@@ -329,16 +372,24 @@ internal class SystemStatusRepository(
         val wifi: WifiReading,
     )
 
-    private companion object {
+    internal companion object {
         // Top index of the shared 0..4 graduated signal range used by both the
         // Wi-Fi level and the cellular SignalStrength.level (which already reports
         // 0 (NONE) .. 4 (GREAT)). The DashboardFooter icon ramp keys off the same
         // range.
-        const val MAX_SIGNAL_LEVEL = 4
+        private const val MAX_SIGNAL_LEVEL = 4
 
         // Number of buckets WifiManager.calculateSignalLevel(rssi, numLevels) maps
         // the RSSI onto; numLevels - 1 is the top index, so this pins the Wi-Fi
         // output to the same 0..MAX_SIGNAL_LEVEL range as cellular.
-        const val SIGNAL_LEVEL_COUNT = MAX_SIGNAL_LEVEL + 1
+        private const val SIGNAL_LEVEL_COUNT = MAX_SIGNAL_LEVEL + 1
+
+        // How long a GPS fix counts as "fresh" before gpsFlow flips back to
+        // searching. A live LocationRepository fix arrives roughly every second,
+        // so 30 s tolerates short reception gaps without flickering the indicator
+        // while still reporting a genuine loss of lock promptly. Exposed as
+        // internal so the test source set asserts against this single value
+        // instead of mirroring the window.
+        internal const val GPS_FIX_FRESHNESS_MS = 30_000L
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -194,7 +194,7 @@ internal class HomeViewModelFactory(
         val weather = WeatherRepository(weatherApi, locationFlow, clockFlow)
         val music = MusicSessionRepository(application)
         val calendar = CalendarRepository(application, clockFlow)
-        val systemStatus = SystemStatusRepository(application)
+        val systemStatus = SystemStatusRepository(application, locationFlow)
         val trip = TripRepository(locationFlow)
         val apps = AppsRepository(application)
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardFooter.kt
@@ -41,6 +41,7 @@ import com.composables.icons.lucide.Mic
 import com.composables.icons.lucide.Music
 import com.composables.icons.lucide.Navigation
 import com.composables.icons.lucide.Phone
+import com.composables.icons.lucide.Satellite
 import com.composables.icons.lucide.Settings
 import com.composables.icons.lucide.Signal
 import com.composables.icons.lucide.SignalHigh
@@ -77,8 +78,8 @@ private val CompactFooterWidth: Dp = 700.dp
  *    Browser / Assistant / Settings). This app IS the launcher, so no Home button.
  *  - A 1 dp vertical divider separates the actionable nav from a read-only
  *    status cluster: cellular (hidden on telephony-less units), Wi-Fi,
- *    Bluetooth, and a battery indicator (icon over percent, with a "Charging"
- *    caption while plugged in).
+ *    Bluetooth, GPS reception, and a battery indicator (icon over percent, with
+ *    a "Charging" caption while plugged in).
  *
  * Iconography is Lucide stroke-1.75 for parity with the design SSOT.
  */
@@ -254,6 +255,14 @@ private fun StatusCluster(
                 },
             ),
     )
+    StatusIcon(
+        icon = Lucide.Satellite,
+        active = status.gpsFixed,
+        description =
+            stringResource(
+                if (status.gpsFixed) R.string.status_gps_fixed else R.string.status_gps_searching,
+            ),
+    )
     BatteryIndicator(percent = status.batteryPercent, charging = status.charging)
 }
 
@@ -354,6 +363,7 @@ private fun DashboardFooterPreview() {
                     bluetoothConnected = true,
                     batteryPercent = 78,
                     charging = true,
+                    gpsFixed = true,
                 ),
             onAction = {},
         )
@@ -377,6 +387,7 @@ private fun DashboardFooterNarrowPreview() {
                     bluetoothConnected = false,
                     batteryPercent = null,
                     charging = false,
+                    gpsFixed = false,
                 ),
             onAction = {},
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,8 @@
     <string name="status_wifi_disconnected">Wi-Fi disconnected</string>
     <string name="status_bluetooth_connected">Bluetooth connected</string>
     <string name="status_bluetooth_disconnected">Bluetooth disconnected</string>
+    <string name="status_gps_fixed">GPS fixed</string>
+    <string name="status_gps_searching">GPS searching</string>
     <string name="status_battery">Battery</string>
     <string name="status_charging">Charging</string>
     <string name="battery_percent">%1$d%%</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/SystemStatusRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/SystemStatusRepositoryTest.kt
@@ -1,8 +1,12 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package io.github.seijikohara.femto.data
 
 import android.app.Application
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationManager
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
@@ -10,8 +14,14 @@ import android.os.BatteryManager
 import androidx.core.content.getSystemService
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
+import io.github.seijikohara.femto.testfixtures.fakeLocation
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.Before
@@ -173,6 +183,68 @@ class SystemStatusRepositoryTest {
 
             assertNull(status.cellularSignalLevel)
         }
+
+    @Test
+    fun `gpsFixed becomes true on a GPS provider fix`() =
+        runTest {
+            val locations = MutableSharedFlow<Location?>(extraBufferCapacity = 1)
+
+            gpsRepository(locations).statusFlow().test {
+                // gpsFlow seeds false via onStart before any fix arrives.
+                assertFalse(awaitItem().gpsFixed)
+
+                locations.emit(fakeLocation(provider = LocationManager.GPS_PROVIDER))
+
+                assertTrue(awaitItem().gpsFixed)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `gpsFixed flips back to false after the freshness window`() =
+        runTest {
+            val locations = MutableSharedFlow<Location?>(extraBufferCapacity = 1)
+
+            gpsRepository(locations).statusFlow().test {
+                assertFalse(awaitItem().gpsFixed)
+
+                locations.emit(fakeLocation(provider = LocationManager.GPS_PROVIDER))
+                assertTrue(awaitItem().gpsFixed)
+
+                // No follow-up fix: once the 30 s freshness window elapses the
+                // indicator returns to searching.
+                advanceTimeBy(SystemStatusRepository.GPS_FIX_FRESHNESS_MS + 1L)
+                assertFalse(awaitItem().gpsFixed)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `gpsFixed stays false for a NETWORK provider fix`() =
+        runTest {
+            val locations = MutableSharedFlow<Location?>(extraBufferCapacity = 1)
+
+            gpsRepository(locations).statusFlow().test {
+                assertFalse(awaitItem().gpsFixed)
+
+                // A cell-tower / Wi-Fi fix centres the map but is not a GPS lock, so
+                // gpsFlow's provider gate drops it and the indicator stays searching.
+                locations.emit(fakeLocation(provider = LocationManager.NETWORK_PROVIDER))
+                advanceTimeBy(SystemStatusRepository.GPS_FIX_FRESHNESS_MS + 1L)
+
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // statusFlow runs its combine on the injected dispatcher; an UnconfinedTestDispatcher
+    // backed by runTest's scheduler lets advanceTimeBy drive gpsFlow's freshness delay.
+    private fun TestScope.gpsRepository(locationFlow: MutableSharedFlow<Location?>): SystemStatusRepository =
+        SystemStatusRepository(
+            context = application,
+            locationFlow = locationFlow,
+            dispatcher = UnconfinedTestDispatcher(testScheduler),
+        )
 
     /**
      * Collect the first [SystemStatus] satisfying [predicate]. statusFlow runs its

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeSystemStatus.kt
@@ -10,6 +10,7 @@ internal fun fakeSystemStatus(
     bluetoothConnected: Boolean = true,
     batteryPercent: Int? = 78,
     charging: Boolean = false,
+    gpsFixed: Boolean = false,
 ): SystemStatus =
     SystemStatus(
         cellularConnected = cellularConnected,
@@ -19,4 +20,5 @@ internal fun fakeSystemStatus(
         bluetoothConnected = bluetoothConnected,
         batteryPercent = batteryPercent,
         charging = charging,
+        gpsFixed = gpsFixed,
     )


### PR DESCRIPTION
## Summary

Adds a GPS-reception indicator to the footer status cluster (plan item 6).

- `SystemStatus` gains `gpsFixed`, derived from a recent `GPS_PROVIDER` fix.
- `SystemStatusRepository` takes an injected `locationFlow` (default `emptyFlow()` keeps existing callers compiling) and a `gpsFlow()` that flips `gpsFixed` true on each fresh GPS fix, then back to false once the last fix ages past `GPS_FIX_FRESHNESS_MS` (30 s). `HomeViewModelFactory` wires the shared `LocationRepository.locationFlow()`.
- `gpsFlow()` joins the existing two-stage combine (from PR C) as the final source; NETWORK-provider fixes never set it true (mirrors `TripRepository`'s GPS-only gate).
- `DashboardFooter` renders a Lucide `Satellite` `StatusIcon` (active = `gpsFixed`); `status_gps_fixed` / `status_gps_searching` strings added.
- No new permission: rides the existing `ACCESS_FINE_LOCATION`.

## Tests

- `SystemStatusRepositoryTest`: `gpsFixed` becomes true on a GPS fix, flips back to false after the freshness window (`advanceTimeBy`), and stays false for a NETWORK fix. Uses an injected `UnconfinedTestDispatcher` so the freshness delay runs under the virtual clock.
- `DashboardFooterTest`: Satellite icon reports "GPS fixed" / "GPS searching" content descriptions.
- `FakeSystemStatus` updated identically in both `test` and `androidTest` source sets.

## Verification

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — BUILD SUCCESSFUL.