### PR TITLE
feat(settings): clarify the map render-quality control

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -212,6 +212,7 @@ internal fun SettingsScreen(
                 value = uiState.mapRenderPercent,
                 range = MIN_MAP_QUALITY..MAX_MAP_QUALITY,
                 onValueChange = { onAction(SettingsAction.SetMapRenderPercent(it)) },
+                description = stringResource(R.string.settings_map_quality_desc),
             )
         }
 
@@ -392,7 +393,8 @@ private fun SwitchRow(
     Switch(checked = checked, onCheckedChange = null)
 }
 
-// A numeric row: an inline slider under the title / current-value line.
+// A numeric row: an inline slider under the title / current-value line, with an
+// optional [description] caption beneath that explains what the value trades off.
 @Composable
 private fun SliderRow(
     title: String,
@@ -401,6 +403,7 @@ private fun SliderRow(
     range: IntRange,
     onValueChange: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    description: String? = null,
 ) = Column(
     modifier =
         modifier
@@ -422,6 +425,13 @@ private fun SliderRow(
         Text(
             text = valueLabel,
             style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    if (description != null) {
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,8 +115,9 @@
     <string name="settings_group_map_zoom">Map zoom</string>
     <string name="settings_map_tilt_value">%1$d°</string>
     <string name="settings_map_zoom_value">z%1$d</string>
-    <string name="settings_group_map_quality">Render quality</string>
+    <string name="settings_group_map_quality">Map sharpness</string>
     <string name="settings_map_quality_value">%1$d%%</string>
+    <string name="settings_map_quality_desc">Lower renders the map faster but softer — useful on slow head units.</string>
     <string name="settings_group_map_look_ahead">Marker look-ahead</string>
     <string name="settings_map_look_ahead_value">%1$d m</string>
     <string name="settings_group_panel_calendar">Calendar panel</string>


### PR DESCRIPTION
## Summary

Addresses the "Render quality is unclear" feedback (#10).

- Renames the cryptic **Render quality** slider to **Map sharpness**.
- Adds an explanatory caption beneath it: *"Lower renders the map faster but softer — useful on slow head units."*
- `SliderRow` gains an optional `description` line for this; the other sliders pass none and render unchanged.
- The underlying `mapRenderPercent` value, key, and 30–100 range are untouched, so existing preferences carry over.

## Verification
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.
- Visual check on the `TBox-Mock` emulator (800×480 @ 150 dpi): the Map section shows "Map sharpness" with the caption rendered below the value and above the slider.