### PR TITLE
feat(map): split render mode into HW/SW/snapshot and drop auto-fallback

### DIFF
--- a/app/src/main/assets/web/map.html
+++ b/app/src/main/assets/web/map.html
@@ -16,19 +16,14 @@
   <body>
     <div id="map"></div>
     <script>
-      // Grace period (ms) to let MapLibre restore a lost GL context before the loss
-      // is treated as persistent and the host falls back to the snapshot backend.
-      var CONTEXT_RESTORE_GRACE_MS = 6000;
-
-      // Report map health to the Android host (WebMapView @JavascriptInterface).
-      function report(fn, arg) {
-        try {
-          if (window.AndroidMapBridge && window.AndroidMapBridge[fn]) window.AndroidMapBridge[fn](arg || "");
-        } catch (e) {}
-      }
+      // Diagnostic logging only (visible via chrome://inspect or the debug PoC's
+      // WebChromeClient). There is NO host fallback path: the chosen render backend
+      // is kept as-is, and MapLibre's own context-loss restore handles transient
+      // WebGL drops, so the page never asks the host to switch away.
+      function log(msg) { try { console.log("[map] " + msg); } catch (e) {} }
       (function () {
         const c = document.createElement("canvas");
-        if (!(c.getContext("webgl2") || c.getContext("webgl"))) report("onWebGlFailed", "no-webgl-context");
+        if (!(c.getContext("webgl2") || c.getContext("webgl"))) log("no-webgl-context");
       })();
 
       let map;
@@ -40,42 +35,16 @@
           zoom: 1,
           attributionControl: false,
         });
-        // Report ready on the first ACTUALLY-RENDERED frame after the style is
-        // applied, not on map.on("load"). In a WebView "load" can stall or never
-        // fire (a sprite/glyph/style fetch on the no-SLA host, or a zero-size
-        // container) while the map is visibly drawing — which previously hit the
-        // 10s ready timeout and fell back. The first "render" after isStyleLoaded()
-        // means real pixels are on screen; it also re-fires after a context restore.
-        let ready = false;
-        function markReady() {
-          if (!ready) { ready = true; report("onMapReady"); }
-        }
-        map.on("render", () => { if (map.isStyleLoaded()) markReady(); });
-        map.on("load", markReady); // belt-and-suspenders if render is missed
+        map.on("render", () => { if (map.isStyleLoaded()) log("rendered"); });
+        map.on("load", () => log("load"));
 
         // WebGL context loss is usually TRANSIENT on mobile / WebView GPUs, and
         // MapLibre auto-recovers: it preventDefault()s the loss, saves the style,
         // and on webglcontextrestored rebuilds the painter and re-renders (see
-        // map.ts _contextLost / _contextRestored, re-fired as Map events). So do
-        // NOT fall back on the first loss — start a grace timer and let MapLibre
-        // restore. Report a PERSISTENT loss only if no restore arrives in time, so
-        // SNAPSHOT is the last resort, not the first reaction. (MapLibre owns the
-        // canvas listener; subscribe to its Map events rather than adding our own.)
-        let contextLostTimer = null;
-        map.on("webglcontextlost", () => {
-          if (contextLostTimer) return;
-          contextLostTimer = setTimeout(() => {
-            contextLostTimer = null;
-            report("onWebGlFailed", "context-lost");
-          }, CONTEXT_RESTORE_GRACE_MS);
-        });
-        map.on("webglcontextrestored", () => {
-          // Recovered within the grace window: cancel the pending failure. We never
-          // reported failure (the host never showed the unavailable surface), and
-          // MapLibre re-renders after restore, so the "render" listener re-confirms
-          // readiness — nothing to re-send here.
-          if (contextLostTimer) { clearTimeout(contextLostTimer); contextLostTimer = null; }
-        });
+        // map.ts _contextLost / _contextRestored, re-fired as Map events). We rely
+        // on that built-in restore and do not fall back to another backend.
+        map.on("webglcontextlost", () => log("webglcontextlost (awaiting MapLibre restore)"));
+        map.on("webglcontextrestored", () => log("webglcontextrestored"));
 
         // Android -> JS: smooth heading-up camera follow (this is how #2 smooth
         // movement is achieved — easeTo interpolates between sparse GPS fixes). The
@@ -93,7 +62,7 @@
         // surface): map.resize() + triggerRepaint().
         window.onHostResume = function () { if (map) { map.resize(); map.triggerRepaint(); } };
       } catch (e) {
-        report("onWebGlFailed", "exception:" + (e && e.message));
+        log("exception:" + (e && e.message));
       }
     </script>
   </body>

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -30,7 +30,6 @@ import io.github.seijikohara.femto.data.DisplayPreferences
 import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
-import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.data.SystemPermissionSignals
 import io.github.seijikohara.femto.data.ThemeMode
 import io.github.seijikohara.femto.data.hasBluetoothConnectPermission
@@ -123,7 +122,6 @@ class MainActivity : ComponentActivity() {
                         temperatureUnit = display.temperatureUnit.resolved(),
                         mapConfig =
                             MapConfig(
-                                fps = display.mapFps,
                                 style = display.mapStyle,
                                 tiltDeg = display.mapTiltDeg,
                                 zoom = display.mapZoom,
@@ -234,14 +232,6 @@ class MainActivity : ComponentActivity() {
                 // Close the drawer overlay so the two bottom sheets never stack.
                 setShowDrawer(false)
                 setShowAssistant(true)
-            }
-
-            HomeEvent.UseSnapshotMap -> {
-                // The live WebGL map failed on this device; persist the snapshot
-                // backend so the dashboard shows the reliable bitmap map instead.
-                lifecycleScope.launch {
-                    displayPreferences.setMapRenderMode(MapRenderMode.SNAPSHOT)
-                }
             }
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -38,18 +38,21 @@ enum class AccentColor { DYNAMIC, BLUE, TEAL, GREEN, AMBER, ORANGE, RED, VIOLET,
 /** Fullscreen: keep the system bars, or hide both status and navigation bars. */
 internal enum class FullscreenSetting { OFF, ON }
 
-/** Default target map frame rate (fps) before the user picks one. */
-internal const val DEFAULT_MAP_FPS = 10
-
 /** Map light/dark style: follow the system theme, or force light / dark. */
 internal enum class MapStyleSetting { AUTO, LIGHT, DARK }
 
 /**
- * Map render backend. SNAPSHOT draws off-screen bitmaps (presents reliably on the
- * projected / virtualised displays of AI boxes); LIVE uses a GL MapView (smoother
- * where the device can scan out GL buffers, but blank on displays that cannot).
+ * Map render backend, picked explicitly by the user (no auto-fallback).
+ *
+ * - [LIVE_HARDWARE]: MapLibre GL JS in a hardware-accelerated WebView (smoothest
+ *   where the device GPU presents WebGL).
+ * - [LIVE_SOFTWARE]: the same WebView forced to the software layer
+ *   (`setLayerType(LAYER_TYPE_SOFTWARE)`), so Chromium renders WebGL via
+ *   SwiftShader — a fallback for GPUs that cannot keep a live WebGL context.
+ * - [SNAPSHOT]: off-screen `MapSnapshotter` bitmaps; presents reliably on the
+ *   projected / virtualised displays of AI boxes. The default.
  */
-internal enum class MapRenderMode { SNAPSHOT, LIVE }
+internal enum class MapRenderMode { LIVE_HARDWARE, LIVE_SOFTWARE, SNAPSHOT }
 
 /** Default oblique-camera tilt (degrees) and zoom level for the map. */
 internal const val DEFAULT_MAP_TILT_DEG = 55
@@ -85,14 +88,11 @@ internal data class DisplaySettings(
     // per-minute instead of per-second.
     val showClockSeconds: Boolean,
     val fullscreen: FullscreenSetting,
-    // Target map frame rate (fps): the snapshot map caps its re-render rate at
-    // this many frames per second. Clamped to the display's max refresh at use.
-    val mapFps: Int,
     val mapStyle: MapStyleSetting,
     val mapTiltDeg: Int,
     val mapZoom: Int,
     // Snapshot render resolution as a percent of the panel pixel size; lower is
-    // blurrier but renders faster, so the frame rate can climb closer to mapFps.
+    // blurrier but renders faster (a smaller bitmap to upscale).
     val mapRenderPercent: Int,
     val mapRenderMode: MapRenderMode,
     // Camera look-ahead (metres): how far ahead of the current position the camera
@@ -115,7 +115,6 @@ internal data class DisplaySettings(
                 clock = ClockSetting.AUTO,
                 showClockSeconds = true,
                 fullscreen = FullscreenSetting.OFF,
-                mapFps = DEFAULT_MAP_FPS,
                 mapStyle = MapStyleSetting.AUTO,
                 mapTiltDeg = DEFAULT_MAP_TILT_DEG,
                 mapZoom = DEFAULT_MAP_ZOOM,
@@ -152,8 +151,6 @@ internal interface DisplaySettingsStore {
     suspend fun setShowClockSeconds(value: Boolean)
 
     suspend fun setFullscreen(value: FullscreenSetting)
-
-    suspend fun setMapFps(value: Int)
 
     suspend fun setMapStyle(value: MapStyleSetting)
 
@@ -194,12 +191,11 @@ internal class DisplayPreferences(
                 clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
                 showClockSeconds = prefs[SHOW_CLOCK_SECONDS_KEY] ?: true,
                 fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.OFF),
-                mapFps = prefs[MAP_FPS_KEY] ?: DEFAULT_MAP_FPS,
                 mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
                 mapTiltDeg = prefs[MAP_TILT_KEY] ?: DEFAULT_MAP_TILT_DEG,
                 mapZoom = prefs[MAP_ZOOM_KEY] ?: DEFAULT_MAP_ZOOM,
                 mapRenderPercent = prefs[MAP_QUALITY_KEY] ?: DEFAULT_MAP_RENDER_PERCENT,
-                mapRenderMode = prefs[MAP_RENDER_MODE_KEY].toEnumOr(MapRenderMode.SNAPSHOT),
+                mapRenderMode = prefs[MAP_RENDER_MODE_KEY].toMapRenderModeOr(MapRenderMode.SNAPSHOT),
                 mapLookAheadM = prefs[MAP_LOOKAHEAD_KEY] ?: DEFAULT_MAP_LOOKAHEAD_M,
                 showCalendar = prefs[SHOW_CALENDAR_KEY] ?: true,
                 showWeather = prefs[SHOW_WEATHER_KEY] ?: true,
@@ -235,10 +231,6 @@ internal class DisplayPreferences(
 
     override suspend fun setFullscreen(value: FullscreenSetting) {
         context.displayDataStore.edit { it[FULLSCREEN_KEY] = value.name }
-    }
-
-    override suspend fun setMapFps(value: Int) {
-        context.displayDataStore.edit { it[MAP_FPS_KEY] = value }
     }
 
     override suspend fun setMapStyle(value: MapStyleSetting) {
@@ -285,7 +277,6 @@ internal class DisplayPreferences(
         val CLOCK_KEY = stringPreferencesKey("clock")
         val SHOW_CLOCK_SECONDS_KEY = booleanPreferencesKey("show_clock_seconds")
         val FULLSCREEN_KEY = stringPreferencesKey("fullscreen")
-        val MAP_FPS_KEY = intPreferencesKey("map_fps")
         val MAP_STYLE_KEY = stringPreferencesKey("map_style")
         val MAP_TILT_KEY = intPreferencesKey("map_tilt_deg")
         val MAP_ZOOM_KEY = intPreferencesKey("map_zoom")
@@ -302,3 +293,12 @@ internal class DisplayPreferences(
 // unrecognised value so the read never throws on a downgrade / renamed entry.
 private inline fun <reified T : Enum<T>> String?.toEnumOr(fallback: T): T =
     this?.let { name -> enumEntries<T>().firstOrNull { it.name == name } } ?: fallback
+
+// Decode the render mode, migrating the pre-3-mode "LIVE" value to LIVE_HARDWARE
+// so a user who chose the live map keeps it (rather than silently reverting to
+// the SNAPSHOT default) after the SNAPSHOT/LIVE enum split into three.
+private fun String?.toMapRenderModeOr(fallback: MapRenderMode): MapRenderMode =
+    when (this) {
+        "LIVE" -> MapRenderMode.LIVE_HARDWARE
+        else -> toEnumOr(fallback)
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
@@ -35,11 +35,4 @@ internal sealed interface HomeAction {
     data object OpenAssistant : HomeAction
 
     data object ResetTrip : HomeAction
-
-    /**
-     * Switch the persisted map render mode to SNAPSHOT. Raised from the live-map
-     * error surface when WebGL is unavailable on this device, so the user opts into
-     * the reliable snapshot backend instead of being silently downgraded.
-     */
-    data object UseSnapshotMap : HomeAction
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
@@ -47,11 +47,4 @@ internal sealed interface HomeEvent {
 
     /** Open the voice-assistant bottom sheet so the user picks which assistant intent to fire. */
     data object OpenAssistantSheet : HomeEvent
-
-    /**
-     * Persist `MapRenderMode.SNAPSHOT`. The host owns the display preferences, so
-     * the live-map error surface requests the switch through this event rather than
-     * writing the preference from the dashboard tree.
-     */
-    data object UseSnapshotMap : HomeEvent
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -148,10 +148,6 @@ internal class HomeViewModel(
             HomeAction.ResetTrip -> {
                 resetTrip()
             }
-
-            HomeAction.UseSnapshotMap -> {
-                mutableEvents.tryEmit(HomeEvent.UseSnapshotMap)
-            }
         }
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -186,7 +186,6 @@ private fun MapPane(
         location = uiState.location,
         mapConfig = mapConfig,
         onTap = { onAction(HomeAction.OpenMaps) },
-        onUseSnapshot = { onAction(HomeAction.UseSnapshotMap) },
         modifier = Modifier.fillMaxSize().hazeSource(hazeState),
     )
     ClockOverlay(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -20,13 +20,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -53,7 +50,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -64,13 +60,10 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.MapPinOff
-import io.github.seijikohara.femto.BuildConfig
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.data.MapStyleSetting
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
-import io.github.seijikohara.femto.ui.theme.FemtoTheme
-import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -93,11 +86,10 @@ import kotlin.math.cos
 import kotlin.math.roundToInt
 import kotlin.math.sin
 
-// User-tunable map rendering config (derived from DisplaySettings): target frame
-// rate, light/dark style, oblique tilt, zoom, and the render resolution percent
-// (lower renders a smaller bitmap, faster, upscaled to fill).
+// User-tunable map rendering config (derived from DisplaySettings): light/dark
+// style, oblique tilt, zoom, the render resolution percent (lower renders a
+// smaller bitmap, faster, upscaled to fill), and the user-picked render backend.
 internal data class MapConfig(
-    val fps: Int = 10,
     val style: MapStyleSetting = MapStyleSetting.AUTO,
     val tiltDeg: Int = 55,
     val zoom: Int = 16,
@@ -107,23 +99,22 @@ internal data class MapConfig(
 )
 
 /**
- * Map tile surface + permission fallback, in one of two backends selected by
- * [MapConfig.renderMode] (both render free OpenStreetMap vector tiles via
- * OpenFreeMap / MapLibre with a heading-up, oblique (tilted) camera):
+ * Map tile surface + permission fallback, in one of three backends selected
+ * explicitly by [MapConfig.renderMode] (all render free OpenStreetMap vector
+ * tiles via OpenFreeMap / MapLibre with a heading-up, oblique (tilted) camera):
  *
  * - SNAPSHOT (default, [SnapshotMap]) draws off-screen [MapSnapshotter] bitmaps
  *   into a Compose [Image]. A native live GL `MapView` never presents frames on
  *   the projected / virtualised displays of CarPlay / Android Auto AI boxes — the
  *   GL buffers are not scanned out, so it shows a grey rectangle — whereas a
  *   bitmap rides the normal Skia composition path and presents reliably. The
- *   snapshot re-renders on movement, capped at the frame-rate (fps) setting,
- *   single-flight, holding the previous frame so there is no flicker.
- * - LIVE ([WebMapView]) renders MapLibre GL JS (WebGL) in a WebView, which
- *   composites inline through HWUI and animates the camera for a smooth follow.
- *   It does NOT auto-downgrade: when WebGL is unavailable or no frame arrives
- *   within [WEBGL_READY_TIMEOUT_MS] it shows [LiveUnsupported], offering a manual
- *   switch to SNAPSHOT. The two backends differ visually (only SNAPSHOT draws the
- *   location marker), so a silent switch would confuse — the user opts in.
+ *   snapshot re-renders on movement, single-flight, holding the previous frame so
+ *   there is no flicker.
+ * - LIVE_HARDWARE / LIVE_SOFTWARE ([WebMapView]) render MapLibre GL JS (WebGL) in
+ *   a WebView, which composites inline through HWUI and animates the camera for a
+ *   smooth follow. LIVE_SOFTWARE forces the WebView onto the software layer so
+ *   Chromium renders WebGL via SwiftShader (for GPUs that cannot keep a hardware
+ *   WebGL context). There is NO auto-fallback: the chosen backend is kept as-is.
  *
  * Clock and speed overlays are placed by the parent on top of this surface.
  */
@@ -132,7 +123,6 @@ internal fun MapPanel(
     location: Location?,
     mapConfig: MapConfig,
     onTap: () -> Unit,
-    onUseSnapshot: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
@@ -145,6 +135,26 @@ internal fun MapPanel(
         // centre point; without it the map has nothing to show, so fall back.
         if (location != null) {
             when (mapConfig.renderMode) {
+                MapRenderMode.LIVE_HARDWARE -> {
+                    WebMapView(
+                        location = location,
+                        mapConfig = mapConfig,
+                        onTap = onTap,
+                        softwareRendering = false,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+
+                MapRenderMode.LIVE_SOFTWARE -> {
+                    WebMapView(
+                        location = location,
+                        mapConfig = mapConfig,
+                        onTap = onTap,
+                        softwareRendering = true,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+
                 MapRenderMode.SNAPSHOT -> {
                     SnapshotMap(
                         location = location,
@@ -152,36 +162,6 @@ internal fun MapPanel(
                         onTap = onTap,
                         modifier = Modifier.fillMaxSize(),
                     )
-                }
-
-                MapRenderMode.LIVE -> {
-                    // LIVE renders the WebGL map ([WebMapView]) and does NOT silently
-                    // downgrade to SNAPSHOT: a WebGL failure (reason from the bridge)
-                    // or a ready timeout shows [LiveUnsupported], which offers a manual
-                    // switch. The backends differ visually, so a silent swap confuses.
-                    var failReason by remember { mutableStateOf<String?>(null) }
-                    var webGlReady by remember { mutableStateOf(false) }
-                    val reason = failReason
-                    if (reason != null) {
-                        LiveUnsupported(
-                            reason = reason,
-                            onUseSnapshot = onUseSnapshot,
-                            modifier = Modifier.fillMaxSize(),
-                        )
-                    } else {
-                        WebMapView(
-                            location = location,
-                            mapConfig = mapConfig,
-                            onTap = onTap,
-                            onReady = { webGlReady = true },
-                            onFail = { failReason = it },
-                            modifier = Modifier.fillMaxSize(),
-                        )
-                        LaunchedEffect(Unit) {
-                            delay(WEBGL_READY_TIMEOUT_MS)
-                            if (!webGlReady) failReason = READY_TIMEOUT_REASON
-                        }
-                    }
                 }
             }
         } else {
@@ -252,8 +232,6 @@ private fun SnapshotMap(
     val lifecycleOwner = LocalLifecycleOwner.current
     LaunchedEffect(snapshotter, mapConfig, lifecycleOwner) {
         val snap = snapshotter ?: return@LaunchedEffect
-        // Target frame interval; coerceAtLeast(1) guards 0 fps from divide-by-zero.
-        val intervalMs = 1_000L / mapConfig.fps.coerceAtLeast(1)
         // Render only while the launcher is visible; pause off-screen to drop the
         // render cost. lastRendered resets on each return to STARTED so a stale
         // map refreshes immediately when the dashboard comes back to the front.
@@ -274,7 +252,10 @@ private fun SnapshotMap(
                         failed = frame == null
                     }
                 }
-                delay(intervalMs)
+                // Poll for movement at a fixed cadence; a frame is produced only when
+                // the fix actually moves (shouldRerender), so this is a cheap throttle
+                // on how often we re-check, not a frame-rate cap.
+                delay(SNAPSHOT_POLL_INTERVAL_MS)
             }
         }
     }
@@ -503,83 +484,16 @@ private fun Fallback(modifier: Modifier = Modifier) =
         )
     }
 
-// Shown when LIVE is selected but WebGL is unavailable on this device (or the map
-// never reported a frame within the timeout). LIVE deliberately does not
-// auto-downgrade — the backends look different (only SNAPSHOT draws the location
-// marker), so a silent switch is confusing. Offer an explicit switch to SNAPSHOT
-// instead. The failure reason is shown in debug builds only, to aid diagnosis.
-@Composable
-private fun LiveUnsupported(
-    reason: String,
-    onUseSnapshot: () -> Unit,
-    modifier: Modifier = Modifier,
-) = Column(
-    modifier = modifier.fillMaxSize().padding(24.dp),
-    verticalArrangement = Arrangement.Center,
-    horizontalAlignment = Alignment.CenterHorizontally,
-) {
-    // Debug-only diagnosis reason, placed ABOVE the icon (top of the centered
-    // group) so it is not hidden behind the SpeedOverlay the parent draws over the
-    // lower-centre of the map (DashboardScaffold.MapPane).
-    if (BuildConfig.DEBUG) {
-        Text(
-            text = reason,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp),
-        )
-    }
-    Icon(
-        imageVector = Lucide.MapPinOff,
-        contentDescription = null,
-        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.size(40.dp),
-    )
-    Text(
-        text = stringResource(R.string.map_live_unavailable_title),
-        style = MaterialTheme.typography.titleMedium,
-        color = MaterialTheme.colorScheme.onSurface,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.padding(top = 8.dp),
-    )
-    Text(
-        text = stringResource(R.string.map_live_unavailable_body),
-        style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.padding(top = 4.dp),
-    )
-    Button(
-        onClick = onUseSnapshot,
-        modifier =
-            Modifier
-                .padding(top = 16.dp)
-                .heightIn(min = FemtoDimens.MinTouchTarget)
-                .widthIn(min = FemtoDimens.MinTouchTarget),
-    ) {
-        Text(text = stringResource(R.string.map_live_use_snapshot))
-    }
-}
-
-@PreviewLightDark
-@Composable
-private fun LiveUnsupportedPreview() =
-    FemtoTheme {
-        LiveUnsupported(reason = "context-lost", onUseSnapshot = {})
-    }
-
 // internal so MapSnapshotRenderTest renders the SAME style host / zoom the panel
 // uses, keeping the OpenFreeMap style URL and zoom a single source of truth.
 internal const val MAP_ZOOM = 16.5
 internal const val POSITRON_STYLE_URL = "https://tiles.openfreemap.org/styles/positron"
 private const val DARK_STYLE_ASSET = "map/dark.json"
 
-// Show the live-map-unavailable surface if the WebGL map has not reported a
-// rendered frame within this window (covers a silent WebGL failure with no event).
-private const val WEBGL_READY_TIMEOUT_MS = 10_000L
-
-// Reason surfaced (debug only) when the timeout above elapses with no frame.
-private const val READY_TIMEOUT_REASON = "ready-timeout"
+// How often the snapshot loop polls the current fix for movement. A frame is only
+// produced when the fix actually moves (shouldRerender), so this just bounds the
+// re-check cadence, not the render rate.
+private const val SNAPSHOT_POLL_INTERVAL_MS = 200L
 
 // Re-render once a fix moves at least this far; below it the last frame is held.
 // Kept small so the map follows movement in smaller steps (smoother panning); the

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -2,9 +2,7 @@ package io.github.seijikohara.femto.ui.home.components
 
 import android.annotation.SuppressLint
 import android.location.Location
-import android.os.Handler
-import android.os.Looper
-import android.webkit.JavascriptInterface
+import android.view.View
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
@@ -16,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -39,15 +36,13 @@ import io.github.seijikohara.femto.data.MapStyleSetting
  * `map.easeTo()` for heading-up smooth follow — this is how #2 smooth movement is
  * delivered (the JS eases between sparse fixes).
  *
- * The page reports health over the `AndroidMapBridge` JS interface: [onReady] on
- * the first rendered frame after the style loads (a `render` once `isStyleLoaded()`
- * — not `load`, which can stall in a WebView, nor `idle`, which never fires while
- * the heading-up camera eases), and again after MapLibre auto-restores a lost GL
- * context. [onFail] fires with a short reason only for a PERSISTENT failure: WebGL
- * unavailable, or a `webglcontextlost` that does not restore within the page's
- * grace window (transient losses are left to MapLibre's built-in restore). The
- * caller does not silently fall back; it surfaces a live-map-unavailable message
- * offering a manual switch to the SNAPSHOT backend.
+ * There is NO auto-fallback: the page relies on MapLibre's built-in WebGL
+ * context-loss restore (`webglcontextlost`/`webglcontextrestored`) and the host
+ * keeps the chosen backend regardless. [softwareRendering] forces the WebView onto
+ * the software layer (`setLayerType(LAYER_TYPE_SOFTWARE)`) so Chromium renders
+ * WebGL via SwiftShader — the LIVE_SOFTWARE backend for GPUs that cannot keep a
+ * hardware WebGL context. Switching the flag rebuilds the WebView (it keys the
+ * `remember`).
  *
  * [ON_START][androidx.lifecycle.Lifecycle.Event.ON_START] resumes the WebView and
  * nudges the map to re-measure/repaint; the WebView is paused only on ON_STOP (a
@@ -59,13 +54,10 @@ internal fun WebMapView(
     location: Location,
     mapConfig: MapConfig,
     onTap: () -> Unit,
-    onReady: () -> Unit,
-    onFail: (String) -> Unit,
+    softwareRendering: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val onReadyState = rememberUpdatedState(onReady)
-    val onFailState = rememberUpdatedState(onFail)
     val bearingHolder = remember { floatArrayOf(0f) }
     val isDark =
         when (mapConfig.style) {
@@ -75,14 +67,17 @@ internal fun WebMapView(
         }
 
     val webView =
-        remember {
+        remember(softwareRendering) {
             val assetLoader =
                 WebViewAssetLoader
                     .Builder()
                     .addPathHandler("/assets/", WebViewAssetLoader.AssetsPathHandler(context))
                     .build()
-            val mainHandler = Handler(Looper.getMainLooper())
             WebView(context).apply {
+                // Hardware layer renders WebGL on the GPU; the software layer routes
+                // Chromium through SwiftShader (the LIVE_SOFTWARE backend) for devices
+                // whose GPU cannot keep a live WebGL context.
+                setLayerType(if (softwareRendering) View.LAYER_TYPE_SOFTWARE else View.LAYER_TYPE_HARDWARE, null)
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true
                 // Keep rasterizing while attached but not yet visible (the Compose
@@ -90,18 +85,6 @@ internal fun WebMapView(
                 // surface eviction dropped the WebGL context a few seconds in on the
                 // head unit. Costs some memory; fine for the single foreground map.
                 settings.offscreenPreRaster = true
-                addJavascriptInterface(
-                    object {
-                        @JavascriptInterface
-                        fun onMapReady() = mainHandler.post { onReadyState.value() }
-
-                        // Forward the failure reason verbatim; the caller surfaces it
-                        // (debug) and offers a manual switch to the SNAPSHOT backend.
-                        @JavascriptInterface
-                        fun onWebGlFailed(reason: String) = mainHandler.post { onFailState.value(reason) }
-                    },
-                    "AndroidMapBridge",
-                )
                 webViewClient =
                     object : WebViewClientCompat() {
                         override fun shouldInterceptRequest(
@@ -113,7 +96,11 @@ internal fun WebMapView(
             }
         }
 
-    LaunchedEffect(location.latitude, location.longitude, mapConfig.zoom, mapConfig.tiltDeg) {
+    // Key on [webView] too: a render-mode switch rebuilds the WebView, and the new
+    // instance must receive the current camera and style immediately rather than
+    // waiting for the next GPS fix / theme change (it would otherwise show the
+    // default [0,0] world view in the meantime).
+    LaunchedEffect(webView, location.latitude, location.longitude, mapConfig.zoom, mapConfig.tiltDeg) {
         val bearing = location.carriedBearing(bearingHolder)
         webView.evaluateJavascript(
             "window.updateCamera && updateCamera(" +
@@ -121,7 +108,7 @@ internal fun WebMapView(
             null,
         )
     }
-    LaunchedEffect(isDark) {
+    LaunchedEffect(webView, isDark) {
         val style = if (isDark) DARK_STYLE_URL else POSITRON_STYLE_URL
         webView.evaluateJavascript("window.setStyleUrl && setStyleUrl('$style')", null)
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -169,24 +168,17 @@ internal fun SettingsScreen(
             )
         }
 
-        val maxFps = rememberMaxDisplayFps()
         SettingsSection(title = stringResource(R.string.settings_section_map)) {
             ChoiceRow(
                 title = stringResource(R.string.settings_group_map_rendering),
                 options =
                     listOf(
+                        MapRenderMode.LIVE_HARDWARE to stringResource(R.string.settings_map_mode_live_hardware),
+                        MapRenderMode.LIVE_SOFTWARE to stringResource(R.string.settings_map_mode_live_software),
                         MapRenderMode.SNAPSHOT to stringResource(R.string.settings_map_mode_snapshot),
-                        MapRenderMode.LIVE to stringResource(R.string.settings_map_mode_live),
                     ),
                 selected = uiState.mapRenderMode,
                 onSelect = { onAction(SettingsAction.SetMapRenderMode(it)) },
-            )
-            SliderRow(
-                title = stringResource(R.string.settings_group_map_refresh),
-                valueLabel = stringResource(R.string.settings_map_fps_value, uiState.mapFps),
-                value = uiState.mapFps,
-                range = MIN_MAP_FPS..maxFps,
-                onValueChange = { onAction(SettingsAction.SetMapFps(it)) },
             )
             ChoiceRow(
                 title = stringResource(R.string.settings_group_map_style),
@@ -600,27 +592,6 @@ private fun TrailingIcon(
     modifier = modifier.size(FemtoDimens.InlineIconSize),
 )
 
-// The display's maximum refresh rate (fps), the ceiling for the map frame-rate
-// slider. Falls back to 60 when the modes cannot be read; clamped to a sane band.
-@Composable
-private fun rememberMaxDisplayFps(): Int {
-    val context = LocalContext.current
-    return remember(context) {
-        // Context.getDisplay() is non-null on a visual (Activity) context but
-        // throws on a non-visual one (e.g. a preview), so guard with runCatching
-        // and fall back to 60 fps rather than null-check a non-null receiver.
-        runCatching {
-            val display = context.display
-            display.supportedModes.maxOfOrNull { it.refreshRate } ?: display.refreshRate
-        }.getOrDefault(DEFAULT_MAX_FPS)
-            .roundToInt()
-            .coerceIn(MIN_MAP_FPS, MAX_MAP_FPS_CEILING)
-    }
-}
-
-private const val MIN_MAP_FPS = 1
-private const val MAX_MAP_FPS_CEILING = 120
-private const val DEFAULT_MAX_FPS = 60f
 private const val MIN_MAP_TILT = 0
 private const val MAX_MAP_TILT = 60
 private const val MIN_MAP_ZOOM = 12

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -20,7 +20,6 @@ internal data class SettingsUiState(
     val clock: ClockSetting,
     val showClockSeconds: Boolean,
     val fullscreen: FullscreenSetting,
-    val mapFps: Int,
     val mapStyle: MapStyleSetting,
     val mapTiltDeg: Int,
     val mapZoom: Int,
@@ -44,7 +43,6 @@ internal data class SettingsUiState(
                 clock = DisplaySettings.Default.clock,
                 showClockSeconds = DisplaySettings.Default.showClockSeconds,
                 fullscreen = DisplaySettings.Default.fullscreen,
-                mapFps = DisplaySettings.Default.mapFps,
                 mapStyle = DisplaySettings.Default.mapStyle,
                 mapTiltDeg = DisplaySettings.Default.mapTiltDeg,
                 mapZoom = DisplaySettings.Default.mapZoom,
@@ -87,10 +85,6 @@ internal sealed interface SettingsAction {
 
     data class SetFullscreen(
         val value: FullscreenSetting,
-    ) : SettingsAction
-
-    data class SetMapFps(
-        val value: Int,
     ) : SettingsAction
 
     data class SetMapStyle(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -28,7 +28,6 @@ internal class SettingsViewModel(
                 clock = display.clock,
                 showClockSeconds = display.showClockSeconds,
                 fullscreen = display.fullscreen,
-                mapFps = display.mapFps,
                 mapStyle = display.mapStyle,
                 mapTiltDeg = display.mapTiltDeg,
                 mapZoom = display.mapZoom,
@@ -53,7 +52,6 @@ internal class SettingsViewModel(
                 is SettingsAction.SetClock -> displayPreferences.setClock(action.value)
                 is SettingsAction.SetShowClockSeconds -> displayPreferences.setShowClockSeconds(action.value)
                 is SettingsAction.SetFullscreen -> displayPreferences.setFullscreen(action.value)
-                is SettingsAction.SetMapFps -> displayPreferences.setMapFps(action.value)
                 is SettingsAction.SetMapStyle -> displayPreferences.setMapStyle(action.value)
                 is SettingsAction.SetMapTilt -> displayPreferences.setMapTilt(action.value)
                 is SettingsAction.SetMapZoom -> displayPreferences.setMapZoom(action.value)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,9 +6,6 @@
     <string name="map_unavailable">Map unavailable</string>
     <string name="map_permission_cta">Grant location access to enable the map and overlays.</string>
     <string name="map_attribution">© OpenStreetMap · OpenMapTiles · OpenFreeMap</string>
-    <string name="map_live_unavailable_title">Live map unavailable</string>
-    <string name="map_live_unavailable_body">This device cannot render the real-time map. Switch to the snapshot map for a reliable still view.</string>
-    <string name="map_live_use_snapshot">Switch to snapshot map</string>
 
     <!-- Speed overlay -->
     <string name="speed_reset_trip">Reset trip</string>
@@ -119,10 +116,9 @@
     <string name="settings_group_clock_seconds">Show seconds</string>
     <string name="settings_group_fullscreen">Fullscreen</string>
     <string name="settings_group_map_rendering">Map rendering</string>
+    <string name="settings_map_mode_live_hardware">Live (hardware)</string>
+    <string name="settings_map_mode_live_software">Live (software)</string>
     <string name="settings_map_mode_snapshot">Snapshot</string>
-    <string name="settings_map_mode_live">Live</string>
-    <string name="settings_group_map_refresh">Map frame rate</string>
-    <string name="settings_map_fps_value">%1$d fps</string>
     <string name="settings_group_map_style">Map style</string>
     <string name="settings_group_map_tilt">Map tilt</string>
     <string name="settings_group_map_zoom">Map zoom</string>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -42,8 +42,6 @@ internal class FakeDisplaySettingsStore(
 
     override suspend fun setFullscreen(value: FullscreenSetting) = state.update { it.copy(fullscreen = value) }
 
-    override suspend fun setMapFps(value: Int) = state.update { it.copy(mapFps = value) }
-
     override suspend fun setMapStyle(value: MapStyleSetting) = state.update { it.copy(mapStyle = value) }
 
     override suspend fun setMapTilt(value: Int) = state.update { it.copy(mapTiltDeg = value) }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -180,15 +180,6 @@ class HomeViewModelTest {
         }
 
     @Test
-    fun `onAction UseSnapshotMap emits UseSnapshotMap event`() =
-        runTest {
-            stubViewModel().assertEvent(
-                action = HomeAction.UseSnapshotMap,
-                expected = HomeEvent.UseSnapshotMap,
-            )
-        }
-
-    @Test
     fun `onAction ConnectMusicPlayer emits OpenNotificationListenerSettings`() =
         runTest {
             stubViewModel().assertEvent(

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -61,14 +61,6 @@ class SettingsViewModelTest {
         }
 
     @Test
-    fun `SetMapFps writes the value to the store`() =
-        runTest(dispatcher) {
-            viewModel().onAction(SettingsAction.SetMapFps(30))
-            advanceUntilIdle()
-            assertEquals(30, store.settings.first().mapFps)
-        }
-
-    @Test
     fun `SetShowMusic writes the value to the store`() =
         runTest(dispatcher) {
             viewModel().onAction(SettingsAction.SetShowMusic(false))
@@ -95,9 +87,9 @@ class SettingsViewModelTest {
     @Test
     fun `SetMapRenderMode writes the value to the store`() =
         runTest(dispatcher) {
-            viewModel().onAction(SettingsAction.SetMapRenderMode(MapRenderMode.LIVE))
+            viewModel().onAction(SettingsAction.SetMapRenderMode(MapRenderMode.LIVE_HARDWARE))
             advanceUntilIdle()
-            assertEquals(MapRenderMode.LIVE, store.settings.first().mapRenderMode)
+            assertEquals(MapRenderMode.LIVE_HARDWARE, store.settings.first().mapRenderMode)
         }
 
     @Test


### PR DESCRIPTION
## Summary

First of a staged series reworking the map per device feedback. This PR makes the
render backend an explicit user choice and removes all automatic fallback, so the
selected mode is always kept (fallback can be re-introduced later if a real need
appears).

## Changes

- **Three render modes.** `MapRenderMode` becomes `{ LIVE_HARDWARE, LIVE_SOFTWARE,
  SNAPSHOT }` (was `SNAPSHOT`/`LIVE`), surfaced as a 3-way choice in Settings. The
  legacy stored `"LIVE"` value migrates to `LIVE_HARDWARE`.
- **Software WebGL backend.** `LIVE_SOFTWARE` forces the WebView onto the software
  layer (`setLayerType(LAYER_TYPE_SOFTWARE)`) so Chromium renders WebGL via
  SwiftShader — a path for GPUs that cannot keep a hardware WebGL context. There is
  no public Android API to select the WebGL backend per app; this is the only lever.
  Whether it renders on a given head unit is device-dependent (to be verified on
  real hardware).
- **No auto-fallback.** Removed the live-map-unavailable surface, the ready
  timeout, the `WebMapView` ready/fail bridge, the `UseSnapshotMap` action/event +
  its host handler, and the `onWebGlFailed` host report in `map.html`. The page now
  relies solely on MapLibre's built-in WebGL context-loss restore and only
  console-logs diagnostics.
- **FPS setting removed.** The map frame-rate slider only ever capped the snapshot
  re-render rate; it is gone end to end (setting, action, UI, `MapConfig.fps`). The
  snapshot loop now polls movement at a fixed cadence and still re-renders only
  after the fix moves ≥ 2 m.

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` —
  green.
- `compose-launcher-reviewer`: no blocking findings; applied the suggestion to key
  the camera/style `LaunchedEffect`s on the WebView so a mode switch repaints the
  new instance immediately.

## Device test (follow-up)

Switch between the three modes in Settings and confirm each is kept (no automatic
downgrade). LIVE_HARDWARE / LIVE_SOFTWARE render the WebGL map; SNAPSHOT renders
the bitmap map with the location marker. Note whether LIVE_SOFTWARE renders on the
head unit.

## Next in the series

PR-B: live-map self-location marker · PR-C/D/E: 3D buildings / terrain / satellite
toggles (LIVE only, via MapLibre `transformStyle`).