### PR TITLE
fix(dashboard): stop the calendar, weather and music cards clipping

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -171,7 +171,7 @@ private fun Strip(
     onSelect: (LocalDate) -> Unit,
 ) = Row(
     modifier = Modifier.fillMaxWidth(),
-    horizontalArrangement = Arrangement.spacedBy(4.dp),
+    horizontalArrangement = Arrangement.spacedBy(3.dp),
 ) {
     days.forEach { day ->
         DayCellView(
@@ -219,12 +219,17 @@ private fun DayCellView(
                 // Sub-64dp tap target: a deliberate exception for the in-card
                 // mini-calendar grid (CLAUDE.md#automotive-overrides keeps 64dp the
                 // default; the strip relaxes it like the footer status cluster).
-                .padding(vertical = 8.dp, horizontal = 4.dp),
+                // Tight horizontal padding so a two-digit day fits the ~20 dp cell
+                // a narrow info-pane card gives each of the six columns.
+                .padding(vertical = 8.dp, horizontal = 2.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         Text(
-            text = day.weekdayLetter.take(3).uppercase(),
+            // Two letters (not three): on the head-unit binding width a 3-letter
+            // Latin abbreviation overflows the cell, while a 2-letter one fits and
+            // stays unambiguous; CJK weekday labels are a single glyph regardless.
+            text = day.weekdayLetter.take(2).uppercase(),
             style = MaterialTheme.typography.sectionLabel(9, 0.08f),
             color = onBackground,
             maxLines = 1,
@@ -234,9 +239,9 @@ private fun DayCellView(
             text = "${day.date.dayOfMonth}",
             style =
                 MaterialTheme.typography.titleSmall.copy(
-                    fontSize = 14.sp,
+                    fontSize = 13.sp,
                     fontWeight = FontWeight.SemiBold,
-                    lineHeight = 16.sp,
+                    lineHeight = 15.sp,
                     fontFeatureSettings = TabularFigures,
                 ),
             color = numberColor,
@@ -351,8 +356,11 @@ private fun PermissionDenied() =
         )
     }
 
+// Sized to the head-unit binding: each top-row card is ~165 x 207 dp (half the
+// info pane on the 853 x 512 dp / 5:3 projection), the geometry that exposed the
+// two-digit-day clip. Wider panels only add slack.
 @PreviewLightDark
-@Preview(name = "Calendar card", widthDp = 240, heightDp = 224)
+@Preview(name = "Calendar card", widthDp = 165, heightDp = 207)
 @Composable
 private fun CalendarCardPreview() {
     FemtoTheme {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -111,51 +111,63 @@ private fun PlayingState(
     nowPlaying: NowPlaying,
     onCommand: (MusicCommand) -> Unit,
     onLaunchSource: (String) -> Unit,
-) = Row(
+) = Column(
     modifier =
         Modifier
             .fillMaxSize()
             .padding(FemtoDimens.CardPadding),
-    horizontalArrangement = Arrangement.spacedBy(14.dp),
-    verticalAlignment = Alignment.CenterVertically,
+    verticalArrangement = Arrangement.spacedBy(10.dp),
 ) {
-    // Album art on the left, sized square to the card height.
-    AlbumArt(
-        nowPlaying = nowPlaying,
-        modifier = Modifier.fillMaxHeight().aspectRatio(1f),
-    )
-    // Track info + transport controls on the right.
-    Column(
-        modifier = Modifier.weight(1f).fillMaxHeight(),
-        verticalArrangement = Arrangement.SpaceBetween,
+    // Album art + track info share the top region; the transport row spans the
+    // full card width below. On a narrow info-pane card a square album beside the
+    // three >= 64 dp controls leaves no room for them, so the controls drop to a
+    // full-width strip where they always fit.
+    Row(
+        modifier = Modifier.fillMaxWidth().weight(1f),
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.Top,
+        // Album art on the left, sized square to the top region's height.
+        AlbumArt(
+            nowPlaying = nowPlaying,
+            modifier = Modifier.fillMaxHeight().aspectRatio(1f),
+        )
+        Column(
+            modifier = Modifier.weight(1f).fillMaxHeight(),
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
         ) {
-            Meta(
-                source = sourceLabel(nowPlaying.packageName),
-                title = nowPlaying.title,
-                artist = nowPlaying.artist,
-                modifier = Modifier.weight(1f),
-            )
-            // Tapping the source app's icon brings that app to the foreground.
-            SourceAppButton(
-                sourceIcon = nowPlaying.sourceIcon,
-                sourceLabel = sourceLabel(nowPlaying.packageName),
-                onClick = { onLaunchSource(nowPlaying.packageName) },
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.Top,
+            ) {
+                Meta(
+                    source = sourceLabel(nowPlaying.packageName),
+                    title = nowPlaying.title,
+                    artist = nowPlaying.artist,
+                    modifier = Modifier.weight(1f),
+                )
+                // Tapping the source app's icon brings that app to the foreground.
+                SourceAppButton(
+                    sourceIcon = nowPlaying.sourceIcon,
+                    sourceLabel = sourceLabel(nowPlaying.packageName),
+                    onClick = { onLaunchSource(nowPlaying.packageName) },
+                )
+            }
+            Progress(
+                positionMs = nowPlaying.positionMs,
+                durationMs = nowPlaying.durationMs,
+                positionUpdateTimeMs = nowPlaying.positionUpdateTimeMs,
+                isPlaying = nowPlaying.isPlaying,
+                playbackSpeed = nowPlaying.playbackSpeed,
             )
         }
-        Progress(
-            positionMs = nowPlaying.positionMs,
-            durationMs = nowPlaying.durationMs,
-            positionUpdateTimeMs = nowPlaying.positionUpdateTimeMs,
-            isPlaying = nowPlaying.isPlaying,
-            playbackSpeed = nowPlaying.playbackSpeed,
-        )
-        TransportRow(isPlaying = nowPlaying.isPlaying, onCommand = onCommand)
     }
+    TransportRow(
+        isPlaying = nowPlaying.isPlaying,
+        onCommand = onCommand,
+        modifier = Modifier.fillMaxWidth(),
+    )
 }
 
 @Composable
@@ -391,8 +403,10 @@ private fun Progress(
 private fun TransportRow(
     isPlaying: Boolean,
     onCommand: (MusicCommand) -> Unit,
+    modifier: Modifier = Modifier,
 ) = Row(
-    horizontalArrangement = Arrangement.spacedBy(16.dp),
+    modifier = modifier,
+    horizontalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterHorizontally),
     verticalAlignment = Alignment.CenterVertically,
 ) {
     TransportButton(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -115,12 +115,15 @@ private fun Head(
     val glyphs = weatherGlyphs()
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Row(verticalAlignment = Alignment.Top) {
             Text(
                 text = tempLabel,
-                style = MaterialTheme.typography.bigNumber(),
+                // One notch below the shared bigNumber() so the hero temperature
+                // does not starve the condition / city column on a narrow
+                // info-pane card (the head-unit binding width).
+                style = MaterialTheme.typography.bigNumber().copy(fontSize = 46.sp, lineHeight = 42.sp),
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
             )
@@ -176,6 +179,7 @@ private fun Head(
                 style = MaterialTheme.typography.sectionLabel(11, 0.14f),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }
@@ -376,8 +380,11 @@ private fun labelResFor(code: WeatherCode): Int =
         WeatherCode.UNKNOWN -> R.string.weather_cond_unknown
     }
 
+// Sized to the head-unit binding: each top-row card is ~165 x 207 dp (half the
+// info pane on the 853 x 512 dp / 5:3 projection), the geometry that starved the
+// condition / city column. CLOUDY exercises the longest short-condition label.
 @PreviewLightDark
-@Preview(name = "Weather card", widthDp = 240, heightDp = 224)
+@Preview(name = "Weather card", widthDp = 165, heightDp = 207)
 @Composable
 private fun WeatherCardPreview() {
     FemtoTheme {
@@ -386,7 +393,7 @@ private fun WeatherCardPreview() {
                 WeatherSnapshot(
                     tempC = 13.0,
                     apparentTempC = 11.0,
-                    code = WeatherCode.CLEAR,
+                    code = WeatherCode.CLOUDY,
                     windKmh = 11.0,
                     humidityPercent = 58,
                     uvIndex = 3.0,


### PR DESCRIPTION
## Summary

Fix the calendar, weather and music cards clipping content on the real
head-unit screen (Carlinkit TBox + ZWE211W, 853x512 dp / 5:3). Each
info-pane card is far narrower than the 240 dp the card previews assumed,
so content overflowed:

- **Music** — a square album art (`fillMaxHeight().aspectRatio(1f)`)
  consumed most of the width, starving the right column so the three
  `>= 64 dp` transport controls (the automotive tap-target floor) did
  not fit and **skip-forward was clipped off the right edge**. The
  controls now sit in a **full-width strip below** the album + track
  info, where all three always fit. Album art + metadata + progress
  share the top region.
- **Weather** — the 56 sp hero temperature crowded out the condition
  column, hard-clipping **"CLOUDY" to "CLO"**. The temperature drops one
  notch to 46 sp, the head gap tightens, and the condition label gets
  an ellipsis.
- **Calendar** — a two-digit day overflowed each ~20 dp strip cell
  (**"10" clipped**). The cell padding and strip gap tighten, the
  weekday uses a 2-letter abbreviation (CJK stays one glyph), and the
  day number drops to 13 sp.

## Why the previews missed it

The card previews were 240 dp wide; the real top-row card is ~165 dp.
They are resized to the ~165 x 207 dp binding geometry so the clipping
reproduces in the preview, and the weather preview now uses CLOUDY to
exercise the longest short-condition label.

## Test

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.
On-device verification to follow on the next nightly.
