### PR TITLE
feat(map): add live-map 3D buildings and terrain toggles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ targets that matter for any head-unit UI, regardless of motion.
 | `ACCESS_NETWORK_STATE` | MapLibre connectivity probe before fetching OpenFreeMap vector map tiles. |
 | `ACCESS_WIFI_STATE` | Read Wi-Fi transport / validation state so the footer status cluster reports a live Wi-Fi indicator. Normal protection; auto-granted at install. |
 | `BLUETOOTH_CONNECT` | Read the set of currently-connected Bluetooth devices (HEADSET / A2DP / GATT) so the footer status cluster reflects head-unit pairing state. Dangerous on Android 12+; runtime grant. When denied, the connected-device APIs are unreadable, so the BT indicator falls back to the adapter power state (on/off) rather than a misleading "disconnected"; the rest of the launcher remains functional. |
-| `INTERNET` | Open-Meteo weather API, OpenFreeMap vector map tile fetch (MapLibre), and Nominatim/OSM reverse geocoding. |
+| `INTERNET` | Open-Meteo weather API, OpenFreeMap vector map tile fetch (MapLibre), Nominatim/OSM reverse geocoding, and the optional live-map terrain layer (Mapterhorn DEM tiles). |
 | `READ_CALENDAR` | Query `CalendarContract.Instances` for the dashboard's Calendar card — the 6-day strip dots and the upcoming-event list. Dangerous; runtime grant. The card falls back to "today's date only" when denied. |
 | `READ_PHONE_STATE` | Read the cellular `SignalStrength.level` via `TelephonyCallback` so the footer status cluster shows graduated cellular signal bars. Dangerous; runtime grant. The cellular indicator degrades to the binary connected/disconnected icon when denied. |
 

--- a/app/src/main/assets/web/map.html
+++ b/app/src/main/assets/web/map.html
@@ -21,6 +21,69 @@
       // is kept as-is, and MapLibre's own context-loss restore handles transient
       // WebGL drops, so the page never asks the host to switch away.
       function log(msg) { try { console.log("[map] " + msg); } catch (e) {} }
+
+      // LIVE-only feature toggles, merged into the style via MapLibre transformStyle
+      // (the official "hybrid satellite map with terrain elevation" approach, minus
+      // satellite). DEM = Mapterhorn (free, no key); 3D buildings reuse the
+      // OpenMapTiles building layer's render_height. The terrain provider's required
+      // credit is shown by the host's Compose attribution overlay when active.
+      var MAPTERHORN_DEM_URL = "https://tiles.mapterhorn.com/tilejson.json";
+      var featureState = { buildings: false, terrain: false };
+      var currentStyleUrl = "https://tiles.openfreemap.org/styles/positron";
+
+      // The first vector source id in a style (the OpenMapTiles source), so 3D
+      // buildings work across positron / the bundled dark.json without hard-coding.
+      function vectorSourceId(style) {
+        var sources = style.sources || {};
+        return Object.keys(sources).find(function (id) { return sources[id].type === "vector"; });
+      }
+
+      // MapLibre transformStyle: merge the active feature layers/sources into a
+      // freshly-loaded base style. OFF features are simply not injected, so toggling
+      // off and re-setting the style removes them cleanly.
+      function injectFeatures(previousStyle, nextStyle) {
+        nextStyle.sources = nextStyle.sources || {};
+        nextStyle.layers = nextStyle.layers || [];
+        // Idempotent: strip any of OUR previously-injected layers/sources first, so a
+        // re-applied style (toggle change, or a setStyle that races the initial load
+        // and reuses the current style) never produces a duplicate-id error.
+        nextStyle.layers = nextStyle.layers.filter(function (l) {
+          return l.id !== "femto-3d-buildings";
+        });
+        // Only strip terrain if WE injected it (terrainSource present), so a base
+        // style that ever ships its own terrain is left intact.
+        if (nextStyle.sources.terrainSource) {
+          delete nextStyle.sources.terrainSource;
+          delete nextStyle.terrain;
+        }
+        var src = vectorSourceId(nextStyle);
+        if (featureState.buildings && src) {
+          // Insert beneath the first label (symbol) layer so labels stay on top.
+          var firstSymbol = nextStyle.layers.find(function (l) { return l.type === "symbol"; });
+          var buildings = {
+            id: "femto-3d-buildings", source: src, "source-layer": "building",
+            type: "fill-extrusion", minzoom: 14,
+            filter: ["!=", ["get", "hide_3d"], true],
+            paint: {
+              "fill-extrusion-color": "#c2c8d0",
+              "fill-extrusion-height": ["interpolate", ["linear"], ["zoom"], 14, 0, 16, ["get", "render_height"]],
+              "fill-extrusion-base": ["interpolate", ["linear"], ["zoom"], 14, 0, 16, ["get", "render_min_height"]],
+              "fill-extrusion-opacity": 0.85,
+            },
+          };
+          if (firstSymbol) nextStyle.layers.splice(nextStyle.layers.indexOf(firstSymbol), 0, buildings);
+          else nextStyle.layers.push(buildings);
+        }
+        if (featureState.terrain) {
+          nextStyle.sources.terrainSource = { type: "raster-dem", url: MAPTERHORN_DEM_URL };
+          nextStyle.terrain = { source: "terrainSource", exaggeration: 1.0 };
+        }
+        return nextStyle;
+      }
+
+      function applyStyle() {
+        if (map && currentStyleUrl) map.setStyle(currentStyleUrl, { transformStyle: injectFeatures });
+      }
       (function () {
         const c = document.createElement("canvas");
         if (!(c.getContext("webgl2") || c.getContext("webgl"))) log("no-webgl-context");
@@ -80,7 +143,13 @@
           if (firstCamera) { firstCamera = false; map.jumpTo(opts); }
           else map.easeTo({ ...opts, duration: 1000, essential: true });
         };
-        window.setStyleUrl = function (url) { if (map && url) map.setStyle(url); };
+        window.setStyleUrl = function (url) { if (url) { currentStyleUrl = url; applyStyle(); } };
+        // Android -> JS: flip the LIVE feature toggles, then re-apply the style so
+        // transformStyle injects (or omits) the matching layers/sources.
+        window.setFeatures = function (buildings, terrain) {
+          featureState = { buildings: !!buildings, terrain: !!terrain };
+          applyStyle();
+        };
         // Host (Android) calls this on lifecycle resume so the map re-measures and
         // repaints after the WebView was paused / not visible (guards a stale GL
         // surface): map.resize() + triggerRepaint().

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -128,6 +128,8 @@ class MainActivity : ComponentActivity() {
                                 renderPercent = display.mapRenderPercent,
                                 renderMode = display.mapRenderMode,
                                 lookAheadM = display.mapLookAheadM,
+                                buildings3d = display.map3dBuildings,
+                                terrain = display.mapTerrain,
                             ),
                         panels =
                             PanelVisibility(

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -98,6 +98,11 @@ internal data class DisplaySettings(
     // Camera look-ahead (metres): how far ahead of the current position the camera
     // aims, which sets how low the location marker sits (closer to the speed panel).
     val mapLookAheadM: Int,
+    // Live-map (WebGL) feature toggles. Both default off; they apply to the LIVE
+    // backends only (SNAPSHOT's native GL cannot extrude/relief safely). 3D buildings
+    // extrude the OpenMapTiles building layer; terrain adds raster-DEM relief.
+    val map3dBuildings: Boolean,
+    val mapTerrain: Boolean,
     // Info-pane card visibility. Each card defaults to shown so a fresh install
     // renders the full dashboard; hiding one lets the remaining cards (or the map)
     // reflow into the freed space.
@@ -121,6 +126,8 @@ internal data class DisplaySettings(
                 mapRenderPercent = DEFAULT_MAP_RENDER_PERCENT,
                 mapRenderMode = MapRenderMode.SNAPSHOT,
                 mapLookAheadM = DEFAULT_MAP_LOOKAHEAD_M,
+                map3dBuildings = false,
+                mapTerrain = false,
                 showCalendar = true,
                 showWeather = true,
                 showMusic = true,
@@ -164,6 +171,10 @@ internal interface DisplaySettingsStore {
 
     suspend fun setMapLookAhead(value: Int)
 
+    suspend fun setMap3dBuildings(value: Boolean)
+
+    suspend fun setMapTerrain(value: Boolean)
+
     suspend fun setShowCalendar(value: Boolean)
 
     suspend fun setShowWeather(value: Boolean)
@@ -197,6 +208,8 @@ internal class DisplayPreferences(
                 mapRenderPercent = prefs[MAP_QUALITY_KEY] ?: DEFAULT_MAP_RENDER_PERCENT,
                 mapRenderMode = prefs[MAP_RENDER_MODE_KEY].toMapRenderModeOr(MapRenderMode.SNAPSHOT),
                 mapLookAheadM = prefs[MAP_LOOKAHEAD_KEY] ?: DEFAULT_MAP_LOOKAHEAD_M,
+                map3dBuildings = prefs[MAP_3D_BUILDINGS_KEY] ?: false,
+                mapTerrain = prefs[MAP_TERRAIN_KEY] ?: false,
                 showCalendar = prefs[SHOW_CALENDAR_KEY] ?: true,
                 showWeather = prefs[SHOW_WEATHER_KEY] ?: true,
                 showMusic = prefs[SHOW_MUSIC_KEY] ?: true,
@@ -257,6 +270,14 @@ internal class DisplayPreferences(
         context.displayDataStore.edit { it[MAP_LOOKAHEAD_KEY] = value }
     }
 
+    override suspend fun setMap3dBuildings(value: Boolean) {
+        context.displayDataStore.edit { it[MAP_3D_BUILDINGS_KEY] = value }
+    }
+
+    override suspend fun setMapTerrain(value: Boolean) {
+        context.displayDataStore.edit { it[MAP_TERRAIN_KEY] = value }
+    }
+
     override suspend fun setShowCalendar(value: Boolean) {
         context.displayDataStore.edit { it[SHOW_CALENDAR_KEY] = value }
     }
@@ -283,6 +304,8 @@ internal class DisplayPreferences(
         val MAP_QUALITY_KEY = intPreferencesKey("map_render_percent")
         val MAP_RENDER_MODE_KEY = stringPreferencesKey("map_render_mode")
         val MAP_LOOKAHEAD_KEY = intPreferencesKey("map_look_ahead_m")
+        val MAP_3D_BUILDINGS_KEY = booleanPreferencesKey("map_3d_buildings")
+        val MAP_TERRAIN_KEY = booleanPreferencesKey("map_terrain")
         val SHOW_CALENDAR_KEY = booleanPreferencesKey("show_calendar")
         val SHOW_WEATHER_KEY = booleanPreferencesKey("show_weather")
         val SHOW_MUSIC_KEY = booleanPreferencesKey("show_music")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -88,7 +88,8 @@ import kotlin.math.sin
 
 // User-tunable map rendering config (derived from DisplaySettings): light/dark
 // style, oblique tilt, zoom, the render resolution percent (lower renders a
-// smaller bitmap, faster, upscaled to fill), and the user-picked render backend.
+// smaller bitmap, faster, upscaled to fill), the user-picked render backend, and
+// the LIVE-only feature toggles (3D buildings / terrain relief).
 internal data class MapConfig(
     val style: MapStyleSetting = MapStyleSetting.AUTO,
     val tiltDeg: Int = 55,
@@ -96,6 +97,8 @@ internal data class MapConfig(
     val renderPercent: Int = 100,
     val renderMode: MapRenderMode = MapRenderMode.SNAPSHOT,
     val lookAheadM: Int = 180,
+    val buildings3d: Boolean = false,
+    val terrain: Boolean = false,
 )
 
 /**
@@ -387,9 +390,18 @@ private fun styleBuilderFor(
     }
 
 @Composable
-internal fun Attribution(modifier: Modifier = Modifier) =
+internal fun Attribution(
+    modifier: Modifier = Modifier,
+    showTerrainCredit: Boolean = false,
+) {
+    // Append the terrain provider's required credit when that LIVE layer is active
+    // (its licence mandates attribution); the base OSM / OpenMapTiles / OpenFreeMap
+    // credit always shows.
+    val base = stringResource(R.string.map_attribution)
+    val terrain = stringResource(R.string.map_attribution_terrain)
+    val text = base + (if (showTerrainCredit) " · $terrain" else "")
     Text(
-        text = stringResource(R.string.map_attribution),
+        text = text,
         // Legal credit, not glance content — OSM ODbL / OpenMapTiles CC-BY require
         // it but it is not read on the move, so it sits well below the body-text
         // floor and is shrunk further here so the centred speed overlay does not
@@ -406,6 +418,7 @@ internal fun Attribution(modifier: Modifier = Modifier) =
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.6f))
                 .padding(horizontal = 4.dp, vertical = 1.dp),
     )
+}
 
 // Current-location puck: a heading-up navigation chevron, positioned by the pixel
 // the location rendered at (see MapFrame). The map is heading-up, so the chevron

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -71,6 +72,14 @@ internal fun WebMapView(
             MapStyleSetting.DARK -> true
         }
 
+    // Flips true once the page's script has run (onPageFinished) so the JS bridge
+    // functions exist. The state-pushing effects below gate + key on it, so the
+    // current camera / style / feature state is (re)applied as soon as the page is
+    // ready — closing the race where an effect fires before the script registers
+    // window.updateCamera / setStyleUrl / setFeatures and is silently dropped.
+    // Reset with the WebView (a render-mode switch rebuilds it and reloads the page).
+    val pageReady = remember(softwareRendering) { mutableStateOf(false) }
+
     val webView =
         remember(softwareRendering) {
             val assetLoader =
@@ -96,6 +105,15 @@ internal fun WebMapView(
                             view: WebView,
                             request: WebResourceRequest,
                         ): WebResourceResponse? = assetLoader.shouldInterceptRequest(request.url)
+
+                        // The inline page script runs synchronously during parse, so by
+                        // onPageFinished the bridge functions are registered.
+                        override fun onPageFinished(
+                            view: WebView,
+                            url: String,
+                        ) {
+                            pageReady.value = true
+                        }
                     }
                 loadUrl("https://appassets.androidplatform.net/assets/web/map.html")
             }
@@ -106,11 +124,18 @@ internal fun WebMapView(
     // self-heals if the first push raced the page load (the next GPS fix re-applies).
     val markerColor = MaterialTheme.colorScheme.primary.toCssHex()
 
-    // Key on [webView] too: a render-mode switch rebuilds the WebView, and the new
-    // instance must receive the current camera and style immediately rather than
-    // waiting for the next GPS fix / theme change (it would otherwise show the
-    // default [0,0] world view in the meantime).
-    LaunchedEffect(webView, location.latitude, location.longitude, mapConfig.zoom, mapConfig.tiltDeg, markerColor) {
+    // Each effect keys on [pageReady] (so it fires once the page is ready) and on
+    // [webView] (a render-mode switch rebuilds it), then pushes the current state.
+    LaunchedEffect(
+        pageReady.value,
+        webView,
+        location.latitude,
+        location.longitude,
+        mapConfig.zoom,
+        mapConfig.tiltDeg,
+        markerColor,
+    ) {
+        if (!pageReady.value) return@LaunchedEffect
         val bearing = location.carriedBearing(bearingHolder)
         webView.evaluateJavascript(
             "window.updateCamera && updateCamera(" +
@@ -119,9 +144,19 @@ internal fun WebMapView(
             null,
         )
     }
-    LaunchedEffect(webView, isDark) {
+    LaunchedEffect(pageReady.value, webView, isDark) {
+        if (!pageReady.value) return@LaunchedEffect
         val style = if (isDark) DARK_STYLE_URL else POSITRON_STYLE_URL
         webView.evaluateJavascript("window.setStyleUrl && setStyleUrl('$style')", null)
+    }
+    // LIVE-only feature toggles (3D buildings / terrain). The page merges them into
+    // the style via MapLibre transformStyle, so this re-applies the style.
+    LaunchedEffect(pageReady.value, webView, mapConfig.buildings3d, mapConfig.terrain) {
+        if (!pageReady.value) return@LaunchedEffect
+        webView.evaluateJavascript(
+            "window.setFeatures && setFeatures(${mapConfig.buildings3d}, ${mapConfig.terrain})",
+            null,
+        )
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -160,7 +195,10 @@ internal fun WebMapView(
             modifier = Modifier.fillMaxSize().clickable { onTap() },
             factory = { webView },
         )
-        Attribution(modifier = Modifier.align(Alignment.BottomStart))
+        Attribution(
+            modifier = Modifier.align(Alignment.BottomStart),
+            showTerrainCredit = mapConfig.terrain,
+        )
     }
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -205,21 +205,39 @@ internal fun SettingsScreen(
                 range = MIN_MAP_ZOOM..MAX_MAP_ZOOM,
                 onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
             )
-            SliderRow(
-                title = stringResource(R.string.settings_group_map_look_ahead),
-                valueLabel = stringResource(R.string.settings_map_look_ahead_value, uiState.mapLookAheadM),
-                value = uiState.mapLookAheadM,
-                range = MIN_MAP_LOOK_AHEAD..MAX_MAP_LOOK_AHEAD,
-                onValueChange = { onAction(SettingsAction.SetMapLookAhead(it)) },
-            )
-            SliderRow(
-                title = stringResource(R.string.settings_group_map_quality),
-                valueLabel = stringResource(R.string.settings_map_quality_value, uiState.mapRenderPercent),
-                value = uiState.mapRenderPercent,
-                range = MIN_MAP_QUALITY..MAX_MAP_QUALITY,
-                onValueChange = { onAction(SettingsAction.SetMapRenderPercent(it)) },
-                description = stringResource(R.string.settings_map_quality_desc),
-            )
+            // Mode-specific rows: the live (WebGL) backends expose 3D buildings /
+            // terrain; the snapshot backend exposes look-ahead framing and the bitmap
+            // sharpness. Showing only the rows that affect the chosen backend keeps
+            // the panel honest (e.g. sharpness does nothing on the live map).
+            if (uiState.mapRenderMode == MapRenderMode.SNAPSHOT) {
+                SliderRow(
+                    title = stringResource(R.string.settings_group_map_look_ahead),
+                    valueLabel = stringResource(R.string.settings_map_look_ahead_value, uiState.mapLookAheadM),
+                    value = uiState.mapLookAheadM,
+                    range = MIN_MAP_LOOK_AHEAD..MAX_MAP_LOOK_AHEAD,
+                    onValueChange = { onAction(SettingsAction.SetMapLookAhead(it)) },
+                )
+                SliderRow(
+                    title = stringResource(R.string.settings_group_map_quality),
+                    valueLabel = stringResource(R.string.settings_map_quality_value, uiState.mapRenderPercent),
+                    value = uiState.mapRenderPercent,
+                    range = MIN_MAP_QUALITY..MAX_MAP_QUALITY,
+                    onValueChange = { onAction(SettingsAction.SetMapRenderPercent(it)) },
+                    description = stringResource(R.string.settings_map_quality_desc),
+                )
+            } else {
+                SwitchRow(
+                    title = stringResource(R.string.settings_group_map_3d),
+                    checked = uiState.map3dBuildings,
+                    onCheckedChange = { onAction(SettingsAction.SetMap3dBuildings(it)) },
+                )
+                SwitchRow(
+                    title = stringResource(R.string.settings_group_map_terrain),
+                    checked = uiState.mapTerrain,
+                    onCheckedChange = { onAction(SettingsAction.SetMapTerrain(it)) },
+                    summary = stringResource(R.string.settings_map_terrain_desc),
+                )
+            }
         }
 
         SettingsSection(title = stringResource(R.string.settings_section_panels)) {
@@ -467,16 +485,19 @@ private fun <T> ChoiceDialog(
 )
 
 // A boolean row: the whole row is the toggle (role = Switch), so the inline
-// Switch is presentation-only (onCheckedChange = null) and never double-fires.
+// Switch is presentation-only (onCheckedChange = null) and never double-fires. An
+// optional [summary] explains what the toggle does (e.g. attribution / cost notes).
 @Composable
 private fun SwitchRow(
     title: String,
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    summary: String? = null,
 ) = SettingRow(
     title = title,
     modifier = modifier.toggleable(value = checked, role = Role.Switch, onValueChange = onCheckedChange),
+    summary = summary,
 ) {
     Switch(checked = checked, onCheckedChange = null)
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -26,6 +26,8 @@ internal data class SettingsUiState(
     val mapRenderPercent: Int,
     val mapRenderMode: MapRenderMode,
     val mapLookAheadM: Int,
+    val map3dBuildings: Boolean,
+    val mapTerrain: Boolean,
     val showCalendar: Boolean,
     val showWeather: Boolean,
     val showMusic: Boolean,
@@ -49,6 +51,8 @@ internal data class SettingsUiState(
                 mapRenderPercent = DisplaySettings.Default.mapRenderPercent,
                 mapRenderMode = DisplaySettings.Default.mapRenderMode,
                 mapLookAheadM = DisplaySettings.Default.mapLookAheadM,
+                map3dBuildings = DisplaySettings.Default.map3dBuildings,
+                mapTerrain = DisplaySettings.Default.mapTerrain,
                 showCalendar = DisplaySettings.Default.showCalendar,
                 showWeather = DisplaySettings.Default.showWeather,
                 showMusic = DisplaySettings.Default.showMusic,
@@ -109,6 +113,14 @@ internal sealed interface SettingsAction {
 
     data class SetMapLookAhead(
         val value: Int,
+    ) : SettingsAction
+
+    data class SetMap3dBuildings(
+        val value: Boolean,
+    ) : SettingsAction
+
+    data class SetMapTerrain(
+        val value: Boolean,
     ) : SettingsAction
 
     data class SetShowCalendar(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -34,6 +34,8 @@ internal class SettingsViewModel(
                 mapRenderPercent = display.mapRenderPercent,
                 mapRenderMode = display.mapRenderMode,
                 mapLookAheadM = display.mapLookAheadM,
+                map3dBuildings = display.map3dBuildings,
+                mapTerrain = display.mapTerrain,
                 showCalendar = display.showCalendar,
                 showWeather = display.showWeather,
                 showMusic = display.showMusic,
@@ -58,6 +60,8 @@ internal class SettingsViewModel(
                 is SettingsAction.SetMapRenderPercent -> displayPreferences.setMapRenderPercent(action.value)
                 is SettingsAction.SetMapRenderMode -> displayPreferences.setMapRenderMode(action.value)
                 is SettingsAction.SetMapLookAhead -> displayPreferences.setMapLookAhead(action.value)
+                is SettingsAction.SetMap3dBuildings -> displayPreferences.setMap3dBuildings(action.value)
+                is SettingsAction.SetMapTerrain -> displayPreferences.setMapTerrain(action.value)
                 is SettingsAction.SetShowCalendar -> displayPreferences.setShowCalendar(action.value)
                 is SettingsAction.SetShowWeather -> displayPreferences.setShowWeather(action.value)
                 is SettingsAction.SetShowMusic -> displayPreferences.setShowMusic(action.value)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="map_unavailable">Map unavailable</string>
     <string name="map_permission_cta">Grant location access to enable the map and overlays.</string>
     <string name="map_attribution">© OpenStreetMap · OpenMapTiles · OpenFreeMap</string>
+    <string name="map_attribution_terrain">Terrain © Mapterhorn</string>
 
     <!-- Speed overlay -->
     <string name="speed_reset_trip">Reset trip</string>
@@ -129,6 +130,9 @@
     <string name="settings_map_quality_desc">Lower renders the map faster but softer — useful on slow head units.</string>
     <string name="settings_group_map_look_ahead">Marker look-ahead</string>
     <string name="settings_map_look_ahead_value">%1$d m</string>
+    <string name="settings_group_map_3d">3D buildings</string>
+    <string name="settings_group_map_terrain">Terrain</string>
+    <string name="settings_map_terrain_desc">3D elevation relief (Mapterhorn). Adds tile downloads; heavier on low-end GPUs.</string>
     <string name="settings_group_panel_calendar">Calendar panel</string>
     <string name="settings_group_panel_weather">Weather panel</string>
     <string name="settings_group_panel_music">Music panel</string>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -54,6 +54,10 @@ internal class FakeDisplaySettingsStore(
 
     override suspend fun setMapLookAhead(value: Int) = state.update { it.copy(mapLookAheadM = value) }
 
+    override suspend fun setMap3dBuildings(value: Boolean) = state.update { it.copy(map3dBuildings = value) }
+
+    override suspend fun setMapTerrain(value: Boolean) = state.update { it.copy(mapTerrain = value) }
+
     override suspend fun setShowCalendar(value: Boolean) = state.update { it.copy(showCalendar = value) }
 
     override suspend fun setShowWeather(value: Boolean) = state.update { it.copy(showWeather = value) }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -100,5 +100,21 @@ class SettingsViewModelTest {
             assertEquals(200, store.settings.first().mapLookAheadM)
         }
 
+    @Test
+    fun `SetMap3dBuildings writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetMap3dBuildings(true))
+            advanceUntilIdle()
+            assertEquals(true, store.settings.first().map3dBuildings)
+        }
+
+    @Test
+    fun `SetMapTerrain writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetMapTerrain(true))
+            advanceUntilIdle()
+            assertEquals(true, store.settings.first().mapTerrain)
+        }
+
     private fun viewModel() = SettingsViewModel(store, FontPreferences(application))
 }


### PR DESCRIPTION
## Summary

Third in the staged map series (follows #89, #92). Adds two **LIVE-only** (WebGL)
map options — **3D buildings** and **terrain** — off by default, surfaced as
Settings switches that appear only when a live render mode is selected.

A **satellite imagery** toggle was scoped (and approved as EOX Sentinel-2 cloudless
2016) but **deferred**: the live EOX WMTS capabilities confirm no commercial-licensed
(CC BY) year is served in web-mercator — only NonCommercial years (2017–2025) and a
generic layer of unclear commercial status. Shipping a NonCommercial basemap in a
product "designed for multi-region distribution" would violate the strictest-rule-wins
licensing posture, so satellite waits for a clean source.

## Changes

- **3D buildings** (`map.html`): a `fill-extrusion` over the OpenMapTiles `building`
  source-layer (`render_height` / `render_min_height`, filtered by `hide_3d`),
  inserted beneath the first label layer. No new tile source / attribution.
- **Terrain** (`map.html`): a Mapterhorn `raster-dem` source + `setTerrain` relief
  (free, no key). Its required credit is appended to the attribution overlay when on.
- Both are merged via MapLibre **`transformStyle`** (the official "hybrid satellite +
  terrain" sample approach). `injectFeatures` is **idempotent** — it strips any
  previously-injected layer/source before re-adding, fixing a duplicate-layer-id error
  that occurs when `setStyle` races the initial page load.
- **Launch-race fix** (`WebMapView.kt`): the camera / style / feature pushes now gate
  on `onPageFinished`, so saved toggles (and dark mode) apply on launch instead of
  only after a manual change.
- **Settings**: the Map section now shows mode-specific rows — SNAPSHOT keeps
  look-ahead + sharpness; LIVE shows the 3D / terrain switches — so the panel only
  exposes settings that affect the chosen backend. `SwitchRow` gained an optional
  `summary`.
- Full DataStore → interface → Fake → ViewModel → UiState → Action → View chain for
  `map3dBuildings` / `mapTerrain`, with ViewModel tests. `CLAUDE.md` INTERNET audit
  log updated for the Mapterhorn host (no new permission).

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` —
  green.
- Desktop Chrome (served `map.html`): 3D buildings extrude over Tokyo, Mapterhorn DEM
  loads (200), repeated `setFeatures` toggling produces no duplicate-id / transformStyle
  errors (only a benign `favicon.ico` 404).
- `compose-launcher-reviewer`: no blocking findings; applied all three suggestions
  (stale comment, the `onPageFinished` launch-race fix, narrowed terrain strip).

## Device test (follow-up)

In a LIVE mode, toggle 3D buildings (expect extruded buildings at zoom ≥ 14, pitched)
and terrain (relief in hilly areas; flat cities show none). Confirm the toggles only
appear for LIVE modes and persist across a relaunch.