### PR TITLE
feat(map): make the marker look-ahead configurable

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -127,6 +127,7 @@ class MainActivity : ComponentActivity() {
                                 zoom = display.mapZoom,
                                 renderPercent = display.mapRenderPercent,
                                 renderMode = display.mapRenderMode,
+                                lookAheadM = display.mapLookAheadM,
                             ),
                         panels =
                             PanelVisibility(

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -52,6 +52,13 @@ internal const val DEFAULT_MAP_ZOOM = 16
 internal const val DEFAULT_MAP_RENDER_PERCENT = 100
 
 /**
+ * Default map look-ahead (metres): the camera aims this far ahead of the current
+ * position along the heading, so the location marker sits low in the frame (near
+ * the speed overlay) with the road ahead visible. Larger = marker lower.
+ */
+internal const val DEFAULT_MAP_LOOKAHEAD_M = 180
+
+/**
  * User display settings that override the locale / system defaults. Every value
  * defaults to the auto / system choice so a fresh install behaves exactly as
  * before the settings screen existed.
@@ -72,6 +79,9 @@ internal data class DisplaySettings(
     // blurrier but renders faster, so the frame rate can climb closer to mapFps.
     val mapRenderPercent: Int,
     val mapRenderMode: MapRenderMode,
+    // Camera look-ahead (metres): how far ahead of the current position the camera
+    // aims, which sets how low the location marker sits (closer to the speed panel).
+    val mapLookAheadM: Int,
     // Info-pane card visibility. Each card defaults to shown so a fresh install
     // renders the full dashboard; hiding one lets the remaining cards (or the map)
     // reflow into the freed space.
@@ -93,6 +103,7 @@ internal data class DisplaySettings(
                 mapZoom = DEFAULT_MAP_ZOOM,
                 mapRenderPercent = DEFAULT_MAP_RENDER_PERCENT,
                 mapRenderMode = MapRenderMode.SNAPSHOT,
+                mapLookAheadM = DEFAULT_MAP_LOOKAHEAD_M,
                 showCalendar = true,
                 showWeather = true,
                 showMusic = true,
@@ -132,6 +143,8 @@ internal interface DisplaySettingsStore {
 
     suspend fun setMapRenderMode(value: MapRenderMode)
 
+    suspend fun setMapLookAhead(value: Int)
+
     suspend fun setShowCalendar(value: Boolean)
 
     suspend fun setShowWeather(value: Boolean)
@@ -163,6 +176,7 @@ internal class DisplayPreferences(
                 mapZoom = prefs[MAP_ZOOM_KEY] ?: DEFAULT_MAP_ZOOM,
                 mapRenderPercent = prefs[MAP_QUALITY_KEY] ?: DEFAULT_MAP_RENDER_PERCENT,
                 mapRenderMode = prefs[MAP_RENDER_MODE_KEY].toEnumOr(MapRenderMode.SNAPSHOT),
+                mapLookAheadM = prefs[MAP_LOOKAHEAD_KEY] ?: DEFAULT_MAP_LOOKAHEAD_M,
                 showCalendar = prefs[SHOW_CALENDAR_KEY] ?: true,
                 showWeather = prefs[SHOW_WEATHER_KEY] ?: true,
                 showMusic = prefs[SHOW_MUSIC_KEY] ?: true,
@@ -215,6 +229,10 @@ internal class DisplayPreferences(
         context.displayDataStore.edit { it[MAP_RENDER_MODE_KEY] = value.name }
     }
 
+    override suspend fun setMapLookAhead(value: Int) {
+        context.displayDataStore.edit { it[MAP_LOOKAHEAD_KEY] = value }
+    }
+
     override suspend fun setShowCalendar(value: Boolean) {
         context.displayDataStore.edit { it[SHOW_CALENDAR_KEY] = value }
     }
@@ -239,6 +257,7 @@ internal class DisplayPreferences(
         val MAP_ZOOM_KEY = intPreferencesKey("map_zoom")
         val MAP_QUALITY_KEY = intPreferencesKey("map_render_percent")
         val MAP_RENDER_MODE_KEY = stringPreferencesKey("map_render_mode")
+        val MAP_LOOKAHEAD_KEY = intPreferencesKey("map_look_ahead_m")
         val SHOW_CALENDAR_KEY = booleanPreferencesKey("show_calendar")
         val SHOW_WEATHER_KEY = booleanPreferencesKey("show_weather")
         val SHOW_MUSIC_KEY = booleanPreferencesKey("show_music")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -88,6 +88,7 @@ internal data class MapConfig(
     val zoom: Int = 16,
     val renderPercent: Int = 100,
     val renderMode: MapRenderMode = MapRenderMode.SNAPSHOT,
+    val lookAheadM: Int = 180,
 )
 
 /**
@@ -220,7 +221,7 @@ private fun SnapshotMap(
             while (isActive) {
                 val loc = currentLocation.value
                 if (shouldRerender(lastRendered, loc)) {
-                    val camera = cameraFor(loc, bearingHolder, mapConfig.tiltDeg, mapConfig.zoom)
+                    val camera = cameraFor(loc, bearingHolder, mapConfig.tiltDeg, mapConfig.zoom, mapConfig.lookAheadM)
                     val rendered = snap.render(camera, LatLng(loc.latitude, loc.longitude), markerScale)
                     if (rendered != null) {
                         frame = rendered
@@ -293,12 +294,15 @@ private fun cameraFor(
     bearingHolder: FloatArray,
     tiltDeg: Int,
     zoom: Int,
+    lookAheadM: Int,
 ): CameraPosition {
     val bearing = location.carriedBearing(bearingHolder).toDouble()
     // Aim the camera ahead of the current position (along the heading) so the
     // current location renders low in the frame: more road ahead is visible and
-    // the marker sits just above the speed overlay (nav-style framing).
-    val target = LatLng(location.latitude, location.longitude).offsetForward(bearing, FORWARD_OFFSET_M)
+    // the marker sits just above the speed overlay (nav-style framing). The
+    // look-ahead distance is user-tunable so the marker can be placed nearer to
+    // (or further from) the speed panel.
+    val target = LatLng(location.latitude, location.longitude).offsetForward(bearing, lookAheadM.toDouble())
     return CameraPosition
         .Builder()
         .target(target)
@@ -632,9 +636,6 @@ private const val DARK_STYLE_ASSET = "map/dark.json"
 // single-flight render + fps throttle still bound how often a frame is produced.
 private const val REFRESH_DISTANCE_M = 2f
 
-// Look-ahead: aim the camera this far ahead of the current position so the marker
-// sits low in the frame (above the speed overlay) with the road ahead visible.
-private const val FORWARD_OFFSET_M = 60.0
 private const val EARTH_RADIUS_M = 6_371_000.0
 private val MARKER_SIZE = 18.dp
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -195,6 +195,13 @@ internal fun SettingsScreen(
                 onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
             )
             SliderRow(
+                title = stringResource(R.string.settings_group_map_look_ahead),
+                valueLabel = stringResource(R.string.settings_map_look_ahead_value, uiState.mapLookAheadM),
+                value = uiState.mapLookAheadM,
+                range = MIN_MAP_LOOK_AHEAD..MAX_MAP_LOOK_AHEAD,
+                onValueChange = { onAction(SettingsAction.SetMapLookAhead(it)) },
+            )
+            SliderRow(
                 title = stringResource(R.string.settings_group_map_quality),
                 valueLabel = stringResource(R.string.settings_map_quality_value, uiState.mapRenderPercent),
                 value = uiState.mapRenderPercent,
@@ -507,6 +514,11 @@ private const val MIN_MAP_TILT = 0
 private const val MAX_MAP_TILT = 60
 private const val MIN_MAP_ZOOM = 12
 private const val MAX_MAP_ZOOM = 19
+
+// Camera look-ahead band (metres): 0 centres the marker; larger pushes it lower,
+// toward the speed panel.
+private const val MIN_MAP_LOOK_AHEAD = 0
+private const val MAX_MAP_LOOK_AHEAD = 400
 
 // Snapshot render resolution band (percent). The floor stays well above zero so
 // the upscaled map keeps roads legible; 100 is full panel resolution.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -23,6 +23,7 @@ internal data class SettingsUiState(
     val mapZoom: Int,
     val mapRenderPercent: Int,
     val mapRenderMode: MapRenderMode,
+    val mapLookAheadM: Int,
     val showCalendar: Boolean,
     val showWeather: Boolean,
     val showMusic: Boolean,
@@ -44,6 +45,7 @@ internal data class SettingsUiState(
                 mapZoom = DisplaySettings.Default.mapZoom,
                 mapRenderPercent = DisplaySettings.Default.mapRenderPercent,
                 mapRenderMode = DisplaySettings.Default.mapRenderMode,
+                mapLookAheadM = DisplaySettings.Default.mapLookAheadM,
                 showCalendar = DisplaySettings.Default.showCalendar,
                 showWeather = DisplaySettings.Default.showWeather,
                 showMusic = DisplaySettings.Default.showMusic,
@@ -96,6 +98,10 @@ internal sealed interface SettingsAction {
 
     data class SetMapRenderMode(
         val value: MapRenderMode,
+    ) : SettingsAction
+
+    data class SetMapLookAhead(
+        val value: Int,
     ) : SettingsAction
 
     data class SetShowCalendar(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -32,6 +32,7 @@ internal class SettingsViewModel(
                 mapZoom = display.mapZoom,
                 mapRenderPercent = display.mapRenderPercent,
                 mapRenderMode = display.mapRenderMode,
+                mapLookAheadM = display.mapLookAheadM,
                 showCalendar = display.showCalendar,
                 showWeather = display.showWeather,
                 showMusic = display.showMusic,
@@ -54,6 +55,7 @@ internal class SettingsViewModel(
                 is SettingsAction.SetMapZoom -> displayPreferences.setMapZoom(action.value)
                 is SettingsAction.SetMapRenderPercent -> displayPreferences.setMapRenderPercent(action.value)
                 is SettingsAction.SetMapRenderMode -> displayPreferences.setMapRenderMode(action.value)
+                is SettingsAction.SetMapLookAhead -> displayPreferences.setMapLookAhead(action.value)
                 is SettingsAction.SetShowCalendar -> displayPreferences.setShowCalendar(action.value)
                 is SettingsAction.SetShowWeather -> displayPreferences.setShowWeather(action.value)
                 is SettingsAction.SetShowMusic -> displayPreferences.setShowMusic(action.value)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
     <string name="settings_map_zoom_value">z%1$d</string>
     <string name="settings_group_map_quality">Render quality</string>
     <string name="settings_map_quality_value">%1$d%%</string>
+    <string name="settings_group_map_look_ahead">Marker look-ahead</string>
+    <string name="settings_map_look_ahead_value">%1$d m</string>
     <string name="settings_group_panel_calendar">Calendar panel</string>
     <string name="settings_group_panel_weather">Weather panel</string>
     <string name="settings_group_panel_music">Music panel</string>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -49,6 +49,8 @@ internal class FakeDisplaySettingsStore(
 
     override suspend fun setMapRenderMode(value: MapRenderMode) = state.update { it.copy(mapRenderMode = value) }
 
+    override suspend fun setMapLookAhead(value: Int) = state.update { it.copy(mapLookAheadM = value) }
+
     override suspend fun setShowCalendar(value: Boolean) = state.update { it.copy(showCalendar = value) }
 
     override suspend fun setShowWeather(value: Boolean) = state.update { it.copy(showWeather = value) }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -83,5 +83,13 @@ class SettingsViewModelTest {
             assertEquals(MapRenderMode.LIVE, store.settings.first().mapRenderMode)
         }
 
+    @Test
+    fun `SetMapLookAhead writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetMapLookAhead(200))
+            advanceUntilIdle()
+            assertEquals(200, store.settings.first().mapLookAheadM)
+        }
+
     private fun viewModel() = SettingsViewModel(store, FontPreferences(application))
 }


### PR DESCRIPTION
## Summary

On-device feedback: the location marker sat too far above the speed
panel. The camera **look-ahead** — how far ahead of the current position
the camera aims, which sets how low the marker renders — was a fixed
60 m.

- Add a **Settings → Map → "Marker look-ahead"** slider (0–400 m).
- Raise the default to **180 m** so the marker starts lower, nearer the
  speed panel out of the box; a larger value pushes it lower still, 0
  centres it.

Threaded through `MapConfig.lookAheadM` into `cameraFor` (replacing the
removed `FORWARD_OFFSET_M` constant).

## Test
- Emulator: marker renders lower with the higher look-ahead; no crash.
- `SettingsViewModelTest`: `SetMapLookAhead` routes to the store.
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.