### PR TITLE
feat(map): add 3D-building, style, tilt and zoom map settings

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
@@ -44,7 +44,7 @@ class DashboardScaffoldTest {
                     is24Hour = true,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     temperatureUnit = TemperatureUnit.CELSIUS,
-                    mapFps = 10,
+                    mapConfig = MapConfig(),
                     onAction = {},
                 )
             }

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -18,8 +18,8 @@ class SettingsScreenTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val groupLabel = context.getString(R.string.settings_group_fullscreen)
-    private val offLabel = context.getString(R.string.settings_fullscreen_off)
-    private val onLabel = context.getString(R.string.settings_fullscreen_on)
+    private val offLabel = context.getString(R.string.settings_off)
+    private val onLabel = context.getString(R.string.settings_on)
 
     @Test
     fun renders_fullscreen_group_chips() {

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -41,6 +41,7 @@ import io.github.seijikohara.femto.ui.assistant.AssistantSheet
 import io.github.seijikohara.femto.ui.drawer.AppDrawerSheet
 import io.github.seijikohara.femto.ui.home.HomeEvent
 import io.github.seijikohara.femto.ui.home.HomeRoute
+import io.github.seijikohara.femto.ui.home.components.MapConfig
 import io.github.seijikohara.femto.ui.locale.resolved
 import io.github.seijikohara.femto.ui.settings.SettingsRoute
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -117,7 +118,14 @@ class MainActivity : ComponentActivity() {
                         is24Hour = resolveIs24Hour(display.clock),
                         speedUnit = display.speedUnit.resolved(),
                         temperatureUnit = display.temperatureUnit.resolved(),
-                        mapFps = display.mapFps,
+                        mapConfig =
+                            MapConfig(
+                                fps = display.mapFps,
+                                buildings3d = display.mapBuildings3d,
+                                style = display.mapStyle,
+                                tiltDeg = display.mapTiltDeg,
+                                zoom = display.mapZoom,
+                            ),
                         onEvent = { event ->
                             handleHomeEvent(
                                 event = event,

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -3,6 +3,7 @@ package io.github.seijikohara.femto.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -29,6 +30,13 @@ internal enum class FullscreenSetting { OFF, ON }
 /** Default target map frame rate (fps) before the user picks one. */
 internal const val DEFAULT_MAP_FPS = 10
 
+/** Map light/dark style: follow the system theme, or force light / dark. */
+internal enum class MapStyleSetting { AUTO, LIGHT, DARK }
+
+/** Default oblique-camera tilt (degrees) and zoom level for the map. */
+internal const val DEFAULT_MAP_TILT_DEG = 55
+internal const val DEFAULT_MAP_ZOOM = 16
+
 /**
  * User display settings that override the locale / system defaults. Every value
  * defaults to the auto / system choice so a fresh install behaves exactly as
@@ -43,6 +51,10 @@ internal data class DisplaySettings(
     // Target map frame rate (fps): the snapshot map caps its re-render rate at
     // this many frames per second. Clamped to the display's max refresh at use.
     val mapFps: Int,
+    val mapBuildings3d: Boolean,
+    val mapStyle: MapStyleSetting,
+    val mapTiltDeg: Int,
+    val mapZoom: Int,
 ) {
     companion object {
         val Default =
@@ -53,6 +65,10 @@ internal data class DisplaySettings(
                 clock = ClockSetting.AUTO,
                 fullscreen = FullscreenSetting.OFF,
                 mapFps = DEFAULT_MAP_FPS,
+                mapBuildings3d = true,
+                mapStyle = MapStyleSetting.AUTO,
+                mapTiltDeg = DEFAULT_MAP_TILT_DEG,
+                mapZoom = DEFAULT_MAP_ZOOM,
             )
     }
 }
@@ -78,6 +94,10 @@ internal class DisplayPreferences(
                 clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
                 fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.OFF),
                 mapFps = prefs[MAP_FPS_KEY] ?: DEFAULT_MAP_FPS,
+                mapBuildings3d = prefs[MAP_BUILDINGS_KEY] ?: true,
+                mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
+                mapTiltDeg = prefs[MAP_TILT_KEY] ?: DEFAULT_MAP_TILT_DEG,
+                mapZoom = prefs[MAP_ZOOM_KEY] ?: DEFAULT_MAP_ZOOM,
             )
         }
 
@@ -95,6 +115,14 @@ internal class DisplayPreferences(
 
     suspend fun setMapFps(value: Int) = context.displayDataStore.edit { it[MAP_FPS_KEY] = value }
 
+    suspend fun setMapBuildings3d(value: Boolean) = context.displayDataStore.edit { it[MAP_BUILDINGS_KEY] = value }
+
+    suspend fun setMapStyle(value: MapStyleSetting) = context.displayDataStore.edit { it[MAP_STYLE_KEY] = value.name }
+
+    suspend fun setMapTilt(value: Int) = context.displayDataStore.edit { it[MAP_TILT_KEY] = value }
+
+    suspend fun setMapZoom(value: Int) = context.displayDataStore.edit { it[MAP_ZOOM_KEY] = value }
+
     private companion object {
         val THEME_KEY = stringPreferencesKey("theme_mode")
         val SPEED_KEY = stringPreferencesKey("speed_unit")
@@ -102,6 +130,10 @@ internal class DisplayPreferences(
         val CLOCK_KEY = stringPreferencesKey("clock")
         val FULLSCREEN_KEY = stringPreferencesKey("fullscreen")
         val MAP_FPS_KEY = intPreferencesKey("map_fps")
+        val MAP_BUILDINGS_KEY = booleanPreferencesKey("map_buildings_3d")
+        val MAP_STYLE_KEY = stringPreferencesKey("map_style")
+        val MAP_TILT_KEY = intPreferencesKey("map_tilt_deg")
+        val MAP_ZOOM_KEY = intPreferencesKey("map_zoom")
     }
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.seijikohara.femto.data.hasFineLocationPermission
+import io.github.seijikohara.femto.ui.home.components.MapConfig
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 
@@ -21,7 +22,7 @@ internal fun HomeRoute(
     is24Hour: Boolean,
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
-    mapFps: Int,
+    mapConfig: MapConfig,
     onEvent: (HomeEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -39,7 +40,7 @@ internal fun HomeRoute(
         is24Hour = is24Hour,
         speedUnit = speedUnit,
         temperatureUnit = temperatureUnit,
-        mapFps = mapFps,
+        mapConfig = mapConfig,
         onAction = viewModel::onAction,
         modifier = modifier,
     )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import io.github.seijikohara.femto.ui.home.components.DashboardScaffold
+import io.github.seijikohara.femto.ui.home.components.MapConfig
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -17,7 +18,7 @@ internal fun HomeScreen(
     is24Hour: Boolean,
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
-    mapFps: Int,
+    mapConfig: MapConfig,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
@@ -29,7 +30,7 @@ internal fun HomeScreen(
         is24Hour = is24Hour,
         speedUnit = speedUnit,
         temperatureUnit = temperatureUnit,
-        mapFps = mapFps,
+        mapConfig = mapConfig,
         onAction = onAction,
         modifier = Modifier.fillMaxSize(),
     )
@@ -44,7 +45,7 @@ private fun HomeScreenPreview() =
             is24Hour = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
-            mapFps = 10,
+            mapConfig = MapConfig(),
             onAction = {},
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -65,7 +65,7 @@ internal fun DashboardScaffold(
     is24Hour: Boolean,
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
-    mapFps: Int,
+    mapConfig: MapConfig,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(
@@ -96,7 +96,7 @@ internal fun DashboardScaffold(
                     uiState = uiState,
                     is24Hour = is24Hour,
                     speedUnit = speedUnit,
-                    mapFps = mapFps,
+                    mapConfig = mapConfig,
                     onAction = onAction,
                     modifier = Modifier.weight(MAP_PANE_PORTRAIT_WEIGHT).fillMaxWidth(),
                 )
@@ -121,7 +121,7 @@ internal fun DashboardScaffold(
                     uiState = uiState,
                     is24Hour = is24Hour,
                     speedUnit = speedUnit,
-                    mapFps = mapFps,
+                    mapConfig = mapConfig,
                     onAction = onAction,
                     modifier = Modifier.weight(MAP_PANE_LANDSCAPE_WEIGHT).fillMaxHeight(),
                 )
@@ -148,13 +148,13 @@ private fun MapPane(
     uiState: HomeUiState,
     is24Hour: Boolean,
     speedUnit: SpeedUnit,
-    mapFps: Int,
+    mapConfig: MapConfig,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Box(modifier = modifier) {
     MapPanel(
         location = uiState.location,
-        mapFps = mapFps,
+        mapConfig = mapConfig,
         onTap = { onAction(HomeAction.OpenMaps) },
         modifier = Modifier.fillMaxSize(),
     )
@@ -254,7 +254,7 @@ private fun DashboardScaffoldLandscapePreview() {
             is24Hour = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
-            mapFps = 10,
+            mapConfig = MapConfig(),
             onAction = {},
         )
     }
@@ -270,7 +270,7 @@ private fun DashboardScaffoldUltraWidePreview() {
             is24Hour = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
-            mapFps = 10,
+            mapConfig = MapConfig(),
             onAction = {},
         )
     }
@@ -289,7 +289,7 @@ private fun DashboardScaffoldHeadUnitPreview() {
             is24Hour = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
-            mapFps = 10,
+            mapConfig = MapConfig(),
             onAction = {},
         )
     }
@@ -305,7 +305,7 @@ private fun DashboardScaffoldPortraitPreview() {
             is24Hour = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
-            mapFps = 10,
+            mapConfig = MapConfig(),
             onAction = {},
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -46,6 +46,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.MapPinOff
 import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.MapStyleSetting
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -65,6 +66,16 @@ import kotlin.math.cos
 import kotlin.math.roundToInt
 import kotlin.math.sin
 
+// User-tunable map rendering config (derived from DisplaySettings): target frame
+// rate, 3D buildings, light/dark style, oblique tilt, and zoom.
+internal data class MapConfig(
+    val fps: Int = 10,
+    val buildings3d: Boolean = true,
+    val style: MapStyleSetting = MapStyleSetting.AUTO,
+    val tiltDeg: Int = 55,
+    val zoom: Int = 16,
+)
+
 /**
  * Map tile surface + permission fallback.
  *
@@ -78,15 +89,14 @@ import kotlin.math.sin
  * yields the oblique 3D view (camera tilt + building fill-extrusion) for free.
  *
  * The snapshot re-renders on movement, capped at the map frame-rate (fps)
- * setting. It is
- * single-flight (one render in flight at a time) and holds the previous frame
- * until the next is ready, so there is no flicker. Clock and speed overlays are
- * placed by the parent on top of this surface.
+ * setting. It is single-flight (one render in flight) and holds the previous
+ * frame until the next is ready, so there is no flicker. Clock and speed
+ * overlays are placed by the parent on top of this surface.
  */
 @Composable
 internal fun MapPanel(
     location: Location?,
-    mapFps: Int,
+    mapConfig: MapConfig,
     onTap: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
@@ -101,7 +111,7 @@ internal fun MapPanel(
         if (location != null) {
             SnapshotMap(
                 location = location,
-                mapFps = mapFps,
+                mapConfig = mapConfig,
                 onTap = onTap,
                 modifier = Modifier.fillMaxSize(),
             )
@@ -114,12 +124,17 @@ internal fun MapPanel(
 @Composable
 private fun SnapshotMap(
     location: Location,
-    mapFps: Int,
+    mapConfig: MapConfig,
     onTap: () -> Unit,
     modifier: Modifier = Modifier,
 ) = BoxWithConstraints(modifier = modifier) {
     val context = LocalContext.current
-    val isDark = isSystemInDarkTheme()
+    val isDark =
+        when (mapConfig.style) {
+            MapStyleSetting.AUTO -> isSystemInDarkTheme()
+            MapStyleSetting.LIGHT -> false
+            MapStyleSetting.DARK -> true
+        }
     val widthPx = with(LocalDensity.current) { maxWidth.roundToPx() }
     val heightPx = with(LocalDensity.current) { maxHeight.roundToPx() }
 
@@ -132,7 +147,7 @@ private fun SnapshotMap(
 
     // One reusable snapshotter, rebuilt only when the panel size or theme changes.
     val snapshotter =
-        remember(widthPx, heightPx, isDark) {
+        remember(widthPx, heightPx, isDark, mapConfig.buildings3d) {
             if (widthPx <= 0 || heightPx <= 0) {
                 null
             } else {
@@ -142,7 +157,7 @@ private fun SnapshotMap(
                     MapSnapshotter
                         .Options(widthPx, heightPx)
                         .withLogo(false)
-                        .withStyleBuilder(styleBuilderFor(context, isDark)),
+                        .withStyleBuilder(styleBuilderFor(context, isDark, mapConfig.buildings3d)),
                 )
             }
         }
@@ -152,10 +167,10 @@ private fun SnapshotMap(
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current
-    LaunchedEffect(snapshotter, mapFps, lifecycleOwner) {
+    LaunchedEffect(snapshotter, mapConfig, lifecycleOwner) {
         val snap = snapshotter ?: return@LaunchedEffect
         // Target frame interval; coerceAtLeast(1) guards 0 fps from divide-by-zero.
-        val intervalMs = 1_000L / mapFps.coerceAtLeast(1)
+        val intervalMs = 1_000L / mapConfig.fps.coerceAtLeast(1)
         // Render only while the launcher is visible; pause off-screen to drop the
         // render cost. lastRendered resets on each return to STARTED so a stale
         // map refreshes immediately when the dashboard comes back to the front.
@@ -164,7 +179,8 @@ private fun SnapshotMap(
             while (isActive) {
                 val loc = currentLocation.value
                 if (shouldRerender(lastRendered, loc)) {
-                    val rendered = snap.render(cameraFor(loc, bearingHolder), LatLng(loc.latitude, loc.longitude))
+                    val camera = cameraFor(loc, bearingHolder, mapConfig.tiltDeg, mapConfig.zoom)
+                    val rendered = snap.render(camera, LatLng(loc.latitude, loc.longitude))
                     if (rendered != null) {
                         frame = rendered
                         failed = false
@@ -231,6 +247,8 @@ private suspend fun MapSnapshotter.render(
 private fun cameraFor(
     location: Location,
     bearingHolder: FloatArray,
+    tiltDeg: Int,
+    zoom: Int,
 ): CameraPosition {
     val bearing = location.carriedBearing(bearingHolder).toDouble()
     // Aim the camera ahead of the current position (along the heading) so the
@@ -240,8 +258,8 @@ private fun cameraFor(
     return CameraPosition
         .Builder()
         .target(target)
-        .zoom(MAP_ZOOM)
-        .tilt(MAP_TILT)
+        .zoom(zoom.toDouble())
+        .tilt(tiltDeg.toDouble())
         .bearing(bearing)
         .build()
 }
@@ -279,6 +297,7 @@ private fun shouldRerender(
 private fun styleBuilderFor(
     context: Context,
     isDark: Boolean,
+    buildings3d: Boolean,
 ): Style.Builder {
     val base =
         if (isDark) {
@@ -295,7 +314,7 @@ private fun styleBuilderFor(
     // MapSnapshotter exposes no post-load style to mutate. Both Positron and the
     // bundled dark style carry OpenStreetMap buildings on the same OpenMapTiles
     // "openmaptiles" vector source / "building" source-layer.
-    return base.withLayer(buildingExtrusionLayer(isDark))
+    return if (buildings3d) base.withLayer(buildingExtrusionLayer(isDark)) else base
 }
 
 private fun buildingExtrusionLayer(isDark: Boolean): FillExtrusionLayer =
@@ -382,7 +401,6 @@ private fun Fallback(modifier: Modifier = Modifier) =
 // internal so MapSnapshotRenderTest renders the SAME style host / zoom the panel
 // uses, keeping the OpenFreeMap style URL and zoom a single source of truth.
 internal const val MAP_ZOOM = 16.5
-private const val MAP_TILT = 55.0
 internal const val POSITRON_STYLE_URL = "https://tiles.openfreemap.org/styles/positron"
 private const val DARK_STYLE_ASSET = "map/dark.json"
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -33,6 +33,7 @@ import com.composables.icons.lucide.Lucide
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.data.MapStyleSetting
 import io.github.seijikohara.femto.data.SpeedUnitSetting
 import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.ThemeMode
@@ -122,8 +123,8 @@ internal fun SettingsScreen(
             title = stringResource(R.string.settings_group_fullscreen),
             options =
                 listOf(
-                    FullscreenSetting.OFF to stringResource(R.string.settings_fullscreen_off),
-                    FullscreenSetting.ON to stringResource(R.string.settings_fullscreen_on),
+                    FullscreenSetting.OFF to stringResource(R.string.settings_off),
+                    FullscreenSetting.ON to stringResource(R.string.settings_on),
                 ),
             selected = uiState.fullscreen,
             onSelect = { onAction(SettingsAction.SetFullscreen(it)) },
@@ -136,6 +137,45 @@ internal fun SettingsScreen(
             value = uiState.mapFps,
             range = MIN_MAP_FPS..maxFps,
             onValueChange = { onAction(SettingsAction.SetMapFps(it)) },
+        )
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_map_3d),
+            options =
+                listOf(
+                    false to stringResource(R.string.settings_off),
+                    true to stringResource(R.string.settings_on),
+                ),
+            selected = uiState.mapBuildings3d,
+            onSelect = { onAction(SettingsAction.SetMapBuildings3d(it)) },
+        )
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_map_style),
+            options =
+                listOf(
+                    MapStyleSetting.AUTO to stringResource(R.string.settings_option_auto),
+                    MapStyleSetting.LIGHT to stringResource(R.string.settings_theme_light),
+                    MapStyleSetting.DARK to stringResource(R.string.settings_theme_dark),
+                ),
+            selected = uiState.mapStyle,
+            onSelect = { onAction(SettingsAction.SetMapStyle(it)) },
+        )
+
+        SliderSetting(
+            title = stringResource(R.string.settings_group_map_tilt),
+            valueLabel = stringResource(R.string.settings_map_tilt_value, uiState.mapTiltDeg),
+            value = uiState.mapTiltDeg,
+            range = MIN_MAP_TILT..MAX_MAP_TILT,
+            onValueChange = { onAction(SettingsAction.SetMapTilt(it)) },
+        )
+
+        SliderSetting(
+            title = stringResource(R.string.settings_group_map_zoom),
+            valueLabel = stringResource(R.string.settings_map_zoom_value, uiState.mapZoom),
+            value = uiState.mapZoom,
+            range = MIN_MAP_ZOOM..MAX_MAP_ZOOM,
+            onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
         )
 
         SettingGroup(
@@ -312,15 +352,25 @@ private fun SliderSetting(
 private fun rememberMaxDisplayFps(): Int {
     val context = LocalContext.current
     return remember(context) {
-        val fromModes = context.display?.supportedModes?.maxOfOrNull { it.refreshRate }
-        val refresh = fromModes ?: context.display?.refreshRate ?: DEFAULT_MAX_FPS
-        refresh.roundToInt().coerceIn(MIN_MAP_FPS, MAX_MAP_FPS_CEILING)
+        // Context.getDisplay() is non-null on a visual (Activity) context but
+        // throws on a non-visual one (e.g. a preview), so guard with runCatching
+        // and fall back to 60 fps rather than null-check a non-null receiver.
+        runCatching {
+            val display = context.display
+            display.supportedModes.maxOfOrNull { it.refreshRate } ?: display.refreshRate
+        }.getOrDefault(DEFAULT_MAX_FPS)
+            .roundToInt()
+            .coerceIn(MIN_MAP_FPS, MAX_MAP_FPS_CEILING)
     }
 }
 
 private const val MIN_MAP_FPS = 1
 private const val MAX_MAP_FPS_CEILING = 120
 private const val DEFAULT_MAX_FPS = 60f
+private const val MIN_MAP_TILT = 0
+private const val MAX_MAP_TILT = 60
+private const val MIN_MAP_ZOOM = 12
+private const val MAX_MAP_ZOOM = 19
 
 // A human-readable label for a font theme (e.g. INTER -> "Inter").
 private fun FontTheme.displayName(): String = name.lowercase().replaceFirstChar(Char::uppercaseChar)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -3,6 +3,7 @@ package io.github.seijikohara.femto.ui.settings
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.data.MapStyleSetting
 import io.github.seijikohara.femto.data.SpeedUnitSetting
 import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.ThemeMode
@@ -16,6 +17,10 @@ internal data class SettingsUiState(
     val clock: ClockSetting,
     val fullscreen: FullscreenSetting,
     val mapFps: Int,
+    val mapBuildings3d: Boolean,
+    val mapStyle: MapStyleSetting,
+    val mapTiltDeg: Int,
+    val mapZoom: Int,
     val fontTheme: FontTheme,
 ) {
     companion object {
@@ -29,6 +34,10 @@ internal data class SettingsUiState(
                 clock = DisplaySettings.Default.clock,
                 fullscreen = DisplaySettings.Default.fullscreen,
                 mapFps = DisplaySettings.Default.mapFps,
+                mapBuildings3d = DisplaySettings.Default.mapBuildings3d,
+                mapStyle = DisplaySettings.Default.mapStyle,
+                mapTiltDeg = DisplaySettings.Default.mapTiltDeg,
+                mapZoom = DisplaySettings.Default.mapZoom,
                 fontTheme = FontTheme.INTER,
             )
     }
@@ -57,6 +66,22 @@ internal sealed interface SettingsAction {
     ) : SettingsAction
 
     data class SetMapFps(
+        val value: Int,
+    ) : SettingsAction
+
+    data class SetMapBuildings3d(
+        val value: Boolean,
+    ) : SettingsAction
+
+    data class SetMapStyle(
+        val value: MapStyleSetting,
+    ) : SettingsAction
+
+    data class SetMapTilt(
+        val value: Int,
+    ) : SettingsAction
+
+    data class SetMapZoom(
         val value: Int,
     ) : SettingsAction
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -26,6 +26,10 @@ internal class SettingsViewModel(
                 clock = display.clock,
                 fullscreen = display.fullscreen,
                 mapFps = display.mapFps,
+                mapBuildings3d = display.mapBuildings3d,
+                mapStyle = display.mapStyle,
+                mapTiltDeg = display.mapTiltDeg,
+                mapZoom = display.mapZoom,
                 fontTheme = font,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState.Initial)
@@ -40,6 +44,10 @@ internal class SettingsViewModel(
                 is SettingsAction.SetClock -> displayPreferences.setClock(action.value)
                 is SettingsAction.SetFullscreen -> displayPreferences.setFullscreen(action.value)
                 is SettingsAction.SetMapFps -> displayPreferences.setMapFps(action.value)
+                is SettingsAction.SetMapBuildings3d -> displayPreferences.setMapBuildings3d(action.value)
+                is SettingsAction.SetMapStyle -> displayPreferences.setMapStyle(action.value)
+                is SettingsAction.SetMapTilt -> displayPreferences.setMapTilt(action.value)
+                is SettingsAction.SetMapZoom -> displayPreferences.setMapZoom(action.value)
                 is SettingsAction.SetFontTheme -> fontPreferences.setFontTheme(action.value)
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,8 @@
     <string name="settings_group_font">Font</string>
     <string name="settings_group_system">System</string>
     <string name="settings_option_auto">Auto</string>
+    <string name="settings_off">Off</string>
+    <string name="settings_on">On</string>
     <string name="settings_theme_light">Light</string>
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_speed_km">km/h</string>
@@ -96,10 +98,14 @@
     <string name="settings_clock_12">12-hour</string>
     <string name="settings_clock_24">24-hour</string>
     <string name="settings_group_fullscreen">Fullscreen</string>
-    <string name="settings_fullscreen_off">Off</string>
-    <string name="settings_fullscreen_on">On</string>
     <string name="settings_group_map_refresh">Map frame rate</string>
     <string name="settings_map_fps_value">%1$d fps</string>
+    <string name="settings_group_map_3d">3D buildings</string>
+    <string name="settings_group_map_style">Map style</string>
+    <string name="settings_group_map_tilt">Map tilt</string>
+    <string name="settings_group_map_zoom">Map zoom</string>
+    <string name="settings_map_tilt_value">%1$d°</string>
+    <string name="settings_map_zoom_value">z%1$d</string>
     <string name="settings_open_notification_access">Notification access</string>
     <string name="settings_open_system_settings">System settings</string>
 </resources>


### PR DESCRIPTION
## Summary

Add four granular map-rendering controls to the Settings screen, the
first slice of the larger settings-overhaul work. Each control is
persisted in `DisplayPreferences` and threaded to the snapshot map via a
single `MapConfig` value built in `MainActivity`:

- **3D buildings** on/off — toggles the fill-extrusion layer.
- **Map style** — auto (follow theme) / light / dark, independent of the
  app theme.
- **Map tilt** — oblique camera angle, 0–60° slider.
- **Map zoom** — 12–19 slider.

Defaults (3D on, style auto, tilt 55°, zoom 16) reproduce the previous
hard-coded look, so a fresh install renders exactly as before.

## Changes

- `data/DisplayPreferences.kt`: `MapStyleSetting` enum + `mapBuildings3d`
  / `mapStyle` / `mapTiltDeg` / `mapZoom` fields, defensive decode, and
  setters, following the existing enum/int pattern.
- `ui/home/components/MapPanel.kt`: introduce `MapConfig`; resolve
  light/dark from `mapStyle`; gate the building extrusion layer on
  `buildings3d`; pass tilt/zoom into `cameraFor`.
- `ui/settings/*`: new `SettingsAction`s, UI state fields, and four
  controls (two `SettingGroup`s + two `SliderSetting`s).
- `MainActivity` / `HomeRoute` / `HomeScreen` / `DashboardScaffold`:
  thread `MapConfig` end to end (replacing the bare `mapFps` int).
- `strings.xml`: consolidate the duplicate "Off"/"On" toggle labels into
  generic `settings_off` / `settings_on`, now shared by the fullscreen
  and 3D-building groups.

## Test

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.
