### PR TITLE
feat(settings): add a clock seconds toggle

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
@@ -42,6 +42,7 @@ class DashboardScaffoldTest {
                 DashboardScaffold(
                     uiState = uiState,
                     is24Hour = true,
+                    showClockSeconds = true,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     mapConfig = MapConfig(),
@@ -70,6 +71,7 @@ class DashboardScaffoldTest {
                 DashboardScaffold(
                     uiState = uiState,
                     is24Hour = true,
+                    showClockSeconds = true,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     mapConfig = MapConfig(),

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.platform.app.InstrumentationRegistry
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.FullscreenSetting
@@ -21,6 +22,7 @@ class SettingsScreenTest {
     private val fullscreenLabel = context.getString(R.string.settings_group_fullscreen)
     private val themeLabel = context.getString(R.string.settings_group_theme)
     private val darkLabel = context.getString(R.string.settings_theme_dark)
+    private val showSecondsLabel = context.getString(R.string.settings_group_clock_seconds)
 
     @Test
     fun renders_fullscreen_row() {
@@ -35,6 +37,17 @@ class SettingsScreenTest {
         // Initial.fullscreen is OFF, so tapping the row flips the switch to ON.
         rule.onNodeWithText(fullscreenLabel).performClick()
         assertEquals(listOf(SettingsAction.SetFullscreen(FullscreenSetting.ON)), actions)
+    }
+
+    @Test
+    fun toggling_show_seconds_dispatches_set_show_clock_seconds_off() {
+        val actions = mutableListOf<SettingsAction>()
+        setScreen(onAction = { actions += it })
+        // The row sits in the Units section, below the fold on a short head unit, so
+        // scroll it into view first. Initial.showClockSeconds is true, so tapping the
+        // row flips the switch off.
+        rule.onNodeWithText(showSecondsLabel).performScrollTo().performClick()
+        assertEquals(listOf(SettingsAction.SetShowClockSeconds(false)), actions)
     }
 
     @Test

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -117,6 +117,7 @@ class MainActivity : ComponentActivity() {
                 } else {
                     HomeRoute(
                         is24Hour = resolveIs24Hour(display.clock),
+                        showClockSeconds = display.showClockSeconds,
                         speedUnit = display.speedUnit.resolved(),
                         temperatureUnit = display.temperatureUnit.resolved(),
                         mapConfig =

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -68,6 +68,10 @@ internal data class DisplaySettings(
     val speedUnit: SpeedUnitSetting,
     val temperatureUnit: TemperatureUnitSetting,
     val clock: ClockSetting,
+    // Whether the clock overlay shows seconds. Defaults to true (the original
+    // HH:mm:ss readout); when false the overlay drops to HH:mm and self-times
+    // per-minute instead of per-second.
+    val showClockSeconds: Boolean,
     val fullscreen: FullscreenSetting,
     // Target map frame rate (fps): the snapshot map caps its re-render rate at
     // this many frames per second. Clamped to the display's max refresh at use.
@@ -96,6 +100,7 @@ internal data class DisplaySettings(
                 speedUnit = SpeedUnitSetting.AUTO,
                 temperatureUnit = TemperatureUnitSetting.AUTO,
                 clock = ClockSetting.AUTO,
+                showClockSeconds = true,
                 fullscreen = FullscreenSetting.OFF,
                 mapFps = DEFAULT_MAP_FPS,
                 mapStyle = MapStyleSetting.AUTO,
@@ -128,6 +133,8 @@ internal interface DisplaySettingsStore {
     suspend fun setTemperatureUnit(value: TemperatureUnitSetting)
 
     suspend fun setClock(value: ClockSetting)
+
+    suspend fun setShowClockSeconds(value: Boolean)
 
     suspend fun setFullscreen(value: FullscreenSetting)
 
@@ -169,6 +176,7 @@ internal class DisplayPreferences(
                 speedUnit = prefs[SPEED_KEY].toEnumOr(SpeedUnitSetting.AUTO),
                 temperatureUnit = prefs[TEMPERATURE_KEY].toEnumOr(TemperatureUnitSetting.AUTO),
                 clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
+                showClockSeconds = prefs[SHOW_CLOCK_SECONDS_KEY] ?: true,
                 fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.OFF),
                 mapFps = prefs[MAP_FPS_KEY] ?: DEFAULT_MAP_FPS,
                 mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
@@ -199,6 +207,10 @@ internal class DisplayPreferences(
 
     override suspend fun setClock(value: ClockSetting) {
         context.displayDataStore.edit { it[CLOCK_KEY] = value.name }
+    }
+
+    override suspend fun setShowClockSeconds(value: Boolean) {
+        context.displayDataStore.edit { it[SHOW_CLOCK_SECONDS_KEY] = value }
     }
 
     override suspend fun setFullscreen(value: FullscreenSetting) {
@@ -250,6 +262,7 @@ internal class DisplayPreferences(
         val SPEED_KEY = stringPreferencesKey("speed_unit")
         val TEMPERATURE_KEY = stringPreferencesKey("temperature_unit")
         val CLOCK_KEY = stringPreferencesKey("clock")
+        val SHOW_CLOCK_SECONDS_KEY = booleanPreferencesKey("show_clock_seconds")
         val FULLSCREEN_KEY = stringPreferencesKey("fullscreen")
         val MAP_FPS_KEY = intPreferencesKey("map_fps")
         val MAP_STYLE_KEY = stringPreferencesKey("map_style")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -21,6 +21,7 @@ import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 @Composable
 internal fun HomeRoute(
     is24Hour: Boolean,
+    showClockSeconds: Boolean,
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
     mapConfig: MapConfig,
@@ -40,6 +41,7 @@ internal fun HomeRoute(
     HomeScreen(
         uiState = uiState,
         is24Hour = is24Hour,
+        showClockSeconds = showClockSeconds,
         speedUnit = speedUnit,
         temperatureUnit = temperatureUnit,
         mapConfig = mapConfig,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 internal fun HomeScreen(
     uiState: HomeUiState,
     is24Hour: Boolean,
+    showClockSeconds: Boolean,
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
     mapConfig: MapConfig,
@@ -30,6 +31,7 @@ internal fun HomeScreen(
     DashboardScaffold(
         uiState = uiState,
         is24Hour = is24Hour,
+        showClockSeconds = showClockSeconds,
         speedUnit = speedUnit,
         temperatureUnit = temperatureUnit,
         mapConfig = mapConfig,
@@ -46,6 +48,7 @@ private fun HomeScreenPreview() =
         HomeScreen(
             uiState = HomeUiState.Initial,
             is24Hour = true,
+            showClockSeconds = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
@@ -25,11 +25,14 @@ import kotlinx.coroutines.delay
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
-// Fixed-width seconds patterns. Both use a leading-zero hour so the 12-hour
-// form stays the same advance count as the 24-hour form; paired with tabular
-// figures this keeps the overlay width constant as the time changes.
+// Fixed-width patterns. Every form uses a leading-zero hour so the 12-hour form
+// stays the same advance count as the 24-hour form; paired with tabular figures
+// this keeps the overlay width constant as the time changes. The NoSeconds forms
+// back the "show seconds = off" setting.
 private val ClockFormatter24 = DateTimeFormatter.ofPattern("HH:mm:ss")
 private val ClockFormatter12 = DateTimeFormatter.ofPattern("hh:mm:ss")
+private val ClockFormatter24NoSeconds = DateTimeFormatter.ofPattern("HH:mm")
+private val ClockFormatter12NoSeconds = DateTimeFormatter.ofPattern("hh:mm")
 
 /**
  * Glass overlay anchored to the map pane's top-right corner.
@@ -39,23 +42,35 @@ private val ClockFormatter12 = DateTimeFormatter.ofPattern("hh:mm:ss")
  * (translucent surface container + 1 dp outline) so the overlay reads as
  * frosted glass over the map tiles below.
  *
- * The overlay self-times its seconds with a local [produceState] loop so the
- * per-second recomposition is scoped to this `Text` alone. The shared
- * minute-resolution `ClockTick` deliberately stays out of this path: a
- * per-second tick there would re-query the calendar every second.
+ * The overlay self-times with a local [produceState] loop so the recomposition
+ * is scoped to this `Text` alone. The shared minute-resolution `ClockTick`
+ * deliberately stays out of this path: a per-second tick there would re-query
+ * the calendar every second. When [showSeconds] is off the loop ticks once per
+ * minute instead of once per second, so a minute-resolution clock costs nothing.
  */
 @Composable
 internal fun ClockOverlay(
     modifier: Modifier = Modifier,
     is24Hour: Boolean = true,
+    showSeconds: Boolean = true,
 ) {
-    val now by produceState(initialValue = LocalTime.now()) {
+    val now by produceState(initialValue = LocalTime.now(), showSeconds) {
         while (true) {
             value = LocalTime.now()
-            delay(1000L - System.currentTimeMillis() % 1000) // align to the next second
+            val nowMs = System.currentTimeMillis()
+            // Align the next tick to the upcoming second boundary, or the upcoming
+            // minute boundary when seconds are hidden (no needless 60x/min wake-ups).
+            val delayMs = if (showSeconds) 1000L - nowMs % 1000 else 60_000L - nowMs % 60_000
+            delay(delayMs)
         }
     }
-    val formatter = if (is24Hour) ClockFormatter24 else ClockFormatter12
+    val formatter =
+        when {
+            is24Hour && showSeconds -> ClockFormatter24
+            is24Hour -> ClockFormatter24NoSeconds
+            showSeconds -> ClockFormatter12
+            else -> ClockFormatter12NoSeconds
+        }
     val glassAlpha = if (isSystemInDarkTheme()) FemtoDimens.GlassBgAlphaDark else FemtoDimens.GlassBgAlphaLight
     Text(
         text = now.format(formatter),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -76,6 +76,7 @@ internal data class PanelVisibility(
 internal fun DashboardScaffold(
     uiState: HomeUiState,
     is24Hour: Boolean,
+    showClockSeconds: Boolean,
     speedUnit: SpeedUnit,
     temperatureUnit: TemperatureUnit,
     mapConfig: MapConfig,
@@ -109,6 +110,7 @@ internal fun DashboardScaffold(
                 MapPane(
                     uiState = uiState,
                     is24Hour = is24Hour,
+                    showClockSeconds = showClockSeconds,
                     speedUnit = speedUnit,
                     mapConfig = mapConfig,
                     onAction = onAction,
@@ -137,6 +139,7 @@ internal fun DashboardScaffold(
                 MapPane(
                     uiState = uiState,
                     is24Hour = is24Hour,
+                    showClockSeconds = showClockSeconds,
                     speedUnit = speedUnit,
                     mapConfig = mapConfig,
                     onAction = onAction,
@@ -167,6 +170,7 @@ internal fun DashboardScaffold(
 private fun MapPane(
     uiState: HomeUiState,
     is24Hour: Boolean,
+    showClockSeconds: Boolean,
     speedUnit: SpeedUnit,
     mapConfig: MapConfig,
     onAction: (HomeAction) -> Unit,
@@ -180,6 +184,7 @@ private fun MapPane(
     )
     ClockOverlay(
         is24Hour = is24Hour,
+        showSeconds = showClockSeconds,
         modifier =
             Modifier
                 .align(Alignment.TopEnd)
@@ -285,6 +290,7 @@ private fun DashboardScaffoldLandscapePreview() {
         DashboardScaffold(
             uiState = HomeUiState.Initial,
             is24Hour = true,
+            showClockSeconds = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),
@@ -302,6 +308,7 @@ private fun DashboardScaffoldUltraWidePreview() {
         DashboardScaffold(
             uiState = HomeUiState.Initial,
             is24Hour = true,
+            showClockSeconds = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),
@@ -322,6 +329,7 @@ private fun DashboardScaffoldHeadUnitPreview() {
         DashboardScaffold(
             uiState = HomeUiState.Initial,
             is24Hour = true,
+            showClockSeconds = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),
@@ -339,6 +347,7 @@ private fun DashboardScaffoldPortraitPreview() {
         DashboardScaffold(
             uiState = HomeUiState.Initial,
             is24Hour = true,
+            showClockSeconds = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),
@@ -358,6 +367,7 @@ private fun DashboardScaffoldHiddenPanelPreview() {
         DashboardScaffold(
             uiState = HomeUiState.Initial,
             is24Hour = true,
+            showClockSeconds = true,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             temperatureUnit = TemperatureUnit.CELSIUS,
             mapConfig = MapConfig(),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -148,6 +148,11 @@ internal fun SettingsScreen(
                 selected = uiState.clock,
                 onSelect = { onAction(SettingsAction.SetClock(it)) },
             )
+            SwitchRow(
+                title = stringResource(R.string.settings_group_clock_seconds),
+                checked = uiState.showClockSeconds,
+                onCheckedChange = { onAction(SettingsAction.SetShowClockSeconds(it)) },
+            )
         }
 
         val maxFps = rememberMaxDisplayFps()

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -16,6 +16,7 @@ internal data class SettingsUiState(
     val speedUnit: SpeedUnitSetting,
     val temperatureUnit: TemperatureUnitSetting,
     val clock: ClockSetting,
+    val showClockSeconds: Boolean,
     val fullscreen: FullscreenSetting,
     val mapFps: Int,
     val mapStyle: MapStyleSetting,
@@ -38,6 +39,7 @@ internal data class SettingsUiState(
                 speedUnit = DisplaySettings.Default.speedUnit,
                 temperatureUnit = DisplaySettings.Default.temperatureUnit,
                 clock = DisplaySettings.Default.clock,
+                showClockSeconds = DisplaySettings.Default.showClockSeconds,
                 fullscreen = DisplaySettings.Default.fullscreen,
                 mapFps = DisplaySettings.Default.mapFps,
                 mapStyle = DisplaySettings.Default.mapStyle,
@@ -70,6 +72,10 @@ internal sealed interface SettingsAction {
 
     data class SetClock(
         val value: ClockSetting,
+    ) : SettingsAction
+
+    data class SetShowClockSeconds(
+        val value: Boolean,
     ) : SettingsAction
 
     data class SetFullscreen(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -25,6 +25,7 @@ internal class SettingsViewModel(
                 speedUnit = display.speedUnit,
                 temperatureUnit = display.temperatureUnit,
                 clock = display.clock,
+                showClockSeconds = display.showClockSeconds,
                 fullscreen = display.fullscreen,
                 mapFps = display.mapFps,
                 mapStyle = display.mapStyle,
@@ -48,6 +49,7 @@ internal class SettingsViewModel(
                 is SettingsAction.SetSpeedUnit -> displayPreferences.setSpeedUnit(action.value)
                 is SettingsAction.SetTemperatureUnit -> displayPreferences.setTemperatureUnit(action.value)
                 is SettingsAction.SetClock -> displayPreferences.setClock(action.value)
+                is SettingsAction.SetShowClockSeconds -> displayPreferences.setShowClockSeconds(action.value)
                 is SettingsAction.SetFullscreen -> displayPreferences.setFullscreen(action.value)
                 is SettingsAction.SetMapFps -> displayPreferences.setMapFps(action.value)
                 is SettingsAction.SetMapStyle -> displayPreferences.setMapStyle(action.value)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="settings_temp_fahrenheit">°F</string>
     <string name="settings_clock_12">12-hour</string>
     <string name="settings_clock_24">24-hour</string>
+    <string name="settings_group_clock_seconds">Show seconds</string>
     <string name="settings_group_fullscreen">Fullscreen</string>
     <string name="settings_group_map_rendering">Map rendering</string>
     <string name="settings_map_mode_snapshot">Snapshot</string>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -35,6 +35,8 @@ internal class FakeDisplaySettingsStore(
 
     override suspend fun setClock(value: ClockSetting) = state.update { it.copy(clock = value) }
 
+    override suspend fun setShowClockSeconds(value: Boolean) = state.update { it.copy(showClockSeconds = value) }
+
     override suspend fun setFullscreen(value: FullscreenSetting) = state.update { it.copy(fullscreen = value) }
 
     override suspend fun setMapFps(value: Int) = state.update { it.copy(mapFps = value) }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -68,6 +68,14 @@ class SettingsViewModelTest {
         }
 
     @Test
+    fun `SetShowClockSeconds writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetShowClockSeconds(false))
+            advanceUntilIdle()
+            assertEquals(false, store.settings.first().showClockSeconds)
+        }
+
+    @Test
     fun `SetMapRenderPercent writes the value to the store`() =
         runTest(dispatcher) {
             viewModel().onAction(SettingsAction.SetMapRenderPercent(50))


### PR DESCRIPTION
## Summary

Adds a **Show seconds** switch to the clock settings (#13). When off, the clock overlay drops from `HH:mm:ss` to `HH:mm` and self-times once per minute instead of once per second — a minute-resolution clock then costs no per-second recomposition.

The setting threads through the existing display-preferences path, mirroring the 12/24-hour `clock` setting:

`DisplaySettings.showClockSeconds` (DataStore, default `true`) -> `SettingsScreen` `SwitchRow` -> `MainActivity` -> `HomeRoute` -> `DashboardScaffold` -> `ClockOverlay(showSeconds = …)`

Defaulting to `true` preserves the original `HH:mm:ss` readout for existing installs.

## Verification
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green. New JVM test `SettingsViewModelTest."SetShowClockSeconds writes the value to the store"`.
- **Instrumented tests on the `TBox-Mock` emulator** (`SettingsScreenTest`): 4/4 passed, including the new `toggling_show_seconds_dispatches_set_show_clock_seconds_off` (the row scrolls into view on the short head-unit screen, then dispatches `SetShowClockSeconds(false)`).
- **Visual check on the emulator** at head-unit geometry (800×480 @ 150 dpi): clock reads `15:19:31` with seconds on (default), and `15:20` after toggling seconds off.