### PR TITLE
feat(dashboard): tighten the speed overlay and shrink the map credit

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -572,16 +573,21 @@ private fun Location.withCarriedBearing(holder: FloatArray): Location =
 private fun Attribution(modifier: Modifier = Modifier) =
     Text(
         text = stringResource(R.string.map_attribution),
-        // Legal credit, not glance content, so it intentionally sits below the
-        // body-text floor — OSM ODbL / OpenMapTiles CC-BY require the credit.
-        style = MaterialTheme.typography.labelSmall,
+        // Legal credit, not glance content — OSM ODbL / OpenMapTiles CC-BY require
+        // it but it is not read on the move, so it sits well below the body-text
+        // floor and is shrunk further here so the centred speed overlay does not
+        // bury it on a narrow map pane.
+        style = MaterialTheme.typography.labelSmall.copy(
+            fontSize = ATTRIBUTION_FONT_SIZE,
+            lineHeight = ATTRIBUTION_FONT_SIZE,
+        ),
         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
         modifier =
             modifier
-                .padding(6.dp)
+                .padding(4.dp)
                 .clip(RoundedCornerShape(4.dp))
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.6f))
-                .padding(horizontal = 6.dp, vertical = 2.dp),
+                .padding(horizontal = 4.dp, vertical = 1.dp),
     )
 
 // Current-location puck: a primary-coloured dot with a white ring, positioned by
@@ -659,6 +665,10 @@ private const val REFRESH_DISTANCE_M = 2f
 private const val FORWARD_OFFSET_M = 60.0
 private const val EARTH_RADIUS_M = 6_371_000.0
 private val MARKER_SIZE = 18.dp
+
+// Small attribution type: legal credit only, deliberately tiny so the centred
+// speed overlay does not bury it on a narrow map pane.
+private val ATTRIBUTION_FONT_SIZE = 8.sp
 
 // Live-map style-reload budget after a load failure: RETRY_BASE_DELAY_MS shifted
 // left by the attempt index yields 2s, 4s, 8s before settling on the fallback.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -134,7 +134,7 @@ internal fun SpeedOverlay(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = FemtoDimens.GlassBorderAlpha),
                     shape = RoundedCornerShape(FemtoDimens.SpeedOverlayCorner),
-                ).padding(horizontal = 18.dp, vertical = 10.dp),
+                ).padding(horizontal = 18.dp, vertical = 6.dp),
     ) {
         MetricRow(
             currentSpeed = currentSpeedText,
@@ -145,9 +145,11 @@ internal fun SpeedOverlay(
             onReset = onReset,
         )
         if (shortAddress.isNotBlank()) {
-            Box(modifier = Modifier.height(8.dp))
+            // Tightened so the metric row's vertical breathing room matches the
+            // address row's, instead of sitting noticeably taller.
+            Box(modifier = Modifier.height(5.dp))
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
-            Box(modifier = Modifier.height(10.dp))
+            Box(modifier = Modifier.height(5.dp))
             AddressRow(text = shortAddress)
         }
     }
@@ -288,9 +290,10 @@ private fun AddressRow(text: String) =
     }
 
 // Trailing reset control for the trip metrics, anchored to the overlay's
-// top-right (the end of the metric row). A 64 dp hit area
-// (CLAUDE.md#automotive-overrides) wraps a small glyph; the box also sets the
-// metric row height, so the tap target is met without a separate overlay.
+// top-right (the end of the metric row). Sized below MinTouchTarget so it does
+// not crowd the metric cells on a narrow overlay — a deliberate in-overlay
+// exception (CLAUDE.md#automotive-overrides keeps 64 dp the default), the same
+// relaxation the calendar strip takes; also trims the metric row's height.
 @Composable
 private fun ResetButton(
     onReset: () -> Unit,
@@ -298,7 +301,7 @@ private fun ResetButton(
 ) = Box(
     modifier =
         modifier
-            .size(FemtoDimens.MinTouchTarget)
+            .size(RESET_BUTTON_SIZE)
             .clip(CircleShape)
             .clickable(onClick = onReset),
     contentAlignment = Alignment.Center,
@@ -338,6 +341,10 @@ private const val SPEED_OVERLAY_EMA_ALPHA = 0.33f
 // the WeatherCard convention and the permissions contract (location
 // panels read empty until granted). It avoids the ambiguous "0".
 private const val NO_SPEED_PLACEHOLDER = "—"
+
+// Reset control size: narrower than MinTouchTarget so it leaves the metric cells
+// more room on a compact overlay and shortens the metric row (see ResetButton).
+private val RESET_BUTTON_SIZE = 48.dp
 
 @PreviewLightDark
 @Preview(name = "Speed overlay", widthDp = 560, heightDp = 160)


### PR DESCRIPTION
## Summary

On-device feedback (wave 5, items 3/8/11):

- **Speed overlay density (#3)** — the metric (first) row sat noticeably
  taller than the address row. Reduced the overlay vertical padding
  (10→6 dp) and the divider gaps (8/10→5/5 dp) so the two rows have
  matching breathing room.
- **Reset button width (#11)** — the trip-reset control was a full 64 dp
  box crowding the metric cells. Shrunk to 48 dp (a documented in-overlay
  exception to the 64 dp tap floor, same relaxation as the calendar
  strip); this also trims the metric row height, helping #3.
- **Map credit size (#8)** — the attribution was large enough to sit
  under the centred speed overlay on a narrow map pane. Dropped to 8 sp
  with tighter padding (still present for OSM ODbL / OpenMapTiles CC-BY).

Part of the wave-5 feedback batch; remaining items follow as their own PRs.

## Test
`./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.