### PR TITLE
feat(assistant): open a bottom sheet of voice-assistant options

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/assistant/AssistantSheetContentTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/assistant/AssistantSheetContentTest.kt
@@ -1,0 +1,70 @@
+package io.github.seijikohara.femto.ui.assistant
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class AssistantSheetContentTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val assistantLabel = context.getString(R.string.assistant_option_assistant)
+    private val voiceCommandLabel = context.getString(R.string.assistant_option_voice_command)
+    private val voiceSearchLabel = context.getString(R.string.assistant_option_voice_search)
+
+    @Test
+    fun renders_all_three_options() {
+        rule.setContent {
+            FemtoTheme {
+                AssistantSheetContent(onLaunchOption = {})
+            }
+        }
+        rule.onNodeWithText(assistantLabel).assertIsDisplayed()
+        rule.onNodeWithText(voiceCommandLabel).assertIsDisplayed()
+        rule.onNodeWithText(voiceSearchLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun tapping_assistant_dispatches_assistant_option() {
+        var launched: AssistantOption? = null
+        rule.setContent {
+            FemtoTheme {
+                AssistantSheetContent(onLaunchOption = { launched = it })
+            }
+        }
+        rule.onNodeWithText(assistantLabel).performClick()
+        assertEquals(AssistantOption.ASSISTANT, launched)
+    }
+
+    @Test
+    fun tapping_voice_command_dispatches_voice_command_option() {
+        var launched: AssistantOption? = null
+        rule.setContent {
+            FemtoTheme {
+                AssistantSheetContent(onLaunchOption = { launched = it })
+            }
+        }
+        rule.onNodeWithText(voiceCommandLabel).performClick()
+        assertEquals(AssistantOption.VOICE_COMMAND, launched)
+    }
+
+    @Test
+    fun tapping_voice_search_dispatches_voice_search_option() {
+        var launched: AssistantOption? = null
+        rule.setContent {
+            FemtoTheme {
+                AssistantSheetContent(onLaunchOption = { launched = it })
+            }
+        }
+        rule.onNodeWithText(voiceSearchLabel).performClick()
+        assertEquals(AssistantOption.VOICE_SEARCH, launched)
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -30,6 +30,8 @@ import io.github.seijikohara.femto.data.hasBluetoothConnectPermission
 import io.github.seijikohara.femto.data.hasFineLocationPermission
 import io.github.seijikohara.femto.data.hasReadCalendarPermission
 import io.github.seijikohara.femto.data.hasReadPhoneStatePermission
+import io.github.seijikohara.femto.ui.assistant.AssistantOption
+import io.github.seijikohara.femto.ui.assistant.AssistantSheet
 import io.github.seijikohara.femto.ui.drawer.AppDrawerSheet
 import io.github.seijikohara.femto.ui.home.HomeEvent
 import io.github.seijikohara.femto.ui.home.HomeRoute
@@ -70,9 +72,10 @@ class MainActivity : ComponentActivity() {
                     ThemeMode.DARK -> true
                 }
             FemtoTheme(fontTheme = fontTheme, darkTheme = darkTheme) {
-                // The dashboard stays composed; the app drawer is a bottom-sheet
-                // overlay and settings is a full destination over it.
+                // The dashboard stays composed; the app drawer and assistant are
+                // bottom-sheet overlays and settings is a full destination over it.
                 var showDrawer by rememberSaveable { mutableStateOf(false) }
+                var showAssistant by rememberSaveable { mutableStateOf(false) }
                 var showSettings by rememberSaveable { mutableStateOf(false) }
                 if (showSettings) {
                     SettingsRoute(
@@ -89,6 +92,7 @@ class MainActivity : ComponentActivity() {
                             handleHomeEvent(
                                 event = event,
                                 setShowDrawer = { showDrawer = it },
+                                setShowAssistant = { showAssistant = it },
                                 setShowSettings = { showSettings = it },
                             )
                         },
@@ -102,6 +106,15 @@ class MainActivity : ComponentActivity() {
                             onDismiss = { showDrawer = false },
                         )
                     }
+                    if (showAssistant) {
+                        AssistantSheet(
+                            onLaunchOption = { option ->
+                                launchAssistantOption(option)
+                                showAssistant = false
+                            },
+                            onDismiss = { showAssistant = false },
+                        )
+                    }
                 }
             }
         }
@@ -110,6 +123,7 @@ class MainActivity : ComponentActivity() {
     private fun handleHomeEvent(
         event: HomeEvent,
         setShowDrawer: (Boolean) -> Unit,
+        setShowAssistant: (Boolean) -> Unit,
         setShowSettings: (Boolean) -> Unit,
     ) {
         when (event) {
@@ -140,19 +154,27 @@ class MainActivity : ComponentActivity() {
                 setShowSettings(true)
             }
 
-            HomeEvent.OpenAssistant -> {
-                openAssistant()
+            HomeEvent.OpenAssistantSheet -> {
+                // Close the drawer overlay so the two bottom sheets never stack.
+                setShowDrawer(false)
+                setShowAssistant(true)
             }
         }
     }
 
-    // Defer to whichever assistant the user has elected (ACTION_ASSIST),
-    // falling back to the generic voice-command intent. No package is
-    // hard-coded, so it works across markets and OEM assistants. `||`
-    // short-circuits: the fallback fires only when no assistant resolves.
-    private fun openAssistant() =
-        tryStartActivity(Intent(Intent.ACTION_ASSIST).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) ||
-            tryStartActivity(Intent(Intent.ACTION_VOICE_COMMAND).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+    // Fire the intent matching the user's elected assistant option. No package is
+    // hard-coded, so each action defers to whichever app the user has elected and
+    // works across markets and OEM assistants. A missing handler is a silent
+    // no-op (tryStartActivity swallows ActivityNotFoundException).
+    private fun launchAssistantOption(option: AssistantOption) {
+        val action =
+            when (option) {
+                AssistantOption.ASSISTANT -> Intent.ACTION_ASSIST
+                AssistantOption.VOICE_COMMAND -> Intent.ACTION_VOICE_COMMAND
+                AssistantOption.VOICE_SEARCH -> Intent.ACTION_WEB_SEARCH
+            }
+        tryStartActivity(Intent(action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+    }
 
     private fun resolveIs24Hour(clock: ClockSetting): Boolean =
         when (clock) {
@@ -217,9 +239,8 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Start [intent], returning whether an activity handled it. Callers that
-     * chain alternatives consume the result (the assistant fallback); fire-and-
-     * forget callers ignore it. [ActivityNotFoundException] means the head unit
+     * Start [intent], returning whether an activity handled it. Fire-and-forget
+     * callers ignore the result. [ActivityNotFoundException] means the head unit
      * has no app for the target — a silent no-op rather than a dead-click crash;
      * any other failure (e.g. `SecurityException`) propagates.
      */

--- a/app/src/main/java/io/github/seijikohara/femto/ui/assistant/AssistantSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/assistant/AssistantSheet.kt
@@ -1,0 +1,159 @@
+package io.github.seijikohara.femto.ui.assistant
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Mic
+import com.composables.icons.lucide.Search
+import com.composables.icons.lucide.Sparkles
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+
+/**
+ * Voice-assistant launch options that map one-to-one to the system intents the
+ * host fires (`ACTION_ASSIST` / `ACTION_VOICE_COMMAND` / `ACTION_WEB_SEARCH`).
+ * The system assistant opens as a separate activity — it cannot be embedded in
+ * the launcher — so the sheet's sole job is to pick which intent to fire.
+ */
+internal enum class AssistantOption {
+    ASSISTANT,
+    VOICE_COMMAND,
+    VOICE_SEARCH,
+}
+
+/**
+ * Voice-assistant options presented as a Material 3 [ModalBottomSheet] over the
+ * dashboard, mirroring [io.github.seijikohara.femto.ui.drawer.AppDrawerSheet].
+ *
+ * The launcher keeps the dashboard composed underneath, so the sheet reads as an
+ * overlay (slide-up + scrim) the user dismisses by swiping down or tapping the
+ * scrim. The sheet height keys off the viewport via
+ * [FemtoDimens.DrawerSheetHeightFraction], never a specific device, so the
+ * dashboard stays visible behind it. Rendering is delegated to
+ * [AssistantSheetContent], which carries the @PreviewLightDark coverage.
+ *
+ * No standalone preview: a [ModalBottomSheet] renders in a popup window that
+ * Compose previews do not capture, so [AssistantSheetContent]'s own
+ * @PreviewLightDark covers the sheet content.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun AssistantSheet(
+    onLaunchOption: (AssistantOption) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(sheetHeight),
+        ) {
+            AssistantSheetContent(onLaunchOption = onLaunchOption)
+        }
+    }
+}
+
+@Composable
+internal fun AssistantSheetContent(
+    onLaunchOption: (AssistantOption) -> Unit,
+    modifier: Modifier = Modifier,
+) = Surface(
+    modifier = modifier.fillMaxWidth(),
+    color = MaterialTheme.colorScheme.background,
+) {
+    Column(
+        modifier = Modifier.padding(FemtoDimens.ScreenPadding),
+        verticalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
+    ) {
+        Text(
+            text = stringResource(R.string.assistant_sheet_title),
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        AssistantOptionRow(
+            option = AssistantOption.ASSISTANT,
+            icon = Lucide.Sparkles,
+            label = stringResource(R.string.assistant_option_assistant),
+            onLaunchOption = onLaunchOption,
+        )
+        AssistantOptionRow(
+            option = AssistantOption.VOICE_COMMAND,
+            icon = Lucide.Mic,
+            label = stringResource(R.string.assistant_option_voice_command),
+            onLaunchOption = onLaunchOption,
+        )
+        AssistantOptionRow(
+            option = AssistantOption.VOICE_SEARCH,
+            icon = Lucide.Search,
+            label = stringResource(R.string.assistant_option_voice_search),
+            onLaunchOption = onLaunchOption,
+        )
+    }
+}
+
+@Composable
+private fun AssistantOptionRow(
+    option: AssistantOption,
+    icon: ImageVector,
+    label: String,
+    onLaunchOption: (AssistantOption) -> Unit,
+    modifier: Modifier = Modifier,
+) = Row(
+    modifier =
+        modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = FemtoDimens.MinTouchTarget)
+            .clickable { onLaunchOption(option) }
+            .padding(horizontal = FemtoDimens.GridGutter),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
+) {
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onBackground,
+        modifier = Modifier.size(FemtoDimens.InlineIconSize),
+    )
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onBackground,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun AssistantSheetContentPreview() {
+    FemtoTheme {
+        AssistantSheetContent(onLaunchOption = {})
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
@@ -45,6 +45,6 @@ internal sealed interface HomeEvent {
     /** Open the in-app settings screen (units, theme, font, system links). */
     data object OpenInAppSettings : HomeEvent
 
-    /** Invoke the device's voice assistant (ACTION_ASSIST, falling back to voice command). */
-    data object OpenAssistant : HomeEvent
+    /** Open the voice-assistant bottom sheet so the user picks which assistant intent to fire. */
+    data object OpenAssistantSheet : HomeEvent
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -142,7 +142,7 @@ internal class HomeViewModel(
             }
 
             HomeAction.OpenAssistant -> {
-                mutableEvents.tryEmit(HomeEvent.OpenAssistant)
+                mutableEvents.tryEmit(HomeEvent.OpenAssistantSheet)
             }
 
             HomeAction.ResetTrip -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,12 @@
     <string name="drawer_load_error">Couldn\'t load apps</string>
     <string name="drawer_retry">Retry</string>
 
+    <!-- Assistant sheet -->
+    <string name="assistant_sheet_title">Voice assistant</string>
+    <string name="assistant_option_assistant">Assistant</string>
+    <string name="assistant_option_voice_command">Voice command</string>
+    <string name="assistant_option_voice_search">Voice search</string>
+
     <!-- Settings -->
     <string name="settings_title">Settings</string>
     <string name="settings_back">Back</string>

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -171,11 +171,11 @@ class HomeViewModelTest {
         }
 
     @Test
-    fun `onAction OpenAssistant emits OpenAssistant`() =
+    fun `onAction OpenAssistant emits OpenAssistantSheet`() =
         runTest {
             stubViewModel().assertEvent(
                 action = HomeAction.OpenAssistant,
-                expected = HomeEvent.OpenAssistant,
+                expected = HomeEvent.OpenAssistantSheet,
             )
         }
 


### PR DESCRIPTION
## Summary

Tapping the footer mic now opens a `ModalBottomSheet` of voice-assistant
launch options instead of firing a single fixed intent:

- **Assistant** (`ACTION_ASSIST`)
- **Voice command** (`ACTION_VOICE_COMMAND`)
- **Voice search** (`ACTION_WEB_SEARCH`)

Each row fires its package-agnostic intent with `FLAG_ACTIVITY_NEW_TASK`,
so the user's default provider handles it. `ACTION_ASSIST` opens the
system assistant as its own Activity (it cannot be embedded), so the
sheet acts purely as a launcher.

`HomeEvent.OpenAssistant` is renamed to `OpenAssistantSheet`; the sheet
is shown via a `rememberSaveable` overlay in `MainActivity`, mirroring
the existing app-drawer pattern (showing the sheet dismisses the
drawer). New `ui/assistant/AssistantSheet.kt` splits content into
`AssistantSheetContent` for `@PreviewLightDark` previews and isolated
testing.

## Files

- `ui/assistant/AssistantSheet.kt` (new) — sheet + `AssistantOption` enum
- `MainActivity.kt` — `showAssistant` overlay + `launchAssistantOption`
- `ui/home/HomeEvent.kt` / `HomeViewModel.kt` — event rename
- `res/values/strings.xml` — sheet title + option labels
- `ui/assistant/AssistantSheetContentTest.kt` (androidTest) — renders 3
  options, tap dispatches the correct `AssistantOption`
- `ui/home/HomeViewModelTest.kt` — event rename follow-up

## How verified

`./gradlew spotlessApply` then
`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin`
— BUILD SUCCESSFUL. Visual layout reviewed via `@PreviewLightDark`.