### PR TITLE
feat(dashboard): tighten the info panels and drop their dividers

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -107,8 +106,10 @@ private fun CalendarContent(snapshot: CalendarSnapshot) {
         modifier =
             Modifier
                 .fillMaxSize()
-                .padding(FemtoDimens.CardPadding),
-        verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGap),
+                // Tighter than the shared card padding/gap: the head-unit info-pane
+                // card is short, so pack the head, strip and events to avoid a clip.
+                .padding(FemtoDimens.CardPaddingCompact),
+        verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGapCompact),
     ) {
         Head(snapshot)
         Strip(
@@ -262,8 +263,7 @@ private fun DayCellView(
 
 @Composable
 private fun Events(events: List<EventItem>) =
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         if (events.isEmpty()) {
             Text(
                 text = stringResource(R.string.calendar_no_events),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
@@ -76,7 +76,7 @@ internal fun ClockOverlay(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = FemtoDimens.GlassBorderAlpha),
                     shape = RoundedCornerShape(FemtoDimens.OverlayCorner),
-                ).padding(horizontal = 20.dp, vertical = 12.dp),
+                ).padding(horizontal = 16.dp, vertical = 6.dp),
     )
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -144,14 +144,14 @@ internal fun SpeedOverlay(
             avgSpeed = avgSpeed,
             onReset = onReset,
         )
-        if (shortAddress.isNotBlank()) {
-            // Tightened so the metric row's vertical breathing room matches the
-            // address row's, instead of sitting noticeably taller.
-            Box(modifier = Modifier.height(5.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
-            Box(modifier = Modifier.height(5.dp))
-            AddressRow(text = shortAddress)
-        }
+        // Always render the address row (even with no fix / unresolved address) so
+        // the overlay keeps a stable height instead of collapsing then growing when
+        // the address arrives. The 5 dp gaps keep the metric row's breathing room in
+        // step with the address row's.
+        Box(modifier = Modifier.height(5.dp))
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+        Box(modifier = Modifier.height(5.dp))
+        AddressRow(text = shortAddress.ifBlank { NO_ADDRESS_PLACEHOLDER })
     }
 }
 
@@ -341,6 +341,10 @@ private const val SPEED_OVERLAY_EMA_ALPHA = 0.33f
 // the WeatherCard convention and the permissions contract (location
 // panels read empty until granted). It avoids the ambiguous "0".
 private const val NO_SPEED_PLACEHOLDER = "—"
+
+// Shown in the address row until a fix / reverse-geocode resolves, so the overlay
+// reserves the row instead of collapsing (and the MapPin still reads as "location").
+private const val NO_ADDRESS_PLACEHOLDER = "—"
 
 // Reset control size: narrower than MinTouchTarget so it leaves the metric cells
 // more room on a compact overlay and shortens the metric row (see ResetButton).

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -93,8 +92,10 @@ internal fun WeatherCard(
                 Modifier
                     .fillMaxWidth()
                     .verticalScroll(rememberScrollState())
-                    .padding(FemtoDimens.CardPadding),
-            verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGap),
+                    // Compact padding/gap so head + metrics + forecast pack into the
+                    // short head-unit info-pane card without needing to scroll/clip.
+                    .padding(FemtoDimens.CardPaddingCompact),
+            verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGapCompact),
         ) {
             Head(snapshot, city, temperatureUnit)
             Metrics(snapshot, temperatureUnit, speedUnit)
@@ -237,8 +238,7 @@ private fun Forecast(
 ) {
     val next = hourly.take(3)
     if (next.isEmpty()) return
-    Column(verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGap)) {
-        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+    Column(verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGapCompact)) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(4.dp),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -103,6 +103,14 @@ object FemtoDimens {
     /** Vertical rhythm between the sections stacked inside a card. */
     val CardSectionGap = 10.dp
 
+    /**
+     * Tighter padding / section rhythm for the short top-row info cards
+     * (calendar, weather) on the head-unit info pane, so the head + strip +
+     * events (or head + metrics + forecast) pack in without clipping.
+     */
+    val CardPaddingCompact = 10.dp
+    val CardSectionGapCompact = 6.dp
+
     /** Corner radius for dashboard cards. Mockup legend: card radius 16 dp (Shapes.large). */
     val CardCorner = 16.dp
 


### PR DESCRIPTION
## Summary

On-device feedback (wave 5, items 4/6/7/20), verified on the emulator:

- **#4** Remove the horizontal divider from the calendar (events) and
  weather (forecast) cards.
- **#7** Pack the calendar and weather cards with compact padding/gap
  (`FemtoDimens.CardPaddingCompact` 10 dp / `CardSectionGapCompact` 6 dp)
  so head + strip/metrics + events/forecast fit the short info-pane card
  without clipping ("CLOUDY" now shows in full, 2-digit days fit).
- **#6** Trim the clock overlay's padding.
- **#20** Keep the speed overlay's address row always rendered (em-dash
  placeholder until a fix / address resolves) so it no longer collapses
  then grows when the address arrives.

## Test
- Emulator (800×480 @150): panels tighter, dividers gone, no clipping,
  address row stable; app stable (no crash).
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.