### PR TITLE
fix(map): stop LIVE falling back to snapshot after it renders

### DIFF
--- a/app/src/main/assets/web/map.html
+++ b/app/src/main/assets/web/map.html
@@ -37,16 +37,19 @@
           zoom: 1,
           attributionControl: false,
         });
+        // Report ready on the first rendered frame via map.on("load"), NOT
+        // map.once("idle"). "idle" means nothing is left to render; the heading-up
+        // camera eases (easeTo) toward every GPS fix, so on a moving vehicle idle
+        // never fires and a perfectly working map would hit the ready timeout and
+        // fall back to SNAPSHOT. "load" fires once the style and first frame are up.
         let ready = false;
-        map.on("load", () =>
-          map.once("idle", () => {
-            if (!ready) { ready = true; report("onMapReady"); }
-          }),
-        );
-        map.on("error", (e) => {
-          const msg = (e && e.error && e.error.message) || "map-error";
-          if (/webgl|context|gl\b/i.test(msg)) report("onWebGlFailed", msg);
+        map.on("load", () => {
+          if (!ready) { ready = true; report("onMapReady"); }
         });
+        // Tile / style fetch errors (OpenFreeMap is a no-SLA host) are NOT WebGL
+        // failures and recover on their own — never fall back on them. Real WebGL
+        // unavailability is caught by the getContext probe above, the constructor
+        // try/catch, and the webglcontextlost listener below (a lost GPU context).
         setTimeout(() => {
           const cv = document.querySelector("#map canvas");
           if (cv) cv.addEventListener("webglcontextlost", (ev) => { ev.preventDefault(); report("onWebGlFailed", "context-lost"); });

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -113,9 +113,9 @@ internal data class MapConfig(
  *   single-flight, holding the previous frame so there is no flicker.
  * - LIVE ([WebMapView]) renders MapLibre GL JS (WebGL) in a WebView, which
  *   composites inline through HWUI and animates the camera for a smooth follow.
- *   It stages down to SNAPSHOT when WebGL is unavailable, its GPU context is
- *   lost, or no frame arrives within [WEBGL_READY_TIMEOUT_MS] — so a map always
- *   shows.
+ *   It stages down to SNAPSHOT when WebGL is unavailable or no frame arrives
+ *   within [WEBGL_READY_TIMEOUT_MS]; once the map has rendered, only a lost GPU
+ *   context drops it — so a working map is never lost to transient noise.
  *
  * Clock and speed overlays are placed by the parent on top of this surface.
  */
@@ -165,7 +165,10 @@ internal fun MapPanel(
                             mapConfig = mapConfig,
                             onTap = onTap,
                             onReady = { webGlReady = true },
-                            onFail = { webGlDown = true },
+                            // Before ready, any failure drops to the snapshot. After
+                            // ready, only a fatal one (lost GPU context) does — a
+                            // working map is not dropped on transient noise.
+                            onFail = { fatal -> if (fatal || !webGlReady) webGlDown = true },
                             modifier = Modifier.fillMaxSize(),
                         )
                         LaunchedEffect(Unit) {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -39,10 +39,14 @@ import io.github.seijikohara.femto.data.MapStyleSetting
  * `map.easeTo()` for heading-up smooth follow — this is how #2 smooth movement is
  * delivered (the JS eases between sparse fixes).
  *
- * The page reports health over the `AndroidMapBridge` JS interface: [onReady] once a
- * frame has rendered, [onFail] when WebGL is unavailable or its context is lost
- * (e.g. a GPU-process crash). The caller falls back to the SNAPSHOT backend on
- * [onFail] or a ready timeout, so a map always shows.
+ * The page reports health over the `AndroidMapBridge` JS interface: [onReady] once
+ * the style and first frame have loaded (`map.on("load")` — not `idle`, which never
+ * fires while the heading-up camera keeps easing between GPS fixes), and [onFail]
+ * when WebGL is unavailable or its GPU context is lost. [onFail]'s `fatal` flag is
+ * true only for a lost context (a hard failure that must fall back even after a
+ * successful render); the caller drops to SNAPSHOT before the map is ready (any
+ * [onFail] or a ready timeout) and, once ready, only on a fatal [onFail] — so a
+ * working map is never lost to transient noise such as a tile fetch error.
  */
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -51,7 +55,7 @@ internal fun WebMapView(
     mapConfig: MapConfig,
     onTap: () -> Unit,
     onReady: () -> Unit,
-    onFail: () -> Unit,
+    onFail: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -81,8 +85,11 @@ internal fun WebMapView(
                         @JavascriptInterface
                         fun onMapReady() = mainHandler.post { onReadyState.value() }
 
+                        // fatal = a lost GPU context, which must fall back even after
+                        // a successful render; other reasons only matter before ready.
                         @JavascriptInterface
-                        fun onWebGlFailed(reason: String) = mainHandler.post { onFailState.value() }
+                        fun onWebGlFailed(reason: String) =
+                            mainHandler.post { onFailState.value(reason == "context-lost") }
                     },
                     "AndroidMapBridge",
                 )


### PR DESCRIPTION
## Summary

Follow-up to #84. On the real head unit, selecting **LIVE** rendered the
MapLibre GL JS WebGL map smoothly for a few seconds and then fell back to the
SNAPSHOT bitmap. The WebGL backend was actually working on the device GPU
(Stage 1) — the fallback fired on a **false signal**, not a render failure.

## Root causes

1. **Ready was reported on `map.once("idle")`.** `idle` means "nothing left to
   render", but the heading-up camera eases (`easeTo`) toward every GPS fix, so
   on a moving vehicle `idle` never fires. `onMapReady` never arrived and the
   10 s ready timeout dropped a working map to SNAPSHOT (the "few seconds" was
   the timeout window).
2. **A transient `map.on("error")` triggered a fallback.** A tile fetch failing
   on the no-SLA OpenFreeMap host matched a loose `/webgl|context|gl\b/` test
   and was treated as a WebGL failure.

## Fix

- Report ready on **`map.on("load")`** (style + first frame up), not `idle`.
- **Stop falling back on `map.on("error")`** entirely — real WebGL loss is
  caught by the `getContext` probe, the constructor `try/catch`, and the
  `webglcontextlost` listener.
- **Harden the gate:** once the map has rendered (`onReady`), only a *fatal*
  failure (a lost GPU context, reason `context-lost`) drops to SNAPSHOT;
  failures *before* ready still fall back. `WebMapView`'s `onFail` now carries a
  `fatal` flag. A map that has drawn frames is no longer lost to transient noise.

SNAPSHOT remains the default `MapRenderMode` and the floor for genuine WebGL
unavailability, so the safe-fallback guarantee is unchanged.

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin`
  — green.
- Device re-test of LIVE pending (expected: the WebGL map now stays up instead
  of dropping to SNAPSHOT after a few seconds).
