### PR TITLE
fix(map): remove the 3D building extrusion that crashed the launcher

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -122,7 +122,6 @@ class MainActivity : ComponentActivity() {
                         mapConfig =
                             MapConfig(
                                 fps = display.mapFps,
-                                buildings3d = display.mapBuildings3d,
                                 style = display.mapStyle,
                                 tiltDeg = display.mapTiltDeg,
                                 zoom = display.mapZoom,

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -65,7 +65,6 @@ internal data class DisplaySettings(
     // Target map frame rate (fps): the snapshot map caps its re-render rate at
     // this many frames per second. Clamped to the display's max refresh at use.
     val mapFps: Int,
-    val mapBuildings3d: Boolean,
     val mapStyle: MapStyleSetting,
     val mapTiltDeg: Int,
     val mapZoom: Int,
@@ -89,7 +88,6 @@ internal data class DisplaySettings(
                 clock = ClockSetting.AUTO,
                 fullscreen = FullscreenSetting.OFF,
                 mapFps = DEFAULT_MAP_FPS,
-                mapBuildings3d = true,
                 mapStyle = MapStyleSetting.AUTO,
                 mapTiltDeg = DEFAULT_MAP_TILT_DEG,
                 mapZoom = DEFAULT_MAP_ZOOM,
@@ -123,8 +121,6 @@ internal interface DisplaySettingsStore {
     suspend fun setFullscreen(value: FullscreenSetting)
 
     suspend fun setMapFps(value: Int)
-
-    suspend fun setMapBuildings3d(value: Boolean)
 
     suspend fun setMapStyle(value: MapStyleSetting)
 
@@ -162,7 +158,6 @@ internal class DisplayPreferences(
                 clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
                 fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.OFF),
                 mapFps = prefs[MAP_FPS_KEY] ?: DEFAULT_MAP_FPS,
-                mapBuildings3d = prefs[MAP_BUILDINGS_KEY] ?: true,
                 mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
                 mapTiltDeg = prefs[MAP_TILT_KEY] ?: DEFAULT_MAP_TILT_DEG,
                 mapZoom = prefs[MAP_ZOOM_KEY] ?: DEFAULT_MAP_ZOOM,
@@ -198,10 +193,6 @@ internal class DisplayPreferences(
 
     override suspend fun setMapFps(value: Int) {
         context.displayDataStore.edit { it[MAP_FPS_KEY] = value }
-    }
-
-    override suspend fun setMapBuildings3d(value: Boolean) {
-        context.displayDataStore.edit { it[MAP_BUILDINGS_KEY] = value }
     }
 
     override suspend fun setMapStyle(value: MapStyleSetting) {
@@ -243,7 +234,6 @@ internal class DisplayPreferences(
         val CLOCK_KEY = stringPreferencesKey("clock")
         val FULLSCREEN_KEY = stringPreferencesKey("fullscreen")
         val MAP_FPS_KEY = intPreferencesKey("map_fps")
-        val MAP_BUILDINGS_KEY = booleanPreferencesKey("map_buildings_3d")
         val MAP_STYLE_KEY = stringPreferencesKey("map_style")
         val MAP_TILT_KEY = intPreferencesKey("map_tilt_deg")
         val MAP_ZOOM_KEY = intPreferencesKey("map_zoom")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -71,9 +71,6 @@ import org.maplibre.android.maps.MapLibreMapOptions
 import org.maplibre.android.maps.MapView
 import org.maplibre.android.maps.Style
 import org.maplibre.android.snapshotter.MapSnapshotter
-import org.maplibre.android.style.expressions.Expression
-import org.maplibre.android.style.layers.FillExtrusionLayer
-import org.maplibre.android.style.layers.PropertyFactory
 import kotlin.coroutines.resume
 import kotlin.math.asin
 import kotlin.math.atan2
@@ -82,11 +79,10 @@ import kotlin.math.roundToInt
 import kotlin.math.sin
 
 // User-tunable map rendering config (derived from DisplaySettings): target frame
-// rate, 3D buildings, light/dark style, oblique tilt, zoom, and the render
-// resolution percent (lower renders a smaller bitmap, faster, upscaled to fill).
+// rate, light/dark style, oblique tilt, zoom, and the render resolution percent
+// (lower renders a smaller bitmap, faster, upscaled to fill).
 internal data class MapConfig(
     val fps: Int = 10,
-    val buildings3d: Boolean = true,
     val style: MapStyleSetting = MapStyleSetting.AUTO,
     val tiltDeg: Int = 55,
     val zoom: Int = 16,
@@ -97,7 +93,7 @@ internal data class MapConfig(
 /**
  * Map tile surface + permission fallback, in one of two backends selected by
  * [MapConfig.renderMode] (both render free OpenStreetMap vector tiles via
- * OpenFreeMap / MapLibre with a heading-up, oblique 3D camera):
+ * OpenFreeMap / MapLibre with a heading-up, oblique (tilted) camera):
  *
  * - SNAPSHOT (default, [SnapshotMap]) draws off-screen [MapSnapshotter] bitmaps
  *   into a Compose [Image]. A live GL `MapView` never presents frames on the
@@ -187,7 +183,7 @@ private fun SnapshotMap(
 
     // One reusable snapshotter, rebuilt only when the render size or theme changes.
     val snapshotter =
-        remember(renderWidthPx, renderHeightPx, isDark, mapConfig.buildings3d) {
+        remember(renderWidthPx, renderHeightPx, isDark) {
             if (widthPx <= 0 || heightPx <= 0) {
                 null
             } else {
@@ -202,7 +198,7 @@ private fun SnapshotMap(
                         // OSM / OpenMapTiles / OpenFreeMap credit (avoids the
                         // duplicate text the baked-in attribution drew on-device).
                         .withAttribution(false)
-                        .withStyleBuilder(styleBuilderFor(context, isDark, mapConfig.buildings3d)),
+                        .withStyleBuilder(styleBuilderFor(context, isDark)),
                 )
             }
         }
@@ -342,50 +338,34 @@ private fun shouldRerender(
     current: Location,
 ): Boolean = last == null || last.distanceTo(current) >= REFRESH_DISTANCE_M
 
+// Build the (light/dark) base style. A 3D building fill-extrusion layer was
+// removed: the MapSnapshotter's GL crashed intermittently (native SIGSEGV in
+// glDrawElements on its "Snapshotter" thread) while re-rendering an extrusion
+// layer, taking the whole launcher down on movement. The oblique camera tilt
+// still gives the map a bird's-eye perspective; only the extruded buildings are
+// gone. True extruded 3D needs the live GL MapView, which does not present on the
+// projected head-unit display.
 private fun styleBuilderFor(
     context: Context,
     isDark: Boolean,
-    buildings3d: Boolean,
-): Style.Builder {
-    val base =
-        if (isDark) {
-            Style.Builder().fromJson(
-                context.assets
-                    .open(DARK_STYLE_ASSET)
-                    .bufferedReader()
-                    .use { it.readText() },
-            )
-        } else {
-            Style.Builder().fromUri(POSITRON_STYLE_URL)
-        }
-    // Add the 3D building layer to the builder before the snapshotter loads it:
-    // MapSnapshotter exposes no post-load style to mutate. Both Positron and the
-    // bundled dark style carry OpenStreetMap buildings on the same OpenMapTiles
-    // "openmaptiles" vector source / "building" source-layer.
-    return if (buildings3d) base.withLayer(buildingExtrusionLayer(isDark)) else base
-}
-
-private fun buildingExtrusionLayer(isDark: Boolean): FillExtrusionLayer =
-    FillExtrusionLayer(BUILDING_3D_LAYER_ID, OPENMAPTILES_SOURCE_ID).apply {
-        setSourceLayer(BUILDING_SOURCE_LAYER)
-        setMinZoom(BUILDING_EXTRUSION_MIN_ZOOM)
-        setProperties(
-            PropertyFactory.fillExtrusionColor(if (isDark) BUILDING_COLOR_DARK else BUILDING_COLOR_LIGHT),
-            PropertyFactory.fillExtrusionHeight(Expression.get("render_height")),
-            PropertyFactory.fillExtrusionBase(Expression.get("render_min_height")),
-            PropertyFactory.fillExtrusionOpacity(BUILDING_OPACITY),
+): Style.Builder =
+    if (isDark) {
+        Style.Builder().fromJson(
+            context.assets
+                .open(DARK_STYLE_ASSET)
+                .bufferedReader()
+                .use { it.readText() },
         )
-        // Only extrude features that actually carry a height, so flat building
-        // polygons without the attribute are left to the base style's fill.
-        setFilter(Expression.all(Expression.has("render_height"), Expression.has("render_min_height")))
+    } else {
+        Style.Builder().fromUri(POSITRON_STYLE_URL)
     }
 
 // Live GL backend. A real MapView (TextureView + RGBA surface) with the location
 // component driving a heading-up TRACKING_GPS camera. Smoother than the snapshot
 // where the device can scan out GL buffers; on projected / virtualised displays
 // that cannot, it shows the fallback's grey rectangle — hence SNAPSHOT is default
-// and this is opt-in so the user can test their hardware. Reuses styleBuilderFor
-// (so the 3D-building setting carries over) and the shared OpenFreeMap host.
+// and this is opt-in so the user can test their hardware. Shares styleBuilderFor
+// and the OpenFreeMap host with the snapshot path.
 @Composable
 private fun LiveMap(
     location: Location,
@@ -445,10 +425,10 @@ private fun LiveMap(
         }
     }
 
-    LaunchedEffect(map, isDark, mapConfig.buildings3d, mapConfig.zoom, mapConfig.tiltDeg, retryTick) {
+    LaunchedEffect(map, isDark, mapConfig.zoom, mapConfig.tiltDeg, retryTick) {
         val ready = map ?: return@LaunchedEffect
         loadFailed = false
-        ready.setStyle(styleBuilderFor(context, isDark, mapConfig.buildings3d)) { style ->
+        ready.setStyle(styleBuilderFor(context, isDark)) { style ->
             retryAttempt = 0
             activateHeadingUp(context, ready, style, mapConfig.zoom, mapConfig.tiltDeg)
             ready.locationComponent.forceLocationUpdate(currentLocation.value.withCarriedBearing(bearingHolder))
@@ -646,14 +626,6 @@ private fun Fallback(modifier: Modifier = Modifier) =
 internal const val MAP_ZOOM = 16.5
 internal const val POSITRON_STYLE_URL = "https://tiles.openfreemap.org/styles/positron"
 private const val DARK_STYLE_ASSET = "map/dark.json"
-
-private const val OPENMAPTILES_SOURCE_ID = "openmaptiles"
-private const val BUILDING_SOURCE_LAYER = "building"
-private const val BUILDING_3D_LAYER_ID = "building-3d"
-private const val BUILDING_EXTRUSION_MIN_ZOOM = 15f
-private const val BUILDING_OPACITY = 0.85f
-private const val BUILDING_COLOR_LIGHT = "#E7E3DC"
-private const val BUILDING_COLOR_DARK = "#2A2E33"
 
 // Re-render once a fix moves at least this far; below it the last frame is held.
 // Kept small so the map follows movement in smaller steps (smoother panning); the

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -169,11 +169,6 @@ internal fun SettingsScreen(
                 range = MIN_MAP_FPS..maxFps,
                 onValueChange = { onAction(SettingsAction.SetMapFps(it)) },
             )
-            SwitchRow(
-                title = stringResource(R.string.settings_group_map_3d),
-                checked = uiState.mapBuildings3d,
-                onCheckedChange = { onAction(SettingsAction.SetMapBuildings3d(it)) },
-            )
             ChoiceRow(
                 title = stringResource(R.string.settings_group_map_style),
                 options =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -18,7 +18,6 @@ internal data class SettingsUiState(
     val clock: ClockSetting,
     val fullscreen: FullscreenSetting,
     val mapFps: Int,
-    val mapBuildings3d: Boolean,
     val mapStyle: MapStyleSetting,
     val mapTiltDeg: Int,
     val mapZoom: Int,
@@ -40,7 +39,6 @@ internal data class SettingsUiState(
                 clock = DisplaySettings.Default.clock,
                 fullscreen = DisplaySettings.Default.fullscreen,
                 mapFps = DisplaySettings.Default.mapFps,
-                mapBuildings3d = DisplaySettings.Default.mapBuildings3d,
                 mapStyle = DisplaySettings.Default.mapStyle,
                 mapTiltDeg = DisplaySettings.Default.mapTiltDeg,
                 mapZoom = DisplaySettings.Default.mapZoom,
@@ -78,10 +76,6 @@ internal sealed interface SettingsAction {
 
     data class SetMapFps(
         val value: Int,
-    ) : SettingsAction
-
-    data class SetMapBuildings3d(
-        val value: Boolean,
     ) : SettingsAction
 
     data class SetMapStyle(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -27,7 +27,6 @@ internal class SettingsViewModel(
                 clock = display.clock,
                 fullscreen = display.fullscreen,
                 mapFps = display.mapFps,
-                mapBuildings3d = display.mapBuildings3d,
                 mapStyle = display.mapStyle,
                 mapTiltDeg = display.mapTiltDeg,
                 mapZoom = display.mapZoom,
@@ -50,7 +49,6 @@ internal class SettingsViewModel(
                 is SettingsAction.SetClock -> displayPreferences.setClock(action.value)
                 is SettingsAction.SetFullscreen -> displayPreferences.setFullscreen(action.value)
                 is SettingsAction.SetMapFps -> displayPreferences.setMapFps(action.value)
-                is SettingsAction.SetMapBuildings3d -> displayPreferences.setMapBuildings3d(action.value)
                 is SettingsAction.SetMapStyle -> displayPreferences.setMapStyle(action.value)
                 is SettingsAction.SetMapTilt -> displayPreferences.setMapTilt(action.value)
                 is SettingsAction.SetMapZoom -> displayPreferences.setMapZoom(action.value)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,7 +106,6 @@
     <string name="settings_map_mode_live">Live</string>
     <string name="settings_group_map_refresh">Map frame rate</string>
     <string name="settings_map_fps_value">%1$d fps</string>
-    <string name="settings_group_map_3d">3D buildings</string>
     <string name="settings_group_map_style">Map style</string>
     <string name="settings_group_map_tilt">Map tilt</string>
     <string name="settings_group_map_zoom">Map zoom</string>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -39,8 +39,6 @@ internal class FakeDisplaySettingsStore(
 
     override suspend fun setMapFps(value: Int) = state.update { it.copy(mapFps = value) }
 
-    override suspend fun setMapBuildings3d(value: Boolean) = state.update { it.copy(mapBuildings3d = value) }
-
     override suspend fun setMapStyle(value: MapStyleSetting) = state.update { it.copy(mapStyle = value) }
 
     override suspend fun setMapTilt(value: Int) = state.update { it.copy(mapTiltDeg = value) }


### PR DESCRIPTION
## Root cause (reproduced on the emulator)

The reported crash loop ("繰り返し停止" / killed) is a **native SIGSEGV in
MapLibre's MapSnapshotter GL thread** — null dereference in `glDrawElements`
on the `Snapshotter` thread — while re-rendering the building
`FillExtrusionLayer`. `adb logcat -b crash` (the dedicated crash buffer,
which the earlier investigation missed) showed:

```
F libc: Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x30
        in tid (Snapshotter), pid (ijikohara.femto)
  #00 libGLESv2_enc.so  GL2Encoder::s_glDrawElements(...)
  #01.. libmaplibre.so
exit-info: reason=5 (APP CRASH(NATIVE)) status=11
```

It is **intermittent and only on repeated renders** (while moving / the
GPS updating), so a parked dashboard looked fine and clearing app data
only seemed to resolve it. **Isolated** by stress-feeding GPS fixes on the
emulator (800×480 @150 head-unit geometry): with the extrusion layer the
process dies within tens of renders; with it removed, 70+ renders are
stable (verified, no new native crashes).

## Fix

Remove the building `FillExtrusionLayer` and the now-dead 3D-buildings
setting (`DisplaySettings.mapBuildings3d`, the Settings toggle, the
`MapConfig` field, strings). The **oblique camera tilt stays**, so the map
keeps its bird's-eye perspective — only the extruded buildings are gone.
True extruded 3D would need the live GL `MapView`, which does not present
on the projected head-unit display.

## Test
- Emulator: 70 GPS-fix renders, zero native crashes (was crashing within
  ~12–40 with extrusion).
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.