### PR TITLE
docs: remove external product names and rewrite the README

### DIFF
--- a/.claude/agents/similar-app-researcher.md
+++ b/.claude/agents/similar-app-researcher.md
@@ -36,6 +36,14 @@ question, not the most numerous.
 - Car Launcher Pro / Free
 - CarWebGuru
 - Fcc Car Launcher (Chinese-language)
+- Car Launcher (CarLab) — https://car-lab.app — Google Navigation SDK
+  integration, radio streaming (50k+ stations), media / phone / app-grid
+  widgets and a speed/weather/clock dashboard; Lite (one-time purchase)
+  vs Pro (subscription with integrated navigation) tiers
+- AutoZen — https://autozenapp.com — positions itself as an "Android Auto
+  alternative": turn-by-turn navigation with live traffic, speed-camera
+  alerts, an AI voice assistant, messaging (WhatsApp / Signal / Messenger),
+  split-screen, and themeable widget dashboards
 
 **iOS / cross-platform reference:**
 - CarBridge (iOS jailbreak tweak) — for UX patterns transferable

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,8 @@
       "WebFetch(domain:docs.anthropic.com)",
       "WebFetch(domain:code.claude.com)",
       "WebFetch(domain:lecoauto.com)",
+      "WebFetch(domain:car-lab.app)",
+      "WebFetch(domain:autozenapp.com)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:api.github.com)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # Femto Car Launcher
 
-Android home launcher for car head units (OTTOCAST / Carlinkit /
-built-in Android units). MVP targets Android 13 (API 33). Reference
-product: [LecoAuto](https://lecoauto.com/?lang=ja).
+Android home launcher for car head units (aftermarket CarPlay /
+Android Auto AI boxes and built-in Android units). MVP targets
+Android 13 (API 33).
 
 The launcher is designed for **multi-region distribution**. No
 single market is privileged in design, code, or documentation;
@@ -118,8 +118,8 @@ filenames (`geist_variable.ttf`, `mplus2_variable.ttf`).
   `stateNotNeeded="true"`.
 - Orientation is **not** locked — both portrait and landscape head
   units must work.
-- Carlinkit / OTTOCAST AI Boxes lock the default-launcher slot; the
-  app launches via "BOOT UP APP" with a ~30 s host-side delay. That
+- Aftermarket AI boxes lock the default-launcher slot; the app
+  launches via a host-side "boot-up app" hook with a ~30 s delay. That
   is outside our control, but cold start inside the process is a key
   product metric — keep `MainActivity#onCreate` lean.
 
@@ -133,8 +133,7 @@ motion. There is **no project-wide driving-lockout gate**.
 - The OEM cluster owns vehicle-state information (speed, RPM, fuel,
   warnings). The launcher's role is the head-unit shell, not a
   redundant driver display.
-- Comparable aftermarket launchers (LecoAuto, Car Launcher Pro,
-  AGAMA, CarWebGuru) ship the same posture today.
+- Comparable aftermarket car launchers ship the same posture today.
 
 If a future feature has a clear and specific distraction profile
 (e.g., embedded video playback inside the launcher itself, a chat
@@ -375,7 +374,7 @@ file before working in its area.
 | Agent | When to use |
 | --- | --- |
 | `compose-launcher-reviewer` | After touching `ui/theme`, `ui/home`, `MainActivity`, manifest, build files, or fonts; before opening a PR. Pass the diff explicitly. |
-| `similar-app-researcher` | Before scoping any feature, to study how comparable apps (LecoAuto, CarCar Launcher, AGAMA, BricksOpenLauncher, AAOS, etc.) solve the same problem. |
+| `similar-app-researcher` | Before scoping any feature, to study how comparable car launchers and prior-art projects solve the same problem. |
 
 ### Skills (`.claude/skills/`)
 
@@ -405,7 +404,7 @@ manually invocable as `/<skill-name>`. Manual-only skills are marked
 
 ## Memory
 
-Persisted decisions (design direction, LecoAuto reference, etc.)
+Persisted decisions (design direction, competitive research, etc.)
 live at
 `~/.claude/projects/-Users-seiji-git-GitHub-seijikohara-femto-car-launcher/memory/`.
 Read it before re-litigating settled choices. Update it when a

--- a/README.md
+++ b/README.md
@@ -1,71 +1,170 @@
 # Femto Car Launcher
 
-Android home launcher for car head units (OTTOCAST / Carlinkit / built-in Android units).
-MVP targets Android 13 (API 33). Reference product: [LecoAuto](https://lecoauto.com/?lang=ja).
+Femto Car Launcher is an Android home-screen replacement (launcher) for
+in-car head units. It targets two hardware classes: aftermarket CarPlay /
+Android Auto AI boxes that inject Android into a factory display, and
+built-in Android head units. The launcher replaces the stock home screen
+with a single glanceable dashboard tuned for automotive viewing distances
+and touch accuracy.
 
-## Overview
+The minimum supported platform is Android 13 (Application Programming
+Interface (API) level 33). The launcher is built for multi-region
+distribution: no single market is privileged, locale-specific behaviour
+(language, units, font fallback, regulation) is parameterised, and the
+strictest applicable rule wins when markets diverge.
 
-Femto Car Launcher is a home-screen replacement designed for aftermarket head units.
-It targets multi-region distribution: no single market is privileged in design, code, or
-documentation — locale-specific behaviour is parameterised and the strictest applicable rule wins
-when markets diverge. Project rules and conventions live in [`CLAUDE.md`](CLAUDE.md).
+## Features
+
+The home screen is a fixed dashboard rather than a scrolling grid of apps.
+
+- **Map panel** — renders OpenStreetMap vector tiles through MapLibre,
+  served by the keyless OpenFreeMap service. The view is heading-up (the
+  map rotates so the travel direction points up) and shows a static
+  placeholder until a location fix arrives. No API key is required.
+- **Trip overlay** — current speed, trip distance, and average speed
+  derived from the Global Positioning System (GPS), plus the
+  reverse-geocoded address of the current position.
+- **Weather card** — current conditions, apparent ("feels-like")
+  temperature, wind, humidity, and an hourly forecast from the Open-Meteo
+  service.
+- **Calendar card** — a six-day strip and the upcoming events read from the
+  device calendar.
+- **Now-playing card** — the active media session (title, artist, source
+  app, and transport controls), read through a notification-listener
+  service.
+- **Clock overlay** — a self-updating clock that honours the system
+  12/24-hour setting.
+- **Status cluster** — graduated Wi-Fi and cellular signal strength,
+  Bluetooth connection state, GPS reception, and battery level and charging
+  state.
+- **App access** — a bottom application bar with shortcuts and a full app
+  drawer.
+- **Voice assistant** — a microphone button opens a bottom sheet that
+  launches the system voice assistant, voice command, or voice search.
+- **Settings** — in-app preferences for theme (follow-system / light /
+  dark), speed and temperature units, clock format, a fullscreen toggle
+  that hides the system bars, and the font pairing, plus shortcuts to the
+  system notification-access and Android settings screens.
+
+Each panel degrades gracefully. A panel whose runtime permission is denied,
+or whose data source is unavailable, renders an empty or reduced state
+instead of failing. The dashboard renders the same tree regardless of
+vehicle motion; distraction responsibility stays with the driver and the
+vehicle's own cluster.
+
+## Architecture
+
+- **UI:** Jetpack Compose with Material 3 and Material You dynamic colour.
+- **Pattern:** unidirectional data flow (UDF). State flows down through an
+  immutable `UiState`; events flow up through an `(Action) -> Unit` lambda.
+  Stateful screens follow the `Route` + `Screen` + `ViewModel` shape.
+- **Entry point:** a single `ComponentActivity` (`MainActivity`) registered
+  as a `HOME` launcher with `launchMode="singleTask"`.
+- **Data:** one repository per dashboard source, each exposing a Kotlin
+  `Flow`. User preferences persist through Jetpack DataStore.
+- **Network:** the map is keyless. Weather (Open-Meteo) and reverse
+  geocoding (OpenStreetMap Nominatim) default to public endpoints and
+  accept configurable production hosts (see [Configuration](#configuration)).
+
+Project rules, the design system, and coding conventions live in
+[`CLAUDE.md`](CLAUDE.md).
 
 ## Tech stack
 
-- Kotlin, Jetpack Compose (Material 3), AGP 9
-- Gradle 9, JDK 21 toolchain, Java 11 source/target
-- `minSdk = 33`, `targetSdk = 36`
+- Kotlin and Jetpack Compose (Material 3), built with the Android Gradle
+  Plugin (AGP) 9.
+- Gradle 9, a Java Development Kit (JDK) 21 toolchain, and Java 11
+  source/target compatibility.
+- `minSdk = 33` (Android 13), `targetSdk = 36`.
 
-See [`CLAUDE.md#tech-stack`](CLAUDE.md#tech-stack) for the full dependency list.
+[`gradle/libs.versions.toml`](gradle/libs.versions.toml) is the single
+source of truth for dependency versions; see
+[`CLAUDE.md#tech-stack`](CLAUDE.md#tech-stack) for the resolved list.
 
-## Developer setup
+## Project layout
 
-**Prerequisites:** JDK 21, Android Studio (latest stable), an Android 13+ device or AVD.
-
-```bash
-./gradlew assembleDebug    # build debug APK
-./gradlew test             # JVM unit tests
-./gradlew spotlessCheck    # format / lint check
+```text
+app/src/main/
+├── java/io/github/seijikohara/femto/
+│   ├── MainActivity.kt   # single launcher entry (HOME activity)
+│   ├── data/             # repositories, DataStore wrappers, network APIs
+│   └── ui/
+│       ├── home/         # the dashboard: panels, overlays, footer cluster
+│       ├── drawer/       # full app drawer (bottom sheet)
+│       ├── assistant/    # voice-assistant bottom sheet
+│       ├── settings/     # in-app settings
+│       ├── locale/       # unit and locale formatting
+│       └── theme/        # FemtoTheme, design tokens, previews
+└── res/                  # themes, bundled fonts, strings
 ```
 
-### Map tiles
+## Build and run
 
-The launcher renders OpenStreetMap vector tiles on the home dashboard
-through [MapLibre](https://maplibre.org/), served by the free, keyless
-[OpenFreeMap](https://openfreemap.org/) service. There is **no API key
-to configure** — `./gradlew assembleDebug` produces a build with a
-working map out of the box. The pane shows a heading-up view (the map
-rotates so the travel direction points up) and falls back to a static
-placeholder until a location fix is available. Light mode uses the
-Positron style; dark mode uses a bundled style under
-`app/src/main/assets/map/`.
+**Prerequisites:** JDK 21, Android Studio (latest stable), and an Android
+13+ device or Android Virtual Device (AVD).
+
+```bash
+./gradlew assembleDebug      # build the debug APK
+./gradlew test               # JVM unit tests
+./gradlew lint               # Android Lint
+./gradlew connectedAndroidTest  # instrumented tests (device / emulator)
+./gradlew spotlessCheck      # format / lint check
+./gradlew spotlessApply      # auto-fix format violations
+```
+
+The debug Android Package (APK) is written to
+`app/build/outputs/apk/debug/app-debug.apk`. Install it with
+`adb install -r <apk>` or run the app from Android Studio. To smoke-test on
+an emulator, create an AVD that approximates a head-unit display (a wide
+landscape profile) and launch the app as the home activity.
+
+## Configuration
+
+The launcher runs with no configuration: `./gradlew assembleDebug`
+produces a working build, and the map needs no API key.
+
+Two network services default to shared public endpoints that are suitable
+for a proof of concept but are rate-limited and unsuitable for production
+traffic. Override them for a release build through the git-ignored
+`local.properties` file, which feeds `BuildConfig` at build time:
+
+| Property | Purpose | Default |
+| --- | --- | --- |
+| `WEATHER_BASE_URL` | Open-Meteo host | public Open-Meteo endpoint |
+| `WEATHER_API_KEY` | Open-Meteo key (keyed/self-hosted) | empty |
+| `GEOCODER_BASE_URL` | Nominatim reverse-geocoding host | public Nominatim endpoint |
+| `GEOCODER_API_KEY` | Geocoder key (when the host requires one) | empty |
+
+When a key is absent, the corresponding service falls back to its public
+endpoint.
 
 ## Continuous integration
 
-The [`CI`](.github/workflows/ci.yml) workflow runs on every pull request and on
-pushes to `main`:
+The [`CI`](.github/workflows/ci.yml) workflow runs on every pull request
+and on pushes to `main`:
 
 - **Validate** (all triggers): runs
-  `./gradlew spotlessCheck test lint assembleDebug` on a Temurin JDK 21 runner.
-- **Publish nightly** (`main` pushes and manual `workflow_dispatch` only): builds a
-  release-signed APK and republishes a rolling prerelease.
+  `./gradlew spotlessCheck test lint assembleDebug` on a Temurin JDK 21
+  runner.
+- **Publish nightly** (`main` pushes and manual `workflow_dispatch` only):
+  builds a release-signed APK and republishes a rolling prerelease.
 
 ### Nightly build
 
-On every merge to `main`, CI builds a release-signed APK and republishes it as a
-rolling prerelease tagged `nightly`. The tag is re-pointed to the built commit each
-run, so the release always reflects the latest `main`. Download the latest APK from
-the [`nightly` release](../../releases/tag/nightly).
+On every merge to `main`, CI builds a release-signed APK and republishes it
+as a rolling prerelease tagged `nightly`. The tag is re-pointed to the built
+commit each run, so the release always reflects the latest `main`. Download
+the latest APK from the [`nightly` release](../../releases/tag/nightly).
 
-The nightly APK is **release-signed**; local and contributor `./gradlew
-assembleRelease` builds stay **unsigned** because no keystore environment variables
-are present. The signing config is registered only when `RELEASE_KEYSTORE_PATH` is
-set, so local release builds keep working.
+The nightly APK is **release-signed**. Local and contributor
+`./gradlew assembleRelease` builds stay **unsigned**, because no keystore
+environment variables are present. The signing config is registered only
+when `RELEASE_KEYSTORE_PATH` is set, so local release builds keep working.
 
 ### Signing secrets
 
-A maintainer must add four repository secrets (Settings -> Secrets and variables ->
-Actions) before the nightly job can sign:
+A maintainer must add four repository secrets (Settings -> Secrets and
+variables -> Actions) before the nightly job can sign:
 
 | Secret | Contents |
 | --- | --- |
@@ -92,12 +191,14 @@ base64 -i release.jks | pbcopy
 base64 -w0 release.jks
 ```
 
-Keep `release.jks` out of version control. If `RELEASE_KEYSTORE_BASE64` is missing,
-the nightly job fails with an explicit message instead of publishing an unsigned APK.
+Keep `release.jks` out of version control. If `RELEASE_KEYSTORE_BASE64` is
+missing, the nightly job fails with an explicit message instead of
+publishing an unsigned APK.
 
-## Conventions
+## Contributing
 
-Project rules, code style, and design system policies live in
-[`CLAUDE.md`](CLAUDE.md). Read it before contributing. Key sections:
-[design system](CLAUDE.md#design-system), [Kotlin style](CLAUDE.md#kotlin-style),
-[testing](CLAUDE.md#testing).
+Project rules, code style, and design-system policies live in
+[`CLAUDE.md`](CLAUDE.md); read it before contributing. Key sections:
+[design system](CLAUDE.md#design-system),
+[Compose architecture](CLAUDE.md#compose-architecture),
+[Kotlin style](CLAUDE.md#kotlin-style), and [testing](CLAUDE.md#testing).

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,8 +85,8 @@
     <!--
         Declare telephony hardware as optional so Play does not implicitly
         hard-require it (requesting READ_PHONE_STATE above otherwise implies
-        required=true). Wi-Fi-only AI boxes (Carlinkit / OTTOCAST) have no
-        telephony hardware; the cellular indicator degrades — cellularFlow()
+        required=true). Wi-Fi-only AI boxes have no telephony
+        hardware; the cellular indicator degrades — cellularFlow()
         and cellularLevelFlow() guard FEATURE_TELEPHONY and emit null — so
         such units must still see and install the launcher (multi-region
         distribution). See CLAUDE.md#launcher-behavior.

--- a/docs/superpowers/plans/2026-05-01-home-dashboard-plan.md
+++ b/docs/superpowers/plans/2026-05-01-home-dashboard-plan.md
@@ -6,7 +6,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace the single-purpose apps grid with a LecoAuto-inspired multi-panel dashboard: hero map (Lite Mode + speed/altitude/address overlays), three right-stack panels (clock, weather, now-playing), and a bottom apps bar. The full apps grid moves into a separate drawer screen.
+**Goal:** Replace the single-purpose apps grid with a multi-panel dashboard: hero map (Lite Mode + speed/altitude/address overlays), three right-stack panels (clock, weather, now-playing), and a bottom apps bar. The full apps grid moves into a separate drawer screen.
 
 **Architecture:** Unidirectional data flow — six independent `data/` repositories produce Kotlin Flows; `HomeViewModel` combines them into a single `HomeUiState`; ten focused Composables render the C2 layout. Maps integration uses Google Maps SDK Lite Mode with a runtime GMS-availability check that gracefully degrades to a static fallback. Address comes from the AOSP `Geocoder` (also GMS-backed). Weather comes from Open-Meteo (no API key, multi-region). Music comes from `MediaSession` via a `NotificationListenerService`.
 
@@ -1387,7 +1387,7 @@ Wraps GoogleApiAvailability so the rest of the codebase doesn't
 import com.google.android.gms.common directly. The dashboard reads
 this once at ViewModel init; MapPanel collapses to its static
 fallback when the call returns false, which is the expected case
-on AOSP-only Carlinkit / OTTOCAST SKUs."
+on AOSP-only AI-box SKUs."
 ```
 
 ### Task 2.6: MusicSession plumbing
@@ -3181,12 +3181,12 @@ Expected: All four commands report BUILD SUCCESSFUL.
 
 - [ ] **Step 2: If any step fails, fix in a follow-up commit.** Do not bypass spotless or lint.
 
-### Task 5.2: Smoke test on TBox-Mock AVD
+### Task 5.2: Smoke test on the head-unit AVD
 
 - [ ] **Step 1: Boot the AVD.**
 
 ```bash
-emulator @TBox-Mock -no-snapshot &
+emulator @<head-unit-avd> -no-snapshot &
 adb wait-for-device
 ```
 
@@ -3239,7 +3239,7 @@ adb exec-out screencap -p > docs/superpowers/specs/img/2026-05-01-dashboard-stat
 
 ### Task 5.3: Real-device smoke (optional, when hardware is available)
 
-- [ ] **Step 1: Connect the TBox Ambient via USB-C / OTG-host adapter.**
+- [ ] **Step 1: Connect the AI box via USB-C / OTG-host adapter.**
 
 - [ ] **Step 2: Confirm GMS is present on the device.**
 

--- a/docs/superpowers/plans/2026-05-01-home-dashboard-pr.md
+++ b/docs/superpowers/plans/2026-05-01-home-dashboard-pr.md
@@ -12,8 +12,8 @@
 
 ### Summary
 
-- Replace the single-purpose apps grid with a LecoAuto-inspired
-  multi-panel dashboard. Layout C2 — map hero on the left, vertical
+- Replace the single-purpose apps grid with a multi-panel
+  dashboard. Layout C2 — map hero on the left, vertical
   stack of three panels (clock, weather, now-playing) on the right,
   apps bar pinned at the bottom. The full apps grid moves into a
   separate AppDrawer route.
@@ -24,7 +24,7 @@
   them into a single `HomeUiState`.
 - Maps integration uses Google Maps SDK Lite Mode with a runtime
   GMS-availability check that gracefully degrades to a static
-  fallback on AOSP-only Carlinkit / OTTOCAST builds.
+  fallback on AOSP-only AI-box builds.
 - Weather temperature reads
   `androidx.core.text.util.LocalePreferences.getTemperatureUnit()`;
   speed/altitude unit derives from the imperial-country set
@@ -51,11 +51,11 @@ Local verification (already green on this branch):
 
 Smoke verification (deferred until reviewer has hardware):
 
-- [ ] `./gradlew connectedDebugAndroidTest` on a TBox-Mock AVD
+- [ ] `./gradlew connectedDebugAndroidTest` on the head-unit AVD
   (the 5 Compose UI tests cover ClockPanel, WeatherPanel,
   MusicPanel, AppsBar, DashboardScaffold)
-- [ ] Real-device install on a TBox Ambient or equivalent
-  Carlinkit / OTTOCAST head unit — confirm:
+- [ ] Real-device install on an aftermarket AI-box head unit —
+  confirm:
   - Map tiles render when a `MAPS_API_KEY` is configured in
     `local.properties`
   - The static-fallback branch renders cleanly when no key is set

--- a/docs/superpowers/specs/2026-05-01-home-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-01-home-dashboard-design.md
@@ -13,9 +13,9 @@
 
 ## 1. Goal
 
-Replace the current single-purpose home screen (one full-screen `LazyVerticalGrid` of installed apps) with a LecoAuto-inspired multi-panel **dashboard**: a hero map on the left with speed / altitude / address overlays, a vertical stack of three ambient panels on the right (clock, weather, now-playing), and a fixed application bar at the bottom that opens a separate full-screen drawer for the complete grid.
+Replace the current single-purpose home screen (one full-screen `LazyVerticalGrid` of installed apps) with a multi-panel **dashboard**: a hero map on the left with speed / altitude / address overlays, a vertical stack of three ambient panels on the right (clock, weather, now-playing), and a fixed application bar at the bottom that opens a separate full-screen drawer for the complete grid.
 
-The dashboard surfaces information that head-unit users — driver and passenger alike — actually consult, and stays in the same shape regardless of vehicle motion. Distraction responsibility is delegated to the driver and to the OEM cluster, in line with comparable aftermarket launchers (LecoAuto, Car Launcher Pro, AGAMA, CarWebGuru).
+The dashboard surfaces information that head-unit users — driver and passenger alike — actually consult, and stays in the same shape regardless of vehicle motion. Distraction responsibility is delegated to the driver and to the OEM cluster, in line with comparable aftermarket car launchers.
 
 ## 2. Non-goals
 
@@ -201,7 +201,7 @@ The launcher renders the same dashboard tree regardless of vehicle motion. Two r
 - **Passenger operation.** A passenger commonly operates the head unit; gating the whole UI on motion punishes the passenger for the driver being in motion.
 - **OEM cluster owns driving information.** Speed, RPM, fuel, warnings come from the vehicle cluster. The launcher's role is the head-unit shell, not a redundant driver display.
 
-Distraction responsibility is therefore delegated to the driver and to the OEM cluster, in line with how comparable aftermarket launchers (LecoAuto, Car Launcher Pro, AGAMA, CarWebGuru) ship today. Map tiles in Lite Mode do not animate, the apps bar does not scroll, and there are no inline videos in the launcher itself, so the always-on dashboard does not introduce a new distraction class beyond what those competitors already ship.
+Distraction responsibility is therefore delegated to the driver and to the OEM cluster, in line with how comparable aftermarket car launchers ship today. Map tiles in Lite Mode do not animate, the apps bar does not scroll, and there are no inline videos in the launcher itself, so the always-on dashboard does not introduce a new distraction class beyond what those competitors already ship.
 
 The `DrivingStateRepository`, `DrivingState.kt` `rememberDrivingLockState()`, and the `gate-driving-visible-feature` skill are removed in the same change set as this spec. The `FemtoDimens.MinBodyTextSize` (18 sp) and `FemtoDimens.MinTouchTarget` (64 dp) tokens stay — they continue to express glance-readability and tap accuracy targets that matter independently of motion.
 
@@ -278,7 +278,7 @@ The project does **not** add `com.google.maps.android:maps-compose` in v1. `MapV
 | `data/` repositories | JVM unit (`runTest` + `TestDispatcher`) | HTTP response parsing (mockwebserver), GMS-absent branch, debounce timing, in-memory cache validity, `Geocoder.isPresent()` false path (Robolectric) |
 | `HomeViewModel` | JVM unit (Turbine) | `combine` ordering on initial empty Flows, `HomeAction.OpenMaps` chooses the geo URI built from the latest location, `HomeAction.LaunchApp` resolves the right `ComponentName` |
 | Compose UI | `createComposeRule` (`androidTest`) | C2 dashboard renders all four panels under representative state; GMS-absent state hides map tiles and shows the static fallback; music-null state shows `Connect a player`; map overlays render speed, altitude, and address when the underlying flows emit values |
-| Manual smoke | TBox-Mock AVD + TBox Ambient real device | Cold start under one second, panel updates at expected cadences, `geo fix` injection updates the speed / altitude / address overlays without changing the layout shape |
+| Manual smoke | the head-unit AVD + a real AI-box device | Cold start under one second, panel updates at expected cadences, `geo fix` injection updates the speed / altitude / address overlays without changing the layout shape |
 
 Test fixtures live in `testfixtures/` packages (one per source set). Builders for `Location`, `WeatherSnapshot`, `NowPlaying`, and `ShortAddress` are the SSOT for those values; tests must not declare their own `data class FakeFoo(...)` literals (CLAUDE.md#ssot-dry).
 
@@ -286,19 +286,19 @@ Test fixtures live in `testfixtures/` packages (one per source set). Builders fo
 
 | Risk | Mitigation |
 | --- | --- |
-| Carlinkit / OTTOCAST SKU without GMS reaches a real user | `mapAvailable = false` + `Geocoder.isPresent() = false` branches both kick in. Music, weather, clock, and the speed / altitude overlays keep working. Documented in CLAUDE.md as a graceful degradation, not a failure |
+| An AI-box SKU without GMS reaches a real user | `mapAvailable = false` + `Geocoder.isPresent() = false` branches both kick in. Music, weather, clock, and the speed / altitude overlays keep working. Documented in CLAUDE.md as a graceful degradation, not a failure |
 | Open-Meteo outage | In-memory snapshot survives until the next successful fetch. `WeatherPanel` shows the stale value with no error UI; on cold start with no network the panel renders an icon-only placeholder |
 | Maps API key leak | App restriction (package + SHA-1) on the Cloud Console. Cost alarm at 80% of the free tier. The key is not committed to git |
 | Maps cost growth past the free tier | `MapPanel` deliberately uses Lite Mode and a stable key; one composition = one map load. Monitoring catches MAU growth before billing crosses zero |
 | User denies location permission | All location-driven surfaces (weather, address, map tiles, speed and altitude overlays) collapse to their absent branches. Clock and music continue to work, the apps bar continues to function |
-| Driver-distraction concerns from store review or end users | The launcher behaves like comparable aftermarket launchers (LecoAuto, Car Launcher Pro, AGAMA): no embedded video, no inline scrolling content larger than the apps bar, Lite-Mode static map. If a future feature is genuinely distraction-prone, it gates itself locally — there is no project-wide gate to maintain |
+| Driver-distraction concerns from store review or end users | The launcher behaves like comparable aftermarket car launchers: no embedded video, no inline scrolling content larger than the apps bar, Lite-Mode static map. If a future feature is genuinely distraction-prone, it gates itself locally — there is no project-wide gate to maintain |
 
 ## 13. Acceptance checklist
 
 - [ ] `./gradlew assembleDebug` and `./gradlew lint` are green
 - [ ] `./gradlew test` covers each repository and the ViewModel combine
 - [ ] `./gradlew connectedAndroidTest` covers the dashboard render under representative state combinations (loaded / loading, GMS present / absent, music null / playing, location null / fixed)
-- [ ] Cold start on TBox-Mock AVD remains under one second
+- [ ] Cold start on the head-unit AVD remains under one second
 - [ ] Permission audit table in CLAUDE.md is updated to include INTERNET and ACCESS_NETWORK_STATE with their justifications, and the ACCESS_FINE_LOCATION justification is rewritten to drop the lockout reference
 - [ ] `local.properties` key `MAPS_API_KEY=` is documented in the project README's developer setup section
 - [ ] CLAUDE.md `#driving-lockout` rule is rewritten to record the no-UI-gating policy, and the `gate-driving-visible-feature` skill plus its references in other skills and agents are removed

--- a/docs/superpowers/specs/2026-06-04-dashboard-device-feedback-design.md
+++ b/docs/superpowers/specs/2026-06-04-dashboard-device-feedback-design.md
@@ -2,8 +2,8 @@
 
 - Date: 2026-06-04
 - Status: Approved (design + PR plan approved by the maintainer on 2026-06-04)
-- Source: real-device testing on a **Carlinkit TBox Ambient** AI box driving a
-  **ZWE211W 9-inch** head-unit display. The maintainer reported 19 feedback
+- Source: real-device testing on an aftermarket AI box driving a
+  **factory 9-inch** head-unit display. The maintainer reported 19 feedback
   items (16 in the first message + 3 follow-ups) covering visual design, layout
   responsiveness, two data bugs, and several new features.
 - Investigation: a multi-agent read-only audit mapped every item to its code and
@@ -48,9 +48,8 @@ are designed to need none).
    notification-listener access is simply **not granted**. The wiring is correct;
    improve discoverability (clearer CTA + first-run guidance) and add a
    metadata-edge safety net.
-9. **Target hardware** — "ZWE211W" is the Toyota Corolla Touring **chassis code**,
-   not a display model; the real surface is the car's **factory 9-inch Toyota
-   Display Audio**, into which the TBox Ambient injects Android over wired
+9. **Target hardware** — the real surface is the car's **factory 9-inch
+   display**, into which an aftermarket AI box injects Android over wired
    CarPlay/AA at the **factory projection resolution (adaptive)**. Most likely
    **1280×720 (16:9) ≈ 640×360 dp at ~xhdpi**, with **1280×480 (8:3 ultra-wide)
    ≈ 640×240 dp** as a real alternative; the box's `Minimum Width` dp is
@@ -327,7 +326,7 @@ grows too large to review.
 
 ## 7. Open / confirm-on-device
 
-- Exact native projection resolution on this car's factory 9-inch Toyota Display
-  Audio (research narrowed it to 1280×720 / 16:9 most-likely, or 1280×480 / 8:3
+- Exact native projection resolution on this car's factory 9-inch display
+  (research narrowed it to 1280×720 / 16:9 most-likely, or 1280×480 / 8:3
   ultra-wide; responsive design handles any value in the ~480–720 dp range).
 - PR2 map fix outcome (grey-rectangle resolved?) — confirm by installing the APK.


### PR DESCRIPTION
## Summary

De-brand the project's authored content and rewrite the README as an
accurate, brand-neutral product overview. The `similar-app-researcher`
agent — the one place external product references legitimately belong —
is kept and extended with two more references.

## Changes

### Remove external product names (repository-wide)
Scope: competitor app names, AI-box vendor brands, and specific
test-hardware names are replaced with generic descriptions. Platform
standards (CarPlay, Android Auto, AAOS) and the technical stack
(MapLibre, OpenFreeMap, Open-Meteo, Nominatim, OSM) are retained as
technical terms.

- `CLAUDE.md` — device descriptor, motion-state policy, subagent table,
  memory section.
- `app/src/main/AndroidManifest.xml` — telephony `<uses-feature>` comment.
- `docs/superpowers/` plans and specs — genericized prose, AVD names,
  and target-hardware descriptions (the projection-resolution technical
  detail is preserved).

### Rewrite `README.md`
Accurate product overview with technical-writing conventions (active
voice, present tense, one idea per sentence, acronyms defined on first
use). Covers features, the unidirectional-data-flow architecture, the
tech stack (versions link to `gradle/libs.versions.toml`), project
layout, build/run, configurable production endpoints, CI, the nightly
build, and signing.

### Enrich the researcher agent (the exception)
`.claude/agents/similar-app-researcher.md` keeps its existing reference
set and gains **CarLab** (car-lab.app) and **AutoZen** (autozenapp.com)
with researched descriptions. `.claude/settings.json` gains the matching
`WebFetch` domain allow-rules (the existing `lecoauto.com` rule is kept).

## Intentionally untouched
- `.claude/settings.json` `lecoauto.com` allow-rule — kept so the agent
  can still research it.
- `.idea/deploymentTargetSelector.xml` — points at the real on-disk AVD;
  editing it would break IDE device selection without renaming the AVD.

## Verification
- README brand-neutrality grep: clean.
- `./gradlew spotlessCheck`: BUILD SUCCESSFUL.
- No production code paths change (docs, one code comment, and config only).