### PR TITLE
fix(map): show a single map attribution credit

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -157,6 +157,11 @@ private fun SnapshotMap(
                     MapSnapshotter
                         .Options(widthPx, heightPx)
                         .withLogo(false)
+                        // Suppress the snapshot's baked-in credit; the styled
+                        // Compose [Attribution] overlay is the single source of the
+                        // OSM / OpenMapTiles / OpenFreeMap credit (avoids the
+                        // duplicate text the baked-in attribution drew on-device).
+                        .withAttribution(false)
                         .withStyleBuilder(styleBuilderFor(context, isDark, mapConfig.buildings3d)),
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <!-- Map panel -->
     <string name="map_unavailable">Map unavailable</string>
     <string name="map_permission_cta">Grant location access to enable the map and overlays.</string>
-    <string name="map_attribution">© OpenStreetMap · OpenMapTiles</string>
+    <string name="map_attribution">© OpenStreetMap · OpenMapTiles · OpenFreeMap</string>
 
     <!-- Speed overlay -->
     <string name="speed_reset_trip">Reset trip</string>


### PR DESCRIPTION
## Summary

The map showed **two** attribution credits on-device: the
`MapSnapshotter` baked one into the bitmap while the Compose `Attribution`
overlay drew another. Disable the snapshotter's baked-in credit with
`withAttribution(false)` and keep the styled Compose overlay as the
single source, extended to name OpenFreeMap alongside OpenStreetMap and
OpenMapTiles so no credit is dropped.

## Test

`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.