### PR TITLE
feat(map): draw the self-location marker on the live (WebGL) map

### DIFF
--- a/app/src/main/assets/web/map.html
+++ b/app/src/main/assets/web/map.html
@@ -46,13 +46,37 @@
         map.on("webglcontextlost", () => log("webglcontextlost (awaiting MapLibre restore)"));
         map.on("webglcontextrestored", () => log("webglcontextrestored"));
 
+        // Self-location puck: a heading-up nav chevron that mirrors the SNAPSHOT
+        // backend's marker so the two render the same. rotationAlignment "map" +
+        // pitchAlignment "map" rotate it to the travel bearing and lay it flat on
+        // the tilted ground plane (the heading-up camera then points it toward the
+        // top of the frame). It is a DOM Marker, so it survives setStyle. The fill
+        // is set from the host's Material primary via updateCamera's last argument;
+        // the inline default only shows for the first frame before the host pushes.
+        var markerEl = document.createElement("div");
+        markerEl.innerHTML =
+          '<svg width="34" height="34" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">' +
+          '<path d="M15 0 L30 30 L15 21.6 L0 30 Z" fill="#3367D6" stroke="#FFFFFF" ' +
+          'stroke-width="1.5" stroke-linejoin="round"/></svg>';
+        var marker = new maplibregl.Marker({ element: markerEl, rotationAlignment: "map", pitchAlignment: "map" });
+        var markerAdded = false;
+
         // Android -> JS: smooth heading-up camera follow (this is how #2 smooth
         // movement is achieved — easeTo interpolates between sparse GPS fixes). The
         // first fix jumps (no dramatic fly-in from the [0,0] start); the rest ease.
+        // The marker rides the same fixes; [markerColor] (Material primary, "#rrggbb")
+        // is applied here so it self-heals if the first push raced page load.
         let firstCamera = true;
-        window.updateCamera = function (lat, lon, bearing, zoom, tilt) {
+        window.updateCamera = function (lat, lon, bearing, zoom, tilt, markerColor) {
           if (!map) return;
-          const opts = { center: [lon, lat], bearing: bearing || 0, zoom: zoom || 16, pitch: tilt || 0 };
+          var heading = bearing || 0;
+          if (markerColor) {
+            var path = markerEl.querySelector("path");
+            if (path) path.setAttribute("fill", markerColor);
+          }
+          marker.setLngLat([lon, lat]).setRotation(heading);
+          if (!markerAdded) { marker.addTo(map); markerAdded = true; }
+          const opts = { center: [lon, lat], bearing: heading, zoom: zoom || 16, pitch: tilt || 0 };
           if (firstCamera) { firstCamera = false; map.jumpTo(opts); }
           else map.easeTo({ ...opts, duration: 1000, essential: true });
         };

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -10,12 +10,15 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
@@ -34,7 +37,9 @@ import io.github.seijikohara.femto.data.MapStyleSetting
  * [WebViewAssetLoader] from the real https origin appassets.androidplatform.net so
  * MapLibre's tile-processing Web Worker can fetch tiles. GPS fixes drive
  * `map.easeTo()` for heading-up smooth follow — this is how #2 smooth movement is
- * delivered (the JS eases between sparse fixes).
+ * delivered (the JS eases between sparse fixes). A `maplibregl.Marker` chevron rides
+ * the same fixes as the self-location puck (filled with the Material primary), laid
+ * on the tilted ground so it matches the SNAPSHOT backend's marker.
  *
  * There is NO auto-fallback: the page relies on MapLibre's built-in WebGL
  * context-loss restore (`webglcontextlost`/`webglcontextrestored`) and the host
@@ -96,15 +101,21 @@ internal fun WebMapView(
             }
         }
 
+    // Material primary as the self-location marker fill, so the WebGL puck matches
+    // the SNAPSHOT marker and the user's accent. Passed on every camera update so it
+    // self-heals if the first push raced the page load (the next GPS fix re-applies).
+    val markerColor = MaterialTheme.colorScheme.primary.toCssHex()
+
     // Key on [webView] too: a render-mode switch rebuilds the WebView, and the new
     // instance must receive the current camera and style immediately rather than
     // waiting for the next GPS fix / theme change (it would otherwise show the
     // default [0,0] world view in the meantime).
-    LaunchedEffect(webView, location.latitude, location.longitude, mapConfig.zoom, mapConfig.tiltDeg) {
+    LaunchedEffect(webView, location.latitude, location.longitude, mapConfig.zoom, mapConfig.tiltDeg, markerColor) {
         val bearing = location.carriedBearing(bearingHolder)
         webView.evaluateJavascript(
             "window.updateCamera && updateCamera(" +
-                "${location.latitude}, ${location.longitude}, $bearing, ${mapConfig.zoom}, ${mapConfig.tiltDeg})",
+                "${location.latitude}, ${location.longitude}, $bearing, ${mapConfig.zoom}, ${mapConfig.tiltDeg}, " +
+                "'$markerColor')",
             null,
         )
     }
@@ -156,3 +167,6 @@ internal fun WebMapView(
 // Dark map served via WebViewAssetLoader from the bundled dark style (shares the
 // OpenFreeMap sources); light uses the hosted positron style ([POSITRON_STYLE_URL]).
 private const val DARK_STYLE_URL = "https://appassets.androidplatform.net/assets/map/dark.json"
+
+// "#rrggbb" for CSS, dropping the alpha (the marker SVG fill is opaque).
+private fun Color.toCssHex(): String = "#%06X".format(0xFFFFFF and toArgb())


### PR DESCRIPTION
## Summary

Second in the staged map series (follows #89). The LIVE backends rendered no
self-location puck — only SNAPSHOT drew one — so switching to a live mode lost the
marker. This adds it to the WebGL map.

## Changes

- **`map.html`**: a `maplibregl.Marker` chevron rides the same GPS fixes as the
  camera. `rotationAlignment: "map"` + `pitchAlignment: "map"` rotate it to the
  travel bearing and lay it flat on the tilted ground plane, so with the heading-up
  camera it points toward the top of the frame — visually matching the SNAPSHOT
  chevron. It is a DOM marker, so it survives `setStyle` (light/dark swap, and the
  upcoming `transformStyle` feature toggles).
- **`WebMapView.kt`**: passes the Material primary colour as the marker fill via the
  last `updateCamera` argument, so the puck tracks the user's accent and self-heals
  if the first push raced page load (the next GPS fix re-applies it).

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` —
  green.
- Emulator (`TBox-Mock`, LIVE_HARDWARE): the chevron renders at the location in the
  Material primary colour, tilted onto the ground and pointing in the travel
  direction; no WebView/console errors.

## Next in the series

PR-C/D/E: 3D buildings / terrain / satellite toggles (LIVE only, via MapLibre
`transformStyle`).