### PR TITLE
test(settings): stabilize the DisplayPreferences persistence tests

### DIFF
--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -7,10 +7,8 @@ import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
@@ -22,7 +20,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
 class SettingsViewModelTest {
@@ -31,8 +28,11 @@ class SettingsViewModelTest {
 
     @Before
     fun setUp() {
-        // Unconfined Main so a viewModelScope.launch from onAction runs eagerly.
-        Dispatchers.setMain(UnconfinedTestDispatcher())
+        // Real Unconfined Main so a viewModelScope.launch from onAction runs its
+        // body eagerly on the calling thread. UnconfinedTestDispatcher would queue
+        // the body on a scheduler that only runTest pumps, so under runBlocking the
+        // write never executed and the await timed out.
+        Dispatchers.setMain(Dispatchers.Unconfined)
     }
 
     @After

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -3,15 +3,17 @@ package io.github.seijikohara.femto.ui.settings
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import io.github.seijikohara.femto.data.DisplayPreferences
+import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -29,6 +31,7 @@ class SettingsViewModelTest {
 
     @Before
     fun setUp() {
+        // Unconfined Main so a viewModelScope.launch from onAction runs eagerly.
         Dispatchers.setMain(UnconfinedTestDispatcher())
     }
 
@@ -39,33 +42,42 @@ class SettingsViewModelTest {
 
     @Test
     fun `SetFullscreen persists via DisplayPreferences`() =
-        runTest {
-            val viewModel = SettingsViewModel(displayPreferences, FontPreferences(application))
-            viewModel.onAction(SettingsAction.SetFullscreen(FullscreenSetting.ON))
-            // Assert the persisted value via first { predicate }: it waits for the
-            // write to land and is robust both to the DataStore being shared across
-            // the tests in this class and to DataStore IO completing off the test
-            // clock. Collecting the ViewModel StateFlow here instead hangs runTest,
-            // because its WhileSubscribed upstream reads the real DataStore on IO.
+        runBlocking {
+            viewModel().onAction(SettingsAction.SetFullscreen(FullscreenSetting.ON))
             assertEquals(
                 FullscreenSetting.ON,
-                displayPreferences.settings.first { it.fullscreen == FullscreenSetting.ON }.fullscreen,
+                awaitSetting { it.fullscreen == FullscreenSetting.ON }.fullscreen,
             )
         }
 
     @Test
     fun `SetMapFps persists via DisplayPreferences`() =
-        runTest {
-            val viewModel = SettingsViewModel(displayPreferences, FontPreferences(application))
-            viewModel.onAction(SettingsAction.SetMapFps(30))
-            assertEquals(30, displayPreferences.settings.first { it.mapFps == 30 }.mapFps)
+        runBlocking {
+            viewModel().onAction(SettingsAction.SetMapFps(30))
+            assertEquals(30, awaitSetting { it.mapFps == 30 }.mapFps)
         }
 
     @Test
     fun `SetShowMusic persists via DisplayPreferences`() =
-        runTest {
-            val viewModel = SettingsViewModel(displayPreferences, FontPreferences(application))
-            viewModel.onAction(SettingsAction.SetShowMusic(false))
-            assertEquals(false, displayPreferences.settings.first { !it.showMusic }.showMusic)
+        runBlocking {
+            viewModel().onAction(SettingsAction.SetShowMusic(false))
+            assertEquals(false, awaitSetting { !it.showMusic }.showMusic)
         }
+
+    private fun viewModel() = SettingsViewModel(displayPreferences, FontPreferences(application))
+
+    // Wait for the persisted settings to satisfy [predicate]. These tests exercise
+    // the real (Robolectric) DataStore round-trip, whose IO runs off the test
+    // scheduler; runTest's virtual clock cannot observe it and its end-of-test
+    // completion check races the write to an UncompletedCoroutinesError. runBlocking
+    // waits on real time instead, and this withTimeout bounds a write that never
+    // lands so a regression fails fast rather than hanging.
+    private suspend fun awaitSetting(predicate: (DisplaySettings) -> Boolean): DisplaySettings =
+        withTimeout(WRITE_TIMEOUT_MS) {
+            displayPreferences.settings.first(predicate)
+        }
+
+    private companion object {
+        const val WRITE_TIMEOUT_MS = 5_000L
+    }
 }


### PR DESCRIPTION
## Summary

`SettingsViewModelTest` drove the real (Robolectric) DataStore through
`runTest`. DataStore IO runs off the test scheduler, so runTest's virtual
clock cannot observe it and its end-of-test completion check raced the
write to an intermittent `UncompletedCoroutinesError` — which started
failing CI reliably on PR #62 (unrelated change).

Run these round-trip tests under `runBlocking` (real time, no completion
check) and bound each write wait with `withTimeout(5s)` so a genuine
regression fails fast instead of hanging. The shared view-model
construction and the await-setting helper are factored out.

## Test

- The three persistence tests pass 3x in a row locally with `--rerun-tasks`.
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.