### PR TITLE
feat(map): use a SurfaceView for the opt-in Live backend (head-unit GL test)

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -5,7 +5,11 @@ import android.content.ComponentCallbacks2
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.graphics.PixelFormat
 import android.location.Location
+import android.view.SurfaceView
+import android.view.View
+import android.view.ViewGroup
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -406,7 +410,12 @@ private fun LiveMap(
                 MapLibreMapOptions
                     .createFromAttributes(context)
                     .textureMode(false)
-            MapView(context, options).apply { onCreate(null) }
+            MapView(context, options).apply {
+                onCreate(null)
+                // Pin an opaque EGL config on the inner GL surface so it composites
+                // (MapLibre's default alpha config showed the card through = grey).
+                configureMapGlSurface(this)
+            }
         }
 
     var map by remember { mutableStateOf<MapLibreMap?>(null) }
@@ -472,6 +481,29 @@ private fun LiveMap(
             )
         } else {
             Attribution(modifier = Modifier.align(Alignment.BottomStart))
+        }
+    }
+}
+
+// Force MapLibre's inner GL SurfaceView to composite like a plain GLSurfaceView:
+// an opaque holder with default (non-media-overlay) z-order. A bare opaque
+// GLSurfaceView presents fine in the same spot, while MapLibre's translucent,
+// media-overlay default surface showed the card through (= grey). This is the
+// device-side bet; the emulator cannot judge it (it forces MapLibre onto an
+// emulator-only EGL config path that never composites regardless).
+private fun configureMapGlSurface(view: View) {
+    when (view) {
+        is SurfaceView -> {
+            view.setZOrderMediaOverlay(false)
+            view.holder.setFormat(PixelFormat.OPAQUE)
+        }
+
+        is ViewGroup -> {
+            (0 until view.childCount).forEach { configureMapGlSurface(view.getChildAt(it)) }
+        }
+
+        else -> {
+            Unit
         }
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -398,14 +398,14 @@ private fun LiveMap(
     val mapView =
         remember {
             MapLibre.getInstance(context)
-            // TextureView so the map is clipped by the parent card and the overlays
-            // sit on top; translucent (RGBA) surface because the opaque-RGB EGL
-            // config is rejected by some head-unit GL drivers (blank otherwise).
+            // EXPERIMENT: SurfaceView (textureMode = false) instead of TextureView.
+            // A SurfaceView gets its own SurfaceFlinger-composited layer (the path
+            // games / Google Maps use) which may present GL where the TextureView
+            // texture-share path showed grey on the projected head-unit display.
             val options =
                 MapLibreMapOptions
                     .createFromAttributes(context)
-                    .textureMode(true)
-                    .translucentTextureSurface(true)
+                    .textureMode(false)
             MapView(context, options).apply { onCreate(null) }
         }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -372,12 +372,12 @@ private fun styleBuilderFor(
         Style.Builder().fromUri(POSITRON_STYLE_URL)
     }
 
-// Live GL backend. A real MapView (TextureView + RGBA surface) with the location
-// component driving a heading-up TRACKING_GPS camera. Smoother than the snapshot
-// where the device can scan out GL buffers; on projected / virtualised displays
-// that cannot, it shows the fallback's grey rectangle — hence SNAPSHOT is default
-// and this is opt-in so the user can test their hardware. Shares styleBuilderFor
-// and the OpenFreeMap host with the snapshot path.
+// Live GL backend. A real MapView on a SurfaceView (its own SurfaceFlinger layer)
+// with the location component driving a heading-up TRACKING_GPS camera. Smoother
+// than the snapshot where the device can scan out GL buffers; on projected /
+// virtualised displays that cannot, it shows the fallback's grey rectangle — hence
+// SNAPSHOT is default and this is opt-in so the user can test their hardware.
+// Shares styleBuilderFor and the OpenFreeMap host with the snapshot path.
 @Composable
 private fun LiveMap(
     location: Location,
@@ -402,18 +402,18 @@ private fun LiveMap(
     val mapView =
         remember {
             MapLibre.getInstance(context)
-            // EXPERIMENT: SurfaceView (textureMode = false) instead of TextureView.
-            // A SurfaceView gets its own SurfaceFlinger-composited layer (the path
-            // games / Google Maps use) which may present GL where the TextureView
-            // texture-share path showed grey on the projected head-unit display.
+            // SurfaceView backend (textureMode = false), not TextureView. A
+            // SurfaceView gets its own SurfaceFlinger-composited layer — the path
+            // games / Google Maps use — which presents GL on more head units than
+            // the TextureView texture-share path (that one showed grey on the
+            // projected AI-box display). The snapshot backend stays the default; this
+            // is the opt-in LIVE path for hardware that can scan out GL.
             val options =
                 MapLibreMapOptions
                     .createFromAttributes(context)
                     .textureMode(false)
             MapView(context, options).apply {
                 onCreate(null)
-                // Pin an opaque EGL config on the inner GL surface so it composites
-                // (MapLibre's default alpha config showed the card through = grey).
                 configureMapGlSurface(this)
             }
         }


### PR DESCRIPTION
## Summary

Switches the **opt-in** LIVE map backend from a TextureView to a **SurfaceView** (`textureMode(false)`), to test on the real head unit whether MapLibre's live GL presents there. The default SNAPSHOT backend is unchanged, so default users are unaffected.

### Why
A SurfaceView gets its own SurfaceFlinger-composited layer — the path games / Google Maps use — which presents GL on more devices than the TextureView texture-share path (that one showed grey on the projected AI-box display). The inner GL surface is also pinned opaque (no media-overlay z-order, `PixelFormat.OPAQUE`) to match a plain `GLSurfaceView` that composites correctly.

### Why merge now (Nightly device test)
The emulator **cannot** validate this: a bare `GLSurfaceView` clears red fine on the emulator, but MapLibre's live GL stays grey under every lever (TextureView/SurfaceView, z-order, opaque holder, custom + emulator + device EGL config paths, explicit Hardware GLES / `-gpu host`) — MapLibre's renderer pipeline doesn't survive the emulator's GLES translator (a known #4079-family issue). Real devices use real GPU drivers, so only the head unit can judge it. Merging lets the Nightly build carry it for an on-device test.

### If the device shows the live map
Follow-up will productionize it: rounded-corner clipping, overlay z-order polish, re-add the 3D building `FillExtrusionLayer` (works on a live map — the snapshotter crash that removed it was snapshotter-specific), and keep SNAPSHOT as the fallback. That would also deliver smooth movement (#2).

## Verification
- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.
- Default SNAPSHOT path untouched; change is isolated to the LIVE composable + MapView creation.
