### PR TITLE
fix(weather): support a configurable Open-Meteo endpoint and key

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,10 +7,12 @@ plugins {
     alias(libs.plugins.spotless)
 }
 
-// Production geocoder host is threaded in via gitignored local.properties so the
-// public PoC endpoint is never the implicit production default. Production builds
-// should set GEOCODER_BASE_URL (and GEOCODER_API_KEY when the host requires one)
-// to a non-public host; absent keys fall back to the public Nominatim PoC endpoint.
+// Production geocoder and weather hosts are threaded in via gitignored
+// local.properties so the public PoC endpoints are never the implicit production
+// default. Production builds should set GEOCODER_BASE_URL / WEATHER_BASE_URL (and
+// the matching *_API_KEY when the host requires one) to a non-public host; absent
+// values fall back to the public Nominatim / Open-Meteo PoC endpoints, which are
+// rate-limited and unsuitable for production traffic.
 val localProperties =
     Properties().apply {
         rootProject
@@ -21,6 +23,8 @@ val localProperties =
     }
 val geocoderBaseUrl = localProperties.getProperty("GEOCODER_BASE_URL", "https://nominatim.openstreetmap.org/")
 val geocoderApiKey = localProperties.getProperty("GEOCODER_API_KEY", "")
+val weatherBaseUrl = localProperties.getProperty("WEATHER_BASE_URL", "https://api.open-meteo.com/")
+val weatherApiKey = localProperties.getProperty("WEATHER_API_KEY", "")
 
 // Release signing is driven entirely by environment variables so CI can sign the
 // nightly APK without committing a keystore, while local `assembleRelease` stays
@@ -62,6 +66,8 @@ android {
 
         buildConfigField("String", "GEOCODER_BASE_URL", "\"${geocoderBaseUrl}\"")
         buildConfigField("String", "GEOCODER_API_KEY", "\"${geocoderApiKey}\"")
+        buildConfigField("String", "WEATHER_BASE_URL", "\"${weatherBaseUrl}\"")
+        buildConfigField("String", "WEATHER_API_KEY", "\"${weatherApiKey}\"")
     }
 
     signingConfigs {

--- a/app/src/main/java/io/github/seijikohara/femto/data/OpenMeteoApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/OpenMeteoApi.kt
@@ -13,6 +13,11 @@ private const val TAG = "OpenMeteoApi"
 internal class OpenMeteoApi(
     private val client: OkHttpClient,
     private val baseUrl: String = "https://api.open-meteo.com/",
+    // Optional Open-Meteo API key. When set, baseUrl points at the keyed customer
+    // host and the request appends &apikey=; the public PoC endpoint needs none.
+    // Request-only secret — never logged (the failure log records the status code,
+    // not the key-bearing URL).
+    private val apiKey: String? = null,
 ) {
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -22,6 +27,7 @@ internal class OpenMeteoApi(
     ): ForecastResponse? =
         withContext(Dispatchers.IO) {
             runCatching {
+                val apiKeyParam = apiKey?.let { "&apikey=$it" }.orEmpty()
                 val request =
                     Request
                         .Builder()
@@ -33,10 +39,17 @@ internal class OpenMeteoApi(
                                 "&hourly=temperature_2m,weathercode" +
                                 "&daily=sunrise,sunset,weathercode," +
                                 "temperature_2m_max,temperature_2m_min" +
-                                "&forecast_days=5&timezone=auto",
+                                "&forecast_days=5&timezone=auto" +
+                                apiKeyParam,
                         ).build()
                 client.newCall(request).execute().use { response ->
-                    if (!response.isSuccessful) return@use null
+                    if (!response.isSuccessful) {
+                        // Log the status only (the URL carries the apiKey) so a
+                        // sustained non-2xx outage — e.g. a 429 rate-limit on the
+                        // public endpoint — is diagnosable instead of silently empty.
+                        Log.w(TAG, "forecast HTTP ${response.code}")
+                        return@use null
+                    }
                     response.body?.string()?.let { body ->
                         json.decodeFromString<ForecastResponse>(body)
                     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -190,7 +190,12 @@ internal class HomeViewModelFactory(
                 apiKey = BuildConfig.GEOCODER_API_KEY.takeIf { it.isNotBlank() },
             )
         val geocoder = ReverseGeocoderRepository(locationFlow, nominatimApi)
-        val weatherApi = OpenMeteoApi(client = httpClient)
+        val weatherApi =
+            OpenMeteoApi(
+                client = httpClient,
+                baseUrl = BuildConfig.WEATHER_BASE_URL,
+                apiKey = BuildConfig.WEATHER_API_KEY.takeIf { it.isNotBlank() },
+            )
         val weather = WeatherRepository(weatherApi, locationFlow, clockFlow)
         val music = MusicSessionRepository(application)
         val calendar = CalendarRepository(application, clockFlow)

--- a/app/src/test/java/io/github/seijikohara/femto/data/OpenMeteoApiTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/OpenMeteoApiTest.kt
@@ -1,0 +1,93 @@
+package io.github.seijikohara.femto.data
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class OpenMeteoApiTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        client = OkHttpClient()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `sends the requested coordinates and forecast parameters`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(FORECAST_BODY))
+
+            newApi().forecast(LAT, LON)
+            val path = server.takeRequest().path.orEmpty()
+
+            assertTrue(path.contains("latitude=$LAT"))
+            assertTrue(path.contains("longitude=$LON"))
+            assertTrue(path.contains("forecast_days=5"))
+            assertTrue(path.contains("timezone=auto"))
+        }
+
+    @Test
+    fun `appends the apikey query parameter when a key is configured`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(FORECAST_BODY))
+
+            OpenMeteoApi(
+                client = client,
+                baseUrl = server.url("/").toString(),
+                apiKey = "secret-key",
+            ).forecast(LAT, LON)
+
+            assertEquals("secret-key", server.takeRequest().requestUrl?.queryParameter("apikey"))
+        }
+
+    @Test
+    fun `omits the apikey query parameter when no key is configured`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(FORECAST_BODY))
+
+            newApi().forecast(LAT, LON)
+
+            assertNull(server.takeRequest().requestUrl?.queryParameter("apikey"))
+        }
+
+    @Test
+    fun `returns null on a 429 rate-limit response`() =
+        runTest {
+            server.enqueue(MockResponse().setResponseCode(429))
+
+            assertNull(newApi().forecast(LAT, LON))
+        }
+
+    private fun newApi(): OpenMeteoApi = OpenMeteoApi(client = client, baseUrl = server.url("/").toString())
+
+    private companion object {
+        const val LAT = 35.690
+        const val LON = 139.700
+
+        // Minimal valid current block: temperature_2m + weathercode are required,
+        // every other field (and the hourly / daily blocks) is optional.
+        const val FORECAST_BODY = """
+            {
+              "current": {
+                "time": "2026-05-01T11:00",
+                "temperature_2m": 18.5,
+                "weathercode": 0
+              }
+            }
+        """
+    }
+}


### PR DESCRIPTION
## Symptom

The dashboard weather card shows only the empty placeholder (a single
cloud glyph). That placeholder renders when `HomeUiState.weather` is
`null`.

## Root cause

The public Open-Meteo endpoint (`api.open-meteo.com`) rate-limits the
shared egress IP with **HTTP 429 "Too many concurrent requests"**
(reproduced from the same network with the app's exact query URL,
sustained across the rate-limit window). `OpenMeteoApi.forecast()`
returned `null` on the non-2xx response **with no log** (only thrown
exceptions were logged), so `WeatherRepository` emitted `null` and the
card fell back to its placeholder — a silent failure.

The reverse geocoder already solves the "public PoC vs. production
host" problem with `GEOCODER_BASE_URL` / `GEOCODER_API_KEY`; weather
had no equivalent and was hardcoded to the unauthenticated public
endpoint.

## Fix

- Add `WEATHER_BASE_URL` / `WEATHER_API_KEY` (gitignored
  `local.properties` → `BuildConfig`), defaulting to the public
  Open-Meteo PoC endpoint, mirroring the geocoder pattern exactly.
- `OpenMeteoApi` appends `&apikey=` when a key is configured, so
  production can target the keyed customer host
  (`customer-api.open-meteo.com`) or a self-hosted instance.
- Log the HTTP status on a non-2xx response (**status code only — the
  URL carries the key**) so a sustained outage is diagnosable instead
  of silently empty.

## Tests

New `OpenMeteoApiTest` (MockWebServer, mirroring `NominatimApiTest`):
apikey appended when configured / omitted otherwise, coordinate +
forecast query parameters, and `null` on a 429. Existing
`WeatherRepositoryTest` (500 → null, parse paths) is unchanged.

## Verification note

Local `./gradlew` is currently blocked by an environment issue
unrelated to this change: the only JDK 21 Gradle can find for the
`androidJdkImage` (`jlink`) transform is the VS Code Red Hat
extension's **JRE** (no `jlink`), so `compileDebugJavaWithJavac`
fails before any of this code runs. CI runs on a complete JDK and is
the authoritative gate here. (Local toolchain fix tracked separately.)