### PR TITLE
feat(map): add a render-quality setting to smooth the snapshot map

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -126,6 +126,7 @@ class MainActivity : ComponentActivity() {
                                 style = display.mapStyle,
                                 tiltDeg = display.mapTiltDeg,
                                 zoom = display.mapZoom,
+                                renderPercent = display.mapRenderPercent,
                             ),
                         panels =
                             PanelVisibility(

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -38,6 +38,13 @@ internal const val DEFAULT_MAP_TILT_DEG = 55
 internal const val DEFAULT_MAP_ZOOM = 16
 
 /**
+ * Default snapshot render resolution, as a percentage of the panel's pixel size.
+ * 100 renders at full resolution; lower values render a smaller bitmap (upscaled
+ * to fill), trading sharpness for a faster render and a smoother frame rate.
+ */
+internal const val DEFAULT_MAP_RENDER_PERCENT = 100
+
+/**
  * User display settings that override the locale / system defaults. Every value
  * defaults to the auto / system choice so a fresh install behaves exactly as
  * before the settings screen existed.
@@ -55,6 +62,9 @@ internal data class DisplaySettings(
     val mapStyle: MapStyleSetting,
     val mapTiltDeg: Int,
     val mapZoom: Int,
+    // Snapshot render resolution as a percent of the panel pixel size; lower is
+    // blurrier but renders faster, so the frame rate can climb closer to mapFps.
+    val mapRenderPercent: Int,
     // Info-pane card visibility. Each card defaults to shown so a fresh install
     // renders the full dashboard; hiding one lets the remaining cards (or the map)
     // reflow into the freed space.
@@ -75,6 +85,7 @@ internal data class DisplaySettings(
                 mapStyle = MapStyleSetting.AUTO,
                 mapTiltDeg = DEFAULT_MAP_TILT_DEG,
                 mapZoom = DEFAULT_MAP_ZOOM,
+                mapRenderPercent = DEFAULT_MAP_RENDER_PERCENT,
                 showCalendar = true,
                 showWeather = true,
                 showMusic = true,
@@ -112,6 +123,8 @@ internal interface DisplaySettingsStore {
 
     suspend fun setMapZoom(value: Int)
 
+    suspend fun setMapRenderPercent(value: Int)
+
     suspend fun setShowCalendar(value: Boolean)
 
     suspend fun setShowWeather(value: Boolean)
@@ -142,6 +155,7 @@ internal class DisplayPreferences(
                 mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
                 mapTiltDeg = prefs[MAP_TILT_KEY] ?: DEFAULT_MAP_TILT_DEG,
                 mapZoom = prefs[MAP_ZOOM_KEY] ?: DEFAULT_MAP_ZOOM,
+                mapRenderPercent = prefs[MAP_QUALITY_KEY] ?: DEFAULT_MAP_RENDER_PERCENT,
                 showCalendar = prefs[SHOW_CALENDAR_KEY] ?: true,
                 showWeather = prefs[SHOW_WEATHER_KEY] ?: true,
                 showMusic = prefs[SHOW_MUSIC_KEY] ?: true,
@@ -190,6 +204,10 @@ internal class DisplayPreferences(
         context.displayDataStore.edit { it[MAP_ZOOM_KEY] = value }
     }
 
+    override suspend fun setMapRenderPercent(value: Int) {
+        context.displayDataStore.edit { it[MAP_QUALITY_KEY] = value }
+    }
+
     override suspend fun setShowCalendar(value: Boolean) {
         context.displayDataStore.edit { it[SHOW_CALENDAR_KEY] = value }
     }
@@ -213,6 +231,7 @@ internal class DisplayPreferences(
         val MAP_STYLE_KEY = stringPreferencesKey("map_style")
         val MAP_TILT_KEY = intPreferencesKey("map_tilt_deg")
         val MAP_ZOOM_KEY = intPreferencesKey("map_zoom")
+        val MAP_QUALITY_KEY = intPreferencesKey("map_render_percent")
         val SHOW_CALENDAR_KEY = booleanPreferencesKey("show_calendar")
         val SHOW_WEATHER_KEY = booleanPreferencesKey("show_weather")
         val SHOW_MUSIC_KEY = booleanPreferencesKey("show_music")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -67,13 +67,15 @@ import kotlin.math.roundToInt
 import kotlin.math.sin
 
 // User-tunable map rendering config (derived from DisplaySettings): target frame
-// rate, 3D buildings, light/dark style, oblique tilt, and zoom.
+// rate, 3D buildings, light/dark style, oblique tilt, zoom, and the render
+// resolution percent (lower renders a smaller bitmap, faster, upscaled to fill).
 internal data class MapConfig(
     val fps: Int = 10,
     val buildings3d: Boolean = true,
     val style: MapStyleSetting = MapStyleSetting.AUTO,
     val tiltDeg: Int = 55,
     val zoom: Int = 16,
+    val renderPercent: Int = 100,
 )
 
 /**
@@ -137,6 +139,15 @@ private fun SnapshotMap(
         }
     val widthPx = with(LocalDensity.current) { maxWidth.roundToPx() }
     val heightPx = with(LocalDensity.current) { maxHeight.roundToPx() }
+    // Render at a fraction of the panel resolution; the Image upscales it to fill,
+    // so a lower percent rasterizes fewer pixels (faster render, higher achievable
+    // frame rate) at the cost of sharpness.
+    val renderPercent = mapConfig.renderPercent.coerceIn(1, 100)
+    val renderWidthPx = (widthPx * renderPercent / 100).coerceAtLeast(1)
+    val renderHeightPx = (heightPx * renderPercent / 100).coerceAtLeast(1)
+    // The snapshot pixels are upscaled to layout pixels by this factor, so the
+    // marker (placed in layout pixels) scales the snapshot pixel it rendered at.
+    val markerScale = widthPx.toFloat() / renderWidthPx
 
     var frame by remember { mutableStateOf<MapFrame?>(null) }
     var failed by remember { mutableStateOf(false) }
@@ -145,9 +156,9 @@ private fun SnapshotMap(
     val bearingHolder = remember { floatArrayOf(0f) }
     val currentLocation = rememberUpdatedState(location)
 
-    // One reusable snapshotter, rebuilt only when the panel size or theme changes.
+    // One reusable snapshotter, rebuilt only when the render size or theme changes.
     val snapshotter =
-        remember(widthPx, heightPx, isDark, mapConfig.buildings3d) {
+        remember(renderWidthPx, renderHeightPx, isDark, mapConfig.buildings3d) {
             if (widthPx <= 0 || heightPx <= 0) {
                 null
             } else {
@@ -155,7 +166,7 @@ private fun SnapshotMap(
                 MapSnapshotter(
                     context,
                     MapSnapshotter
-                        .Options(widthPx, heightPx)
+                        .Options(renderWidthPx, renderHeightPx)
                         .withLogo(false)
                         // Suppress the snapshot's baked-in credit; the styled
                         // Compose [Attribution] overlay is the single source of the
@@ -185,7 +196,7 @@ private fun SnapshotMap(
                 val loc = currentLocation.value
                 if (shouldRerender(lastRendered, loc)) {
                     val camera = cameraFor(loc, bearingHolder, mapConfig.tiltDeg, mapConfig.zoom)
-                    val rendered = snap.render(camera, LatLng(loc.latitude, loc.longitude))
+                    val rendered = snap.render(camera, LatLng(loc.latitude, loc.longitude), markerScale)
                     if (rendered != null) {
                         frame = rendered
                         failed = false
@@ -236,13 +247,16 @@ private class MapFrame(
 private suspend fun MapSnapshotter.render(
     camera: CameraPosition,
     markerLatLng: LatLng,
+    markerScale: Float,
 ): MapFrame? =
     suspendCancellableCoroutine { cont ->
         setCameraPosition(camera)
         start(
             { snapshot ->
+                // pixelForLatLng is in snapshot (render-bitmap) pixels; scale to the
+                // layout pixels the upscaled Image occupies so the marker lands true.
                 val p = snapshot.pixelForLatLng(markerLatLng)
-                if (cont.isActive) cont.resume(MapFrame(snapshot.bitmap, p.x, p.y))
+                if (cont.isActive) cont.resume(MapFrame(snapshot.bitmap, p.x * markerScale, p.y * markerScale))
             },
             { _ -> if (cont.isActive) cont.resume(null) },
         )
@@ -354,8 +368,9 @@ private fun Attribution(modifier: Modifier = Modifier) =
     )
 
 // Current-location puck: a primary-coloured dot with a white ring, positioned by
-// the exact pixel the location rendered at (see MapFrame). offset {} takes layout
-// pixels, which match the snapshot pixels because the Image fills the panel 1:1.
+// the pixel the location rendered at (see MapFrame). offset {} takes layout
+// pixels; MapFrame already scaled the snapshot pixel to layout space, so an
+// upscaled (sub-100%) render still lands the marker on the true position.
 @Composable
 private fun LocationMarker(
     xPx: Float,
@@ -418,7 +433,9 @@ private const val BUILDING_COLOR_LIGHT = "#E7E3DC"
 private const val BUILDING_COLOR_DARK = "#2A2E33"
 
 // Re-render once a fix moves at least this far; below it the last frame is held.
-private const val REFRESH_DISTANCE_M = 8f
+// Kept small so the map follows movement in smaller steps (smoother panning); the
+// single-flight render + fps throttle still bound how often a frame is produced.
+private const val REFRESH_DISTANCE_M = 2f
 
 // Look-ahead: aim the camera this far ahead of the current position so the marker
 // sits low in the frame (above the speed overlay) with the road ahead visible.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -188,6 +188,13 @@ internal fun SettingsScreen(
                 range = MIN_MAP_ZOOM..MAX_MAP_ZOOM,
                 onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
             )
+            SliderRow(
+                title = stringResource(R.string.settings_group_map_quality),
+                valueLabel = stringResource(R.string.settings_map_quality_value, uiState.mapRenderPercent),
+                value = uiState.mapRenderPercent,
+                range = MIN_MAP_QUALITY..MAX_MAP_QUALITY,
+                onValueChange = { onAction(SettingsAction.SetMapRenderPercent(it)) },
+            )
         }
 
         SettingsSection(title = stringResource(R.string.settings_section_panels)) {
@@ -494,6 +501,11 @@ private const val MIN_MAP_TILT = 0
 private const val MAX_MAP_TILT = 60
 private const val MIN_MAP_ZOOM = 12
 private const val MAX_MAP_ZOOM = 19
+
+// Snapshot render resolution band (percent). The floor stays well above zero so
+// the upscaled map keeps roads legible; 100 is full panel resolution.
+private const val MIN_MAP_QUALITY = 30
+private const val MAX_MAP_QUALITY = 100
 
 private fun Boolean.toFullscreen(): FullscreenSetting = if (this) FullscreenSetting.ON else FullscreenSetting.OFF
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -21,6 +21,7 @@ internal data class SettingsUiState(
     val mapStyle: MapStyleSetting,
     val mapTiltDeg: Int,
     val mapZoom: Int,
+    val mapRenderPercent: Int,
     val showCalendar: Boolean,
     val showWeather: Boolean,
     val showMusic: Boolean,
@@ -41,6 +42,7 @@ internal data class SettingsUiState(
                 mapStyle = DisplaySettings.Default.mapStyle,
                 mapTiltDeg = DisplaySettings.Default.mapTiltDeg,
                 mapZoom = DisplaySettings.Default.mapZoom,
+                mapRenderPercent = DisplaySettings.Default.mapRenderPercent,
                 showCalendar = DisplaySettings.Default.showCalendar,
                 showWeather = DisplaySettings.Default.showWeather,
                 showMusic = DisplaySettings.Default.showMusic,
@@ -88,6 +90,10 @@ internal sealed interface SettingsAction {
     ) : SettingsAction
 
     data class SetMapZoom(
+        val value: Int,
+    ) : SettingsAction
+
+    data class SetMapRenderPercent(
         val value: Int,
     ) : SettingsAction
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -31,6 +31,7 @@ internal class SettingsViewModel(
                 mapStyle = display.mapStyle,
                 mapTiltDeg = display.mapTiltDeg,
                 mapZoom = display.mapZoom,
+                mapRenderPercent = display.mapRenderPercent,
                 showCalendar = display.showCalendar,
                 showWeather = display.showWeather,
                 showMusic = display.showMusic,
@@ -52,6 +53,7 @@ internal class SettingsViewModel(
                 is SettingsAction.SetMapStyle -> displayPreferences.setMapStyle(action.value)
                 is SettingsAction.SetMapTilt -> displayPreferences.setMapTilt(action.value)
                 is SettingsAction.SetMapZoom -> displayPreferences.setMapZoom(action.value)
+                is SettingsAction.SetMapRenderPercent -> displayPreferences.setMapRenderPercent(action.value)
                 is SettingsAction.SetShowCalendar -> displayPreferences.setShowCalendar(action.value)
                 is SettingsAction.SetShowWeather -> displayPreferences.setShowWeather(action.value)
                 is SettingsAction.SetShowMusic -> displayPreferences.setShowMusic(action.value)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,8 @@
     <string name="settings_group_map_zoom">Map zoom</string>
     <string name="settings_map_tilt_value">%1$d°</string>
     <string name="settings_map_zoom_value">z%1$d</string>
+    <string name="settings_group_map_quality">Render quality</string>
+    <string name="settings_map_quality_value">%1$d%%</string>
     <string name="settings_group_panel_calendar">Calendar panel</string>
     <string name="settings_group_panel_weather">Weather panel</string>
     <string name="settings_group_panel_music">Music panel</string>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -46,6 +46,8 @@ internal class FakeDisplaySettingsStore(
 
     override suspend fun setMapZoom(value: Int) = state.update { it.copy(mapZoom = value) }
 
+    override suspend fun setMapRenderPercent(value: Int) = state.update { it.copy(mapRenderPercent = value) }
+
     override suspend fun setShowCalendar(value: Boolean) = state.update { it.copy(showCalendar = value) }
 
     override suspend fun setShowWeather(value: Boolean) = state.update { it.copy(showWeather = value) }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -66,5 +66,13 @@ class SettingsViewModelTest {
             assertEquals(false, store.settings.first().showMusic)
         }
 
+    @Test
+    fun `SetMapRenderPercent writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetMapRenderPercent(50))
+            advanceUntilIdle()
+            assertEquals(50, store.settings.first().mapRenderPercent)
+        }
+
     private fun viewModel() = SettingsViewModel(store, FontPreferences(application))
 }


### PR DESCRIPTION
## Summary

Maxing the frame-rate slider could not smooth the map: each snapshot
re-renders the full-resolution bitmap off-screen, so **render time**, not
the fps throttle, caps the achievable rate.

Add a **Render quality** setting (30–100 %, default 100) under Settings →
Map. It renders the snapshot at that fraction of the panel resolution and
the Compose `Image` upscales it to fill. A lower percent rasterizes far
fewer pixels, so each render finishes sooner and the frame rate climbs
toward the chosen fps — the user trades sharpness for smoothness, finely.

## Changes

- `DisplayPreferences`: `mapRenderPercent` (default 100) + key/decode/setter
  on the `DisplaySettingsStore` contract.
- `MapPanel`: render the snapshot at `renderPercent` of the panel size and
  upscale; the location marker scales its snapshot pixel to layout space so
  it still lands true; the re-render distance drops 8 m → 2 m so movement
  tracks in smaller, smoother steps.
- `MainActivity` / `ui/settings/*`: thread the value through `MapConfig` and
  add the Render-quality slider to the Map section.

## Test

- `SettingsViewModelTest`: `SetMapRenderPercent` routes to the store (the
  in-memory fake from #64).
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.
- On-device smoothness check to follow on the next nightly (lower the
  quality slider to raise the effective frame rate).
