### PR TITLE
feat(map): replace LIVE auto-fallback with a manual snapshot switch

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -30,6 +30,7 @@ import io.github.seijikohara.femto.data.DisplayPreferences
 import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.data.SystemPermissionSignals
 import io.github.seijikohara.femto.data.ThemeMode
 import io.github.seijikohara.femto.data.hasBluetoothConnectPermission
@@ -233,6 +234,14 @@ class MainActivity : ComponentActivity() {
                 // Close the drawer overlay so the two bottom sheets never stack.
                 setShowDrawer(false)
                 setShowAssistant(true)
+            }
+
+            HomeEvent.UseSnapshotMap -> {
+                // The live WebGL map failed on this device; persist the snapshot
+                // backend so the dashboard shows the reliable bitmap map instead.
+                lifecycleScope.launch {
+                    displayPreferences.setMapRenderMode(MapRenderMode.SNAPSHOT)
+                }
             }
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
@@ -35,4 +35,11 @@ internal sealed interface HomeAction {
     data object OpenAssistant : HomeAction
 
     data object ResetTrip : HomeAction
+
+    /**
+     * Switch the persisted map render mode to SNAPSHOT. Raised from the live-map
+     * error surface when WebGL is unavailable on this device, so the user opts into
+     * the reliable snapshot backend instead of being silently downgraded.
+     */
+    data object UseSnapshotMap : HomeAction
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
@@ -47,4 +47,11 @@ internal sealed interface HomeEvent {
 
     /** Open the voice-assistant bottom sheet so the user picks which assistant intent to fire. */
     data object OpenAssistantSheet : HomeEvent
+
+    /**
+     * Persist `MapRenderMode.SNAPSHOT`. The host owns the display preferences, so
+     * the live-map error surface requests the switch through this event rather than
+     * writing the preference from the dashboard tree.
+     */
+    data object UseSnapshotMap : HomeEvent
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -148,6 +148,10 @@ internal class HomeViewModel(
             HomeAction.ResetTrip -> {
                 resetTrip()
             }
+
+            HomeAction.UseSnapshotMap -> {
+                mutableEvents.tryEmit(HomeEvent.UseSnapshotMap)
+            }
         }
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -186,6 +186,7 @@ private fun MapPane(
         location = uiState.location,
         mapConfig = mapConfig,
         onTap = { onAction(HomeAction.OpenMaps) },
+        onUseSnapshot = { onAction(HomeAction.UseSnapshotMap) },
         modifier = Modifier.fillMaxSize().hazeSource(hazeState),
     )
     ClockOverlay(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -20,10 +20,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -50,6 +53,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -60,10 +64,13 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.MapPinOff
+import io.github.seijikohara.femto.BuildConfig
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.data.MapStyleSetting
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -113,9 +120,10 @@ internal data class MapConfig(
  *   single-flight, holding the previous frame so there is no flicker.
  * - LIVE ([WebMapView]) renders MapLibre GL JS (WebGL) in a WebView, which
  *   composites inline through HWUI and animates the camera for a smooth follow.
- *   It stages down to SNAPSHOT when WebGL is unavailable or no frame arrives
- *   within [WEBGL_READY_TIMEOUT_MS]; once the map has rendered, only a lost GPU
- *   context drops it — so a working map is never lost to transient noise.
+ *   It does NOT auto-downgrade: when WebGL is unavailable or no frame arrives
+ *   within [WEBGL_READY_TIMEOUT_MS] it shows [LiveUnsupported], offering a manual
+ *   switch to SNAPSHOT. The two backends differ visually (only SNAPSHOT draws the
+ *   location marker), so a silent switch would confuse — the user opts in.
  *
  * Clock and speed overlays are placed by the parent on top of this surface.
  */
@@ -124,6 +132,7 @@ internal fun MapPanel(
     location: Location?,
     mapConfig: MapConfig,
     onTap: () -> Unit,
+    onUseSnapshot: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
@@ -146,17 +155,17 @@ internal fun MapPanel(
                 }
 
                 MapRenderMode.LIVE -> {
-                    // Staged fallback: Hardware/Software WebGL ([WebMapView]) -> SNAPSHOT.
-                    // WebMapView reports ready (cancels the timeout) or failed (WebGL
-                    // unavailable / GPU-process crash); either a failure or a ready
-                    // timeout drops to the snapshot bitmap so a map always shows.
-                    var webGlDown by remember { mutableStateOf(false) }
+                    // LIVE renders the WebGL map ([WebMapView]) and does NOT silently
+                    // downgrade to SNAPSHOT: a WebGL failure (reason from the bridge)
+                    // or a ready timeout shows [LiveUnsupported], which offers a manual
+                    // switch. The backends differ visually, so a silent swap confuses.
+                    var failReason by remember { mutableStateOf<String?>(null) }
                     var webGlReady by remember { mutableStateOf(false) }
-                    if (webGlDown) {
-                        SnapshotMap(
-                            location = location,
-                            mapConfig = mapConfig,
-                            onTap = onTap,
+                    val reason = failReason
+                    if (reason != null) {
+                        LiveUnsupported(
+                            reason = reason,
+                            onUseSnapshot = onUseSnapshot,
                             modifier = Modifier.fillMaxSize(),
                         )
                     } else {
@@ -165,15 +174,12 @@ internal fun MapPanel(
                             mapConfig = mapConfig,
                             onTap = onTap,
                             onReady = { webGlReady = true },
-                            // Before ready, any failure drops to the snapshot. After
-                            // ready, only a fatal one (lost GPU context) does — a
-                            // working map is not dropped on transient noise.
-                            onFail = { fatal -> if (fatal || !webGlReady) webGlDown = true },
+                            onFail = { failReason = it },
                             modifier = Modifier.fillMaxSize(),
                         )
                         LaunchedEffect(Unit) {
                             delay(WEBGL_READY_TIMEOUT_MS)
-                            if (!webGlReady) webGlDown = true
+                            if (!webGlReady) failReason = READY_TIMEOUT_REASON
                         }
                     }
                 }
@@ -497,15 +503,80 @@ private fun Fallback(modifier: Modifier = Modifier) =
         )
     }
 
+// Shown when LIVE is selected but WebGL is unavailable on this device (or the map
+// never reported a frame within the timeout). LIVE deliberately does not
+// auto-downgrade — the backends look different (only SNAPSHOT draws the location
+// marker), so a silent switch is confusing. Offer an explicit switch to SNAPSHOT
+// instead. The failure reason is shown in debug builds only, to aid diagnosis.
+@Composable
+private fun LiveUnsupported(
+    reason: String,
+    onUseSnapshot: () -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier = modifier.fillMaxSize().padding(24.dp),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+) {
+    Icon(
+        imageVector = Lucide.MapPinOff,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(40.dp),
+    )
+    Text(
+        text = stringResource(R.string.map_live_unavailable_title),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(top = 8.dp),
+    )
+    Text(
+        text = stringResource(R.string.map_live_unavailable_body),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(top = 4.dp),
+    )
+    Button(
+        onClick = onUseSnapshot,
+        modifier =
+            Modifier
+                .padding(top = 16.dp)
+                .heightIn(min = FemtoDimens.MinTouchTarget)
+                .widthIn(min = FemtoDimens.MinTouchTarget),
+    ) {
+        Text(text = stringResource(R.string.map_live_use_snapshot))
+    }
+    if (BuildConfig.DEBUG) {
+        Text(
+            text = reason,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun LiveUnsupportedPreview() =
+    FemtoTheme {
+        LiveUnsupported(reason = "context-lost", onUseSnapshot = {})
+    }
+
 // internal so MapSnapshotRenderTest renders the SAME style host / zoom the panel
 // uses, keeping the OpenFreeMap style URL and zoom a single source of truth.
 internal const val MAP_ZOOM = 16.5
 internal const val POSITRON_STYLE_URL = "https://tiles.openfreemap.org/styles/positron"
 private const val DARK_STYLE_ASSET = "map/dark.json"
 
-// Fall back from the WebGL map to the snapshot bitmap if it has not reported a
+// Show the live-map-unavailable surface if the WebGL map has not reported a
 // rendered frame within this window (covers a silent WebGL failure with no event).
 private const val WEBGL_READY_TIMEOUT_MS = 10_000L
+
+// Reason surfaced (debug only) when the timeout above elapses with no frame.
+private const val READY_TIMEOUT_REASON = "ready-timeout"
 
 // Re-render once a fix moves at least this far; below it the last frame is held.
 // Kept small so the map follows movement in smaller steps (smoother panning); the

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -42,11 +42,11 @@ import io.github.seijikohara.femto.data.MapStyleSetting
  * The page reports health over the `AndroidMapBridge` JS interface: [onReady] once
  * the style and first frame have loaded (`map.on("load")` — not `idle`, which never
  * fires while the heading-up camera keeps easing between GPS fixes), and [onFail]
- * when WebGL is unavailable or its GPU context is lost. [onFail]'s `fatal` flag is
- * true only for a lost context (a hard failure that must fall back even after a
- * successful render); the caller drops to SNAPSHOT before the map is ready (any
- * [onFail] or a ready timeout) and, once ready, only on a fatal [onFail] — so a
- * working map is never lost to transient noise such as a tile fetch error.
+ * with a short reason (`context-lost`, `no-webgl-context`, `exception:...`) when
+ * WebGL is unavailable or its GPU context is lost. The caller does not silently
+ * fall back: it surfaces a live-map-unavailable message offering a manual switch
+ * to the SNAPSHOT backend, so the map never changes appearance behind the user's
+ * back.
  */
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -55,7 +55,7 @@ internal fun WebMapView(
     mapConfig: MapConfig,
     onTap: () -> Unit,
     onReady: () -> Unit,
-    onFail: (Boolean) -> Unit,
+    onFail: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -85,11 +85,10 @@ internal fun WebMapView(
                         @JavascriptInterface
                         fun onMapReady() = mainHandler.post { onReadyState.value() }
 
-                        // fatal = a lost GPU context, which must fall back even after
-                        // a successful render; other reasons only matter before ready.
+                        // Forward the failure reason verbatim; the caller surfaces it
+                        // (debug) and offers a manual switch to the SNAPSHOT backend.
                         @JavascriptInterface
-                        fun onWebGlFailed(reason: String) =
-                            mainHandler.post { onFailState.value(reason == "context-lost") }
+                        fun onWebGlFailed(reason: String) = mainHandler.post { onFailState.value(reason) }
                     },
                     "AndroidMapBridge",
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,9 @@
     <string name="map_unavailable">Map unavailable</string>
     <string name="map_permission_cta">Grant location access to enable the map and overlays.</string>
     <string name="map_attribution">© OpenStreetMap · OpenMapTiles · OpenFreeMap</string>
+    <string name="map_live_unavailable_title">Live map unavailable</string>
+    <string name="map_live_unavailable_body">This device cannot render the real-time map. Switch to the snapshot map for a reliable still view.</string>
+    <string name="map_live_use_snapshot">Switch to snapshot map</string>
 
     <!-- Speed overlay -->
     <string name="speed_reset_trip">Reset trip</string>

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -180,6 +180,15 @@ class HomeViewModelTest {
         }
 
     @Test
+    fun `onAction UseSnapshotMap emits UseSnapshotMap event`() =
+        runTest {
+            stubViewModel().assertEvent(
+                action = HomeAction.UseSnapshotMap,
+                expected = HomeEvent.UseSnapshotMap,
+            )
+        }
+
+    @Test
     fun `onAction ConnectMusicPlayer emits OpenNotificationListenerSettings`() =
         runTest {
             stubViewModel().assertEvent(


### PR DESCRIPTION
## Summary

Follow-up to #86. On the real head unit, LIVE still dropped to SNAPSHOT after a
few seconds. Two problems, addressed here:

1. The auto-downgrade was confusing — the backends look different (only SNAPSHOT
   draws the location marker), so a silent swap is jarring.
2. The downgrade fired even though the WebGL map was rendering, so the trigger is
   a false signal (a ready timeout or a transient event), not a real render
   failure.

Per the maintainer's request, **LIVE no longer auto-downgrades**. Instead:

- When WebGL is unavailable (reason from the JS bridge) or no frame arrives
  within `WEBGL_READY_TIMEOUT_MS`, `MapPanel` shows a new `LiveUnsupported`
  surface: an explanation that the device cannot render the real-time map, plus a
  **"Switch to snapshot map"** button.
- The button persists `MapRenderMode.SNAPSHOT` via a new
  `HomeAction.UseSnapshotMap` → `HomeEvent.UseSnapshotMap` → `MainActivity` (the
  host owns `DisplayPreferences`, matching the Settings flow).
- `WebMapView.onFail` now carries the failure **reason** (string) instead of a
  fatal flag. The reason is shown **in debug builds only**, so the next on-device
  test reveals *why* LIVE drops (e.g. `context-lost` vs `ready-timeout`).

`SNAPSHOT` remains the default render mode and renders identically on every
device, so users who never enable LIVE are unaffected.

## Why this also helps diagnosis

The reason text means the device test now reports the failure cause directly,
which #84/#86 could not (the WebView's WebGL is not capturable via screencap).

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin`
  — green. Added a `HomeViewModelTest` case for the new action.
- `compose-launcher-reviewer`: no blocking findings; applied the width-direction
  touch target and a `@PreviewLightDark` preview.

## Device test (follow-up)

Select LIVE. Expected: the WebGL map stays, or — if WebGL truly fails — a clear
"Live map unavailable" screen with a switch button (and, in this debug build, the
reason). Please report the reason text shown so the root cause of the drop can be
fixed.
