### PR TITLE
feat(dashboard): add a backdrop blur behind the clock and speed panels

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,6 +135,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material3)
     implementation(libs.material.kolor)
+    implementation(libs.haze)
     implementation(libs.composables.icons.lucide)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
@@ -1,6 +1,5 @@
 package io.github.seijikohara.femto.ui.home.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
@@ -17,6 +16,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.rememberHazeState
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
@@ -53,6 +56,7 @@ internal fun ClockOverlay(
     modifier: Modifier = Modifier,
     is24Hour: Boolean = true,
     showSeconds: Boolean = true,
+    hazeState: HazeState = rememberHazeState(),
 ) {
     val now by produceState(initialValue = LocalTime.now(), showSeconds) {
         while (true) {
@@ -72,6 +76,9 @@ internal fun ClockOverlay(
             else -> ClockFormatter12NoSeconds
         }
     val glassAlpha = if (isSystemInDarkTheme()) FemtoDimens.GlassBgAlphaDark else FemtoDimens.GlassBgAlphaLight
+    // Capture the theme colors outside the hazeEffect block, which is a draw-time
+    // lambda and cannot read MaterialTheme.
+    val surfaceColor = MaterialTheme.colorScheme.surface
     Text(
         text = now.format(formatter),
         style =
@@ -86,8 +93,11 @@ internal fun ClockOverlay(
         modifier =
             modifier
                 .clip(RoundedCornerShape(FemtoDimens.OverlayCorner))
-                .background(MaterialTheme.colorScheme.surface.copy(alpha = glassAlpha))
-                .border(
+                .hazeEffect(state = hazeState) {
+                    backgroundColor = surfaceColor
+                    tints = listOf(HazeTint(surfaceColor.copy(alpha = glassAlpha)))
+                    blurRadius = FemtoDimens.GlassBlurRadius
+                }.border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = FemtoDimens.GlassBorderAlpha),
                     shape = RoundedCornerShape(FemtoDimens.OverlayCorner),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
 import io.github.seijikohara.femto.ui.home.HomeAction
 import io.github.seijikohara.femto.ui.home.HomeUiState
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
@@ -176,15 +178,20 @@ private fun MapPane(
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Box(modifier = modifier) {
+    // Shared Haze state: the map registers as the blur source, the glass overlays
+    // sample it for their backdrop blur. Only the snapshot backend (a Compose
+    // Image) can be captured; the Live GL surface falls back to the opaque tint.
+    val hazeState = rememberHazeState()
     MapPanel(
         location = uiState.location,
         mapConfig = mapConfig,
         onTap = { onAction(HomeAction.OpenMaps) },
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize().hazeSource(hazeState),
     )
     ClockOverlay(
         is24Hour = is24Hour,
         showSeconds = showClockSeconds,
+        hazeState = hazeState,
         modifier =
             Modifier
                 .align(Alignment.TopEnd)
@@ -196,6 +203,7 @@ private fun MapPane(
         tripState = uiState.tripState,
         speedUnit = speedUnit,
         onReset = { onAction(HomeAction.ResetTrip) },
+        hazeState = hazeState,
         modifier =
             Modifier
                 .align(Alignment.BottomCenter)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -41,6 +41,10 @@ import androidx.compose.ui.unit.sp
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.MapPin
 import com.composables.icons.lucide.RotateCcw
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.rememberHazeState
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.ShortAddress
 import io.github.seijikohara.femto.data.TripState
@@ -92,6 +96,7 @@ internal fun SpeedOverlay(
     speedUnit: SpeedUnit,
     onReset: () -> Unit,
     modifier: Modifier = Modifier,
+    hazeState: HazeState = rememberHazeState(),
 ) {
     // Source the hero numeral from the trip's effective speed, not
     // location.speed: cheap GPS chips leave Location.speed at 0.0
@@ -118,6 +123,9 @@ internal fun SpeedOverlay(
     // altitude readout rather than showing a misleading 0.
     val altitudeM = location?.takeIf { it.hasAltitude() }?.altitude?.roundToInt()
     val glassAlpha = if (isSystemInDarkTheme()) FemtoDimens.GlassBgAlphaDark else FemtoDimens.GlassBgAlphaLight
+    // Capture the surface color outside the draw-time hazeEffect block, which
+    // cannot read MaterialTheme.
+    val surfaceColor = MaterialTheme.colorScheme.surface
     Column(
         modifier =
             modifier
@@ -132,8 +140,11 @@ internal fun SpeedOverlay(
                 // maximum, and the address row ellipsizes within it.
                 .widthIn(max = FemtoDimens.SpeedOverlayMaxWidth)
                 .clip(RoundedCornerShape(FemtoDimens.SpeedOverlayCorner))
-                .background(MaterialTheme.colorScheme.surface.copy(alpha = glassAlpha))
-                .border(
+                .hazeEffect(state = hazeState) {
+                    backgroundColor = surfaceColor
+                    tints = listOf(HazeTint(surfaceColor.copy(alpha = glassAlpha)))
+                    blurRadius = FemtoDimens.GlassBlurRadius
+                }.border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = FemtoDimens.GlassBorderAlpha),
                     shape = RoundedCornerShape(FemtoDimens.SpeedOverlayCorner),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -124,22 +124,29 @@ object FemtoDimens {
     val ArtCorner = 14.dp
 
     /**
-     * Glass overlay background opacity in light theme.
+     * Glass overlay tint opacity in light theme: the surface tint laid over the
+     * blurred map backdrop (the clock / speed panels use Haze). Kept below a fully
+     * opaque scrim so the backdrop blur stays visible while text contrast holds; on
+     * the Live map backend (no captured backdrop) the panel falls back to an opaque
+     * surface base under this tint, so it stays legible there too.
      *
      * The glass alpha tokens keep the PascalCase token vocabulary of this object
      * rather than ktlint's SCREAMING_SNAKE_CASE for `const val`, so they read as
      * siblings of the dp tokens above.
      */
     @Suppress("ktlint:standard:property-naming")
-    const val GlassBgAlphaLight = 0.78f
+    const val GlassBgAlphaLight = 0.6f
 
-    /** Glass overlay background opacity in dark theme — more translucent so the darker map reads through. */
+    /** Glass overlay tint opacity in dark theme — more translucent so the darker blurred map reads through. */
     @Suppress("ktlint:standard:property-naming")
-    const val GlassBgAlphaDark = 0.55f
+    const val GlassBgAlphaDark = 0.42f
 
     /** Glass overlay hairline border opacity, shared across light and dark themes. */
     @Suppress("ktlint:standard:property-naming")
     const val GlassBorderAlpha = 0.6f
+
+    /** Backdrop blur radius for the glass overlays (clock / speed) over the map. */
+    val GlassBlurRadius = 24.dp
 
     /**
      * App-drawer bottom-sheet height as a fraction of the viewport, so the

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ composeBom = "2026.05.01"
 coreKtx = "1.19.0"
 datastore = "1.2.1"
 espressoCore = "3.7.0"
+haze = "1.7.2"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 kotlin = "2.4.0"
@@ -44,6 +45,7 @@ androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-ru
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 composables-icons-lucide = { module = "com.composables:icons-lucide", version.ref = "composablesIconsLucide" }
+haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }


### PR DESCRIPTION
## Summary

The clock and speed glass overlays now **blur the map behind them** instead of laying a flat scrim over it (#19), so they read as frosted glass.

- `MapPanel` registers as the Haze blur source (`hazeSource`); the overlays sample it through a shared `HazeState` (`hazeEffect`) and render the blurred backdrop plus a surface tint.
- Lowered the glass tint alphas (0.78 → 0.6 light, 0.55 → 0.42 dark) so the blur stays visible while text contrast holds; added `FemtoDimens.GlassBlurRadius` (24 dp).
- Only the snapshot backend (a Compose `Image`) can be captured for blur; the Live GL surface falls back to the opaque tint base, as do previews and tests — each gets its own empty `HazeState` via the `rememberHazeState()` default, so no preview or test signatures changed.

## Dependency
Adds `dev.chrisbanes.haze:haze` (1.7.2). Compose has no built-in backdrop blur; Haze is the standard library for it and resolves cleanly against the AndroidX Compose BOM (builds green).

## Verification
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.
- **Visual check on the `TBox-Mock` emulator** (800×480 @ 150 dpi) with the snapshot map rendering: the clock and speed panels show a frosted-glass blur — the map detail directly behind each panel is softened while the surrounding tiles stay sharp.