### PR TITLE
fix(calendar): guard event-observer registration when calendar is denied

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
@@ -191,6 +191,16 @@ internal class CalendarRepository(
      * Re-emit whenever the calendar provider notifies a change. Debounced
      * because edit / delete operations on a single event can fire several
      * notifications in quick succession.
+     *
+     * Registering an observer on the calendar provider requires `READ_CALENDAR`;
+     * without it `registerContentObserver` throws `SecurityException`. On a
+     * launcher that would crash the home screen on every cold start until the
+     * user grants the calendar, so a denied (or racing-revoked) grant skips
+     * registration rather than throwing. The card already renders the denial
+     * fallback from the clock alone (see [snapshotFlow]), and a grant that
+     * arrives later is picked up on the next clock tick, which re-runs
+     * [buildSnapshot] and its permission check. This mirrors [readWindow], whose
+     * `runCatching` already guards the query side against the same fault.
      */
     private fun calendarChangeFlow(): Flow<Unit> =
         callbackFlow {
@@ -199,13 +209,19 @@ internal class CalendarRepository(
                     trySend(Unit)
                 }
             }
-            context.contentResolver.registerContentObserver(
-                CalendarContract.Events.CONTENT_URI,
-                // notifyForDescendants =
-                true,
-                observer,
-            )
-            awaitClose { context.contentResolver.unregisterContentObserver(observer) }
+            val registered =
+                hasPermission() &&
+                    runCatching {
+                        context.contentResolver.registerContentObserver(
+                            CalendarContract.Events.CONTENT_URI,
+                            // notifyForDescendants =
+                            true,
+                            observer,
+                        )
+                    }.isSuccess
+            awaitClose {
+                if (registered) context.contentResolver.unregisterContentObserver(observer)
+            }
         }.debounce(CHANGE_DEBOUNCE_MS)
 
     private companion object {


### PR DESCRIPTION
## Summary

Fixes a launcher crash on cold start when `READ_CALENDAR` is denied.

`CalendarRepository.calendarChangeFlow()` registered a `ContentObserver` on
the calendar provider unconditionally. `registerContentObserver` requires
`READ_CALENDAR`; without the grant it throws `SecurityException`, which —
uncaught inside the `callbackFlow` producer — crashed the home screen on
every cold start the user had not granted the calendar. This broke the
documented contract (class KDoc) that the card falls back to a clock-only
snapshot when access is denied. `readWindow()` (the query side) was already
guarded with `runCatching` + a permission check; only the observer
registration was not.

## Fix

Check the permission and wrap the registration in `runCatching` before
subscribing, mirroring `readWindow`'s guard. A denied or racing-revoked
grant skips registration instead of throwing; a grant that arrives later is
picked up on the next clock tick (which re-runs `buildSnapshot` and its
permission check).

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — green.
- On an Android 13 device with `READ_CALENDAR` revoked: the dashboard renders
  the "Calendar access not granted" fallback with no crash. Before the fix the
  same scenario produced a FATAL `SecurityException` at `CalendarRepository.kt`
  (`registerContentObserver`).

Robolectric does not enforce the permission on `registerContentObserver`, so
the framework-enforced crash cannot be reproduced in a JVM test; the existing
denied-path unit test covers the clock-only contract and the crash itself is
verified on-device.
