### PR TITLE
test(settings): drive SettingsViewModel through an in-memory store

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -85,6 +85,41 @@ internal data class DisplaySettings(
 private val Context.displayDataStore: DataStore<Preferences> by preferencesDataStore(name = "display_preferences")
 
 /**
+ * Read/write surface for [DisplaySettings]. [DisplayPreferences] is the
+ * DataStore-backed production implementation; tests substitute an in-memory fake
+ * so the view-model can be exercised without real DataStore IO.
+ */
+internal interface DisplaySettingsStore {
+    val settings: Flow<DisplaySettings>
+
+    suspend fun setThemeMode(value: ThemeMode)
+
+    suspend fun setSpeedUnit(value: SpeedUnitSetting)
+
+    suspend fun setTemperatureUnit(value: TemperatureUnitSetting)
+
+    suspend fun setClock(value: ClockSetting)
+
+    suspend fun setFullscreen(value: FullscreenSetting)
+
+    suspend fun setMapFps(value: Int)
+
+    suspend fun setMapBuildings3d(value: Boolean)
+
+    suspend fun setMapStyle(value: MapStyleSetting)
+
+    suspend fun setMapTilt(value: Int)
+
+    suspend fun setMapZoom(value: Int)
+
+    suspend fun setShowCalendar(value: Boolean)
+
+    suspend fun setShowWeather(value: Boolean)
+
+    suspend fun setShowMusic(value: Boolean)
+}
+
+/**
  * DataStore-backed accessor for [DisplaySettings].
  *
  * Each enum is stored by name and decoded defensively (an unknown / renamed
@@ -93,8 +128,8 @@ private val Context.displayDataStore: DataStore<Preferences> by preferencesDataS
  */
 internal class DisplayPreferences(
     private val context: Context,
-) {
-    val settings: Flow<DisplaySettings> =
+) : DisplaySettingsStore {
+    override val settings: Flow<DisplaySettings> =
         context.displayDataStore.data.map { prefs ->
             DisplaySettings(
                 themeMode = prefs[THEME_KEY].toEnumOr(ThemeMode.SYSTEM),
@@ -113,33 +148,59 @@ internal class DisplayPreferences(
             )
         }
 
-    suspend fun setThemeMode(value: ThemeMode) = context.displayDataStore.edit { it[THEME_KEY] = value.name }
+    // Block bodies (returning Unit): edit() yields Preferences, which the
+    // DisplaySettingsStore contract intentionally discards.
+    override suspend fun setThemeMode(value: ThemeMode) {
+        context.displayDataStore.edit { it[THEME_KEY] = value.name }
+    }
 
-    suspend fun setSpeedUnit(value: SpeedUnitSetting) = context.displayDataStore.edit { it[SPEED_KEY] = value.name }
+    override suspend fun setSpeedUnit(value: SpeedUnitSetting) {
+        context.displayDataStore.edit { it[SPEED_KEY] = value.name }
+    }
 
-    suspend fun setTemperatureUnit(value: TemperatureUnitSetting) =
+    override suspend fun setTemperatureUnit(value: TemperatureUnitSetting) {
         context.displayDataStore.edit { it[TEMPERATURE_KEY] = value.name }
+    }
 
-    suspend fun setClock(value: ClockSetting) = context.displayDataStore.edit { it[CLOCK_KEY] = value.name }
+    override suspend fun setClock(value: ClockSetting) {
+        context.displayDataStore.edit { it[CLOCK_KEY] = value.name }
+    }
 
-    suspend fun setFullscreen(value: FullscreenSetting) =
+    override suspend fun setFullscreen(value: FullscreenSetting) {
         context.displayDataStore.edit { it[FULLSCREEN_KEY] = value.name }
+    }
 
-    suspend fun setMapFps(value: Int) = context.displayDataStore.edit { it[MAP_FPS_KEY] = value }
+    override suspend fun setMapFps(value: Int) {
+        context.displayDataStore.edit { it[MAP_FPS_KEY] = value }
+    }
 
-    suspend fun setMapBuildings3d(value: Boolean) = context.displayDataStore.edit { it[MAP_BUILDINGS_KEY] = value }
+    override suspend fun setMapBuildings3d(value: Boolean) {
+        context.displayDataStore.edit { it[MAP_BUILDINGS_KEY] = value }
+    }
 
-    suspend fun setMapStyle(value: MapStyleSetting) = context.displayDataStore.edit { it[MAP_STYLE_KEY] = value.name }
+    override suspend fun setMapStyle(value: MapStyleSetting) {
+        context.displayDataStore.edit { it[MAP_STYLE_KEY] = value.name }
+    }
 
-    suspend fun setMapTilt(value: Int) = context.displayDataStore.edit { it[MAP_TILT_KEY] = value }
+    override suspend fun setMapTilt(value: Int) {
+        context.displayDataStore.edit { it[MAP_TILT_KEY] = value }
+    }
 
-    suspend fun setMapZoom(value: Int) = context.displayDataStore.edit { it[MAP_ZOOM_KEY] = value }
+    override suspend fun setMapZoom(value: Int) {
+        context.displayDataStore.edit { it[MAP_ZOOM_KEY] = value }
+    }
 
-    suspend fun setShowCalendar(value: Boolean) = context.displayDataStore.edit { it[SHOW_CALENDAR_KEY] = value }
+    override suspend fun setShowCalendar(value: Boolean) {
+        context.displayDataStore.edit { it[SHOW_CALENDAR_KEY] = value }
+    }
 
-    suspend fun setShowWeather(value: Boolean) = context.displayDataStore.edit { it[SHOW_WEATHER_KEY] = value }
+    override suspend fun setShowWeather(value: Boolean) {
+        context.displayDataStore.edit { it[SHOW_WEATHER_KEY] = value }
+    }
 
-    suspend fun setShowMusic(value: Boolean) = context.displayDataStore.edit { it[SHOW_MUSIC_KEY] = value }
+    override suspend fun setShowMusic(value: Boolean) {
+        context.displayDataStore.edit { it[SHOW_MUSIC_KEY] = value }
+    }
 
     private companion object {
         val THEME_KEY = stringPreferencesKey("theme_mode")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import io.github.seijikohara.femto.data.DisplayPreferences
+import io.github.seijikohara.femto.data.DisplaySettingsStore
 import io.github.seijikohara.femto.data.FontPreferences
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -14,7 +15,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 internal class SettingsViewModel(
-    private val displayPreferences: DisplayPreferences,
+    private val displayPreferences: DisplaySettingsStore,
     private val fontPreferences: FontPreferences,
 ) : ViewModel() {
     val uiState: StateFlow<SettingsUiState> =

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -1,0 +1,54 @@
+package io.github.seijikohara.femto.testfixtures
+
+import io.github.seijikohara.femto.data.ClockSetting
+import io.github.seijikohara.femto.data.DisplaySettings
+import io.github.seijikohara.femto.data.DisplaySettingsStore
+import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.data.MapStyleSetting
+import io.github.seijikohara.femto.data.SpeedUnitSetting
+import io.github.seijikohara.femto.data.TemperatureUnitSetting
+import io.github.seijikohara.femto.data.ThemeMode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * In-memory [DisplaySettingsStore] for view-model tests: every setter mutates a
+ * [MutableStateFlow] synchronously, so a test sees the write with no DataStore IO
+ * and no cross-dispatcher timing. Defaults match [DisplaySettings.Default].
+ */
+internal class FakeDisplaySettingsStore(
+    initial: DisplaySettings = DisplaySettings.Default,
+) : DisplaySettingsStore {
+    private val state = MutableStateFlow(initial)
+    override val settings: Flow<DisplaySettings> = state
+
+    override suspend fun setThemeMode(value: ThemeMode) = state.update { it.copy(themeMode = value) }
+
+    override suspend fun setSpeedUnit(value: SpeedUnitSetting) = state.update { it.copy(speedUnit = value) }
+
+    override suspend fun setTemperatureUnit(value: TemperatureUnitSetting) =
+        state.update {
+            it.copy(temperatureUnit = value)
+        }
+
+    override suspend fun setClock(value: ClockSetting) = state.update { it.copy(clock = value) }
+
+    override suspend fun setFullscreen(value: FullscreenSetting) = state.update { it.copy(fullscreen = value) }
+
+    override suspend fun setMapFps(value: Int) = state.update { it.copy(mapFps = value) }
+
+    override suspend fun setMapBuildings3d(value: Boolean) = state.update { it.copy(mapBuildings3d = value) }
+
+    override suspend fun setMapStyle(value: MapStyleSetting) = state.update { it.copy(mapStyle = value) }
+
+    override suspend fun setMapTilt(value: Int) = state.update { it.copy(mapTiltDeg = value) }
+
+    override suspend fun setMapZoom(value: Int) = state.update { it.copy(mapZoom = value) }
+
+    override suspend fun setShowCalendar(value: Boolean) = state.update { it.copy(showCalendar = value) }
+
+    override suspend fun setShowWeather(value: Boolean) = state.update { it.copy(showWeather = value) }
+
+    override suspend fun setShowMusic(value: Boolean) = state.update { it.copy(showMusic = value) }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -2,16 +2,17 @@ package io.github.seijikohara.femto.ui.settings
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
-import io.github.seijikohara.femto.data.DisplayPreferences
-import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.testfixtures.FakeDisplaySettingsStore
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -20,19 +21,20 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 
+// Robolectric only to obtain an Application for the (inert) FontPreferences; the
+// settings under test go through an in-memory FakeDisplaySettingsStore, so there
+// is no DataStore IO and the test is fully driven by the StandardTestDispatcher.
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
 class SettingsViewModelTest {
     private val application: Application = ApplicationProvider.getApplicationContext()
-    private val displayPreferences = DisplayPreferences(application)
+    private val store = FakeDisplaySettingsStore()
+    private val dispatcher = StandardTestDispatcher()
 
     @Before
     fun setUp() {
-        // Real Unconfined Main so a viewModelScope.launch from onAction runs its
-        // body eagerly on the calling thread. UnconfinedTestDispatcher would queue
-        // the body on a scheduler that only runTest pumps, so under runBlocking the
-        // write never executed and the await timed out.
-        Dispatchers.setMain(Dispatchers.Unconfined)
+        Dispatchers.setMain(dispatcher)
     }
 
     @After
@@ -41,43 +43,28 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `SetFullscreen persists via DisplayPreferences`() =
-        runBlocking {
+    fun `SetFullscreen writes the value to the store`() =
+        runTest(dispatcher) {
             viewModel().onAction(SettingsAction.SetFullscreen(FullscreenSetting.ON))
-            assertEquals(
-                FullscreenSetting.ON,
-                awaitSetting { it.fullscreen == FullscreenSetting.ON }.fullscreen,
-            )
+            advanceUntilIdle()
+            assertEquals(FullscreenSetting.ON, store.settings.first().fullscreen)
         }
 
     @Test
-    fun `SetMapFps persists via DisplayPreferences`() =
-        runBlocking {
+    fun `SetMapFps writes the value to the store`() =
+        runTest(dispatcher) {
             viewModel().onAction(SettingsAction.SetMapFps(30))
-            assertEquals(30, awaitSetting { it.mapFps == 30 }.mapFps)
+            advanceUntilIdle()
+            assertEquals(30, store.settings.first().mapFps)
         }
 
     @Test
-    fun `SetShowMusic persists via DisplayPreferences`() =
-        runBlocking {
+    fun `SetShowMusic writes the value to the store`() =
+        runTest(dispatcher) {
             viewModel().onAction(SettingsAction.SetShowMusic(false))
-            assertEquals(false, awaitSetting { !it.showMusic }.showMusic)
+            advanceUntilIdle()
+            assertEquals(false, store.settings.first().showMusic)
         }
 
-    private fun viewModel() = SettingsViewModel(displayPreferences, FontPreferences(application))
-
-    // Wait for the persisted settings to satisfy [predicate]. These tests exercise
-    // the real (Robolectric) DataStore round-trip, whose IO runs off the test
-    // scheduler; runTest's virtual clock cannot observe it and its end-of-test
-    // completion check races the write to an UncompletedCoroutinesError. runBlocking
-    // waits on real time instead, and this withTimeout bounds a write that never
-    // lands so a regression fails fast rather than hanging.
-    private suspend fun awaitSetting(predicate: (DisplaySettings) -> Boolean): DisplaySettings =
-        withTimeout(WRITE_TIMEOUT_MS) {
-            displayPreferences.settings.first(predicate)
-        }
-
-    private companion object {
-        const val WRITE_TIMEOUT_MS = 5_000L
-    }
+    private fun viewModel() = SettingsViewModel(store, FontPreferences(application))
 }


### PR DESCRIPTION
## Summary

The `SettingsViewModelTest` persistence cases round-tripped through a
real (Robolectric) DataStore, whose IO runs off the test scheduler. That
made them fail CI: under `runTest` the end-of-test completion check raced
the write (`UncompletedCoroutinesError`), and a `runBlocking` attempt
deadlocked on Robolectric's paused main looper (timeout).

Extract a `DisplaySettingsStore` interface (implemented by
`DisplayPreferences`), have `SettingsViewModel` depend on it, and inject an
in-memory `FakeDisplaySettingsStore` in the test. With no DataStore IO the
view-model's `onAction` is fully driven by a `StandardTestDispatcher` +
`advanceUntilIdle` — deterministic, no real time, no looper blocking. The
`DisplayPreferences` setters become block bodies returning `Unit` to match
the new contract.

## Test

- The three cases pass 5x in a row locally with `--rerun-tasks`.
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.