### PR TITLE
fix(map): survive transient WebGL context loss instead of falling back

### DIFF
--- a/app/src/main/assets/web/map.html
+++ b/app/src/main/assets/web/map.html
@@ -16,8 +16,11 @@
   <body>
     <div id="map"></div>
     <script>
-      // Report map health to the Android host (WebMapView @JavascriptInterface) so it
-      // can fall back Hardware WebGL -> Software WebGL -> SNAPSHOT.
+      // Grace period (ms) to let MapLibre restore a lost GL context before the loss
+      // is treated as persistent and the host falls back to the snapshot backend.
+      var CONTEXT_RESTORE_GRACE_MS = 6000;
+
+      // Report map health to the Android host (WebMapView @JavascriptInterface).
       function report(fn, arg) {
         try {
           if (window.AndroidMapBridge && window.AndroidMapBridge[fn]) window.AndroidMapBridge[fn](arg || "");
@@ -37,23 +40,42 @@
           zoom: 1,
           attributionControl: false,
         });
-        // Report ready on the first rendered frame via map.on("load"), NOT
-        // map.once("idle"). "idle" means nothing is left to render; the heading-up
-        // camera eases (easeTo) toward every GPS fix, so on a moving vehicle idle
-        // never fires and a perfectly working map would hit the ready timeout and
-        // fall back to SNAPSHOT. "load" fires once the style and first frame are up.
+        // Report ready on the first ACTUALLY-RENDERED frame after the style is
+        // applied, not on map.on("load"). In a WebView "load" can stall or never
+        // fire (a sprite/glyph/style fetch on the no-SLA host, or a zero-size
+        // container) while the map is visibly drawing — which previously hit the
+        // 10s ready timeout and fell back. The first "render" after isStyleLoaded()
+        // means real pixels are on screen; it also re-fires after a context restore.
         let ready = false;
-        map.on("load", () => {
+        function markReady() {
           if (!ready) { ready = true; report("onMapReady"); }
+        }
+        map.on("render", () => { if (map.isStyleLoaded()) markReady(); });
+        map.on("load", markReady); // belt-and-suspenders if render is missed
+
+        // WebGL context loss is usually TRANSIENT on mobile / WebView GPUs, and
+        // MapLibre auto-recovers: it preventDefault()s the loss, saves the style,
+        // and on webglcontextrestored rebuilds the painter and re-renders (see
+        // map.ts _contextLost / _contextRestored, re-fired as Map events). So do
+        // NOT fall back on the first loss — start a grace timer and let MapLibre
+        // restore. Report a PERSISTENT loss only if no restore arrives in time, so
+        // SNAPSHOT is the last resort, not the first reaction. (MapLibre owns the
+        // canvas listener; subscribe to its Map events rather than adding our own.)
+        let contextLostTimer = null;
+        map.on("webglcontextlost", () => {
+          if (contextLostTimer) return;
+          contextLostTimer = setTimeout(() => {
+            contextLostTimer = null;
+            report("onWebGlFailed", "context-lost");
+          }, CONTEXT_RESTORE_GRACE_MS);
         });
-        // Tile / style fetch errors (OpenFreeMap is a no-SLA host) are NOT WebGL
-        // failures and recover on their own — never fall back on them. Real WebGL
-        // unavailability is caught by the getContext probe above, the constructor
-        // try/catch, and the webglcontextlost listener below (a lost GPU context).
-        setTimeout(() => {
-          const cv = document.querySelector("#map canvas");
-          if (cv) cv.addEventListener("webglcontextlost", (ev) => { ev.preventDefault(); report("onWebGlFailed", "context-lost"); });
-        }, 0);
+        map.on("webglcontextrestored", () => {
+          // Recovered within the grace window: cancel the pending failure. We never
+          // reported failure (the host never showed the unavailable surface), and
+          // MapLibre re-renders after restore, so the "render" listener re-confirms
+          // readiness — nothing to re-send here.
+          if (contextLostTimer) { clearTimeout(contextLostTimer); contextLostTimer = null; }
+        });
 
         // Android -> JS: smooth heading-up camera follow (this is how #2 smooth
         // movement is achieved — easeTo interpolates between sparse GPS fixes). The
@@ -66,6 +88,10 @@
           else map.easeTo({ ...opts, duration: 1000, essential: true });
         };
         window.setStyleUrl = function (url) { if (map && url) map.setStyle(url); };
+        // Host (Android) calls this on lifecycle resume so the map re-measures and
+        // repaints after the WebView was paused / not visible (guards a stale GL
+        // surface): map.resize() + triggerRepaint().
+        window.onHostResume = function () { if (map) { map.resize(); map.triggerRepaint(); } };
       } catch (e) {
         report("onWebGlFailed", "exception:" + (e && e.message));
       }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -518,6 +518,17 @@ private fun LiveUnsupported(
     verticalArrangement = Arrangement.Center,
     horizontalAlignment = Alignment.CenterHorizontally,
 ) {
+    // Debug-only diagnosis reason, placed ABOVE the icon (top of the centered
+    // group) so it is not hidden behind the SpeedOverlay the parent draws over the
+    // lower-centre of the map (DashboardScaffold.MapPane).
+    if (BuildConfig.DEBUG) {
+        Text(
+            text = reason,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+    }
     Icon(
         imageVector = Lucide.MapPinOff,
         contentDescription = null,
@@ -547,14 +558,6 @@ private fun LiveUnsupported(
                 .widthIn(min = FemtoDimens.MinTouchTarget),
     ) {
         Text(text = stringResource(R.string.map_live_use_snapshot))
-    }
-    if (BuildConfig.DEBUG) {
-        Text(
-            text = reason,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(top = 8.dp),
-        )
     }
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -39,14 +39,19 @@ import io.github.seijikohara.femto.data.MapStyleSetting
  * `map.easeTo()` for heading-up smooth follow — this is how #2 smooth movement is
  * delivered (the JS eases between sparse fixes).
  *
- * The page reports health over the `AndroidMapBridge` JS interface: [onReady] once
- * the style and first frame have loaded (`map.on("load")` — not `idle`, which never
- * fires while the heading-up camera keeps easing between GPS fixes), and [onFail]
- * with a short reason (`context-lost`, `no-webgl-context`, `exception:...`) when
- * WebGL is unavailable or its GPU context is lost. The caller does not silently
- * fall back: it surfaces a live-map-unavailable message offering a manual switch
- * to the SNAPSHOT backend, so the map never changes appearance behind the user's
- * back.
+ * The page reports health over the `AndroidMapBridge` JS interface: [onReady] on
+ * the first rendered frame after the style loads (a `render` once `isStyleLoaded()`
+ * — not `load`, which can stall in a WebView, nor `idle`, which never fires while
+ * the heading-up camera eases), and again after MapLibre auto-restores a lost GL
+ * context. [onFail] fires with a short reason only for a PERSISTENT failure: WebGL
+ * unavailable, or a `webglcontextlost` that does not restore within the page's
+ * grace window (transient losses are left to MapLibre's built-in restore). The
+ * caller does not silently fall back; it surfaces a live-map-unavailable message
+ * offering a manual switch to the SNAPSHOT backend.
+ *
+ * [ON_START][androidx.lifecycle.Lifecycle.Event.ON_START] resumes the WebView and
+ * nudges the map to re-measure/repaint; the WebView is paused only on ON_STOP (a
+ * visible WebView paused on ON_PAUSE can drop its GL context).
  */
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -80,6 +85,11 @@ internal fun WebMapView(
             WebView(context).apply {
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true
+                // Keep rasterizing while attached but not yet visible (the Compose
+                // AndroidView attach window) so the GL surface is not evicted —
+                // surface eviction dropped the WebGL context a few seconds in on the
+                // head unit. Costs some memory; fine for the single foreground map.
+                settings.offscreenPreRaster = true
                 addJavascriptInterface(
                     object {
                         @JavascriptInterface
@@ -121,9 +131,23 @@ internal fun WebMapView(
         val observer =
             LifecycleEventObserver { _, event ->
                 when (event) {
-                    Lifecycle.Event.ON_RESUME -> webView.onResume()
-                    Lifecycle.Event.ON_PAUSE -> webView.onPause()
-                    else -> Unit
+                    // Pause only when truly backgrounded (ON_STOP), not ON_PAUSE: the
+                    // launcher map stays visible behind transient lifecycle dips, and
+                    // pausing a visible WebView can drop its GL context (the "few
+                    // seconds then grey" cause). Resume on ON_START and nudge the map
+                    // to re-measure / repaint after a possible surface loss.
+                    Lifecycle.Event.ON_START -> {
+                        webView.onResume()
+                        webView.evaluateJavascript("window.onHostResume && onHostResume()", null)
+                    }
+
+                    Lifecycle.Event.ON_STOP -> {
+                        webView.onPause()
+                    }
+
+                    else -> {
+                        Unit
+                    }
                 }
             }
         lifecycleOwner.lifecycle.addObserver(observer)


### PR DESCRIPTION
## Summary

Follow-up to #87. On the real head unit the LIVE map rendered the WebGL map
smoothly for a few seconds, then fell back to SNAPSHOT — too eagerly, since the
live map was clearly working. Per the maintainer's request this is a
reference-driven root-cause fix, not a band-aid.

## Root cause (researched)

Sources: MapLibre GL JS v5 source (`_contextLost`/`_contextRestored`), the WebGL
1.0 spec (§5.15), Chromium/WebView issues (#40249037), Android `WebSettings`.

- **MapLibre GL JS auto-recovers from WebGL context loss** — it `preventDefault()`s
  the loss, saves the style, and on `webglcontextrestored` rebuilds the painter and
  re-renders, re-firing both as `Map` events. Our `map.html` had its own
  `webglcontextlost` listener that reported failure to native on the **first** loss,
  abandoning the live map before MapLibre could restore. (Most likely cause if the
  device reason was `context-lost`.)
- **`map.on("load")` can stall in a WebView** while the map is visibly drawing,
  hitting the 10 s ready-timeout. (Most likely cause if the reason was
  `ready-timeout`.)

The reason text was unreadable on-device because it sat behind the speed panel, so
the exact cause is still unconfirmed — this fixes **both** possible causes so the
outcome is correct either way.

## Changes

**`map.html`**
- Readiness: report `onMapReady` on the first `render` after `map.isStyleLoaded()`
  (keep `load` as a fallback). `render` reflects real pixels and re-fires after a
  context restore.
- Context loss: subscribe to MapLibre's `webglcontextlost`/`webglcontextrestored`
  Map events. On loss, start a 6 s grace timer; on restore, cancel it. Report
  `onWebGlFailed("context-lost")` **only** if no restore arrives in time. Removed
  the old custom canvas listener that fell back immediately.
- Added `onHostResume` (resize + triggerRepaint) called by the host on resume.

**`WebMapView.kt`**
- `settings.offscreenPreRaster = true` — avoid GPU-surface eviction during the
  Compose `AndroidView` attach window (a documented "context lost a few seconds in"
  cause).
- Pause the WebView only on `ON_STOP` (was `ON_PAUSE`); resume on `ON_START` and
  call `onHostResume()`. A visible WebView paused on `ON_PAUSE` can drop its context.

**`MapPanel.kt`**
- Move the DEBUG-only failure reason in `LiveUnsupported` above the icon so it is
  not hidden behind the `SpeedOverlay` (it was unreadable in the device screenshot).

SNAPSHOT remains the default render mode and the last resort for a genuinely
unrecoverable loss.

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` —
  green.
- `compose-launcher-reviewer`: no blocking findings; applied the
  `webglcontextrestored` simplification (let the `render` listener re-confirm
  readiness).

## Device test (follow-up)

Select LIVE. Expected: the WebGL map now survives a transient context loss (the
first-few-seconds blip) and keeps rendering instead of dropping to SNAPSHOT. If a
device truly cannot keep WebGL alive, the unavailable surface still appears after
the 6 s grace — and its reason text is now readable above the icon.

To watch recovery live: `chrome://inspect` the WebView and run
`gl.getExtension('WEBGL_lose_context').loseContext()` then `.restoreContext()`; the
map should restore rather than fall back.
