### PR TITLE
fix(dashboard): fit the layout to short, wide head units

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -214,9 +214,11 @@ private fun InfoPane(
 }
 
 // Below either breakpoint the dashboard switches to its compact spacing. The
-// thresholds are deliberately coarse: they separate small head units from large
-// in-dash panels without targeting any one resolution.
-private val CompactHeightBreakpoint: Dp = 420.dp
+// thresholds are deliberately coarse: they separate small / short head units
+// from large in-dash panels without targeting any one resolution. The height
+// threshold sits above the common ~512 dp 5:3 projection so those short
+// landscapes take the tighter spacing, leaving more room for the info-pane cards.
+private val CompactHeightBreakpoint: Dp = 560.dp
 private val CompactWidthBreakpoint: Dp = 600.dp
 
 // Compact outer / inter-pane spacing; the comfortable values are the FemtoDimens
@@ -226,12 +228,13 @@ private val CompactPaneGap: Dp = 10.dp
 
 // Pane weights. The map is the dominant surface in landscape; in portrait it
 // sits a little taller than the info pane. The info pane splits its height
-// roughly 0.43 : 0.57 between the calendar/weather row and the music card,
-// preserving the mockup's top-row-to-music proportion without a fixed height.
-private const val MAP_PANE_LANDSCAPE_WEIGHT = 1.5f
+// roughly evenly between the calendar/weather row and the music card so neither
+// is starved on a short head unit — a ~512 dp-tall 5:3 projection clipped the
+// calendar/weather row when the music card was weighted heavier.
+private const val MAP_PANE_LANDSCAPE_WEIGHT = 1.4f
 private const val MAP_PANE_PORTRAIT_WEIGHT = 1.1f
 private const val TOP_ROW_WEIGHT = 1f
-private const val MUSIC_CARD_WEIGHT = 1.35f
+private const val MUSIC_CARD_WEIGHT = 1.05f
 
 // Responsive previews. HomeUiState.Initial renders the empty/loading states (no
 // network/GL in a preview), which is enough to lock the responsive arrangement
@@ -255,6 +258,24 @@ private fun DashboardScaffoldLandscapePreview() {
 @Preview(name = "Dashboard - 8:3 ultra-wide", widthDp = 640, heightDp = 240)
 @Composable
 private fun DashboardScaffoldUltraWidePreview() {
+    FemtoTheme {
+        DashboardScaffold(
+            uiState = HomeUiState.Initial,
+            is24Hour = true,
+            speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            temperatureUnit = TemperatureUnit.CELSIUS,
+            onAction = {},
+        )
+    }
+}
+
+// The real Carlinkit-class projection: 800x480 px at 150 dpi = 853x512 dp (5:3).
+// Wider and shorter in dp than the 16:9 case, so it is the binding geometry for
+// the speed-overlay width cap and the info-pane height split.
+@PreviewLightDark
+@Preview(name = "Dashboard - 5:3 head unit", widthDp = 853, heightDp = 512)
+@Composable
+private fun DashboardScaffoldHeadUnitPreview() {
     FemtoTheme {
         DashboardScaffold(
             uiState = HomeUiState.Initial,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -32,6 +33,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
@@ -121,13 +123,18 @@ internal fun SpeedOverlay(
                 // defaults to fillMaxWidth) would stretch the card to the full
                 // map pane. The address-row divider then spans the same width.
                 .width(IntrinsicSize.Max)
+                // Cap the width so a wide map pane (e.g. an 853 dp 5:3 head unit)
+                // keeps the overlay a centred glass card, not a full-width bar.
+                // IntrinsicSize.Max still hugs short content; this only bounds the
+                // maximum, and the address row ellipsizes within it.
+                .widthIn(max = FemtoDimens.SpeedOverlayMaxWidth)
                 .clip(RoundedCornerShape(FemtoDimens.SpeedOverlayCorner))
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = glassAlpha))
                 .border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = FemtoDimens.GlassBorderAlpha),
                     shape = RoundedCornerShape(FemtoDimens.SpeedOverlayCorner),
-                ).padding(horizontal = 24.dp, vertical = 16.dp),
+                ).padding(horizontal = 18.dp, vertical = 16.dp),
     ) {
         MetricRow(
             currentSpeed = currentSpeedText,
@@ -156,7 +163,7 @@ private fun MetricRow(
     onReset: () -> Unit,
 ) = Row(
     verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(16.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
 ) {
     NowMetric(value = currentSpeed, unit = speedUnitLabel)
     Separator()
@@ -253,6 +260,9 @@ private fun SecondaryMetric(
 @Composable
 private fun AddressRow(text: String) =
     Row(
+        // Fill the overlay's (metric-row-defined) width so a long address
+        // ellipsizes within it instead of stretching the card wider.
+        modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -272,6 +282,8 @@ private fun AddressRow(text: String) =
                 ),
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.86f),
             maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
         )
     }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -76,6 +76,15 @@ object FemtoDimens {
      */
     val SpeedMetricMinWidth = 76.dp
 
+    /**
+     * Upper bound on the speed overlay's width so it reads as a centred glass
+     * card on the map pane rather than stretching toward a full-width bar on a
+     * wide head unit (e.g. an 853 dp-wide 5:3 projection). The overlay still
+     * sizes to its content via `IntrinsicSize.Max`; this only caps the maximum,
+     * and the address row ellipsizes within it instead of expanding the card.
+     */
+    val SpeedOverlayMaxWidth = 440.dp
+
     /** Weather glyph beside the city name in the weather card head row. */
     val WeatherGlyphLarge = 20.dp
 


### PR DESCRIPTION
## Real-device feedback (Carlinkit AI box, 800×480 px @ 150 dpi = **853×512 dp, 5:3**)

Two of the three reported issues are layout (the third, the grey map, is tracked separately — it is a GL-surface-presentation problem on the projected display, fix in progress).

| Reported | Cause | Fix |
| --- | --- | --- |
| Speed panel too wide | The overlay sizes to its content (`IntrinsicSize.Max`); on a ~473 dp map pane its metric row nearly fills the pane, and a long reverse-geocoded address could stretch it further | Cap the width with `FemtoDimens.SpeedOverlayMaxWidth` (440 dp), ellipsize the address so it can't expand the card, tighten the metric-row gap (16→12) and horizontal padding (24→18) |
| Calendar / weather / music cut off | At 512 dp tall the info pane's calendar/weather row was starved (music card weighted 1.35×), and the comfortable spacing applied because 512 dp > the old 420 dp compact threshold | Split the info-pane height ~evenly (music weight 1.35→1.05), widen the info pane (map weight 1.5→1.4), and raise the compact-height breakpoint to 560 dp so short landscapes take the tighter spacing |

Also adds an **853×512 dp (5:3)** dashboard preview — the binding head-unit geometry, wider and shorter in dp than the existing 16:9 / 8:3 previews.

## Verification
`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` → BUILD SUCCESSFUL.

Pixel-level fit is best confirmed on the device; this targets the now-known real geometry and is expected to iterate against the next nightly. The layout stays geometry-driven (no device-specific branch).