### PR TITLE
feat(speed): show altitude and count stopped time in the average

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/TripRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/TripRepository.kt
@@ -151,9 +151,13 @@ internal class TripRepository(
                 // sub-second gaps): do not publish or accrue them.
                 if (speed != null && speed <= MAX_PLAUSIBLE_SPEED_MS) {
                     currentSpeedMs = speed
+                    // Count every tracked interval toward the average's time base,
+                    // including time spent stopped, so AVG is the overall trip
+                    // average (distance / elapsed) rather than a moving-only average.
+                    // Long gaps are already excluded by the deltaSeconds window above.
+                    totalSeconds += deltaSeconds
                     if (speed >= MIN_MOVING_SPEED_MS) {
                         totalMeters += previous.distanceTo(current).toDouble()
-                        totalSeconds += deltaSeconds
                     }
                 }
             }

--- a/app/src/main/java/io/github/seijikohara/femto/data/TripState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/TripState.kt
@@ -7,9 +7,10 @@ import androidx.compose.runtime.Immutable
  *
  * `distanceMeters` is the total ground distance covered since the
  * activity (and therefore the launcher process) started. `avgSpeedMs`
- * is the moving average — total distance divided by the time the
- * device was actually moving (jitter at rest is filtered out at the
- * repository level). `currentSpeedMs` is the latest instantaneous
+ * is the overall trip average — total distance divided by the total
+ * tracked time, including time spent stopped (only untracked gaps, e.g.
+ * the app backgrounded, are excluded at the repository level).
+ * `currentSpeedMs` is the latest instantaneous
  * effective speed: the reported fix speed when the GPS chip supplies
  * one, otherwise the position-derived speed so the hero numeral still
  * moves on speed-less HALs.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -114,6 +114,9 @@ internal fun SpeedOverlay(
     val distance = speedUnit.tripDistanceFromMeters(tripState.distanceMeters)
     val avgSpeed = speedUnit.fromMetersPerSecond(tripState.avgSpeedMs.toFloat()).roundToInt()
     val shortAddress = address?.displayString().orEmpty()
+    // Altitude (metres) from the fix when the chip reports it; null hides the
+    // altitude readout rather than showing a misleading 0.
+    val altitudeM = location?.takeIf { it.hasAltitude() }?.altitude?.roundToInt()
     val glassAlpha = if (isSystemInDarkTheme()) FemtoDimens.GlassBgAlphaDark else FemtoDimens.GlassBgAlphaLight
     Column(
         modifier =
@@ -151,7 +154,7 @@ internal fun SpeedOverlay(
         Box(modifier = Modifier.height(5.dp))
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
         Box(modifier = Modifier.height(5.dp))
-        AddressRow(text = shortAddress.ifBlank { NO_ADDRESS_PLACEHOLDER })
+        AddressRow(text = shortAddress.ifBlank { NO_ADDRESS_PLACEHOLDER }, altitudeM = altitudeM)
     }
 }
 
@@ -260,34 +263,46 @@ private fun SecondaryMetric(
 }
 
 @Composable
-private fun AddressRow(text: String) =
-    Row(
-        // Fill the overlay's (metric-row-defined) width so a long address
-        // ellipsizes within it instead of stretching the card wider.
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Icon(
-            imageVector = Lucide.MapPin,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.86f),
-            modifier = Modifier.size(FemtoDimens.WeatherGlyphSmall),
-        )
+private fun AddressRow(
+    text: String,
+    altitudeM: Int?,
+) = Row(
+    // Fill the overlay's (metric-row-defined) width so a long address
+    // ellipsizes within it instead of stretching the card wider.
+    modifier = Modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+) {
+    Icon(
+        imageVector = Lucide.MapPin,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.86f),
+        modifier = Modifier.size(FemtoDimens.WeatherGlyphSmall),
+    )
+    Text(
+        text = text,
+        style =
+            MaterialTheme.typography.bodyMedium.copy(
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+                lineHeight = 16.sp,
+            ),
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.86f),
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.weight(1f),
+    )
+    // Altitude readout, trailing the address (the address ellipsizes to make
+    // room). Hidden when the fix carries no altitude.
+    if (altitudeM != null) {
         Text(
-            text = text,
-            style =
-                MaterialTheme.typography.bodyMedium.copy(
-                    fontSize = 13.sp,
-                    fontWeight = FontWeight.Medium,
-                    lineHeight = 16.sp,
-                ),
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.86f),
+            text = stringResource(R.string.speed_altitude, altitudeM),
+            style = MaterialTheme.typography.sectionLabel(11, 0.04f),
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.86f),
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
         )
     }
+}
 
 // Trailing reset control for the trip metrics, anchored to the overlay's
 // top-right (the end of the metric row). Sized below MinTouchTarget so it does
@@ -358,7 +373,11 @@ private fun SpeedOverlayPreview() {
         // A non-null fix exercises the live-speed path so the hero numeral
         // renders the smoothed value rather than the no-fix em-dash.
         SpeedOverlay(
-            location = Location("preview").apply { speed = 13.2f },
+            location =
+                Location("preview").apply {
+                    speed = 13.2f
+                    altitude = 42.0
+                },
             address = ShortAddress(locality = "Minato-ku", region = "Tokyo"),
             tripState = TripState(distanceMeters = 24_400.0, avgSpeedMs = 11.7, currentSpeedMs = 13.2),
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
 
     <!-- Speed overlay -->
     <string name="speed_reset_trip">Reset trip</string>
+    <string name="speed_altitude">ALT %1$d m</string>
 
     <!-- Calendar card -->
     <string name="calendar_no_events">No upcoming events</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/TripRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/TripRepositoryTest.kt
@@ -48,7 +48,9 @@ class TripRepositoryTest {
     @Test
     fun `excludes stationary fixes below the moving-speed floor`() =
         runTest {
-            // Same position, reported speed below MIN_MOVING_SPEED_MS.
+            // Same position, reported speed below MIN_MOVING_SPEED_MS. Stationary
+            // fixes add no DISTANCE (asserted here); their time still counts toward
+            // the average — see `average includes stopped time`.
             val flow =
                 flowOf(
                     fakeLocation(speedMps = 0.1f, elapsedRealtimeNanos = 0L),
@@ -58,6 +60,29 @@ class TripRepositoryTest {
             TripRepository(flow).stateFlow().test {
                 skipItems(2) // initial snapshot + first fix
                 assertEquals(0.0, awaitItem().distanceMeters, 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `average includes stopped time`() =
+        runTest {
+            // Move for 10 s, then sit stopped for another 10 s at the same spot: the
+            // stopped interval adds time but no distance, so the overall average must
+            // drop below the moving-only average.
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 11f, elapsedRealtimeNanos = tenSeconds(1)),
+                    fakeLocation(latitude = ORIGIN_LAT + STEP, speedMps = 0.1f, elapsedRealtimeNanos = tenSeconds(2)),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix (no previous yet)
+                val moving = awaitItem() // after the second (moving) fix
+                val afterStop = awaitItem() // after the stopped fix
+                assertTrue(afterStop.avgSpeedMs > 0.0)
+                assertTrue(afterStop.avgSpeedMs < moving.avgSpeedMs)
                 cancelAndIgnoreRemainingEvents()
             }
         }


### PR DESCRIPTION
## Summary

On-device feedback (wave 5, items 17/9):

- **#17 Altitude** — show the fix altitude in the speed overlay's address
  row ("ALT <n> m"), trailing the address (which ellipsizes to make
  room); hidden when the fix carries no altitude.
- **#9 AVG includes stopped time** — `AVG.` now divides total distance by
  total *tracked* time including time spent stopped, so it is the overall
  trip average rather than a moving-only one. Only untracked gaps (app
  backgrounded, > the delta window) are still excluded. Distance still
  excludes sub-floor jitter.

## Test
- New `TripRepositoryTest`: a stopped interval lowers the average.
- Emulator: the "ALT" readout renders in the address row (the emulator's
  GPS reports 0 m; a real fix shows the true altitude).
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.