### PR TITLE
feat(dashboard): compact the speed overlay and use a horizontal music card

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -109,21 +111,42 @@ private fun PlayingState(
     nowPlaying: NowPlaying,
     onCommand: (MusicCommand) -> Unit,
     onLaunchSource: (String) -> Unit,
-) = Box(modifier = Modifier.fillMaxSize()) {
+) = Row(
+    modifier =
+        Modifier
+            .fillMaxSize()
+            .padding(FemtoDimens.CardPadding),
+    horizontalArrangement = Arrangement.spacedBy(14.dp),
+    verticalAlignment = Alignment.CenterVertically,
+) {
+    // Album art on the left, sized square to the card height.
+    AlbumArt(
+        nowPlaying = nowPlaying,
+        modifier = Modifier.fillMaxHeight().aspectRatio(1f),
+    )
+    // Track info + transport controls on the right.
     Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(FemtoDimens.CardPadding),
-        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.weight(1f).fillMaxHeight(),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
-        AlbumArt(nowPlaying = nowPlaying)
-        Meta(
-            source = sourceLabel(nowPlaying.packageName),
-            title = nowPlaying.title,
-            artist = nowPlaying.artist,
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Meta(
+                source = sourceLabel(nowPlaying.packageName),
+                title = nowPlaying.title,
+                artist = nowPlaying.artist,
+                modifier = Modifier.weight(1f),
+            )
+            // Tapping the source app's icon brings that app to the foreground.
+            SourceAppButton(
+                sourceIcon = nowPlaying.sourceIcon,
+                sourceLabel = sourceLabel(nowPlaying.packageName),
+                onClick = { onLaunchSource(nowPlaying.packageName) },
+            )
+        }
         Progress(
             positionMs = nowPlaying.positionMs,
             durationMs = nowPlaying.durationMs,
@@ -133,12 +156,6 @@ private fun PlayingState(
         )
         TransportRow(isPlaying = nowPlaying.isPlaying, onCommand = onCommand)
     }
-    SourceAppButton(
-        sourceIcon = nowPlaying.sourceIcon,
-        sourceLabel = sourceLabel(nowPlaying.packageName),
-        onClick = { onLaunchSource(nowPlaying.packageName) },
-        modifier = Modifier.align(Alignment.TopEnd),
-    )
 }
 
 @Composable
@@ -181,12 +198,14 @@ private fun SourceAppButton(
 }
 
 @Composable
-private fun AlbumArt(nowPlaying: NowPlaying) {
+private fun AlbumArt(
+    nowPlaying: NowPlaying,
+    modifier: Modifier = Modifier,
+) {
     val art = nowPlaying.albumArt
     Box(
         modifier =
-            Modifier
-                .size(FemtoDimens.MusicArtSize)
+            modifier
                 .clip(RoundedCornerShape(FemtoDimens.ArtCorner))
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         contentAlignment = Alignment.Center,
@@ -229,9 +248,10 @@ private fun Meta(
     source: String,
     title: String,
     artist: String?,
+    modifier: Modifier = Modifier,
 ) = Column(
-    modifier = Modifier.fillMaxWidth(),
-    horizontalAlignment = Alignment.CenterHorizontally,
+    modifier = modifier.fillMaxWidth(),
+    horizontalAlignment = Alignment.Start,
     verticalArrangement = Arrangement.spacedBy(2.dp),
 ) {
     Row(
@@ -533,7 +553,7 @@ private fun formatMillis(ms: Long): String {
 }
 
 @PreviewLightDark
-@Preview(name = "Music card · playing", widthDp = 360, heightDp = 360)
+@Preview(name = "Music card · playing", widthDp = 360, heightDp = 200)
 @Composable
 private fun MusicCardPlayingPreview() {
     FemtoTheme {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -134,7 +134,7 @@ internal fun SpeedOverlay(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = FemtoDimens.GlassBorderAlpha),
                     shape = RoundedCornerShape(FemtoDimens.SpeedOverlayCorner),
-                ).padding(horizontal = 18.dp, vertical = 16.dp),
+                ).padding(horizontal = 18.dp, vertical = 10.dp),
     ) {
         MetricRow(
             currentSpeed = currentSpeedText,
@@ -145,7 +145,7 @@ internal fun SpeedOverlay(
             onReset = onReset,
         )
         if (shortAddress.isNotBlank()) {
-            Box(modifier = Modifier.height(12.dp))
+            Box(modifier = Modifier.height(8.dp))
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
             Box(modifier = Modifier.height(10.dp))
             AddressRow(text = shortAddress)


### PR DESCRIPTION
On-device head-unit feedback (1 of the map/panel batch).

- **Speed overlay** — compress the first row's vertical whitespace: overlay vertical padding 16→10 dp and the metric-row→divider gap 12→8 dp.
- **Music card** — horizontal playing layout: **album art left** (square, card-height), **track info + progress + transport controls right**. The tappable **source-app icon** sits in the right column header; tapping it brings that app to the foreground (existing `LaunchMusicSource` path). Playing preview → 360×200 to match the real card shape.

Verification: `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` → BUILD SUCCESSFUL. (Remaining batch items: map current-location marker + forward framing; map frame-rate slider; Android-style settings redesign.)