### PR TITLE
fix(map): remove the non-functional live-software render mode

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -44,15 +44,18 @@ internal enum class MapStyleSetting { AUTO, LIGHT, DARK }
 /**
  * Map render backend, picked explicitly by the user (no auto-fallback).
  *
- * - [LIVE_HARDWARE]: MapLibre GL JS in a hardware-accelerated WebView (smoothest
- *   where the device GPU presents WebGL).
- * - [LIVE_SOFTWARE]: the same WebView forced to the software layer
- *   (`setLayerType(LAYER_TYPE_SOFTWARE)`), so Chromium renders WebGL via
- *   SwiftShader — a fallback for GPUs that cannot keep a live WebGL context.
- * - [SNAPSHOT]: off-screen `MapSnapshotter` bitmaps; presents reliably on the
- *   projected / virtualised displays of AI boxes. The default.
+ * - [LIVE]: MapLibre GL JS (WebGL) in a hardware-accelerated WebView — smooth,
+ *   animated, renders on both the emulator and the head unit.
+ * - [SNAPSHOT]: off-screen `MapSnapshotter` bitmaps; presents reliably on any
+ *   display (the robust floor for hardware that cannot keep a WebGL context).
+ *   The default.
+ *
+ * A software-WebGL (SwiftShader) backend was removed: there is no per-app API to
+ * route WebView WebGL through SwiftShader (`setLayerType(LAYER_TYPE_SOFTWARE)`
+ * yields a blank map, not software WebGL), and hardware WebGL works on the target
+ * device, so SNAPSHOT already covers the no-WebGL case.
  */
-internal enum class MapRenderMode { LIVE_HARDWARE, LIVE_SOFTWARE, SNAPSHOT }
+internal enum class MapRenderMode { LIVE, SNAPSHOT }
 
 /** Default oblique-camera tilt (degrees) and zoom level for the map. */
 internal const val DEFAULT_MAP_TILT_DEG = 55
@@ -317,11 +320,11 @@ internal class DisplayPreferences(
 private inline fun <reified T : Enum<T>> String?.toEnumOr(fallback: T): T =
     this?.let { name -> enumEntries<T>().firstOrNull { it.name == name } } ?: fallback
 
-// Decode the render mode, migrating the pre-3-mode "LIVE" value to LIVE_HARDWARE
-// so a user who chose the live map keeps it (rather than silently reverting to
-// the SNAPSHOT default) after the SNAPSHOT/LIVE enum split into three.
+// Decode the render mode, migrating the short-lived three-mode values
+// (LIVE_HARDWARE / LIVE_SOFTWARE) back to LIVE, so anyone who picked a live map
+// keeps it after the software backend was removed.
 private fun String?.toMapRenderModeOr(fallback: MapRenderMode): MapRenderMode =
     when (this) {
-        "LIVE" -> MapRenderMode.LIVE_HARDWARE
+        "LIVE_HARDWARE", "LIVE_SOFTWARE" -> MapRenderMode.LIVE
         else -> toEnumOr(fallback)
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -113,11 +113,9 @@ internal data class MapConfig(
  *   bitmap rides the normal Skia composition path and presents reliably. The
  *   snapshot re-renders on movement, single-flight, holding the previous frame so
  *   there is no flicker.
- * - LIVE_HARDWARE / LIVE_SOFTWARE ([WebMapView]) render MapLibre GL JS (WebGL) in
- *   a WebView, which composites inline through HWUI and animates the camera for a
- *   smooth follow. LIVE_SOFTWARE forces the WebView onto the software layer so
- *   Chromium renders WebGL via SwiftShader (for GPUs that cannot keep a hardware
- *   WebGL context). There is NO auto-fallback: the chosen backend is kept as-is.
+ * - LIVE ([WebMapView]) renders MapLibre GL JS (WebGL) in a hardware-accelerated
+ *   WebView, which composites inline through HWUI and animates the camera for a
+ *   smooth follow. There is NO auto-fallback: the chosen backend is kept as-is.
  *
  * Clock and speed overlays are placed by the parent on top of this surface.
  */
@@ -138,22 +136,11 @@ internal fun MapPanel(
         // centre point; without it the map has nothing to show, so fall back.
         if (location != null) {
             when (mapConfig.renderMode) {
-                MapRenderMode.LIVE_HARDWARE -> {
+                MapRenderMode.LIVE -> {
                     WebMapView(
                         location = location,
                         mapConfig = mapConfig,
                         onTap = onTap,
-                        softwareRendering = false,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
-
-                MapRenderMode.LIVE_SOFTWARE -> {
-                    WebMapView(
-                        location = location,
-                        mapConfig = mapConfig,
-                        onTap = onTap,
-                        softwareRendering = true,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -2,7 +2,6 @@ package io.github.seijikohara.femto.ui.home.components
 
 import android.annotation.SuppressLint
 import android.location.Location
-import android.view.View
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
@@ -44,11 +43,9 @@ import io.github.seijikohara.femto.data.MapStyleSetting
  *
  * There is NO auto-fallback: the page relies on MapLibre's built-in WebGL
  * context-loss restore (`webglcontextlost`/`webglcontextrestored`) and the host
- * keeps the chosen backend regardless. [softwareRendering] forces the WebView onto
- * the software layer (`setLayerType(LAYER_TYPE_SOFTWARE)`) so Chromium renders
- * WebGL via SwiftShader — the LIVE_SOFTWARE backend for GPUs that cannot keep a
- * hardware WebGL context. Switching the flag rebuilds the WebView (it keys the
- * `remember`).
+ * keeps the chosen backend regardless. The WebView renders WebGL on the GPU
+ * (hardware-accelerated); a device that cannot keep a WebGL context uses the
+ * SNAPSHOT backend instead.
  *
  * [ON_START][androidx.lifecycle.Lifecycle.Event.ON_START] resumes the WebView and
  * nudges the map to re-measure/repaint; the WebView is paused only on ON_STOP (a
@@ -60,7 +57,6 @@ internal fun WebMapView(
     location: Location,
     mapConfig: MapConfig,
     onTap: () -> Unit,
-    softwareRendering: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -77,21 +73,16 @@ internal fun WebMapView(
     // current camera / style / feature state is (re)applied as soon as the page is
     // ready — closing the race where an effect fires before the script registers
     // window.updateCamera / setStyleUrl / setFeatures and is silently dropped.
-    // Reset with the WebView (a render-mode switch rebuilds it and reloads the page).
-    val pageReady = remember(softwareRendering) { mutableStateOf(false) }
+    val pageReady = remember { mutableStateOf(false) }
 
     val webView =
-        remember(softwareRendering) {
+        remember {
             val assetLoader =
                 WebViewAssetLoader
                     .Builder()
                     .addPathHandler("/assets/", WebViewAssetLoader.AssetsPathHandler(context))
                     .build()
             WebView(context).apply {
-                // Hardware layer renders WebGL on the GPU; the software layer routes
-                // Chromium through SwiftShader (the LIVE_SOFTWARE backend) for devices
-                // whose GPU cannot keep a live WebGL context.
-                setLayerType(if (softwareRendering) View.LAYER_TYPE_SOFTWARE else View.LAYER_TYPE_HARDWARE, null)
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true
                 // Keep rasterizing while attached but not yet visible (the Compose
@@ -120,15 +111,13 @@ internal fun WebMapView(
         }
 
     // Material primary as the self-location marker fill, so the WebGL puck matches
-    // the SNAPSHOT marker and the user's accent. Passed on every camera update so it
-    // self-heals if the first push raced the page load (the next GPS fix re-applies).
+    // the SNAPSHOT marker and the user's accent.
     val markerColor = MaterialTheme.colorScheme.primary.toCssHex()
 
-    // Each effect keys on [pageReady] (so it fires once the page is ready) and on
-    // [webView] (a render-mode switch rebuilds it), then pushes the current state.
+    // Each effect keys on [pageReady] (so it fires once the page is ready), then
+    // pushes the current state to the page.
     LaunchedEffect(
         pageReady.value,
-        webView,
         location.latitude,
         location.longitude,
         mapConfig.zoom,
@@ -144,14 +133,14 @@ internal fun WebMapView(
             null,
         )
     }
-    LaunchedEffect(pageReady.value, webView, isDark) {
+    LaunchedEffect(pageReady.value, isDark) {
         if (!pageReady.value) return@LaunchedEffect
         val style = if (isDark) DARK_STYLE_URL else POSITRON_STYLE_URL
         webView.evaluateJavascript("window.setStyleUrl && setStyleUrl('$style')", null)
     }
     // LIVE-only feature toggles (3D buildings / terrain). The page merges them into
     // the style via MapLibre transformStyle, so this re-applies the style.
-    LaunchedEffect(pageReady.value, webView, mapConfig.buildings3d, mapConfig.terrain) {
+    LaunchedEffect(pageReady.value, mapConfig.buildings3d, mapConfig.terrain) {
         if (!pageReady.value) return@LaunchedEffect
         webView.evaluateJavascript(
             "window.setFeatures && setFeatures(${mapConfig.buildings3d}, ${mapConfig.terrain})",

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -173,8 +173,7 @@ internal fun SettingsScreen(
                 title = stringResource(R.string.settings_group_map_rendering),
                 options =
                     listOf(
-                        MapRenderMode.LIVE_HARDWARE to stringResource(R.string.settings_map_mode_live_hardware),
-                        MapRenderMode.LIVE_SOFTWARE to stringResource(R.string.settings_map_mode_live_software),
+                        MapRenderMode.LIVE to stringResource(R.string.settings_map_mode_live),
                         MapRenderMode.SNAPSHOT to stringResource(R.string.settings_map_mode_snapshot),
                     ),
                 selected = uiState.mapRenderMode,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,8 +117,7 @@
     <string name="settings_group_clock_seconds">Show seconds</string>
     <string name="settings_group_fullscreen">Fullscreen</string>
     <string name="settings_group_map_rendering">Map rendering</string>
-    <string name="settings_map_mode_live_hardware">Live (hardware)</string>
-    <string name="settings_map_mode_live_software">Live (software)</string>
+    <string name="settings_map_mode_live">Live</string>
     <string name="settings_map_mode_snapshot">Snapshot</string>
     <string name="settings_group_map_style">Map style</string>
     <string name="settings_group_map_tilt">Map tilt</string>

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -87,9 +87,9 @@ class SettingsViewModelTest {
     @Test
     fun `SetMapRenderMode writes the value to the store`() =
         runTest(dispatcher) {
-            viewModel().onAction(SettingsAction.SetMapRenderMode(MapRenderMode.LIVE_HARDWARE))
+            viewModel().onAction(SettingsAction.SetMapRenderMode(MapRenderMode.LIVE))
             advanceUntilIdle()
-            assertEquals(MapRenderMode.LIVE_HARDWARE, store.settings.first().mapRenderMode)
+            assertEquals(MapRenderMode.LIVE, store.settings.first().mapRenderMode)
         }
 
     @Test


### PR DESCRIPTION
## Summary

`LIVE_SOFTWARE` (added in #89) never rendered — on the emulator **or** the head
unit it shows a blank map. The cause: there is no per-app API to route WebView WebGL
through SwiftShader; `setLayerType(LAYER_TYPE_SOFTWARE)` simply disables the WebGL
path rather than falling back to software rendering (SwiftShader needs the debug-only
Chromium `--use-angle=swiftshader` flag, not settable in production).

Since **hardware WebGL (`LIVE`) works on both the emulator and the device**, and
**SNAPSHOT** is the robust universal floor for any hardware that cannot keep a WebGL
context, the software mode added a broken, confusing option with no role.

## Changes

- `MapRenderMode` collapses back to `{ LIVE, SNAPSHOT }`. The short-lived
  `LIVE_HARDWARE` / `LIVE_SOFTWARE` stored values migrate to `LIVE`, so anyone who
  picked a live map keeps it.
- `WebMapView` drops the `softwareRendering` parameter and the `setLayerType` call
  (the WebView is hardware-accelerated, the default).
- Settings render-mode choice is now Live / Snapshot; the live-only feature toggles
  still gate on "not SNAPSHOT".

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` —
  green.
- Emulator: the stored live preference migrates to `LIVE` and the WebGL map renders
  with the location marker; the render-mode setting now offers two options.