### PR TITLE
feat(map): make the map frame rate a configurable fps slider

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import io.github.seijikohara.femto.data.ClockTick
-import io.github.seijikohara.femto.data.MapRefreshSetting
 import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.testfixtures.fakeAddress
 import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
@@ -45,7 +44,7 @@ class DashboardScaffoldTest {
                     is24Hour = true,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     temperatureUnit = TemperatureUnit.CELSIUS,
-                    mapRefresh = MapRefreshSetting.RESPONSIVE,
+                    mapFps = 10,
                     onAction = {},
                 )
             }

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -117,7 +117,7 @@ class MainActivity : ComponentActivity() {
                         is24Hour = resolveIs24Hour(display.clock),
                         speedUnit = display.speedUnit.resolved(),
                         temperatureUnit = display.temperatureUnit.resolved(),
-                        mapRefresh = display.mapRefresh,
+                        mapFps = display.mapFps,
                         onEvent = { event ->
                             handleHomeEvent(
                                 event = event,

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -25,12 +26,8 @@ internal enum class ClockSetting { AUTO, TWELVE_HOUR, TWENTY_FOUR_HOUR }
 /** Fullscreen: keep the system bars, or hide both status and navigation bars. */
 internal enum class FullscreenSetting { OFF, ON }
 
-/**
- * Map refresh cadence. The snapshot map re-renders on movement; this caps how
- * often it does so: RESPONSIVE (~2 Hz) trades battery for smoother motion,
- * BALANCED (~1 Hz), BATTERY_SAVER (every few seconds).
- */
-internal enum class MapRefreshSetting { RESPONSIVE, BALANCED, BATTERY_SAVER }
+/** Default target map frame rate (fps) before the user picks one. */
+internal const val DEFAULT_MAP_FPS = 10
 
 /**
  * User display settings that override the locale / system defaults. Every value
@@ -43,7 +40,9 @@ internal data class DisplaySettings(
     val temperatureUnit: TemperatureUnitSetting,
     val clock: ClockSetting,
     val fullscreen: FullscreenSetting,
-    val mapRefresh: MapRefreshSetting,
+    // Target map frame rate (fps): the snapshot map caps its re-render rate at
+    // this many frames per second. Clamped to the display's max refresh at use.
+    val mapFps: Int,
 ) {
     companion object {
         val Default =
@@ -53,7 +52,7 @@ internal data class DisplaySettings(
                 temperatureUnit = TemperatureUnitSetting.AUTO,
                 clock = ClockSetting.AUTO,
                 fullscreen = FullscreenSetting.OFF,
-                mapRefresh = MapRefreshSetting.RESPONSIVE,
+                mapFps = DEFAULT_MAP_FPS,
             )
     }
 }
@@ -78,7 +77,7 @@ internal class DisplayPreferences(
                 temperatureUnit = prefs[TEMPERATURE_KEY].toEnumOr(TemperatureUnitSetting.AUTO),
                 clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
                 fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.OFF),
-                mapRefresh = prefs[MAP_REFRESH_KEY].toEnumOr(MapRefreshSetting.RESPONSIVE),
+                mapFps = prefs[MAP_FPS_KEY] ?: DEFAULT_MAP_FPS,
             )
         }
 
@@ -94,8 +93,7 @@ internal class DisplayPreferences(
     suspend fun setFullscreen(value: FullscreenSetting) =
         context.displayDataStore.edit { it[FULLSCREEN_KEY] = value.name }
 
-    suspend fun setMapRefresh(value: MapRefreshSetting) =
-        context.displayDataStore.edit { it[MAP_REFRESH_KEY] = value.name }
+    suspend fun setMapFps(value: Int) = context.displayDataStore.edit { it[MAP_FPS_KEY] = value }
 
     private companion object {
         val THEME_KEY = stringPreferencesKey("theme_mode")
@@ -103,7 +101,7 @@ internal class DisplayPreferences(
         val TEMPERATURE_KEY = stringPreferencesKey("temperature_unit")
         val CLOCK_KEY = stringPreferencesKey("clock")
         val FULLSCREEN_KEY = stringPreferencesKey("fullscreen")
-        val MAP_REFRESH_KEY = stringPreferencesKey("map_refresh")
+        val MAP_FPS_KEY = intPreferencesKey("map_fps")
     }
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import io.github.seijikohara.femto.data.MapRefreshSetting
 import io.github.seijikohara.femto.data.hasFineLocationPermission
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.locale.TemperatureUnit
@@ -22,7 +21,7 @@ internal fun HomeRoute(
     is24Hour: Boolean,
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
-    mapRefresh: MapRefreshSetting,
+    mapFps: Int,
     onEvent: (HomeEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -40,7 +39,7 @@ internal fun HomeRoute(
         is24Hour = is24Hour,
         speedUnit = speedUnit,
         temperatureUnit = temperatureUnit,
-        mapRefresh = mapRefresh,
+        mapFps = mapFps,
         onAction = viewModel::onAction,
         modifier = modifier,
     )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import io.github.seijikohara.femto.data.MapRefreshSetting
 import io.github.seijikohara.femto.ui.home.components.DashboardScaffold
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.locale.TemperatureUnit
@@ -18,7 +17,7 @@ internal fun HomeScreen(
     is24Hour: Boolean,
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
-    mapRefresh: MapRefreshSetting,
+    mapFps: Int,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
@@ -30,7 +29,7 @@ internal fun HomeScreen(
         is24Hour = is24Hour,
         speedUnit = speedUnit,
         temperatureUnit = temperatureUnit,
-        mapRefresh = mapRefresh,
+        mapFps = mapFps,
         onAction = onAction,
         modifier = Modifier.fillMaxSize(),
     )
@@ -45,7 +44,7 @@ private fun HomeScreenPreview() =
             is24Hour = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
-            mapRefresh = MapRefreshSetting.RESPONSIVE,
+            mapFps = 10,
             onAction = {},
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import io.github.seijikohara.femto.data.MapRefreshSetting
 import io.github.seijikohara.femto.ui.home.HomeAction
 import io.github.seijikohara.femto.ui.home.HomeUiState
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
@@ -66,7 +65,7 @@ internal fun DashboardScaffold(
     is24Hour: Boolean,
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
-    mapRefresh: MapRefreshSetting,
+    mapFps: Int,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(
@@ -97,7 +96,7 @@ internal fun DashboardScaffold(
                     uiState = uiState,
                     is24Hour = is24Hour,
                     speedUnit = speedUnit,
-                    mapRefresh = mapRefresh,
+                    mapFps = mapFps,
                     onAction = onAction,
                     modifier = Modifier.weight(MAP_PANE_PORTRAIT_WEIGHT).fillMaxWidth(),
                 )
@@ -122,7 +121,7 @@ internal fun DashboardScaffold(
                     uiState = uiState,
                     is24Hour = is24Hour,
                     speedUnit = speedUnit,
-                    mapRefresh = mapRefresh,
+                    mapFps = mapFps,
                     onAction = onAction,
                     modifier = Modifier.weight(MAP_PANE_LANDSCAPE_WEIGHT).fillMaxHeight(),
                 )
@@ -149,13 +148,13 @@ private fun MapPane(
     uiState: HomeUiState,
     is24Hour: Boolean,
     speedUnit: SpeedUnit,
-    mapRefresh: MapRefreshSetting,
+    mapFps: Int,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Box(modifier = modifier) {
     MapPanel(
         location = uiState.location,
-        mapRefresh = mapRefresh,
+        mapFps = mapFps,
         onTap = { onAction(HomeAction.OpenMaps) },
         modifier = Modifier.fillMaxSize(),
     )
@@ -255,7 +254,7 @@ private fun DashboardScaffoldLandscapePreview() {
             is24Hour = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
-            mapRefresh = MapRefreshSetting.RESPONSIVE,
+            mapFps = 10,
             onAction = {},
         )
     }
@@ -271,7 +270,7 @@ private fun DashboardScaffoldUltraWidePreview() {
             is24Hour = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
-            mapRefresh = MapRefreshSetting.RESPONSIVE,
+            mapFps = 10,
             onAction = {},
         )
     }
@@ -290,7 +289,7 @@ private fun DashboardScaffoldHeadUnitPreview() {
             is24Hour = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
-            mapRefresh = MapRefreshSetting.RESPONSIVE,
+            mapFps = 10,
             onAction = {},
         )
     }
@@ -306,7 +305,7 @@ private fun DashboardScaffoldPortraitPreview() {
             is24Hour = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
-            mapRefresh = MapRefreshSetting.RESPONSIVE,
+            mapFps = 10,
             onAction = {},
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -46,7 +46,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.MapPinOff
 import io.github.seijikohara.femto.R
-import io.github.seijikohara.femto.data.MapRefreshSetting
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -78,7 +77,8 @@ import kotlin.math.sin
  * normal Skia composition path and presents reliably; the snapshotter also
  * yields the oblique 3D view (camera tilt + building fill-extrusion) for free.
  *
- * The snapshot re-renders on movement, throttled by [MapRefreshSetting]. It is
+ * The snapshot re-renders on movement, capped at the map frame-rate (fps)
+ * setting. It is
  * single-flight (one render in flight at a time) and holds the previous frame
  * until the next is ready, so there is no flicker. Clock and speed overlays are
  * placed by the parent on top of this surface.
@@ -86,7 +86,7 @@ import kotlin.math.sin
 @Composable
 internal fun MapPanel(
     location: Location?,
-    mapRefresh: MapRefreshSetting,
+    mapFps: Int,
     onTap: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
@@ -101,7 +101,7 @@ internal fun MapPanel(
         if (location != null) {
             SnapshotMap(
                 location = location,
-                mapRefresh = mapRefresh,
+                mapFps = mapFps,
                 onTap = onTap,
                 modifier = Modifier.fillMaxSize(),
             )
@@ -114,7 +114,7 @@ internal fun MapPanel(
 @Composable
 private fun SnapshotMap(
     location: Location,
-    mapRefresh: MapRefreshSetting,
+    mapFps: Int,
     onTap: () -> Unit,
     modifier: Modifier = Modifier,
 ) = BoxWithConstraints(modifier = modifier) {
@@ -152,9 +152,10 @@ private fun SnapshotMap(
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current
-    LaunchedEffect(snapshotter, mapRefresh, lifecycleOwner) {
+    LaunchedEffect(snapshotter, mapFps, lifecycleOwner) {
         val snap = snapshotter ?: return@LaunchedEffect
-        val intervalMs = mapRefresh.intervalMs()
+        // Target frame interval; coerceAtLeast(1) guards 0 fps from divide-by-zero.
+        val intervalMs = 1_000L / mapFps.coerceAtLeast(1)
         // Render only while the launcher is visible; pause off-screen to drop the
         // render cost. lastRendered resets on each return to STARTED so a stale
         // map refreshes immediately when the dashboard comes back to the front.
@@ -274,13 +275,6 @@ private fun shouldRerender(
     last: Location?,
     current: Location,
 ): Boolean = last == null || last.distanceTo(current) >= REFRESH_DISTANCE_M
-
-private fun MapRefreshSetting.intervalMs(): Long =
-    when (this) {
-        MapRefreshSetting.RESPONSIVE -> RESPONSIVE_INTERVAL_MS
-        MapRefreshSetting.BALANCED -> BALANCED_INTERVAL_MS
-        MapRefreshSetting.BATTERY_SAVER -> BATTERY_SAVER_INTERVAL_MS
-    }
 
 private fun styleBuilderFor(
     context: Context,
@@ -408,8 +402,3 @@ private const val REFRESH_DISTANCE_M = 8f
 private const val FORWARD_OFFSET_M = 60.0
 private const val EARTH_RADIUS_M = 6_371_000.0
 private val MARKER_SIZE = 18.dp
-
-// Snapshot cadence per MapRefreshSetting — the minimum interval between renders.
-private const val RESPONSIVE_INTERVAL_MS = 500L
-private const val BALANCED_INTERVAL_MS = 1_000L
-private const val BATTERY_SAVER_INTERVAL_MS = 3_000L

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -17,12 +17,15 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ArrowLeft
@@ -30,7 +33,6 @@ import com.composables.icons.lucide.Lucide
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.FullscreenSetting
-import io.github.seijikohara.femto.data.MapRefreshSetting
 import io.github.seijikohara.femto.data.SpeedUnitSetting
 import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.ThemeMode
@@ -38,6 +40,7 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.FontTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+import kotlin.math.roundToInt
 
 /**
  * In-app settings: theme, units, clock, font, and links out to the relevant
@@ -126,16 +129,13 @@ internal fun SettingsScreen(
             onSelect = { onAction(SettingsAction.SetFullscreen(it)) },
         )
 
-        SettingGroup(
+        val maxFps = rememberMaxDisplayFps()
+        SliderSetting(
             title = stringResource(R.string.settings_group_map_refresh),
-            options =
-                listOf(
-                    MapRefreshSetting.RESPONSIVE to stringResource(R.string.settings_map_refresh_responsive),
-                    MapRefreshSetting.BALANCED to stringResource(R.string.settings_map_refresh_balanced),
-                    MapRefreshSetting.BATTERY_SAVER to stringResource(R.string.settings_map_refresh_battery),
-                ),
-            selected = uiState.mapRefresh,
-            onSelect = { onAction(SettingsAction.SetMapRefresh(it)) },
+            valueLabel = stringResource(R.string.settings_map_fps_value, uiState.mapFps),
+            value = uiState.mapFps,
+            range = MIN_MAP_FPS..maxFps,
+            onValueChange = { onAction(SettingsAction.SetMapFps(it)) },
         )
 
         SettingGroup(
@@ -270,6 +270,57 @@ private fun SystemGroup(
         Text(text = stringResource(R.string.settings_open_system_settings))
     }
 }
+
+@Composable
+private fun SliderSetting(
+    title: String,
+    valueLabel: String,
+    value: Int,
+    range: IntRange,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier = modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(4.dp),
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = valueLabel,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+    Slider(
+        value = value.coerceIn(range.first, range.last).toFloat(),
+        onValueChange = { onValueChange(it.roundToInt().coerceIn(range.first, range.last)) },
+        valueRange = range.first.toFloat()..range.last.toFloat(),
+    )
+}
+
+// The display's maximum refresh rate (fps), the ceiling for the map frame-rate
+// slider. Falls back to 60 when the modes cannot be read; clamped to a sane band.
+@Composable
+private fun rememberMaxDisplayFps(): Int {
+    val context = LocalContext.current
+    return remember(context) {
+        val fromModes = context.display?.supportedModes?.maxOfOrNull { it.refreshRate }
+        val refresh = fromModes ?: context.display?.refreshRate ?: DEFAULT_MAX_FPS
+        refresh.roundToInt().coerceIn(MIN_MAP_FPS, MAX_MAP_FPS_CEILING)
+    }
+}
+
+private const val MIN_MAP_FPS = 1
+private const val MAX_MAP_FPS_CEILING = 120
+private const val DEFAULT_MAX_FPS = 60f
 
 // A human-readable label for a font theme (e.g. INTER -> "Inter").
 private fun FontTheme.displayName(): String = name.lowercase().replaceFirstChar(Char::uppercaseChar)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -3,7 +3,6 @@ package io.github.seijikohara.femto.ui.settings
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FullscreenSetting
-import io.github.seijikohara.femto.data.MapRefreshSetting
 import io.github.seijikohara.femto.data.SpeedUnitSetting
 import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.ThemeMode
@@ -16,7 +15,7 @@ internal data class SettingsUiState(
     val temperatureUnit: TemperatureUnitSetting,
     val clock: ClockSetting,
     val fullscreen: FullscreenSetting,
-    val mapRefresh: MapRefreshSetting,
+    val mapFps: Int,
     val fontTheme: FontTheme,
 ) {
     companion object {
@@ -29,7 +28,7 @@ internal data class SettingsUiState(
                 temperatureUnit = DisplaySettings.Default.temperatureUnit,
                 clock = DisplaySettings.Default.clock,
                 fullscreen = DisplaySettings.Default.fullscreen,
-                mapRefresh = DisplaySettings.Default.mapRefresh,
+                mapFps = DisplaySettings.Default.mapFps,
                 fontTheme = FontTheme.INTER,
             )
     }
@@ -57,8 +56,8 @@ internal sealed interface SettingsAction {
         val value: FullscreenSetting,
     ) : SettingsAction
 
-    data class SetMapRefresh(
-        val value: MapRefreshSetting,
+    data class SetMapFps(
+        val value: Int,
     ) : SettingsAction
 
     data class SetFontTheme(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -25,7 +25,7 @@ internal class SettingsViewModel(
                 temperatureUnit = display.temperatureUnit,
                 clock = display.clock,
                 fullscreen = display.fullscreen,
-                mapRefresh = display.mapRefresh,
+                mapFps = display.mapFps,
                 fontTheme = font,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState.Initial)
@@ -39,7 +39,7 @@ internal class SettingsViewModel(
                 is SettingsAction.SetTemperatureUnit -> displayPreferences.setTemperatureUnit(action.value)
                 is SettingsAction.SetClock -> displayPreferences.setClock(action.value)
                 is SettingsAction.SetFullscreen -> displayPreferences.setFullscreen(action.value)
-                is SettingsAction.SetMapRefresh -> displayPreferences.setMapRefresh(action.value)
+                is SettingsAction.SetMapFps -> displayPreferences.setMapFps(action.value)
                 is SettingsAction.SetFontTheme -> fontPreferences.setFontTheme(action.value)
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,10 +98,8 @@
     <string name="settings_group_fullscreen">Fullscreen</string>
     <string name="settings_fullscreen_off">Off</string>
     <string name="settings_fullscreen_on">On</string>
-    <string name="settings_group_map_refresh">Map refresh</string>
-    <string name="settings_map_refresh_responsive">Responsive</string>
-    <string name="settings_map_refresh_balanced">Balanced</string>
-    <string name="settings_map_refresh_battery">Battery saver</string>
+    <string name="settings_group_map_refresh">Map frame rate</string>
+    <string name="settings_map_fps_value">%1$d fps</string>
     <string name="settings_open_notification_access">Notification access</string>
     <string name="settings_open_system_settings">System settings</string>
 </resources>

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -5,7 +5,6 @@ import androidx.test.core.app.ApplicationProvider
 import io.github.seijikohara.femto.data.DisplayPreferences
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
-import io.github.seijikohara.femto.data.MapRefreshSetting
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -55,13 +54,10 @@ class SettingsViewModelTest {
         }
 
     @Test
-    fun `SetMapRefresh persists via DisplayPreferences`() =
+    fun `SetMapFps persists via DisplayPreferences`() =
         runTest {
             val viewModel = SettingsViewModel(displayPreferences, FontPreferences(application))
-            viewModel.onAction(SettingsAction.SetMapRefresh(MapRefreshSetting.BALANCED))
-            assertEquals(
-                MapRefreshSetting.BALANCED,
-                displayPreferences.settings.first { it.mapRefresh == MapRefreshSetting.BALANCED }.mapRefresh,
-            )
+            viewModel.onAction(SettingsAction.SetMapFps(30))
+            assertEquals(30, displayPreferences.settings.first { it.mapFps == 30 }.mapFps)
         }
 }


### PR DESCRIPTION
On-device: the snapshot map stepped like a slideshow. Replace the three-bucket `MapRefreshSetting` with a **target frame rate (fps)** the user sets on a **slider from 1 fps up to the display's detected maximum refresh rate**. High load is accepted by design — the snapshotter renders as fast as it can up to the cap.

- **DisplayPreferences** — `DisplaySettings.mapFps: Int` (DataStore Int, default 10) + `setMapFps`; the `MapRefreshSetting` enum is removed.
- **MapPanel** — render interval = `1000 / mapFps` (coerced ≥ 1 fps).
- **SettingsScreen** — a `SliderSetting` (1..display-max) replaces the chip group; `rememberMaxDisplayFps()` reads `Display.supportedModes` (fallback 60), clamped to 1..120.
- `mapFps` threaded `HomeRoute → HomeScreen → DashboardScaffold → MapPanel`, replacing `mapRefresh` end-to-end (tests updated).

Verification: `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` → BUILD SUCCESSFUL. On a weak box the achievable fps is bounded by render cost; raise/lower the slider to taste.