### PR TITLE
feat(settings): redesign the settings screen with Android-style IA

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.data.ThemeMode
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -17,43 +18,47 @@ class SettingsScreenTest {
     val rule = createComposeRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val groupLabel = context.getString(R.string.settings_group_fullscreen)
-    private val offLabel = context.getString(R.string.settings_off)
-    private val onLabel = context.getString(R.string.settings_on)
+    private val fullscreenLabel = context.getString(R.string.settings_group_fullscreen)
+    private val themeLabel = context.getString(R.string.settings_group_theme)
+    private val darkLabel = context.getString(R.string.settings_theme_dark)
 
     @Test
-    fun renders_fullscreen_group_chips() {
-        rule.setContent {
-            FemtoTheme {
-                SettingsScreen(
-                    uiState = SettingsUiState.Initial,
-                    onAction = {},
-                    onBack = {},
-                    onOpenNotificationAccess = {},
-                    onOpenSystemSettings = {},
-                )
-            }
-        }
-        rule.onNodeWithText(groupLabel).assertIsDisplayed()
-        rule.onNodeWithText(offLabel).assertIsDisplayed()
-        rule.onNodeWithText(onLabel).assertIsDisplayed()
+    fun renders_fullscreen_row() {
+        setScreen()
+        rule.onNodeWithText(fullscreenLabel).assertIsDisplayed()
     }
 
     @Test
-    fun tapping_on_dispatches_set_fullscreen_on() {
+    fun toggling_fullscreen_dispatches_set_fullscreen_on() {
         val actions = mutableListOf<SettingsAction>()
+        setScreen(onAction = { actions += it })
+        // Initial.fullscreen is OFF, so tapping the row flips the switch to ON.
+        rule.onNodeWithText(fullscreenLabel).performClick()
+        assertEquals(listOf(SettingsAction.SetFullscreen(FullscreenSetting.ON)), actions)
+    }
+
+    @Test
+    fun choosing_theme_option_dispatches_set_theme_mode() {
+        val actions = mutableListOf<SettingsAction>()
+        setScreen(onAction = { actions += it })
+        // The Theme row opens a radio dialog; picking "Dark" reports the choice
+        // and closes the dialog.
+        rule.onNodeWithText(themeLabel).performClick()
+        rule.onNodeWithText(darkLabel).performClick()
+        assertEquals(listOf(SettingsAction.SetThemeMode(ThemeMode.DARK)), actions)
+    }
+
+    private fun setScreen(onAction: (SettingsAction) -> Unit = {}) {
         rule.setContent {
             FemtoTheme {
                 SettingsScreen(
                     uiState = SettingsUiState.Initial,
-                    onAction = { actions += it },
+                    onAction = onAction,
                     onBack = {},
                     onOpenNotificationAccess = {},
                     onOpenSystemSettings = {},
                 )
             }
         }
-        rule.onNodeWithText(onLabel).performClick()
-        assertEquals(listOf(SettingsAction.SetFullscreen(FullscreenSetting.ON)), actions)
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,23 +12,35 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.ChevronRight
+import com.composables.icons.lucide.ExternalLink
 import com.composables.icons.lucide.Lucide
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.ClockSetting
@@ -44,10 +56,15 @@ import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import kotlin.math.roundToInt
 
 /**
- * In-app settings: theme, units, clock, font, and links out to the relevant
- * system screens. Pure UI — persisted changes flow up via [onAction]; the
- * host-level navigation / system intents flow up via the dedicated callbacks so
- * the screen stays previewable and testable in isolation.
+ * In-app settings, laid out like the Android system Settings app: category
+ * sections, each a flat rounded card of rows. A row carries a title plus the
+ * current value as a summary; single-choice rows open a radio dialog, boolean
+ * rows toggle an inline switch, numeric rows host an inline slider, and the
+ * System rows link out.
+ *
+ * Pure UI — persisted changes flow up via [onAction]; host-level navigation and
+ * system intents flow up via the dedicated callbacks so the screen stays
+ * previewable and testable in isolation.
  */
 @Composable
 internal fun SettingsScreen(
@@ -71,141 +88,136 @@ internal fun SettingsScreen(
     ) {
         Header(onBack = onBack)
 
-        SettingGroup(
-            title = stringResource(R.string.settings_group_theme),
-            options =
-                listOf(
-                    ThemeMode.SYSTEM to stringResource(R.string.settings_option_auto),
-                    ThemeMode.LIGHT to stringResource(R.string.settings_theme_light),
-                    ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
-                ),
-            selected = uiState.themeMode,
-            onSelect = { onAction(SettingsAction.SetThemeMode(it)) },
-        )
+        SettingsSection(title = stringResource(R.string.settings_section_display)) {
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_theme),
+                options =
+                    listOf(
+                        ThemeMode.SYSTEM to stringResource(R.string.settings_option_auto),
+                        ThemeMode.LIGHT to stringResource(R.string.settings_theme_light),
+                        ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
+                    ),
+                selected = uiState.themeMode,
+                onSelect = { onAction(SettingsAction.SetThemeMode(it)) },
+            )
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_font),
+                options = FontTheme.entries.map { it to it.displayName() },
+                selected = uiState.fontTheme,
+                onSelect = { onAction(SettingsAction.SetFontTheme(it)) },
+            )
+            SwitchRow(
+                title = stringResource(R.string.settings_group_fullscreen),
+                checked = uiState.fullscreen == FullscreenSetting.ON,
+                onCheckedChange = { onAction(SettingsAction.SetFullscreen(it.toFullscreen())) },
+            )
+        }
 
-        SettingGroup(
-            title = stringResource(R.string.settings_group_speed),
-            options =
-                listOf(
-                    SpeedUnitSetting.AUTO to stringResource(R.string.settings_option_auto),
-                    SpeedUnitSetting.KILOMETERS to stringResource(R.string.settings_speed_km),
-                    SpeedUnitSetting.MILES to stringResource(R.string.settings_speed_mi),
-                ),
-            selected = uiState.speedUnit,
-            onSelect = { onAction(SettingsAction.SetSpeedUnit(it)) },
-        )
-
-        SettingGroup(
-            title = stringResource(R.string.settings_group_temperature),
-            options =
-                listOf(
-                    TemperatureUnitSetting.AUTO to stringResource(R.string.settings_option_auto),
-                    TemperatureUnitSetting.CELSIUS to stringResource(R.string.settings_temp_celsius),
-                    TemperatureUnitSetting.FAHRENHEIT to stringResource(R.string.settings_temp_fahrenheit),
-                ),
-            selected = uiState.temperatureUnit,
-            onSelect = { onAction(SettingsAction.SetTemperatureUnit(it)) },
-        )
-
-        SettingGroup(
-            title = stringResource(R.string.settings_group_clock),
-            options =
-                listOf(
-                    ClockSetting.AUTO to stringResource(R.string.settings_option_auto),
-                    ClockSetting.TWELVE_HOUR to stringResource(R.string.settings_clock_12),
-                    ClockSetting.TWENTY_FOUR_HOUR to stringResource(R.string.settings_clock_24),
-                ),
-            selected = uiState.clock,
-            onSelect = { onAction(SettingsAction.SetClock(it)) },
-        )
-
-        SettingGroup(
-            title = stringResource(R.string.settings_group_fullscreen),
-            options =
-                listOf(
-                    FullscreenSetting.OFF to stringResource(R.string.settings_off),
-                    FullscreenSetting.ON to stringResource(R.string.settings_on),
-                ),
-            selected = uiState.fullscreen,
-            onSelect = { onAction(SettingsAction.SetFullscreen(it)) },
-        )
+        SettingsSection(title = stringResource(R.string.settings_section_units)) {
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_speed),
+                options =
+                    listOf(
+                        SpeedUnitSetting.AUTO to stringResource(R.string.settings_option_auto),
+                        SpeedUnitSetting.KILOMETERS to stringResource(R.string.settings_speed_km),
+                        SpeedUnitSetting.MILES to stringResource(R.string.settings_speed_mi),
+                    ),
+                selected = uiState.speedUnit,
+                onSelect = { onAction(SettingsAction.SetSpeedUnit(it)) },
+            )
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_temperature),
+                options =
+                    listOf(
+                        TemperatureUnitSetting.AUTO to stringResource(R.string.settings_option_auto),
+                        TemperatureUnitSetting.CELSIUS to stringResource(R.string.settings_temp_celsius),
+                        TemperatureUnitSetting.FAHRENHEIT to stringResource(R.string.settings_temp_fahrenheit),
+                    ),
+                selected = uiState.temperatureUnit,
+                onSelect = { onAction(SettingsAction.SetTemperatureUnit(it)) },
+            )
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_clock),
+                options =
+                    listOf(
+                        ClockSetting.AUTO to stringResource(R.string.settings_option_auto),
+                        ClockSetting.TWELVE_HOUR to stringResource(R.string.settings_clock_12),
+                        ClockSetting.TWENTY_FOUR_HOUR to stringResource(R.string.settings_clock_24),
+                    ),
+                selected = uiState.clock,
+                onSelect = { onAction(SettingsAction.SetClock(it)) },
+            )
+        }
 
         val maxFps = rememberMaxDisplayFps()
-        SliderSetting(
-            title = stringResource(R.string.settings_group_map_refresh),
-            valueLabel = stringResource(R.string.settings_map_fps_value, uiState.mapFps),
-            value = uiState.mapFps,
-            range = MIN_MAP_FPS..maxFps,
-            onValueChange = { onAction(SettingsAction.SetMapFps(it)) },
-        )
+        SettingsSection(title = stringResource(R.string.settings_section_map)) {
+            SliderRow(
+                title = stringResource(R.string.settings_group_map_refresh),
+                valueLabel = stringResource(R.string.settings_map_fps_value, uiState.mapFps),
+                value = uiState.mapFps,
+                range = MIN_MAP_FPS..maxFps,
+                onValueChange = { onAction(SettingsAction.SetMapFps(it)) },
+            )
+            SwitchRow(
+                title = stringResource(R.string.settings_group_map_3d),
+                checked = uiState.mapBuildings3d,
+                onCheckedChange = { onAction(SettingsAction.SetMapBuildings3d(it)) },
+            )
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_map_style),
+                options =
+                    listOf(
+                        MapStyleSetting.AUTO to stringResource(R.string.settings_option_auto),
+                        MapStyleSetting.LIGHT to stringResource(R.string.settings_theme_light),
+                        MapStyleSetting.DARK to stringResource(R.string.settings_theme_dark),
+                    ),
+                selected = uiState.mapStyle,
+                onSelect = { onAction(SettingsAction.SetMapStyle(it)) },
+            )
+            SliderRow(
+                title = stringResource(R.string.settings_group_map_tilt),
+                valueLabel = stringResource(R.string.settings_map_tilt_value, uiState.mapTiltDeg),
+                value = uiState.mapTiltDeg,
+                range = MIN_MAP_TILT..MAX_MAP_TILT,
+                onValueChange = { onAction(SettingsAction.SetMapTilt(it)) },
+            )
+            SliderRow(
+                title = stringResource(R.string.settings_group_map_zoom),
+                valueLabel = stringResource(R.string.settings_map_zoom_value, uiState.mapZoom),
+                value = uiState.mapZoom,
+                range = MIN_MAP_ZOOM..MAX_MAP_ZOOM,
+                onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
+            )
+        }
 
-        SettingGroup(
-            title = stringResource(R.string.settings_group_map_3d),
-            options = offOnOptions(),
-            selected = uiState.mapBuildings3d,
-            onSelect = { onAction(SettingsAction.SetMapBuildings3d(it)) },
-        )
+        SettingsSection(title = stringResource(R.string.settings_section_panels)) {
+            SwitchRow(
+                title = stringResource(R.string.settings_group_panel_calendar),
+                checked = uiState.showCalendar,
+                onCheckedChange = { onAction(SettingsAction.SetShowCalendar(it)) },
+            )
+            SwitchRow(
+                title = stringResource(R.string.settings_group_panel_weather),
+                checked = uiState.showWeather,
+                onCheckedChange = { onAction(SettingsAction.SetShowWeather(it)) },
+            )
+            SwitchRow(
+                title = stringResource(R.string.settings_group_panel_music),
+                checked = uiState.showMusic,
+                onCheckedChange = { onAction(SettingsAction.SetShowMusic(it)) },
+            )
+        }
 
-        SettingGroup(
-            title = stringResource(R.string.settings_group_map_style),
-            options =
-                listOf(
-                    MapStyleSetting.AUTO to stringResource(R.string.settings_option_auto),
-                    MapStyleSetting.LIGHT to stringResource(R.string.settings_theme_light),
-                    MapStyleSetting.DARK to stringResource(R.string.settings_theme_dark),
-                ),
-            selected = uiState.mapStyle,
-            onSelect = { onAction(SettingsAction.SetMapStyle(it)) },
-        )
-
-        SliderSetting(
-            title = stringResource(R.string.settings_group_map_tilt),
-            valueLabel = stringResource(R.string.settings_map_tilt_value, uiState.mapTiltDeg),
-            value = uiState.mapTiltDeg,
-            range = MIN_MAP_TILT..MAX_MAP_TILT,
-            onValueChange = { onAction(SettingsAction.SetMapTilt(it)) },
-        )
-
-        SliderSetting(
-            title = stringResource(R.string.settings_group_map_zoom),
-            valueLabel = stringResource(R.string.settings_map_zoom_value, uiState.mapZoom),
-            value = uiState.mapZoom,
-            range = MIN_MAP_ZOOM..MAX_MAP_ZOOM,
-            onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
-        )
-
-        SettingGroup(
-            title = stringResource(R.string.settings_group_panel_calendar),
-            options = offOnOptions(),
-            selected = uiState.showCalendar,
-            onSelect = { onAction(SettingsAction.SetShowCalendar(it)) },
-        )
-
-        SettingGroup(
-            title = stringResource(R.string.settings_group_panel_weather),
-            options = offOnOptions(),
-            selected = uiState.showWeather,
-            onSelect = { onAction(SettingsAction.SetShowWeather(it)) },
-        )
-
-        SettingGroup(
-            title = stringResource(R.string.settings_group_panel_music),
-            options = offOnOptions(),
-            selected = uiState.showMusic,
-            onSelect = { onAction(SettingsAction.SetShowMusic(it)) },
-        )
-
-        SettingGroup(
-            title = stringResource(R.string.settings_group_font),
-            options = FontTheme.entries.map { it to it.displayName() },
-            selected = uiState.fontTheme,
-            onSelect = { onAction(SettingsAction.SetFontTheme(it)) },
-        )
-
-        SystemGroup(
-            onOpenNotificationAccess = onOpenNotificationAccess,
-            onOpenSystemSettings = onOpenSystemSettings,
-        )
+        SettingsSection(title = stringResource(R.string.settings_group_system)) {
+            ActionRow(
+                title = stringResource(R.string.settings_open_notification_access),
+                onClick = onOpenNotificationAccess,
+            )
+            ActionRow(
+                title = stringResource(R.string.settings_open_system_settings),
+                onClick = onOpenSystemSettings,
+            )
+        }
     }
 }
 
@@ -239,97 +251,125 @@ private fun Header(
     )
 }
 
+// A category: a small colored header above a flat (0 dp) rounded card holding the
+// section's rows, echoing the Android Settings app's grouped layout.
 @Composable
-private fun <T> SettingGroup(
+private fun SettingsSection(
     title: String,
-    options: List<Pair<T, String>>,
-    selected: T,
-    onSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
 ) = Column(
     modifier = modifier.fillMaxWidth(),
     verticalArrangement = Arrangement.spacedBy(8.dp),
 ) {
     Text(
         text = title,
-        style = MaterialTheme.typography.titleMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(start = 12.dp),
     )
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        options.forEach { (value, label) ->
-            OptionChip(
-                label = label,
-                selected = value == selected,
-                onClick = { onSelect(value) },
-            )
-        }
-    }
-}
-
-@Composable
-private fun OptionChip(
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val container =
-        if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainerHigh
-    val content =
-        if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
     Surface(
-        onClick = onClick,
-        modifier = modifier.heightIn(min = FemtoDimens.MinTouchTarget),
-        shape = RoundedCornerShape(14.dp),
-        color = container,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(FemtoDimens.CardCorner),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = FemtoDimens.CardElevation,
     ) {
-        Box(
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyLarge,
-                color = content,
-                maxLines = 1,
-            )
-        }
+        Column(content = content)
     }
 }
 
+// A single-choice row: shows the current value as its summary and opens a radio
+// dialog on tap (the Android ListPreference pattern).
 @Composable
-private fun SystemGroup(
-    onOpenNotificationAccess: () -> Unit,
-    onOpenSystemSettings: () -> Unit,
+private fun <T> ChoiceRow(
+    title: String,
+    options: List<Pair<T, String>>,
+    selected: T,
+    onSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
-) = Column(
-    modifier = modifier.fillMaxWidth(),
-    verticalArrangement = Arrangement.spacedBy(8.dp),
 ) {
-    Text(
-        text = stringResource(R.string.settings_group_system),
-        style = MaterialTheme.typography.titleMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-    FilledTonalButton(
-        onClick = onOpenNotificationAccess,
-        modifier = Modifier.fillMaxWidth().heightIn(min = FemtoDimens.MinTouchTarget),
+    var dialogOpen by remember { mutableStateOf(false) }
+    SettingRow(
+        title = title,
+        modifier = modifier.clickable { dialogOpen = true },
+        summary = options.firstOrNull { it.first == selected }?.second,
     ) {
-        Text(text = stringResource(R.string.settings_open_notification_access))
+        TrailingIcon(Lucide.ChevronRight)
     }
-    FilledTonalButton(
-        onClick = onOpenSystemSettings,
-        modifier = Modifier.fillMaxWidth().heightIn(min = FemtoDimens.MinTouchTarget),
-    ) {
-        Text(text = stringResource(R.string.settings_open_system_settings))
+    if (dialogOpen) {
+        ChoiceDialog(
+            title = title,
+            options = options,
+            selected = selected,
+            onSelect = {
+                onSelect(it)
+                dialogOpen = false
+            },
+            onDismiss = { dialogOpen = false },
+        )
     }
 }
 
 @Composable
-private fun SliderSetting(
+private fun <T> ChoiceDialog(
+    title: String,
+    options: List<Pair<T, String>>,
+    selected: T,
+    onSelect: (T) -> Unit,
+    onDismiss: () -> Unit,
+) = AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text(text = title) },
+    text = {
+        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+            options.forEach { (value, label) ->
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = FemtoDimens.MinTouchTarget)
+                            .selectable(
+                                selected = value == selected,
+                                role = Role.RadioButton,
+                                onClick = { onSelect(value) },
+                            ),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    RadioButton(selected = value == selected, onClick = null)
+                    Text(text = label, style = MaterialTheme.typography.bodyLarge)
+                }
+            }
+        }
+    },
+    // Tapping a radio option commits and dismisses (select-on-tap), so there is
+    // no confirm action — only Cancel.
+    confirmButton = {},
+    dismissButton = {
+        TextButton(onClick = onDismiss) {
+            Text(text = stringResource(R.string.settings_cancel))
+        }
+    },
+)
+
+// A boolean row: the whole row is the toggle (role = Switch), so the inline
+// Switch is presentation-only (onCheckedChange = null) and never double-fires.
+@Composable
+private fun SwitchRow(
+    title: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) = SettingRow(
+    title = title,
+    modifier = modifier.toggleable(value = checked, role = Role.Switch, onValueChange = onCheckedChange),
+) {
+    Switch(checked = checked, onCheckedChange = null)
+}
+
+// A numeric row: an inline slider under the title / current-value line.
+@Composable
+private fun SliderRow(
     title: String,
     valueLabel: String,
     value: Int,
@@ -337,7 +377,11 @@ private fun SliderSetting(
     onValueChange: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(
-    modifier = modifier.fillMaxWidth(),
+    modifier =
+        modifier
+            .fillMaxWidth()
+            .heightIn(min = FemtoDimens.MinTouchTarget)
+            .padding(horizontal = 20.dp, vertical = 10.dp),
     verticalArrangement = Arrangement.spacedBy(4.dp),
 ) {
     Row(
@@ -348,12 +392,12 @@ private fun SliderSetting(
         Text(
             text = title,
             style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = MaterialTheme.colorScheme.onSurface,
         )
         Text(
             text = valueLabel,
             style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
     Slider(
@@ -363,14 +407,67 @@ private fun SliderSetting(
     )
 }
 
-// Shared Off/On options for a boolean SettingGroup. @Composable to resolve the
-// localized labels; keeps the boolean toggles from each repeating the pair.
+// A navigation row: links out to a system screen, marked with an external glyph.
 @Composable
-private fun offOnOptions(): List<Pair<Boolean, String>> =
-    listOf(
-        false to stringResource(R.string.settings_off),
-        true to stringResource(R.string.settings_on),
-    )
+private fun ActionRow(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) = SettingRow(
+    title = title,
+    modifier = modifier.clickable(onClick = onClick),
+) {
+    TrailingIcon(Lucide.ExternalLink)
+}
+
+// Shared row scaffold: a tap target ≥ MinTouchTarget with a title, optional
+// summary, and a trailing slot. The caller supplies the interaction (clickable /
+// toggleable) through [modifier] so each row keeps the right accessibility role.
+@Composable
+private fun SettingRow(
+    title: String,
+    modifier: Modifier = Modifier,
+    summary: String? = null,
+    trailing: @Composable () -> Unit = {},
+) = Row(
+    modifier =
+        modifier
+            .fillMaxWidth()
+            .heightIn(min = FemtoDimens.MinTouchTarget)
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(16.dp),
+) {
+    Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        if (summary != null) {
+            Text(
+                text = summary,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+    trailing()
+}
+
+@Composable
+private fun TrailingIcon(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+) = Icon(
+    imageVector = imageVector,
+    contentDescription = null,
+    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    modifier = modifier.size(FemtoDimens.InlineIconSize),
+)
 
 // The display's maximum refresh rate (fps), the ceiling for the map frame-rate
 // slider. Falls back to 60 when the modes cannot be read; clamped to a sane band.
@@ -397,6 +494,8 @@ private const val MIN_MAP_TILT = 0
 private const val MAX_MAP_TILT = 60
 private const val MIN_MAP_ZOOM = 12
 private const val MAX_MAP_ZOOM = 19
+
+private fun Boolean.toFullscreen(): FullscreenSetting = if (this) FullscreenSetting.ON else FullscreenSetting.OFF
 
 // A human-readable label for a font theme (e.g. INTER -> "Inter").
 private fun FontTheme.displayName(): String = name.lowercase().replaceFirstChar(Char::uppercaseChar)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,11 @@
     <!-- Settings -->
     <string name="settings_title">Settings</string>
     <string name="settings_back">Back</string>
+    <string name="settings_cancel">Cancel</string>
+    <string name="settings_section_display">Display</string>
+    <string name="settings_section_units">Units</string>
+    <string name="settings_section_map">Map</string>
+    <string name="settings_section_panels">Panels</string>
     <string name="settings_group_theme">Theme</string>
     <string name="settings_group_speed">Speed &amp; distance</string>
     <string name="settings_group_temperature">Temperature</string>
@@ -87,8 +92,6 @@
     <string name="settings_group_font">Font</string>
     <string name="settings_group_system">System</string>
     <string name="settings_option_auto">Auto</string>
-    <string name="settings_off">Off</string>
-    <string name="settings_on">On</string>
     <string name="settings_theme_light">Light</string>
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_speed_km">km/h</string>


### PR DESCRIPTION
## Summary

Redesign the in-app settings screen to look like the Android system
Settings app — the final slice of the settings overhaul (after the
granular map controls in #58 and the panel toggles in #59).

The old flat, chip-based list is replaced with **category sections**,
each a flat (0 dp) rounded `surfaceContainer` card of rows. A row shows
its title plus the current value as a summary and adapts its control to
the setting type:

| Row | Used for | Interaction |
| --- | --- | --- |
| `ChoiceRow` | theme, font, units, clock, map style | opens a radio-button `AlertDialog` (select-on-tap) |
| `SwitchRow` | fullscreen, 3D buildings, panel visibility | `toggleable` row (role = Switch) + inline switch |
| `SliderRow` | map frame rate, tilt, zoom | inline slider |
| `ActionRow` | notification access, system settings | links out (`ExternalLink` glyph) |

Sections: **Display** (theme, font, fullscreen) · **Units** (speed,
temperature, clock) · **Map** (frame rate, 3D buildings, style, tilt,
zoom) · **Panels** (calendar, weather, music) · **System** (links out).

## Design notes

- A shared `SettingRow` scaffold enforces the `FemtoDimens.MinTouchTarget`
  (64 dp) tap target. The caller supplies the interaction (`clickable`
  vs `toggleable`) through `modifier`, so each row keeps the correct
  accessibility role.
- `SwitchRow` makes the **whole row** the toggle (`role = Switch`) and
  the inline `Switch` is presentation-only (`onCheckedChange = null`),
  matching the `RadioButton(onClick = null)` + `selectable` pattern in
  the dialog and avoiding any double-fire.
- All values come from `MaterialTheme.colorScheme` / `typography`; the
  card is flat per the Bold Minimal rule (`FemtoDimens.CardElevation`).
- No new persisted settings — this is presentation only. The backing
  `SettingsUiState` / actions are unchanged.
- The now-unused `settings_off` / `settings_on` strings are removed.

## Test

- `SettingsScreenTest` rewritten for the new interactions: renders the
  Fullscreen row, toggling it dispatches `SetFullscreen(ON)`, and
  choosing "Dark" in the Theme dialog dispatches `SetThemeMode(DARK)`.
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.
- Reviewed with `compose-launcher-reviewer`; modifier ordering and the
  switch interaction were tightened per its findings.
