### PR TITLE
feat(theme): add a selectable accent color

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,10 +68,15 @@ with automotive overrides on top.
 
 - Always wrap composables in `FemtoTheme { ... }`. Do not call
   `MaterialTheme(...)` directly outside `FemtoTheme.kt`.
-- Color: Material You dynamic color is always on
-  (`dynamicLightColorScheme` / `dynamicDarkColorScheme`). Pull from
-  `MaterialTheme.colorScheme.*`; never hardcode hex outside
-  `Color.kt`.
+- Color: Material You dynamic color
+  (`dynamicLightColorScheme` / `dynamicDarkColorScheme`) is the
+  **default** (`AccentColor.DYNAMIC`). The user may instead pick a
+  fixed accent in Settings, which generates the Material 3 scheme from
+  a preset seed (`AccentColor` + `accentSeedColor` + MaterialKolor's
+  `rememberDynamicColorScheme`); `FemtoTheme(accent = ...)` selects
+  between them. Either way, pull from `MaterialTheme.colorScheme.*`;
+  the seed colors in `ui/theme/AccentColors.kt` are the only hardcoded
+  hex outside `Color.kt`.
 - Shape: M3 default `Shapes` (squircles). Do not customise.
 - Typography: Bold Minimal on M3 roles, tuned **one weight notch
   lighter** than the original scale after on-device review found the

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,6 +134,7 @@ dependencies {
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material3)
+    implementation(libs.material.kolor)
     implementation(libs.composables.icons.lucide)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -2,11 +2,13 @@ package io.github.seijikohara.femto.ui.settings
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.platform.app.InstrumentationRegistry
 import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.ThemeMode
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -23,6 +25,7 @@ class SettingsScreenTest {
     private val themeLabel = context.getString(R.string.settings_group_theme)
     private val darkLabel = context.getString(R.string.settings_theme_dark)
     private val showSecondsLabel = context.getString(R.string.settings_group_clock_seconds)
+    private val tealAccentLabel = context.getString(R.string.settings_accent_teal)
 
     @Test
     fun renders_fullscreen_row() {
@@ -48,6 +51,16 @@ class SettingsScreenTest {
         // row flips the switch off.
         rule.onNodeWithText(showSecondsLabel).performScrollTo().performClick()
         assertEquals(listOf(SettingsAction.SetShowClockSeconds(false)), actions)
+    }
+
+    @Test
+    fun tapping_an_accent_swatch_dispatches_set_accent_color() {
+        val actions = mutableListOf<SettingsAction>()
+        setScreen(onAction = { actions += it })
+        // The accent swatches scroll horizontally; bring the Teal chip into view,
+        // then tapping it reports the matching AccentColor.
+        rule.onNodeWithContentDescription(tealAccentLabel).performScrollTo().performClick()
+        assertEquals(listOf(SettingsAction.SetAccentColor(AccentColor.TEAL)), actions)
     }
 
     @Test

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -102,7 +102,7 @@ class MainActivity : ComponentActivity() {
             LaunchedEffect(display.fullscreen) {
                 applyFullscreen(display.fullscreen)
             }
-            FemtoTheme(fontTheme = fontTheme, darkTheme = darkTheme) {
+            FemtoTheme(fontTheme = fontTheme, accent = display.accentColor, darkTheme = darkTheme) {
                 // The dashboard stays composed; the app drawer and assistant are
                 // bottom-sheet overlays and settings is a full destination over it.
                 var showDrawer by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -24,6 +24,17 @@ internal enum class TemperatureUnitSetting { AUTO, CELSIUS, FAHRENHEIT }
 /** Clock: follow the system 12/24h setting, or force 12h / 24h. */
 internal enum class ClockSetting { AUTO, TWELVE_HOUR, TWENTY_FOUR_HOUR }
 
+/**
+ * App accent: [DYNAMIC] keeps Material You wallpaper-derived color (the default);
+ * every other entry forces a fixed preset seed from which the whole Material 3
+ * scheme is generated. The seed color for each preset lives in the theme layer
+ * (`accentSeedColor`), keeping this data enum free of any Compose dependency.
+ *
+ * Public (unlike the other display enums) because the public [FemtoTheme] takes
+ * it as a parameter, mirroring [FontTheme]'s visibility.
+ */
+enum class AccentColor { DYNAMIC, BLUE, TEAL, GREEN, AMBER, ORANGE, RED, VIOLET, PINK }
+
 /** Fullscreen: keep the system bars, or hide both status and navigation bars. */
 internal enum class FullscreenSetting { OFF, ON }
 
@@ -65,6 +76,7 @@ internal const val DEFAULT_MAP_LOOKAHEAD_M = 180
  */
 internal data class DisplaySettings(
     val themeMode: ThemeMode,
+    val accentColor: AccentColor,
     val speedUnit: SpeedUnitSetting,
     val temperatureUnit: TemperatureUnitSetting,
     val clock: ClockSetting,
@@ -97,6 +109,7 @@ internal data class DisplaySettings(
         val Default =
             DisplaySettings(
                 themeMode = ThemeMode.SYSTEM,
+                accentColor = AccentColor.DYNAMIC,
                 speedUnit = SpeedUnitSetting.AUTO,
                 temperatureUnit = TemperatureUnitSetting.AUTO,
                 clock = ClockSetting.AUTO,
@@ -127,6 +140,8 @@ internal interface DisplaySettingsStore {
     val settings: Flow<DisplaySettings>
 
     suspend fun setThemeMode(value: ThemeMode)
+
+    suspend fun setAccentColor(value: AccentColor)
 
     suspend fun setSpeedUnit(value: SpeedUnitSetting)
 
@@ -173,6 +188,7 @@ internal class DisplayPreferences(
         context.displayDataStore.data.map { prefs ->
             DisplaySettings(
                 themeMode = prefs[THEME_KEY].toEnumOr(ThemeMode.SYSTEM),
+                accentColor = prefs[ACCENT_KEY].toEnumOr(AccentColor.DYNAMIC),
                 speedUnit = prefs[SPEED_KEY].toEnumOr(SpeedUnitSetting.AUTO),
                 temperatureUnit = prefs[TEMPERATURE_KEY].toEnumOr(TemperatureUnitSetting.AUTO),
                 clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
@@ -195,6 +211,10 @@ internal class DisplayPreferences(
     // DisplaySettingsStore contract intentionally discards.
     override suspend fun setThemeMode(value: ThemeMode) {
         context.displayDataStore.edit { it[THEME_KEY] = value.name }
+    }
+
+    override suspend fun setAccentColor(value: AccentColor) {
+        context.displayDataStore.edit { it[ACCENT_KEY] = value.name }
     }
 
     override suspend fun setSpeedUnit(value: SpeedUnitSetting) {
@@ -259,6 +279,7 @@ internal class DisplayPreferences(
 
     private companion object {
         val THEME_KEY = stringPreferencesKey("theme_mode")
+        val ACCENT_KEY = stringPreferencesKey("accent_color")
         val SPEED_KEY = stringPreferencesKey("speed_unit")
         val TEMPERATURE_KEY = stringPreferencesKey("temperature_unit")
         val CLOCK_KEY = stringPreferencesKey("clock")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -1,6 +1,9 @@
 package io.github.seijikohara.femto.ui.settings
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +17,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -33,16 +37,21 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.ChevronRight
 import com.composables.icons.lucide.ExternalLink
 import com.composables.icons.lucide.Lucide
 import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.MapRenderMode
@@ -54,6 +63,7 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.FontTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+import io.github.seijikohara.femto.ui.theme.accentSeedColor
 import kotlin.math.roundToInt
 
 /**
@@ -100,6 +110,10 @@ internal fun SettingsScreen(
                     ),
                 selected = uiState.themeMode,
                 onSelect = { onAction(SettingsAction.SetThemeMode(it)) },
+            )
+            AccentRow(
+                selected = uiState.accentColor,
+                onSelect = { onAction(SettingsAction.SetAccentColor(it)) },
             )
             ChoiceRow(
                 title = stringResource(R.string.settings_group_font),
@@ -301,6 +315,88 @@ private fun SettingsSection(
         tonalElevation = FemtoDimens.CardElevation,
     ) {
         Column(content = content)
+    }
+}
+
+// The accent picker: a title over a horizontally-scrolling row of color swatches.
+// Selecting a swatch applies its seed immediately, so the picker (and the whole
+// app) recolors live. DYNAMIC keeps Material You wallpaper color.
+@Composable
+private fun AccentRow(
+    selected: AccentColor,
+    onSelect: (AccentColor) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier =
+        modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+) {
+    Text(
+        text = stringResource(R.string.settings_group_accent),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        AccentColor.entries.forEach { accent ->
+            AccentSwatch(
+                accent = accent,
+                selected = accent == selected,
+                onClick = { onSelect(accent) },
+            )
+        }
+    }
+}
+
+// One accent swatch: a >= MinTouchTarget tap target around a circular color chip.
+// A preset shows its seed; DYNAMIC shows a sweep gradient to read as "automatic".
+// The selected chip grows and gains an onSurface ring (color-agnostic, unlike a
+// tinted check that could vanish on a light seed).
+@Composable
+private fun AccentSwatch(
+    accent: AccentColor,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val description = stringResource(accent.labelRes())
+    val seed = accent.accentSeedColor()
+    val ringColor =
+        if (selected) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outlineVariant
+    Box(
+        modifier =
+            modifier
+                .size(FemtoDimens.MinTouchTarget)
+                .clip(CircleShape)
+                .clickable(onClick = onClick)
+                .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        val fill =
+            if (seed != null) {
+                Modifier.background(seed)
+            } else {
+                Modifier.background(Brush.sweepGradient(DynamicAccentSweep))
+            }
+        Box(
+            modifier =
+                Modifier
+                    .size(if (selected) 44.dp else 38.dp)
+                    .clip(CircleShape)
+                    .then(fill)
+                    .border(
+                        width = if (selected) 3.dp else 1.dp,
+                        color = ringColor,
+                        shape = CircleShape,
+                    ),
+        )
     }
 }
 
@@ -541,6 +637,34 @@ private const val MIN_MAP_QUALITY = 30
 private const val MAX_MAP_QUALITY = 100
 
 private fun Boolean.toFullscreen(): FullscreenSetting = if (this) FullscreenSetting.ON else FullscreenSetting.OFF
+
+// The human-readable label for an accent, used as each swatch's content
+// description (the swatches are color-only, so they need an accessible name).
+private fun AccentColor.labelRes(): Int =
+    when (this) {
+        AccentColor.DYNAMIC -> R.string.settings_accent_dynamic
+        AccentColor.BLUE -> R.string.settings_accent_blue
+        AccentColor.TEAL -> R.string.settings_accent_teal
+        AccentColor.GREEN -> R.string.settings_accent_green
+        AccentColor.AMBER -> R.string.settings_accent_amber
+        AccentColor.ORANGE -> R.string.settings_accent_orange
+        AccentColor.RED -> R.string.settings_accent_red
+        AccentColor.VIOLET -> R.string.settings_accent_violet
+        AccentColor.PINK -> R.string.settings_accent_pink
+    }
+
+// Rainbow stops for the DYNAMIC swatch's sweep gradient; the first hue repeats at
+// the end so the sweep closes seamlessly. Signals "automatic / wallpaper-derived".
+private val DynamicAccentSweep =
+    listOf(
+        Color(0xFFEF5350),
+        Color(0xFFFFCA28),
+        Color(0xFF66BB6A),
+        Color(0xFF26C6DA),
+        Color(0xFF42A5F5),
+        Color(0xFFAB47BC),
+        Color(0xFFEF5350),
+    )
 
 // A human-readable label for a font theme (e.g. INTER -> "Inter").
 private fun FontTheme.displayName(): String = name.lowercase().replaceFirstChar(Char::uppercaseChar)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.ui.settings
 
+import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FullscreenSetting
@@ -13,6 +14,7 @@ import io.github.seijikohara.femto.ui.theme.FontTheme
 /** State for the in-app settings screen: the persisted display + font choices. */
 internal data class SettingsUiState(
     val themeMode: ThemeMode,
+    val accentColor: AccentColor,
     val speedUnit: SpeedUnitSetting,
     val temperatureUnit: TemperatureUnitSetting,
     val clock: ClockSetting,
@@ -36,6 +38,7 @@ internal data class SettingsUiState(
         val Initial =
             SettingsUiState(
                 themeMode = DisplaySettings.Default.themeMode,
+                accentColor = DisplaySettings.Default.accentColor,
                 speedUnit = DisplaySettings.Default.speedUnit,
                 temperatureUnit = DisplaySettings.Default.temperatureUnit,
                 clock = DisplaySettings.Default.clock,
@@ -60,6 +63,10 @@ internal data class SettingsUiState(
 internal sealed interface SettingsAction {
     data class SetThemeMode(
         val value: ThemeMode,
+    ) : SettingsAction
+
+    data class SetAccentColor(
+        val value: AccentColor,
     ) : SettingsAction
 
     data class SetSpeedUnit(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -22,6 +22,7 @@ internal class SettingsViewModel(
         combine(displayPreferences.settings, fontPreferences.fontTheme) { display, font ->
             SettingsUiState(
                 themeMode = display.themeMode,
+                accentColor = display.accentColor,
                 speedUnit = display.speedUnit,
                 temperatureUnit = display.temperatureUnit,
                 clock = display.clock,
@@ -46,6 +47,7 @@ internal class SettingsViewModel(
         viewModelScope.launch {
             when (action) {
                 is SettingsAction.SetThemeMode -> displayPreferences.setThemeMode(action.value)
+                is SettingsAction.SetAccentColor -> displayPreferences.setAccentColor(action.value)
                 is SettingsAction.SetSpeedUnit -> displayPreferences.setSpeedUnit(action.value)
                 is SettingsAction.SetTemperatureUnit -> displayPreferences.setTemperatureUnit(action.value)
                 is SettingsAction.SetClock -> displayPreferences.setClock(action.value)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/AccentColors.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/AccentColors.kt
@@ -1,0 +1,25 @@
+package io.github.seijikohara.femto.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import io.github.seijikohara.femto.data.AccentColor
+
+/**
+ * Seed color for each [AccentColor] preset, or null for [AccentColor.DYNAMIC]
+ * (which keeps the Material You wallpaper-derived scheme). Each seed is a vivid
+ * anchor; the full Material 3 tonal scheme is generated from it at theme time.
+ *
+ * This mapping is the single bridge between the Compose-free data enum and the
+ * theme layer, so the swatch UI and [FemtoTheme] read the same colors.
+ */
+internal fun AccentColor.accentSeedColor(): Color? =
+    when (this) {
+        AccentColor.DYNAMIC -> null
+        AccentColor.BLUE -> Color(0xFF2962FF)
+        AccentColor.TEAL -> Color(0xFF00897B)
+        AccentColor.GREEN -> Color(0xFF2E7D32)
+        AccentColor.AMBER -> Color(0xFFFFB300)
+        AccentColor.ORANGE -> Color(0xFFF4511E)
+        AccentColor.RED -> Color(0xFFD32F2F)
+        AccentColor.VIOLET -> Color(0xFF7E57C2)
+        AccentColor.PINK -> Color(0xFFEC407A)
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoTheme.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoTheme.kt
@@ -7,12 +7,16 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import com.materialkolor.rememberDynamicColorScheme
+import io.github.seijikohara.femto.data.AccentColor
 
 /**
  * Root theme for the launcher.
  *
- * Color: Material You dynamic color (always available because minSdk = 33).
- * Falls back to a Bold Minimal monochrome scheme inside Compose previews.
+ * Color: [AccentColor.DYNAMIC] (the default) uses Material You wallpaper-derived
+ * color (always available because minSdk = 33); any other [accent] generates the
+ * Material 3 scheme from a fixed preset seed. Falls back to a Bold Minimal
+ * monochrome scheme inside Compose previews when on the dynamic path.
  *
  * Typography: Bold Minimal weights and automotive sizing on top of M3 roles.
  *
@@ -24,17 +28,26 @@ import androidx.compose.ui.platform.LocalInspectionMode
 @Composable
 fun FemtoTheme(
     fontTheme: FontTheme = FontTheme.INTER,
+    accent: AccentColor = AccentColor.DYNAMIC,
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
     val context = LocalContext.current
     val inPreview = LocalInspectionMode.current
+    val seed = accent.accentSeedColor()
     MaterialTheme(
         colorScheme =
             when {
+                // A fixed preset seed generates a full M3 scheme and works without a
+                // context (so it also previews), so it takes precedence everywhere.
+                seed != null -> rememberDynamicColorScheme(seedColor = seed, isDark = darkTheme)
+
                 inPreview && darkTheme -> DarkFallback
+
                 inPreview -> LightFallback
+
                 darkTheme -> dynamicDarkColorScheme(context)
+
                 else -> dynamicLightColorScheme(context)
             },
         typography = femtoTypography(fontPairOf(fontTheme).latin),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,16 @@
     <string name="settings_option_auto">Auto</string>
     <string name="settings_theme_light">Light</string>
     <string name="settings_theme_dark">Dark</string>
+    <string name="settings_group_accent">Accent color</string>
+    <string name="settings_accent_dynamic">Dynamic</string>
+    <string name="settings_accent_blue">Blue</string>
+    <string name="settings_accent_teal">Teal</string>
+    <string name="settings_accent_green">Green</string>
+    <string name="settings_accent_amber">Amber</string>
+    <string name="settings_accent_orange">Orange</string>
+    <string name="settings_accent_red">Red</string>
+    <string name="settings_accent_violet">Violet</string>
+    <string name="settings_accent_pink">Pink</string>
     <string name="settings_speed_km">km/h</string>
     <string name="settings_speed_mi">mph</string>
     <string name="settings_temp_celsius">°C</string>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.testfixtures
 
+import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.DisplaySettingsStore
@@ -25,6 +26,8 @@ internal class FakeDisplaySettingsStore(
     override val settings: Flow<DisplaySettings> = state
 
     override suspend fun setThemeMode(value: ThemeMode) = state.update { it.copy(themeMode = value) }
+
+    override suspend fun setAccentColor(value: AccentColor) = state.update { it.copy(accentColor = value) }
 
     override suspend fun setSpeedUnit(value: SpeedUnitSetting) = state.update { it.copy(speedUnit = value) }
 

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.ui.settings
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.MapRenderMode
@@ -49,6 +50,14 @@ class SettingsViewModelTest {
             viewModel().onAction(SettingsAction.SetFullscreen(FullscreenSetting.ON))
             advanceUntilIdle()
             assertEquals(FullscreenSetting.ON, store.settings.first().fullscreen)
+        }
+
+    @Test
+    fun `SetAccentColor writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetAccentColor(AccentColor.TEAL))
+            advanceUntilIdle()
+            assertEquals(AccentColor.TEAL, store.settings.first().accentColor)
         }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ ktlintComposeRules = "0.5.9"
 lifecycle = "2.10.0"
 maplibre = "13.2.0"
 material = "1.14.0"
+materialKolor = "4.1.1"
 okhttp = "5.3.2"
 robolectric = "4.16.1"
 splashscreen = "1.2.0"
@@ -49,6 +50,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 maplibre-android = { module = "org.maplibre.gl:android-sdk-opengl", version.ref = "maplibre" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
+material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
 okhttp = { module = "com.squareup.okhttp3:okhttp" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver" }


### PR DESCRIPTION
## Summary

Adds a user-selectable **Accent color** (#21). Material You dynamic color remains the **default**; the user can instead pick a fixed preset whose seed generates the whole Material 3 scheme. The entire app recolors live on selection.

### Mechanism
- `AccentColor` enum (in `data`, Compose-free) — `DYNAMIC` + 8 presets (Blue, Teal, Green, Amber, Orange, Red, Violet, Pink).
- `accentSeedColor()` (in `ui/theme`) maps each preset to a seed `Color`; the only bridge between the data enum and the theme layer.
- `FemtoTheme` gains an `accent` parameter. A preset seed routes through MaterialKolor's `rememberDynamicColorScheme`; `DYNAMIC` keeps the existing dynamic / preview-fallback path unchanged.
- `DisplaySettings.accentColor` (DataStore, default `DYNAMIC`) threads Settings → `MainActivity` → `FemtoTheme`, mirroring the existing display settings.

### UI
A horizontally-scrolling row of swatches in the Display section. Each swatch is a ≥ `MinTouchTarget` tap target; `DYNAMIC` renders a sweep gradient ("automatic"); the selected chip grows and gains an `onSurface` ring (color-agnostic, unlike a tinted check that could vanish on a light seed).

### Dependency
Adds `com.materialkolor:material-kolor` (4.1.1). Compose Material 3 has no public seed→`ColorScheme` generator; MaterialKolor is the idiomatic Compose library for it and resolves cleanly against the AndroidX Compose BOM (verified — no resolution conflict, builds green).

### Rule change
Updates `CLAUDE.md#design-system`: dynamic color is now the **default** rather than always-on; the seed colors in `ui/theme/AccentColors.kt` are the only hardcoded hex outside `Color.kt`.

## Verification
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green. New JVM test: `SettingsViewModelTest."SetAccentColor writes the value to the store"`.
- **Instrumented tests on the `TBox-Mock` emulator** (`SettingsScreenTest`): 5/5 passed, including `tapping_an_accent_swatch_dispatches_set_accent_color`.
- **Visual check on the emulator** (800×480 @ 150 dpi): the swatch row renders with DYNAMIC selected by default; picking **Red** recolors the settings screen and the whole dashboard (card tints, calendar/music accents, section headers) live.