### PR TITLE
feat(calendar): scrollable 30-day agenda list

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
@@ -10,7 +10,7 @@ internal fun fakeCalendarSnapshot(
     today: LocalDate = LocalDate.of(2026, 5, 1),
     weekday: String = "Friday",
     monthLabel: String = "May 2026",
-    dayStrip: List<DayCell> =
+    days: List<DayCell> =
         listOf(
             DayCell(
                 LocalDate.of(2026, 5, 1),
@@ -32,6 +32,6 @@ internal fun fakeCalendarSnapshot(
         today = today,
         weekday = weekday,
         monthLabel = monthLabel,
-        dayStrip = dayStrip,
+        days = days,
         hasCalendarAccess = hasCalendarAccess,
     )

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
@@ -1,12 +1,9 @@
 package io.github.seijikohara.femto.ui.home.components
 
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.testfixtures.fakeCalendarSnapshot
@@ -19,49 +16,29 @@ class CalendarCardTest {
     val rule = createComposeRule()
 
     @Test
-    fun renders_selected_day_event_title_for_granted_snapshot() {
+    fun renders_each_days_events_in_the_agenda_list() {
         rule.setContent {
             FemtoTheme {
                 CalendarCard(snapshot = fakeCalendarSnapshot())
             }
         }
-        // Selection defaults to today (the first strip cell), so today's first
-        // event title appears in the events section.
+        // The agenda lists every day, so events from different days all render
+        // simultaneously (no per-day selection).
         rule.onNodeWithText("Team standup").assertIsDisplayed()
-    }
-
-    @Test
-    fun selecting_a_day_shows_that_days_events_and_keeps_the_head_on_today() {
-        rule.setContent {
-            FemtoTheme {
-                CalendarCard(snapshot = fakeCalendarSnapshot())
-            }
-        }
-        // Strip cells expose their ISO date as the content description.
-        rule.onNodeWithContentDescription("2026-05-03").performClick()
-
-        // The events section switches to the selected day; today's events leave.
         rule.onNodeWithText("Brunch").assertIsDisplayed()
-        rule.onAllNodesWithText("Team standup").assertCountEquals(0)
-        // The hero head stays on today regardless of the selected day.
-        rule.onNodeWithText("Friday").assertIsDisplayed()
     }
 
     @Test
-    fun selecting_a_day_without_events_shows_the_empty_message() {
+    fun shows_a_placeholder_for_days_without_events() {
         rule.setContent {
             FemtoTheme {
                 CalendarCard(snapshot = fakeCalendarSnapshot())
             }
         }
-        rule.onNodeWithContentDescription("2026-05-02").performClick()
-
-        val noEvents =
-            InstrumentationRegistry
-                .getInstrumentation()
-                .targetContext
-                .getString(R.string.calendar_no_events)
-        rule.onNodeWithText(noEvents).assertIsDisplayed()
+        // The fixture has free days (e.g. 2026-05-02), each shown with the em-dash
+        // placeholder, so at least one renders.
+        val placeholders = rule.onAllNodesWithText("—").fetchSemanticsNodes()
+        assert(placeholders.isNotEmpty()) { "expected at least one free-day placeholder" }
     }
 
     @Test
@@ -72,9 +49,8 @@ class CalendarCardTest {
             }
         }
         // The hero head renders the day-of-month of the fixture's `today`
-        // (2026-05-01); the strip also leads with the same "1" cell. Compose has
-        // no assertCountIsAtLeast, so fetch the matching nodes and assert the
-        // day-of-month rendered at least once.
+        // (2026-05-01). Compose has no assertCountIsAtLeast, so fetch the matching
+        // nodes and assert the day-of-month rendered at least once.
         val dayNodes = rule.onAllNodesWithText("1").fetchSemanticsNodes()
         assert(dayNodes.isNotEmpty()) { "expected the day-of-month '1' to render at least once" }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
@@ -37,9 +37,9 @@ import java.util.Locale
  * Combines two upstream signals — the wall clock (so today / weekday /
  * month follow real time without an extra timer) and the events provider
  * (so the per-day events refresh when the user edits a calendar event). The
- * events query window is `today + 5 days` to match the 6-cell strip on the
- * calendar card; each day's events are attached to its strip cell so the card
- * can switch the shown day from card-local selection without a re-query.
+ * events query window is `today + WINDOW_DAYS` so the card can render a vertical
+ * scrollable list of the coming days; each day's full event list is attached to
+ * its day cell (days with no events are present too, with an empty list).
  *
  * When `READ_CALENDAR` is denied the snapshot still emits from the clock
  * alone, but with `hasCalendarAccess = false` so the card renders the denial
@@ -64,7 +64,7 @@ internal class CalendarRepository(
     private fun buildSnapshot(today: LocalDate): CalendarSnapshot {
         val granted = hasPermission()
         val eventsByDay = if (granted) readWindow(today) else emptyMap()
-        val strip = (0 until DAY_STRIP_LENGTH).map { offset ->
+        val days = (0 until WINDOW_DAYS).map { offset ->
             val date = today.plusDays(offset.toLong())
             DayCell(
                 date = date,
@@ -76,7 +76,7 @@ internal class CalendarRepository(
             today = today,
             weekday = today.dayOfWeek.getDisplayName(TextStyle.FULL, locale),
             monthLabel = monthLabelOf(today),
-            dayStrip = strip,
+            days = days,
             hasCalendarAccess = granted,
         )
     }
@@ -101,7 +101,7 @@ internal class CalendarRepository(
             PackageManager.PERMISSION_GRANTED
 
     /**
-     * Build the `Instances` content URI for the `today .. today + DAY_STRIP_LENGTH`
+     * Build the `Instances` content URI for the `today .. today + WINDOW_DAYS`
      * window. `Instances` requires the begin / end millis embedded as path ids
      * rather than passed as a selection.
      */
@@ -114,7 +114,7 @@ internal class CalendarRepository(
                 ContentUris.appendId(
                     it,
                     today
-                        .plusDays(DAY_STRIP_LENGTH.toLong())
+                        .plusDays(WINDOW_DAYS.toLong())
                         .atStartOfDay(zone)
                         .toInstant()
                         .toEpochMilli(),
@@ -122,11 +122,10 @@ internal class CalendarRepository(
             }.build()
 
     /**
-     * Scan the strip window once and group every event by its local day. The
-     * card shows whichever day the user selects, so the window holds the whole
-     * day (no `BEGIN >= now` future-only filter) capped at [EVENTS_PER_DAY_LIMIT]
-     * per day to bound the card height. Rows arrive `BEGIN ASC`, so each day's
-     * list stays time-ordered and the cap keeps the earliest events.
+     * Scan the window once and group every event by its local day. The card lists
+     * each day's full set of events (no per-day cap — the card scrolls), so the
+     * whole day is held with no `BEGIN >= now` future-only filter. Rows arrive
+     * `BEGIN ASC`, so each day's list stays time-ordered.
      *
      * A mid-stream permission revoke (SecurityException) or an OEM provider
      * fault (SQLiteException) must not tear down the dashboard StateFlow, so the
@@ -150,21 +149,18 @@ internal class CalendarRepository(
                 )?.use { cursor ->
                     while (cursor.moveToNext()) {
                         val startMs = cursor.getLong(0)
-                        // Skip null-title rows entirely: with the dot derived from
-                        // the listed events, a row that cannot be shown must not
-                        // dot its day either.
+                        // Skip null-title rows entirely: a row that cannot be shown
+                        // must not contribute to its day's list either.
                         val title = cursor.getString(1) ?: continue
                         val allDay = cursor.getInt(2) != 0
-                        val dayEvents = byDay.getOrPut(localDateOf(startMs, allDay)) { mutableListOf() }
-                        if (dayEvents.size < EVENTS_PER_DAY_LIMIT) {
-                            dayEvents += EventItem(
+                        byDay.getOrPut(localDateOf(startMs, allDay)) { mutableListOf() } +=
+                            EventItem(
                                 // All-day rows carry no clock time; surface null
                                 // so the card renders an "all day" label instead
                                 // of a spurious 00:00 derived from the system zone.
                                 time = if (allDay) null else LocalTime.ofInstant(Instant.ofEpochMilli(startMs), zone),
                                 title = title,
                             )
-                        }
                     }
                 }
             byDay.mapValues { (_, events) -> events.toList() }
@@ -225,8 +221,8 @@ internal class CalendarRepository(
         }.debounce(CHANGE_DEBOUNCE_MS)
 
     private companion object {
-        const val DAY_STRIP_LENGTH = 6
-        const val EVENTS_PER_DAY_LIMIT = 3
+        // Vertical day-list horizon (today .. today + WINDOW_DAYS).
+        const val WINDOW_DAYS = 30
         const val CHANGE_DEBOUNCE_MS = 500L
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarSnapshot.kt
@@ -7,25 +7,22 @@ import java.time.LocalTime
 /**
  * Calendar surface for the dashboard.
  *
- * The shape mirrors the visual hierarchy of the calendar card: a hero
- * "today" anchor on the left, a 6-day strip rolling forward, and the events
- * of whichever day the user has selected. The strip is always six entries
- * starting at [today] so the card can iterate without size guards, and each
- * cell carries its own day's events so selecting a cell needs no second
- * query.
+ * A hero "today" anchor plus a forward-rolling vertical list of [days] (each with
+ * that day's full event list, days with no events included), which the card renders
+ * as a scrollable column starting at [today].
  *
  * `null` denotes "not loaded yet" only. Permission denial is carried
  * in-band by [hasCalendarAccess]: a non-null snapshot with
  * [hasCalendarAccess] == false tells the card to render the denial message
- * instead of an empty strip plus a misleading "no upcoming events".
+ * instead of an empty list plus a misleading "no upcoming events".
  */
 @Immutable
 data class CalendarSnapshot(
     val today: LocalDate,
     val weekday: String,
     val monthLabel: String,
-    val dayStrip: List<DayCell>,
-    // false means READ_CALENDAR is denied, so the strip carries no real data
+    val days: List<DayCell>,
+    // false means READ_CALENDAR is denied, so the list carries no real data
     // and the card shows the denial message instead.
     val hasCalendarAccess: Boolean,
 )
@@ -34,12 +31,9 @@ data class CalendarSnapshot(
 data class DayCell(
     val date: LocalDate,
     val weekdayLetter: String,
-    // The day's events, ordered by start time and capped per day upstream so a
-    // busy day cannot grow the card without bound.
+    // The day's events, ordered by start time (the full set — the card scrolls).
     val events: List<EventItem>,
 ) {
-    // Derive the strip dot from the listed events so "has an event" and the
-    // shown events can never disagree.
     val hasEvent: Boolean get() = events.isNotEmpty()
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -1,34 +1,22 @@
 package io.github.seijikohara.femto.ui.home.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -50,21 +38,16 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 /**
- * Calendar card. Three vertical sections on the [FemtoDimens.CardSectionGap]
- * rhythm:
+ * Calendar card:
  *
- *  1. Head — big day number (primary tint) + weekday + month label. The head
- *     always shows **today**; selecting another day in the strip never moves it.
- *  2. Strip — 6 days starting today, each tappable. The selected cell carries
- *     the highlight; today keeps a thin ring while another day is previewed.
- *  3. Events — the selected day's events, bottom-anchored so the per-day-capped
- *     list grows into the flexible gap rather than pushing the card taller.
+ *  1. Head — big day number (primary tint) + weekday + month label, always today.
+ *  2. Days — a scrollable vertical list of the coming days (today first), each row
+ *     showing that day's full set of events. Days with no events are shown too,
+ *     with a muted placeholder, so the list reads as a continuous agenda.
  *
- * Selection is card-local ([rememberSaveable]); the dashboard owns no calendar
- * selection state. Typography and spacing follow
- * `docs/design/dashboard-v2-mockup.html` (`.calendar-card` rules); the
- * dashboard's 18sp body-size floor is intentionally relaxed here so the strip
- * and event list match the design.
+ * Typography and spacing follow `docs/design/dashboard-v2-mockup.html`; the
+ * dashboard's 18sp body-size floor is intentionally relaxed here so the agenda
+ * fits the short head-unit info-pane card.
  */
 @Composable
 internal fun CalendarCard(
@@ -81,8 +64,8 @@ internal fun CalendarCard(
         // user has not earned yet.
         snapshot == null -> Unit
 
-        // A non-null snapshot with access denied carries no real strip data, so
-        // show the denial message instead of a hollow strip.
+        // A non-null snapshot with access denied carries no real data, so show the
+        // denial message instead of a hollow agenda.
         !snapshot.hasCalendarAccess -> PermissionDenied()
 
         else -> CalendarContent(snapshot)
@@ -90,44 +73,26 @@ internal fun CalendarCard(
 }
 
 @Composable
-private fun CalendarContent(snapshot: CalendarSnapshot) {
-    // Card-local selection, defaulting to today and surviving configuration
-    // change via the epoch-day saver. The big-day head stays on today.
-    var selectedDate by rememberSaveable(stateSaver = LocalDateSaver) {
-        mutableStateOf(snapshot.today)
-    }
-    val days = snapshot.dayStrip
-    // A selection outside the rolling window — after a midnight rollover, or a
-    // stale restored value — clamps back to today, so the events area never
-    // shows an out-of-window blank. This is the spec's "reset to today on
-    // rollover" without clobbering a config-change-restored selection.
-    val selected = days.firstOrNull { it.date == selectedDate } ?: days.first()
+private fun CalendarContent(snapshot: CalendarSnapshot) =
     Column(
         modifier =
             Modifier
                 .fillMaxSize()
                 // Tighter than the shared card padding/gap: the head-unit info-pane
-                // card is short, so pack the head, strip and events to avoid a clip.
+                // card is short, so pack the head and the list to avoid a clip.
                 .padding(FemtoDimens.CardPaddingCompact),
         verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGapCompact),
     ) {
         Head(snapshot)
-        Strip(
-            days = days,
-            today = snapshot.today,
-            // Highlight the clamped selection (`selected.date`), not the raw
-            // `selectedDate` state: after a rollover the stored value can point
-            // outside the window, and the clamp keeps exactly one cell lit.
-            selectedDate = selected.date,
-            onSelect = { selectedDate = it },
-        )
-        // Bottom-anchor the events: the per-day cap bounds their count, so they
-        // grow upward into this flexible gap instead of pushing the card taller
-        // — selecting a busy day cannot worsen the clip.
-        Spacer(Modifier.weight(1f))
-        Events(selected.events)
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth().weight(1f),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(items = snapshot.days, key = { it.date.toString() }) { day ->
+                DayRow(day = day, isToday = day.date == snapshot.today)
+            }
+        }
     }
-}
 
 @Composable
 private fun Head(snapshot: CalendarSnapshot) =
@@ -164,75 +129,30 @@ private fun Head(snapshot: CalendarSnapshot) =
         }
     }
 
+// One agenda row: a fixed-width date gutter on the left (today tinted primary) and
+// the day's events on the right — every event for the day, or a muted dash when the
+// day is free.
 @Composable
-private fun Strip(
-    days: List<DayCell>,
-    today: LocalDate,
-    selectedDate: LocalDate,
-    onSelect: (LocalDate) -> Unit,
-) = Row(
-    modifier = Modifier.fillMaxWidth(),
-    horizontalArrangement = Arrangement.spacedBy(3.dp),
-) {
-    days.forEach { day ->
-        DayCellView(
-            day = day,
-            isToday = day.date == today,
-            isSelected = day.date == selectedDate,
-            onClick = { onSelect(day.date) },
-            modifier = Modifier.weight(1f),
-        )
-    }
-}
-
-@Composable
-private fun DayCellView(
+private fun DayRow(
     day: DayCell,
     isToday: Boolean,
-    isSelected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
+) = Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+    verticalAlignment = Alignment.Top,
 ) {
-    val background =
-        if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer
-    val onBackground =
-        if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
-    val numberColor =
-        if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
-    val shape = RoundedCornerShape(FemtoDimens.DayCellCorner)
+    val accent = if (isToday) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
     Column(
-        modifier =
-            modifier
-                .clip(shape)
-                // Today keeps a thin ring when it is not the selected cell, so it
-                // stays identifiable while the user previews another day.
-                .then(
-                    if (isToday && !isSelected) {
-                        Modifier.border(1.dp, MaterialTheme.colorScheme.primary, shape)
-                    } else {
-                        Modifier
-                    },
-                ).background(background)
-                .clickable(onClick = onClick)
-                // The day-of-month alone repeats across months; the ISO date is a
-                // stable, unique label for selection and testing.
-                .semantics { contentDescription = day.date.toString() }
-                // Sub-64dp tap target: a deliberate exception for the in-card
-                // mini-calendar grid (CLAUDE.md#automotive-overrides keeps 64dp the
-                // default; the strip relaxes it like the footer status cluster).
-                // Tight horizontal padding so a two-digit day fits the ~20 dp cell
-                // a narrow info-pane card gives each of the six columns.
-                .padding(vertical = 8.dp, horizontal = 2.dp),
+        modifier = Modifier.width(28.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp),
+        verticalArrangement = Arrangement.spacedBy(1.dp),
     ) {
         Text(
-            // Two letters (not three): on the head-unit binding width a 3-letter
-            // Latin abbreviation overflows the cell, while a 2-letter one fits and
-            // stays unambiguous; CJK weekday labels are a single glyph regardless.
+            // Two letters keep a Latin abbreviation inside the narrow gutter; a CJK
+            // weekday label is a single glyph regardless.
             text = day.weekdayLetter.take(2).uppercase(),
             style = MaterialTheme.typography.sectionLabel(9, 0.08f),
-            color = onBackground,
+            color = if (isToday) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
             softWrap = false,
         )
@@ -240,106 +160,68 @@ private fun DayCellView(
             text = "${day.date.dayOfMonth}",
             style =
                 MaterialTheme.typography.titleSmall.copy(
-                    fontSize = 13.sp,
+                    fontSize = 16.sp,
                     fontWeight = FontWeight.SemiBold,
-                    lineHeight = 15.sp,
+                    lineHeight = 18.sp,
                     fontFeatureSettings = TabularFigures,
                 ),
-            color = numberColor,
+            color = accent,
             maxLines = 1,
             softWrap = false,
         )
-        Box(
-            modifier =
-                Modifier
-                    .size(4.dp)
-                    .clip(CircleShape)
-                    .background(
-                        if (day.hasEvent) onBackground else background,
-                    ),
-        )
     }
-}
-
-@Composable
-private fun Events(events: List<EventItem>) =
-    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        if (events.isEmpty()) {
+    Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        if (day.events.isEmpty()) {
             Text(
-                text = stringResource(R.string.calendar_no_events),
-                style =
-                    MaterialTheme.typography.bodyMedium.copy(
-                        fontSize = 13.sp,
-                        lineHeight = 17.sp,
-                    ),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = NO_EVENTS_PLACEHOLDER,
+                style = MaterialTheme.typography.bodyMedium.copy(fontSize = 13.sp, lineHeight = 18.sp),
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                 maxLines = 1,
             )
         } else {
-            events.forEachIndexed { index, event ->
+            day.events.forEach { event ->
                 EventRow(
                     // A null time marks an all-day event.
                     time = event.time?.format(EventTimeFormatter) ?: stringResource(R.string.calendar_all_day),
                     title = event.title,
-                    isPrimary = index == 0,
                 )
             }
         }
     }
-
-private val EventTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
-
-// Store the card-local selection as an epoch day so rememberSaveable can persist
-// it across configuration change without a Parcelable wrapper.
-private val LocalDateSaver: Saver<LocalDate, Long> =
-    Saver(
-        save = { it.toEpochDay() },
-        restore = { LocalDate.ofEpochDay(it) },
-    )
+}
 
 @Composable
 private fun EventRow(
     time: String,
     title: String,
-    isPrimary: Boolean,
+) = Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+    verticalAlignment = Alignment.Top,
 ) {
-    val dotColor =
-        if (isPrimary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Box(
-            modifier =
-                Modifier
-                    .size(6.dp)
-                    .clip(CircleShape)
-                    .background(dotColor),
-        )
-        Text(
-            text = time,
-            style =
-                MaterialTheme.typography.labelLarge.copy(
-                    fontSize = 13.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    lineHeight = 17.sp,
-                    fontFeatureSettings = TabularFigures,
-                ),
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-        )
-        Text(
-            text = title,
-            style =
-                MaterialTheme.typography.bodyMedium.copy(
-                    fontSize = 13.sp,
-                    lineHeight = 17.sp,
-                ),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
+    Text(
+        text = time,
+        style =
+            MaterialTheme.typography.labelLarge.copy(
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                lineHeight = 18.sp,
+                fontFeatureSettings = TabularFigures,
+            ),
+        color = MaterialTheme.colorScheme.onSurface,
+        maxLines = 1,
+        softWrap = false,
+    )
+    Text(
+        text = title,
+        style = MaterialTheme.typography.bodyMedium.copy(fontSize = 13.sp, lineHeight = 18.sp),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+    )
 }
 
 @Composable
@@ -356,9 +238,12 @@ private fun PermissionDenied() =
         )
     }
 
+private const val NO_EVENTS_PLACEHOLDER = "—"
+
+private val EventTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
 // Sized to the head-unit binding: each top-row card is ~165 x 207 dp (half the
-// info pane on the 853 x 512 dp / 5:3 projection), the geometry that exposed the
-// two-digit-day clip. Wider panels only add slack.
+// info pane on the 853 x 512 dp / 5:3 projection). Wider panels only add slack.
 @PreviewLightDark
 @Preview(name = "Calendar card", widthDp = 165, heightDp = 207)
 @Composable
@@ -370,7 +255,7 @@ private fun CalendarCardPreview() {
                     today = LocalDate.of(2026, 3, 30),
                     weekday = "Monday",
                     monthLabel = "March 2026",
-                    dayStrip =
+                    days =
                         listOf(
                             DayCell(
                                 LocalDate.of(2026, 3, 30),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,6 @@
     <string name="speed_altitude">ALT %1$d m</string>
 
     <!-- Calendar card -->
-    <string name="calendar_no_events">No upcoming events</string>
     <string name="calendar_permission_denied">Calendar access not granted</string>
     <string name="calendar_all_day">All day</string>
 

--- a/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
@@ -53,8 +53,8 @@ class CalendarRepositoryTest {
             // The snapshot must mark access denied in-band so the card can
             // render the denial message rather than a hollow strip.
             assertFalse(snapshot.hasCalendarAccess)
-            assertTrue(snapshot.dayStrip.all { it.events.isEmpty() })
-            assertEquals(6, snapshot.dayStrip.size)
+            assertTrue(snapshot.days.all { it.events.isEmpty() })
+            assertEquals(30, snapshot.days.size)
         }
 
     @Test
@@ -79,8 +79,8 @@ class CalendarRepositoryTest {
             val snapshot = repository.snapshotFlow().first()
 
             assertNotNull(snapshot)
-            assertTrue(snapshot.dayStrip.all { it.events.isEmpty() })
-            assertEquals(6, snapshot.dayStrip.size)
+            assertTrue(snapshot.days.all { it.events.isEmpty() })
+            assertEquals(30, snapshot.days.size)
         }
 
     @Test
@@ -113,11 +113,11 @@ class CalendarRepositoryTest {
             // second strip cell and leaves today (cell 0) undotted; a system-zone
             // read would shift the dot to today.
             val eventDay = AllDayCalendarProvider.EVENT_DATE
-            val dottedDays = snapshot.dayStrip.filter { it.hasEvent }.map { it.date }
+            val dottedDays = snapshot.days.filter { it.hasEvent }.map { it.date }
             assertEquals(listOf(eventDay), dottedDays)
-            assertTrue(snapshot.dayStrip.first { it.date == eventDay }.hasEvent)
+            assertTrue(snapshot.days.first { it.date == eventDay }.hasEvent)
             assertTrue(
-                snapshot.dayStrip
+                snapshot.days
                     .first { it.date == AllDayCalendarProvider.TODAY }
                     .hasEvent
                     .not(),
@@ -125,17 +125,17 @@ class CalendarRepositoryTest {
 
             // The all-day event lands on its own day's cell and carries no clock
             // time.
-            val eventDayEvents = snapshot.dayStrip.first { it.date == eventDay }.events
+            val eventDayEvents = snapshot.days.first { it.date == eventDay }.events
             assertEquals(1, eventDayEvents.size)
             assertNull(eventDayEvents.single().time)
         }
 
     @Test
-    fun `groups events onto their own day cells and caps each day`() =
+    fun `groups every event onto its own day cell in time order`() =
         runTest {
-            // Four events on today (over the per-day cap) plus one two days out.
-            // Each lands on its day's cell; today keeps only the earliest three
-            // and stays time-ordered; the day between carries nothing.
+            // Four events on today plus one two days out. Each lands on its day's
+            // cell; today keeps all four in time order (no per-day cap); the day
+            // between carries nothing.
             shadowOf(application).grantPermissions(Manifest.permission.READ_CALENDAR)
             Robolectric
                 .buildContentProvider(MultiDayCalendarProvider::class.java)
@@ -151,14 +151,14 @@ class CalendarRepositoryTest {
             val snapshot = repository.snapshotFlow().first()
             assertNotNull(snapshot)
 
-            val today = snapshot.dayStrip.first { it.date == MultiDayCalendarProvider.TODAY }
-            assertEquals(listOf("A", "B", "C"), today.events.map { it.title })
+            val today = snapshot.days.first { it.date == MultiDayCalendarProvider.TODAY }
+            assertEquals(listOf("A", "B", "C", "D"), today.events.map { it.title })
 
-            val later = snapshot.dayStrip.first { it.date == MultiDayCalendarProvider.TODAY.plusDays(2) }
+            val later = snapshot.days.first { it.date == MultiDayCalendarProvider.TODAY.plusDays(2) }
             assertEquals(listOf("E"), later.events.map { it.title })
 
             assertTrue(
-                snapshot.dayStrip
+                snapshot.days
                     .first { it.date == MultiDayCalendarProvider.TODAY.plusDays(1) }
                     .events
                     .isEmpty(),
@@ -277,8 +277,8 @@ class CalendarRepositoryTest {
 
     /**
      * Stand-in calendar provider returning four timed rows on [TODAY] and one on
-     * `TODAY + 2`, all titled, in `BEGIN ASC` order. Exercises per-day grouping
-     * and the per-day cap (today's fourth row must drop).
+     * `TODAY + 2`, all titled, in `BEGIN ASC` order. Exercises per-day grouping and
+     * time-ordering (all four of today's rows are kept — there is no per-day cap).
      */
     class MultiDayCalendarProvider : ContentProvider() {
         override fun onCreate(): Boolean = true

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
@@ -10,7 +10,7 @@ internal fun fakeCalendarSnapshot(
     today: LocalDate = LocalDate.of(2026, 5, 1),
     weekday: String = "Friday",
     monthLabel: String = "May 2026",
-    dayStrip: List<DayCell> =
+    days: List<DayCell> =
         listOf(
             DayCell(
                 LocalDate.of(2026, 5, 1),
@@ -32,6 +32,6 @@ internal fun fakeCalendarSnapshot(
         today = today,
         weekday = weekday,
         monthLabel = monthLabel,
-        dayStrip = dayStrip,
+        days = days,
         hasCalendarAccess = hasCalendarAccess,
     )


### PR DESCRIPTION
## Summary

Fourth of the dashboard UI brush-up series. The calendar card's second half (a
6-day strip + the selected day's first three events) is replaced with a vertical,
scrollable agenda.

## Changes

- **Card**: today's hero head is kept; below it a `LazyColumn` of the coming 30 days
  (today first), each row = a date gutter (today tinted primary) + that day's **full**
  event list. Free days are shown with a muted em-dash placeholder. The per-day
  selection state, the strip, and the day-cell grid are removed.
- **Repository**: the query window grows 6 → 30 days; the per-day cap
  (`EVENTS_PER_DAY_LIMIT`) is removed so every event for a day is shown.
- `CalendarSnapshot.dayStrip` → `days` (it's a list, not a strip now).

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` —
  green. Repository tests updated (30-day window, no cap); card tests rewritten for
  the agenda (all days' events render; free days show a placeholder).
- Emulator (READ_CALENDAR granted, no events): the agenda lists each upcoming day
  with the em-dash placeholder; scrolls.