### PR TITLE
feat(settings): add a fullscreen (hide system bars) toggle

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -1,0 +1,59 @@
+package io.github.seijikohara.femto.ui.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class SettingsScreenTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val groupLabel = context.getString(R.string.settings_group_fullscreen)
+    private val offLabel = context.getString(R.string.settings_fullscreen_off)
+    private val onLabel = context.getString(R.string.settings_fullscreen_on)
+
+    @Test
+    fun renders_fullscreen_group_chips() {
+        rule.setContent {
+            FemtoTheme {
+                SettingsScreen(
+                    uiState = SettingsUiState.Initial,
+                    onAction = {},
+                    onBack = {},
+                    onOpenNotificationAccess = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        rule.onNodeWithText(groupLabel).assertIsDisplayed()
+        rule.onNodeWithText(offLabel).assertIsDisplayed()
+        rule.onNodeWithText(onLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun tapping_on_dispatches_set_fullscreen_on() {
+        val actions = mutableListOf<SettingsAction>()
+        rule.setContent {
+            FemtoTheme {
+                SettingsScreen(
+                    uiState = SettingsUiState.Initial,
+                    onAction = { actions += it },
+                    onBack = {},
+                    onOpenNotificationAccess = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        rule.onNodeWithText(onLabel).performClick()
+        assertEquals(listOf(SettingsAction.SetFullscreen(FullscreenSetting.ON)), actions)
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -13,17 +13,23 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import io.github.seijikohara.femto.data.AppsRepository
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.DisplayPreferences
 import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FontPreferences
+import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.SystemPermissionSignals
 import io.github.seijikohara.femto.data.ThemeMode
 import io.github.seijikohara.femto.data.hasBluetoothConnectPermission
@@ -39,11 +45,20 @@ import io.github.seijikohara.femto.ui.locale.resolved
 import io.github.seijikohara.femto.ui.settings.SettingsRoute
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.FontTheme
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     private val appsRepository by lazy { AppsRepository(this) }
     private val displayPreferences by lazy { DisplayPreferences(this) }
     private val fontPreferences by lazy { FontPreferences(this) }
+
+    // Cache the latest fullscreen choice so [onWindowFocusChanged] can re-hide the
+    // system bars when focus returns from another Activity. The Compose
+    // LaunchedEffect only fires on a setting change, not on a focus regain, so the
+    // bars would otherwise stay visible after returning from an external app.
+    private var fullscreenSetting = FullscreenSetting.OFF
 
     // Emit on the process-wide refresh signal so permission-gated flows (e.g.
     // the Bluetooth footer indicator) re-read after a late runtime grant.
@@ -58,6 +73,14 @@ class MainActivity : ComponentActivity() {
         enableEmulatorMapRendering()
         enableEdgeToEdge()
         requestRuntimePermissions()
+        // Keep the cached fullscreen choice in sync so onWindowFocusChanged can
+        // re-hide the bars after focus returns from another Activity.
+        lifecycleScope.launch {
+            displayPreferences.settings
+                .map { it.fullscreen }
+                .distinctUntilChanged()
+                .collect { fullscreenSetting = it }
+        }
         setContent {
             // User display settings override the locale/system defaults; the
             // theme + font feed FemtoTheme, the units + clock feed the dashboard.
@@ -71,6 +94,12 @@ class MainActivity : ComponentActivity() {
                     ThemeMode.LIGHT -> false
                     ThemeMode.DARK -> true
                 }
+            // Drive the system bars from the persisted fullscreen choice. This
+            // fires only on a setting change; onWindowFocusChanged handles the
+            // focus-regain case.
+            LaunchedEffect(display.fullscreen) {
+                applyFullscreen(display.fullscreen)
+            }
             FemtoTheme(fontTheme = fontTheme, darkTheme = darkTheme) {
                 // The dashboard stays composed; the app drawer and assistant are
                 // bottom-sheet overlays and settings is a full destination over it.
@@ -116,6 +145,33 @@ class MainActivity : ComponentActivity() {
                         )
                     }
                 }
+            }
+        }
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        // Returning from another Activity (e.g. an external app) restores the
+        // system bars even when fullscreen is on. Re-hide them once focus returns.
+        if (hasFocus && fullscreenSetting == FullscreenSetting.ON) {
+            applyFullscreen(FullscreenSetting.ON)
+        }
+    }
+
+    // Hide or show both the status and navigation bars per the fullscreen choice.
+    // ON uses the transient-swipe behaviour so the bars reappear on a swipe and
+    // auto-hide again, matching an immersive-sticky launcher experience.
+    private fun applyFullscreen(setting: FullscreenSetting) {
+        val controller = WindowCompat.getInsetsController(window, window.decorView)
+        when (setting) {
+            FullscreenSetting.ON -> {
+                controller.systemBarsBehavior =
+                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                controller.hide(WindowInsetsCompat.Type.systemBars())
+            }
+
+            FullscreenSetting.OFF -> {
+                controller.show(WindowInsetsCompat.Type.systemBars())
             }
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -22,6 +22,9 @@ internal enum class TemperatureUnitSetting { AUTO, CELSIUS, FAHRENHEIT }
 /** Clock: follow the system 12/24h setting, or force 12h / 24h. */
 internal enum class ClockSetting { AUTO, TWELVE_HOUR, TWENTY_FOUR_HOUR }
 
+/** Fullscreen: keep the system bars, or hide both status and navigation bars. */
+internal enum class FullscreenSetting { OFF, ON }
+
 /**
  * User display settings that override the locale / system defaults. Every value
  * defaults to the auto / system choice so a fresh install behaves exactly as
@@ -32,6 +35,7 @@ internal data class DisplaySettings(
     val speedUnit: SpeedUnitSetting,
     val temperatureUnit: TemperatureUnitSetting,
     val clock: ClockSetting,
+    val fullscreen: FullscreenSetting,
 ) {
     companion object {
         val Default =
@@ -40,6 +44,7 @@ internal data class DisplaySettings(
                 speedUnit = SpeedUnitSetting.AUTO,
                 temperatureUnit = TemperatureUnitSetting.AUTO,
                 clock = ClockSetting.AUTO,
+                fullscreen = FullscreenSetting.OFF,
             )
     }
 }
@@ -63,6 +68,7 @@ internal class DisplayPreferences(
                 speedUnit = prefs[SPEED_KEY].toEnumOr(SpeedUnitSetting.AUTO),
                 temperatureUnit = prefs[TEMPERATURE_KEY].toEnumOr(TemperatureUnitSetting.AUTO),
                 clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
+                fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.OFF),
             )
         }
 
@@ -75,11 +81,18 @@ internal class DisplayPreferences(
 
     suspend fun setClock(value: ClockSetting) = context.displayDataStore.edit { it[CLOCK_KEY] = value.name }
 
+    suspend fun setFullscreen(value: FullscreenSetting) =
+        context.displayDataStore.edit {
+            it[FULLSCREEN_KEY] =
+                value.name
+        }
+
     private companion object {
         val THEME_KEY = stringPreferencesKey("theme_mode")
         val SPEED_KEY = stringPreferencesKey("speed_unit")
         val TEMPERATURE_KEY = stringPreferencesKey("temperature_unit")
         val CLOCK_KEY = stringPreferencesKey("clock")
+        val FULLSCREEN_KEY = stringPreferencesKey("fullscreen")
     }
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -29,6 +29,7 @@ import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Lucide
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.ClockSetting
+import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.SpeedUnitSetting
 import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.ThemeMode
@@ -111,6 +112,17 @@ internal fun SettingsScreen(
                 ),
             selected = uiState.clock,
             onSelect = { onAction(SettingsAction.SetClock(it)) },
+        )
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_fullscreen),
+            options =
+                listOf(
+                    FullscreenSetting.OFF to stringResource(R.string.settings_fullscreen_off),
+                    FullscreenSetting.ON to stringResource(R.string.settings_fullscreen_on),
+                ),
+            selected = uiState.fullscreen,
+            onSelect = { onAction(SettingsAction.SetFullscreen(it)) },
         )
 
         SettingGroup(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.ui.settings
 
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.DisplaySettings
+import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.SpeedUnitSetting
 import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.ThemeMode
@@ -13,6 +14,7 @@ internal data class SettingsUiState(
     val speedUnit: SpeedUnitSetting,
     val temperatureUnit: TemperatureUnitSetting,
     val clock: ClockSetting,
+    val fullscreen: FullscreenSetting,
     val fontTheme: FontTheme,
 ) {
     companion object {
@@ -24,6 +26,7 @@ internal data class SettingsUiState(
                 speedUnit = DisplaySettings.Default.speedUnit,
                 temperatureUnit = DisplaySettings.Default.temperatureUnit,
                 clock = DisplaySettings.Default.clock,
+                fullscreen = DisplaySettings.Default.fullscreen,
                 fontTheme = FontTheme.INTER,
             )
     }
@@ -45,6 +48,10 @@ internal sealed interface SettingsAction {
 
     data class SetClock(
         val value: ClockSetting,
+    ) : SettingsAction
+
+    data class SetFullscreen(
+        val value: FullscreenSetting,
     ) : SettingsAction
 
     data class SetFontTheme(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -24,6 +24,7 @@ internal class SettingsViewModel(
                 speedUnit = display.speedUnit,
                 temperatureUnit = display.temperatureUnit,
                 clock = display.clock,
+                fullscreen = display.fullscreen,
                 fontTheme = font,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState.Initial)
@@ -36,6 +37,7 @@ internal class SettingsViewModel(
                 is SettingsAction.SetSpeedUnit -> displayPreferences.setSpeedUnit(action.value)
                 is SettingsAction.SetTemperatureUnit -> displayPreferences.setTemperatureUnit(action.value)
                 is SettingsAction.SetClock -> displayPreferences.setClock(action.value)
+                is SettingsAction.SetFullscreen -> displayPreferences.setFullscreen(action.value)
                 is SettingsAction.SetFontTheme -> fontPreferences.setFontTheme(action.value)
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,9 @@
     <string name="settings_temp_fahrenheit">°F</string>
     <string name="settings_clock_12">12-hour</string>
     <string name="settings_clock_24">24-hour</string>
+    <string name="settings_group_fullscreen">Fullscreen</string>
+    <string name="settings_fullscreen_off">Off</string>
+    <string name="settings_fullscreen_on">On</string>
     <string name="settings_open_notification_access">Notification access</string>
     <string name="settings_open_system_settings">System settings</string>
 </resources>

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,53 @@
+package io.github.seijikohara.femto.ui.settings
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import io.github.seijikohara.femto.data.DisplayPreferences
+import io.github.seijikohara.femto.data.FontPreferences
+import io.github.seijikohara.femto.data.FullscreenSetting
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class SettingsViewModelTest {
+    private val application: Application = ApplicationProvider.getApplicationContext()
+    private val displayPreferences = DisplayPreferences(application)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `SetFullscreen ON persists via DisplayPreferences and uiState reflects it`() =
+        runTest {
+            val viewModel = SettingsViewModel(displayPreferences, FontPreferences(application))
+            viewModel.uiState.test {
+                assertEquals(FullscreenSetting.OFF, awaitItem().fullscreen)
+                viewModel.onAction(SettingsAction.SetFullscreen(FullscreenSetting.ON))
+                assertEquals(FullscreenSetting.ON, awaitItem().fullscreen)
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertEquals(FullscreenSetting.ON, displayPreferences.settings.first().fullscreen)
+        }
+}


### PR DESCRIPTION
## Summary

Add a Settings toggle that hides both the status bar and the navigation bar for an immersive head-unit display.

- `DisplayPreferences`: new `FullscreenSetting { OFF, ON }` persisted in DataStore (default `OFF`), with `setFullscreen()` and an unknown-value-tolerant decode.
- Settings UI: a new "Fullscreen" group (Off/On) reusing the existing `SettingGroup`/`OptionChip` pattern, plus `SettingsAction.SetFullscreen`.
- `MainActivity`: drives `WindowInsetsController` from the persisted value — ON hides the system bars with `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE`, OFF shows them. The value is cached on the Activity and re-applied in `onWindowFocusChanged` so bars stay hidden after returning from another Activity.
- `minSdk = 33` makes `WindowInsetsController` unconditional (no `Build.VERSION` branch).
- Default off.

## How verified

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — BUILD SUCCESSFUL.
- Unit test `SettingsViewModelTest`: `SetFullscreen` calls `setFullscreen` and the new value is reflected in `uiState`.
- Compose test `SettingsScreenTest`: the Fullscreen group chips render and dispatch the action.
- Real-behaviour (bars hide, swipe shows transient bars, persistence across focus) confirmed by the @PreviewLightDark previews plus on-device/emulator visual review per the project verification posture.