### PR TITLE
feat(settings): add show/hide toggles for the info-pane panels

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
@@ -45,12 +45,41 @@ class DashboardScaffoldTest {
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     mapConfig = MapConfig(),
+                    panels = PanelVisibility(),
                     onAction = {},
                 )
             }
         }
         rule.onNodeWithText("Map unavailable").assertIsDisplayed()
         rule.onNodeWithText("Strobe").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Apps").assertIsDisplayed()
+    }
+
+    @Test
+    fun hides_info_panels_disabled_by_visibility_flags() {
+        // Disabling every info-pane panel drops the whole info pane, so none of
+        // their content renders while the map and footer stay put.
+        val uiState =
+            HomeUiState.Initial.copy(
+                location = null,
+                weather = fakeWeatherSnapshot(),
+                musicState = MusicCardState.Playing(fakeNowPlaying()),
+            )
+        rule.setContent {
+            FemtoTheme {
+                DashboardScaffold(
+                    uiState = uiState,
+                    is24Hour = true,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    temperatureUnit = TemperatureUnit.CELSIUS,
+                    mapConfig = MapConfig(),
+                    panels = PanelVisibility(calendar = false, weather = false, music = false),
+                    onAction = {},
+                )
+            }
+        }
+        rule.onNodeWithText("Strobe").assertDoesNotExist()
+        rule.onNodeWithText("Map unavailable").assertIsDisplayed()
         rule.onNodeWithContentDescription("Apps").assertIsDisplayed()
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -42,6 +42,7 @@ import io.github.seijikohara.femto.ui.drawer.AppDrawerSheet
 import io.github.seijikohara.femto.ui.home.HomeEvent
 import io.github.seijikohara.femto.ui.home.HomeRoute
 import io.github.seijikohara.femto.ui.home.components.MapConfig
+import io.github.seijikohara.femto.ui.home.components.PanelVisibility
 import io.github.seijikohara.femto.ui.locale.resolved
 import io.github.seijikohara.femto.ui.settings.SettingsRoute
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -125,6 +126,12 @@ class MainActivity : ComponentActivity() {
                                 style = display.mapStyle,
                                 tiltDeg = display.mapTiltDeg,
                                 zoom = display.mapZoom,
+                            ),
+                        panels =
+                            PanelVisibility(
+                                calendar = display.showCalendar,
+                                weather = display.showWeather,
+                                music = display.showMusic,
                             ),
                         onEvent = { event ->
                             handleHomeEvent(

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -55,6 +55,12 @@ internal data class DisplaySettings(
     val mapStyle: MapStyleSetting,
     val mapTiltDeg: Int,
     val mapZoom: Int,
+    // Info-pane card visibility. Each card defaults to shown so a fresh install
+    // renders the full dashboard; hiding one lets the remaining cards (or the map)
+    // reflow into the freed space.
+    val showCalendar: Boolean,
+    val showWeather: Boolean,
+    val showMusic: Boolean,
 ) {
     companion object {
         val Default =
@@ -69,6 +75,9 @@ internal data class DisplaySettings(
                 mapStyle = MapStyleSetting.AUTO,
                 mapTiltDeg = DEFAULT_MAP_TILT_DEG,
                 mapZoom = DEFAULT_MAP_ZOOM,
+                showCalendar = true,
+                showWeather = true,
+                showMusic = true,
             )
     }
 }
@@ -98,6 +107,9 @@ internal class DisplayPreferences(
                 mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
                 mapTiltDeg = prefs[MAP_TILT_KEY] ?: DEFAULT_MAP_TILT_DEG,
                 mapZoom = prefs[MAP_ZOOM_KEY] ?: DEFAULT_MAP_ZOOM,
+                showCalendar = prefs[SHOW_CALENDAR_KEY] ?: true,
+                showWeather = prefs[SHOW_WEATHER_KEY] ?: true,
+                showMusic = prefs[SHOW_MUSIC_KEY] ?: true,
             )
         }
 
@@ -123,6 +135,12 @@ internal class DisplayPreferences(
 
     suspend fun setMapZoom(value: Int) = context.displayDataStore.edit { it[MAP_ZOOM_KEY] = value }
 
+    suspend fun setShowCalendar(value: Boolean) = context.displayDataStore.edit { it[SHOW_CALENDAR_KEY] = value }
+
+    suspend fun setShowWeather(value: Boolean) = context.displayDataStore.edit { it[SHOW_WEATHER_KEY] = value }
+
+    suspend fun setShowMusic(value: Boolean) = context.displayDataStore.edit { it[SHOW_MUSIC_KEY] = value }
+
     private companion object {
         val THEME_KEY = stringPreferencesKey("theme_mode")
         val SPEED_KEY = stringPreferencesKey("speed_unit")
@@ -134,6 +152,9 @@ internal class DisplayPreferences(
         val MAP_STYLE_KEY = stringPreferencesKey("map_style")
         val MAP_TILT_KEY = intPreferencesKey("map_tilt_deg")
         val MAP_ZOOM_KEY = intPreferencesKey("map_zoom")
+        val SHOW_CALENDAR_KEY = booleanPreferencesKey("show_calendar")
+        val SHOW_WEATHER_KEY = booleanPreferencesKey("show_weather")
+        val SHOW_MUSIC_KEY = booleanPreferencesKey("show_music")
     }
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.seijikohara.femto.data.hasFineLocationPermission
 import io.github.seijikohara.femto.ui.home.components.MapConfig
+import io.github.seijikohara.femto.ui.home.components.PanelVisibility
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 
@@ -23,6 +24,7 @@ internal fun HomeRoute(
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
     mapConfig: MapConfig,
+    panels: PanelVisibility,
     onEvent: (HomeEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -41,6 +43,7 @@ internal fun HomeRoute(
         speedUnit = speedUnit,
         temperatureUnit = temperatureUnit,
         mapConfig = mapConfig,
+        panels = panels,
         onAction = viewModel::onAction,
         modifier = modifier,
     )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import io.github.seijikohara.femto.ui.home.components.DashboardScaffold
 import io.github.seijikohara.femto.ui.home.components.MapConfig
+import io.github.seijikohara.femto.ui.home.components.PanelVisibility
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -19,6 +20,7 @@ internal fun HomeScreen(
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
     mapConfig: MapConfig,
+    panels: PanelVisibility,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
@@ -31,6 +33,7 @@ internal fun HomeScreen(
         speedUnit = speedUnit,
         temperatureUnit = temperatureUnit,
         mapConfig = mapConfig,
+        panels = panels,
         onAction = onAction,
         modifier = Modifier.fillMaxSize(),
     )
@@ -46,6 +49,7 @@ private fun HomeScreenPreview() =
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),
+            panels = PanelVisibility(),
             onAction = {},
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -26,6 +26,19 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 
+// Which info-pane cards the dashboard renders. Each defaults to visible; hiding
+// one lets the remaining cards — or the map, when none remain — reflow into the
+// freed space. Sourced from DisplaySettings and threaded down like MapConfig.
+internal data class PanelVisibility(
+    val calendar: Boolean = true,
+    val weather: Boolean = true,
+    val music: Boolean = true,
+) {
+    // True while at least one info-pane card is shown. When false the scaffold
+    // drops the info pane entirely so the map fills the whole viewport.
+    val anyInfoPanel: Boolean get() = calendar || weather || music
+}
+
 /**
  * Top-level dashboard layout. Two panes plus a fixed footer, arranged
  * responsively from the available viewport rather than a fixed canvas:
@@ -66,6 +79,7 @@ internal fun DashboardScaffold(
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
     mapConfig: MapConfig,
+    panels: PanelVisibility,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(
@@ -100,14 +114,17 @@ internal fun DashboardScaffold(
                     onAction = onAction,
                     modifier = Modifier.weight(MAP_PANE_PORTRAIT_WEIGHT).fillMaxWidth(),
                 )
-                InfoPane(
-                    uiState = uiState,
-                    temperatureUnit = temperatureUnit,
-                    speedUnit = speedUnit,
-                    paneGap = paneGap,
-                    onAction = onAction,
-                    modifier = Modifier.weight(1f).fillMaxWidth(),
-                )
+                if (panels.anyInfoPanel) {
+                    InfoPane(
+                        uiState = uiState,
+                        temperatureUnit = temperatureUnit,
+                        speedUnit = speedUnit,
+                        panels = panels,
+                        paneGap = paneGap,
+                        onAction = onAction,
+                        modifier = Modifier.weight(1f).fillMaxWidth(),
+                    )
+                }
             }
         } else {
             Row(
@@ -125,14 +142,17 @@ internal fun DashboardScaffold(
                     onAction = onAction,
                     modifier = Modifier.weight(MAP_PANE_LANDSCAPE_WEIGHT).fillMaxHeight(),
                 )
-                InfoPane(
-                    uiState = uiState,
-                    temperatureUnit = temperatureUnit,
-                    speedUnit = speedUnit,
-                    paneGap = paneGap,
-                    onAction = onAction,
-                    modifier = Modifier.weight(1f).fillMaxHeight(),
-                )
+                if (panels.anyInfoPanel) {
+                    InfoPane(
+                        uiState = uiState,
+                        temperatureUnit = temperatureUnit,
+                        speedUnit = speedUnit,
+                        panels = panels,
+                        paneGap = paneGap,
+                        onAction = onAction,
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                    )
+                }
             }
         }
     }
@@ -183,6 +203,7 @@ private fun InfoPane(
     uiState: HomeUiState,
     temperatureUnit: TemperatureUnit,
     speedUnit: SpeedUnit,
+    panels: PanelVisibility,
     paneGap: Dp,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
@@ -190,32 +211,44 @@ private fun InfoPane(
     modifier = modifier,
     verticalArrangement = Arrangement.spacedBy(paneGap),
 ) {
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .weight(TOP_ROW_WEIGHT),
-        horizontalArrangement = Arrangement.spacedBy(paneGap),
-    ) {
-        CalendarCard(
-            snapshot = uiState.calendar,
-            modifier = Modifier.weight(1f).fillMaxHeight(),
-        )
-        WeatherCard(
-            snapshot = uiState.weather,
-            city = uiState.address?.locality,
-            temperatureUnit = temperatureUnit,
-            speedUnit = speedUnit,
-            modifier = Modifier.weight(1f).fillMaxHeight(),
+    // The calendar/weather row only exists when at least one of the two is shown.
+    // A single visible card takes the full row width (it is the only weighted
+    // child); with both hidden the row is skipped and the music card fills the
+    // pane on its own.
+    if (panels.calendar || panels.weather) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .weight(TOP_ROW_WEIGHT),
+            horizontalArrangement = Arrangement.spacedBy(paneGap),
+        ) {
+            if (panels.calendar) {
+                CalendarCard(
+                    snapshot = uiState.calendar,
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                )
+            }
+            if (panels.weather) {
+                WeatherCard(
+                    snapshot = uiState.weather,
+                    city = uiState.address?.locality,
+                    temperatureUnit = temperatureUnit,
+                    speedUnit = speedUnit,
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                )
+            }
+        }
+    }
+    if (panels.music) {
+        MusicCard(
+            state = uiState.musicState,
+            onCommand = { command -> onAction(HomeAction.Music(command)) },
+            onConnect = { onAction(HomeAction.ConnectMusicPlayer) },
+            onLaunchSource = { packageName -> onAction(HomeAction.LaunchMusicSource(packageName)) },
+            modifier = Modifier.weight(MUSIC_CARD_WEIGHT).fillMaxWidth(),
         )
     }
-    MusicCard(
-        state = uiState.musicState,
-        onCommand = { command -> onAction(HomeAction.Music(command)) },
-        onConnect = { onAction(HomeAction.ConnectMusicPlayer) },
-        onLaunchSource = { packageName -> onAction(HomeAction.LaunchMusicSource(packageName)) },
-        modifier = Modifier.weight(MUSIC_CARD_WEIGHT).fillMaxWidth(),
-    )
 }
 
 // Below either breakpoint the dashboard switches to its compact spacing. The
@@ -255,6 +288,7 @@ private fun DashboardScaffoldLandscapePreview() {
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),
+            panels = PanelVisibility(),
             onAction = {},
         )
     }
@@ -271,6 +305,7 @@ private fun DashboardScaffoldUltraWidePreview() {
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),
+            panels = PanelVisibility(),
             onAction = {},
         )
     }
@@ -290,6 +325,7 @@ private fun DashboardScaffoldHeadUnitPreview() {
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),
+            panels = PanelVisibility(),
             onAction = {},
         )
     }
@@ -306,6 +342,26 @@ private fun DashboardScaffoldPortraitPreview() {
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),
+            panels = PanelVisibility(),
+            onAction = {},
+        )
+    }
+}
+
+// Calendar hidden: the weather card reflows to the full row width and the music
+// card keeps its slot, exercising the partial-visibility layout path.
+@PreviewLightDark
+@Preview(name = "Dashboard - calendar hidden", widthDp = 853, heightDp = 512)
+@Composable
+private fun DashboardScaffoldHiddenPanelPreview() {
+    FemtoTheme {
+        DashboardScaffold(
+            uiState = HomeUiState.Initial,
+            is24Hour = true,
+            speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            temperatureUnit = TemperatureUnit.CELSIUS,
+            mapConfig = MapConfig(),
+            panels = PanelVisibility(calendar = false),
             onAction = {},
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -141,11 +141,7 @@ internal fun SettingsScreen(
 
         SettingGroup(
             title = stringResource(R.string.settings_group_map_3d),
-            options =
-                listOf(
-                    false to stringResource(R.string.settings_off),
-                    true to stringResource(R.string.settings_on),
-                ),
+            options = offOnOptions(),
             selected = uiState.mapBuildings3d,
             onSelect = { onAction(SettingsAction.SetMapBuildings3d(it)) },
         )
@@ -176,6 +172,27 @@ internal fun SettingsScreen(
             value = uiState.mapZoom,
             range = MIN_MAP_ZOOM..MAX_MAP_ZOOM,
             onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
+        )
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_panel_calendar),
+            options = offOnOptions(),
+            selected = uiState.showCalendar,
+            onSelect = { onAction(SettingsAction.SetShowCalendar(it)) },
+        )
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_panel_weather),
+            options = offOnOptions(),
+            selected = uiState.showWeather,
+            onSelect = { onAction(SettingsAction.SetShowWeather(it)) },
+        )
+
+        SettingGroup(
+            title = stringResource(R.string.settings_group_panel_music),
+            options = offOnOptions(),
+            selected = uiState.showMusic,
+            onSelect = { onAction(SettingsAction.SetShowMusic(it)) },
         )
 
         SettingGroup(
@@ -345,6 +362,15 @@ private fun SliderSetting(
         valueRange = range.first.toFloat()..range.last.toFloat(),
     )
 }
+
+// Shared Off/On options for a boolean SettingGroup. @Composable to resolve the
+// localized labels; keeps the boolean toggles from each repeating the pair.
+@Composable
+private fun offOnOptions(): List<Pair<Boolean, String>> =
+    listOf(
+        false to stringResource(R.string.settings_off),
+        true to stringResource(R.string.settings_on),
+    )
 
 // The display's maximum refresh rate (fps), the ceiling for the map frame-rate
 // slider. Falls back to 60 when the modes cannot be read; clamped to a sane band.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -21,6 +21,9 @@ internal data class SettingsUiState(
     val mapStyle: MapStyleSetting,
     val mapTiltDeg: Int,
     val mapZoom: Int,
+    val showCalendar: Boolean,
+    val showWeather: Boolean,
+    val showMusic: Boolean,
     val fontTheme: FontTheme,
 ) {
     companion object {
@@ -38,6 +41,9 @@ internal data class SettingsUiState(
                 mapStyle = DisplaySettings.Default.mapStyle,
                 mapTiltDeg = DisplaySettings.Default.mapTiltDeg,
                 mapZoom = DisplaySettings.Default.mapZoom,
+                showCalendar = DisplaySettings.Default.showCalendar,
+                showWeather = DisplaySettings.Default.showWeather,
+                showMusic = DisplaySettings.Default.showMusic,
                 fontTheme = FontTheme.INTER,
             )
     }
@@ -83,6 +89,18 @@ internal sealed interface SettingsAction {
 
     data class SetMapZoom(
         val value: Int,
+    ) : SettingsAction
+
+    data class SetShowCalendar(
+        val value: Boolean,
+    ) : SettingsAction
+
+    data class SetShowWeather(
+        val value: Boolean,
+    ) : SettingsAction
+
+    data class SetShowMusic(
+        val value: Boolean,
     ) : SettingsAction
 
     data class SetFontTheme(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -30,6 +30,9 @@ internal class SettingsViewModel(
                 mapStyle = display.mapStyle,
                 mapTiltDeg = display.mapTiltDeg,
                 mapZoom = display.mapZoom,
+                showCalendar = display.showCalendar,
+                showWeather = display.showWeather,
+                showMusic = display.showMusic,
                 fontTheme = font,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState.Initial)
@@ -48,6 +51,9 @@ internal class SettingsViewModel(
                 is SettingsAction.SetMapStyle -> displayPreferences.setMapStyle(action.value)
                 is SettingsAction.SetMapTilt -> displayPreferences.setMapTilt(action.value)
                 is SettingsAction.SetMapZoom -> displayPreferences.setMapZoom(action.value)
+                is SettingsAction.SetShowCalendar -> displayPreferences.setShowCalendar(action.value)
+                is SettingsAction.SetShowWeather -> displayPreferences.setShowWeather(action.value)
+                is SettingsAction.SetShowMusic -> displayPreferences.setShowMusic(action.value)
                 is SettingsAction.SetFontTheme -> fontPreferences.setFontTheme(action.value)
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,9 @@
     <string name="settings_group_map_zoom">Map zoom</string>
     <string name="settings_map_tilt_value">%1$d°</string>
     <string name="settings_map_zoom_value">z%1$d</string>
+    <string name="settings_group_panel_calendar">Calendar panel</string>
+    <string name="settings_group_panel_weather">Weather panel</string>
+    <string name="settings_group_panel_music">Music panel</string>
     <string name="settings_open_notification_access">Notification access</string>
     <string name="settings_open_system_settings">System settings</string>
 </resources>

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -60,4 +60,12 @@ class SettingsViewModelTest {
             viewModel.onAction(SettingsAction.SetMapFps(30))
             assertEquals(30, displayPreferences.settings.first { it.mapFps == 30 }.mapFps)
         }
+
+    @Test
+    fun `SetShowMusic persists via DisplayPreferences`() =
+        runTest {
+            val viewModel = SettingsViewModel(displayPreferences, FontPreferences(application))
+            viewModel.onAction(SettingsAction.SetShowMusic(false))
+            assertEquals(false, displayPreferences.settings.first { !it.showMusic }.showMusic)
+        }
 }


### PR DESCRIPTION
## Summary

Let the user show or hide each dashboard info-pane card — calendar,
weather, music — from Settings. This is the second slice of the
settings-overhaul work (after the granular map controls in #58).

Each choice is persisted in `DisplayPreferences` and threaded to the
dashboard through a new `PanelVisibility` value, mirroring how
`MapConfig` is passed down. The scaffold reflows gracefully as panels
disappear:

- A single visible calendar/weather card takes the **full row width**.
- Hiding **both** collapses the top row; the music card fills the pane.
- Hiding **every** card drops the info pane entirely so the map fills
  the whole viewport.

Defaults keep all three cards visible, so a fresh install is unchanged.

## Changes

- `data/DisplayPreferences.kt`: `showCalendar` / `showWeather` /
  `showMusic` booleans (default true), defensive decode, setters, keys.
- `ui/home/components/DashboardScaffold.kt`: `PanelVisibility` data
  class with an `anyInfoPanel` helper; conditional rendering of the
  info pane, the calendar/weather row, and each card; a
  partial-visibility preview (calendar hidden).
- `MainActivity` / `HomeRoute` / `HomeScreen`: thread `PanelVisibility`
  end to end.
- `ui/settings/*`: three Off/On toggles plus the backing actions and UI
  state; the repeated Off/On option pair is factored into an
  `offOnOptions()` helper shared with the 3D-building toggle.

## Test

- `DashboardScaffoldTest`: new case asserting the info pane is gone when
  all three flags are off (map + footer still render).
- `SettingsViewModelTest`: `SetShowMusic` persists via
  `DisplayPreferences`.
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.
