### PR TITLE
feat(map): adjustable marker vertical position

### DIFF
--- a/app/src/main/assets/web/map.html
+++ b/app/src/main/assets/web/map.html
@@ -124,13 +124,27 @@
         var marker = new maplibregl.Marker({ element: markerEl, rotationAlignment: "map", pitchAlignment: "map" });
         var markerAdded = false;
 
+        // The lowest the marker drops below centre, as a fraction of map height, at
+        // markerPos = 100 (mirrors MAX_MARKER_DROP in MapPanel.kt).
+        var MAX_MARKER_DROP = 0.32;
+
+        // Top camera padding (px) that places the centred location at the height the
+        // marker-position setting asks for. padTop shifts the focal point down, so
+        // the location (and its marker) sits lower in the frame; markerPos 0 keeps it
+        // centred, 100 drops it MAX_MARKER_DROP of the height toward the speed panel.
+        function markerPadTop(markerPos) {
+          var pos = Math.max(0, Math.min(100, markerPos || 0));
+          var drop = (pos / 100) * MAX_MARKER_DROP;
+          return 2 * drop * (map.getContainer().clientHeight || 0);
+        }
+
         // Android -> JS: smooth heading-up camera follow (this is how #2 smooth
         // movement is achieved — easeTo interpolates between sparse GPS fixes). The
         // first fix jumps (no dramatic fly-in from the [0,0] start); the rest ease.
         // The marker rides the same fixes; [markerColor] (Material primary, "#rrggbb")
         // is applied here so it self-heals if the first push raced page load.
         let firstCamera = true;
-        window.updateCamera = function (lat, lon, bearing, zoom, tilt, markerColor) {
+        window.updateCamera = function (lat, lon, bearing, zoom, tilt, markerPos, markerColor) {
           if (!map) return;
           var heading = bearing || 0;
           if (markerColor) {
@@ -139,7 +153,13 @@
           }
           marker.setLngLat([lon, lat]).setRotation(heading);
           if (!markerAdded) { marker.addTo(map); markerAdded = true; }
-          const opts = { center: [lon, lat], bearing: heading, zoom: zoom || 16, pitch: tilt || 0 };
+          const opts = {
+            center: [lon, lat],
+            bearing: heading,
+            zoom: zoom || 16,
+            pitch: tilt || 0,
+            padding: { top: markerPadTop(markerPos), bottom: 0, left: 0, right: 0 },
+          };
           if (firstCamera) { firstCamera = false; map.jumpTo(opts); }
           else map.easeTo({ ...opts, duration: 1000, essential: true });
         };

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -127,7 +127,7 @@ class MainActivity : ComponentActivity() {
                                 zoom = display.mapZoom,
                                 renderPercent = display.mapRenderPercent,
                                 renderMode = display.mapRenderMode,
-                                lookAheadM = display.mapLookAheadM,
+                                markerPos = display.mapMarkerPos,
                                 buildings3d = display.map3dBuildings,
                                 terrain = display.mapTerrain,
                             ),

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -69,11 +69,11 @@ internal const val DEFAULT_MAP_ZOOM = 16
 internal const val DEFAULT_MAP_RENDER_PERCENT = 100
 
 /**
- * Default map look-ahead (metres): the camera aims this far ahead of the current
- * position along the heading, so the location marker sits low in the frame (near
- * the speed overlay) with the road ahead visible. Larger = marker lower.
+ * Default location-marker vertical position (0..100): 0 centres the marker in the
+ * map, 100 drops it just above the speed overlay. The camera is shifted so the
+ * marker lands at the chosen height.
  */
-internal const val DEFAULT_MAP_LOOKAHEAD_M = 180
+internal const val DEFAULT_MAP_MARKER_POS = 70
 
 /**
  * User display settings that override the locale / system defaults. Every value
@@ -98,9 +98,9 @@ internal data class DisplaySettings(
     // blurrier but renders faster (a smaller bitmap to upscale).
     val mapRenderPercent: Int,
     val mapRenderMode: MapRenderMode,
-    // Camera look-ahead (metres): how far ahead of the current position the camera
-    // aims, which sets how low the location marker sits (closer to the speed panel).
-    val mapLookAheadM: Int,
+    // Location-marker vertical position (0..100): 0 = map centre, 100 = just above
+    // the speed overlay. Applied to both backends.
+    val mapMarkerPos: Int,
     // Live-map (WebGL) feature toggles. Both default off; they apply to the LIVE
     // backends only (SNAPSHOT's native GL cannot extrude/relief safely). 3D buildings
     // extrude the OpenMapTiles building layer; terrain adds raster-DEM relief.
@@ -128,7 +128,7 @@ internal data class DisplaySettings(
                 mapZoom = DEFAULT_MAP_ZOOM,
                 mapRenderPercent = DEFAULT_MAP_RENDER_PERCENT,
                 mapRenderMode = MapRenderMode.SNAPSHOT,
-                mapLookAheadM = DEFAULT_MAP_LOOKAHEAD_M,
+                mapMarkerPos = DEFAULT_MAP_MARKER_POS,
                 map3dBuildings = false,
                 mapTerrain = false,
                 showCalendar = true,
@@ -172,7 +172,7 @@ internal interface DisplaySettingsStore {
 
     suspend fun setMapRenderMode(value: MapRenderMode)
 
-    suspend fun setMapLookAhead(value: Int)
+    suspend fun setMapMarkerPos(value: Int)
 
     suspend fun setMap3dBuildings(value: Boolean)
 
@@ -210,7 +210,7 @@ internal class DisplayPreferences(
                 mapZoom = prefs[MAP_ZOOM_KEY] ?: DEFAULT_MAP_ZOOM,
                 mapRenderPercent = prefs[MAP_QUALITY_KEY] ?: DEFAULT_MAP_RENDER_PERCENT,
                 mapRenderMode = prefs[MAP_RENDER_MODE_KEY].toMapRenderModeOr(MapRenderMode.SNAPSHOT),
-                mapLookAheadM = prefs[MAP_LOOKAHEAD_KEY] ?: DEFAULT_MAP_LOOKAHEAD_M,
+                mapMarkerPos = prefs[MAP_MARKER_POS_KEY] ?: DEFAULT_MAP_MARKER_POS,
                 map3dBuildings = prefs[MAP_3D_BUILDINGS_KEY] ?: false,
                 mapTerrain = prefs[MAP_TERRAIN_KEY] ?: false,
                 showCalendar = prefs[SHOW_CALENDAR_KEY] ?: true,
@@ -269,8 +269,8 @@ internal class DisplayPreferences(
         context.displayDataStore.edit { it[MAP_RENDER_MODE_KEY] = value.name }
     }
 
-    override suspend fun setMapLookAhead(value: Int) {
-        context.displayDataStore.edit { it[MAP_LOOKAHEAD_KEY] = value }
+    override suspend fun setMapMarkerPos(value: Int) {
+        context.displayDataStore.edit { it[MAP_MARKER_POS_KEY] = value }
     }
 
     override suspend fun setMap3dBuildings(value: Boolean) {
@@ -306,7 +306,7 @@ internal class DisplayPreferences(
         val MAP_ZOOM_KEY = intPreferencesKey("map_zoom")
         val MAP_QUALITY_KEY = intPreferencesKey("map_render_percent")
         val MAP_RENDER_MODE_KEY = stringPreferencesKey("map_render_mode")
-        val MAP_LOOKAHEAD_KEY = intPreferencesKey("map_look_ahead_m")
+        val MAP_MARKER_POS_KEY = intPreferencesKey("map_marker_pos")
         val MAP_3D_BUILDINGS_KEY = booleanPreferencesKey("map_3d_buildings")
         val MAP_TERRAIN_KEY = booleanPreferencesKey("map_terrain")
         val SHOW_CALENDAR_KEY = booleanPreferencesKey("show_calendar")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -83,6 +83,7 @@ import kotlin.coroutines.resume
 import kotlin.math.asin
 import kotlin.math.atan2
 import kotlin.math.cos
+import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sin
 
@@ -96,7 +97,7 @@ internal data class MapConfig(
     val zoom: Int = 16,
     val renderPercent: Int = 100,
     val renderMode: MapRenderMode = MapRenderMode.SNAPSHOT,
-    val lookAheadM: Int = 180,
+    val markerPos: Int = 70,
     val buildings3d: Boolean = false,
     val terrain: Boolean = false,
 )
@@ -230,7 +231,15 @@ private fun SnapshotMap(
             while (isActive) {
                 val loc = currentLocation.value
                 if (shouldRerender(lastRendered, loc)) {
-                    val camera = cameraFor(loc, bearingHolder, mapConfig.tiltDeg, mapConfig.zoom, mapConfig.lookAheadM)
+                    val camera =
+                        cameraFor(
+                            location = loc,
+                            bearingHolder = bearingHolder,
+                            tiltDeg = mapConfig.tiltDeg,
+                            zoom = mapConfig.zoom,
+                            markerPos = mapConfig.markerPos,
+                            renderHeightPx = renderHeightPx,
+                        )
                     val rendered = snap.render(camera, LatLng(loc.latitude, loc.longitude), markerScale)
                     if (rendered != null) {
                         frame = rendered
@@ -306,15 +315,20 @@ private fun cameraFor(
     bearingHolder: FloatArray,
     tiltDeg: Int,
     zoom: Int,
-    lookAheadM: Int,
+    markerPos: Int,
+    renderHeightPx: Int,
 ): CameraPosition {
     val bearing = location.carriedBearing(bearingHolder).toDouble()
     // Aim the camera ahead of the current position (along the heading) so the
-    // current location renders low in the frame: more road ahead is visible and
-    // the marker sits just above the speed overlay (nav-style framing). The
-    // look-ahead distance is user-tunable so the marker can be placed nearer to
-    // (or further from) the speed panel.
-    val target = LatLng(location.latitude, location.longitude).offsetForward(bearing, lookAheadM.toDouble())
+    // location renders low in the frame (nav-style framing). [markerPos] (0..100)
+    // picks the marker's screen height: 0 keeps it centred, 100 drops it just above
+    // the speed overlay. Convert that to a look-ahead distance via the ground
+    // resolution at this zoom/latitude so the same setting reads consistently across
+    // zooms (the tilt makes this approximate; pixelForLatLng still places the marker
+    // exactly where the location renders).
+    val dropFraction = (markerPos.coerceIn(0, 100) / 100.0) * MAX_MARKER_DROP
+    val lookAheadM = dropFraction * renderHeightPx * metersPerPixel(zoom, location.latitude)
+    val target = LatLng(location.latitude, location.longitude).offsetForward(bearing, lookAheadM)
     return CameraPosition
         .Builder()
         .target(target)
@@ -323,6 +337,13 @@ private fun cameraFor(
         .bearing(bearing)
         .build()
 }
+
+// Ground metres per screen pixel for a MapLibre (512-px tile) web-mercator zoom at
+// [latDeg]; the basis for turning the marker-position fraction into a look-ahead.
+private fun metersPerPixel(
+    zoom: Int,
+    latDeg: Double,
+): Double = EARTH_CIRCUMFERENCE_M * cos(Math.toRadians(latDeg)) / (512.0 * 2.0.pow(zoom))
 
 // Destination point [meters] ahead of this point along [bearingDeg] (great-circle).
 private fun LatLng.offsetForward(
@@ -501,6 +522,12 @@ private const val SNAPSHOT_POLL_INTERVAL_MS = 200L
 private const val REFRESH_DISTANCE_M = 2f
 
 private const val EARTH_RADIUS_M = 6_371_000.0
+private const val EARTH_CIRCUMFERENCE_M = 40_075_016.686
+
+// The lowest the marker drops as a fraction of the map height below centre at
+// markerPos = 100 — kept below 0.5 so the puck stays clear of the speed overlay
+// (mirrored by MAX_MARKER_DROP in map.html for the live backend).
+private const val MAX_MARKER_DROP = 0.32
 
 // Heading-up nav chevron size and the graphicsLayer camera distance (multiplied by
 // density) that softens the perspective when the chevron is laid onto the tilt.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -122,6 +122,7 @@ internal fun WebMapView(
         location.longitude,
         mapConfig.zoom,
         mapConfig.tiltDeg,
+        mapConfig.markerPos,
         markerColor,
     ) {
         if (!pageReady.value) return@LaunchedEffect
@@ -129,7 +130,7 @@ internal fun WebMapView(
         webView.evaluateJavascript(
             "window.updateCamera && updateCamera(" +
                 "${location.latitude}, ${location.longitude}, $bearing, ${mapConfig.zoom}, ${mapConfig.tiltDeg}, " +
-                "'$markerColor')",
+                "${mapConfig.markerPos}, '$markerColor')",
             null,
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -204,18 +204,21 @@ internal fun SettingsScreen(
                 range = MIN_MAP_ZOOM..MAX_MAP_ZOOM,
                 onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
             )
+            // Marker vertical position applies to both backends (0 = map centre,
+            // 100 = just above the speed overlay), so it sits outside the
+            // mode-specific block below.
+            SliderRow(
+                title = stringResource(R.string.settings_group_map_marker_pos),
+                valueLabel = stringResource(R.string.settings_map_marker_pos_value, uiState.mapMarkerPos),
+                value = uiState.mapMarkerPos,
+                range = MIN_MAP_MARKER_POS..MAX_MAP_MARKER_POS,
+                onValueChange = { onAction(SettingsAction.SetMapMarkerPos(it)) },
+            )
             // Mode-specific rows: the live (WebGL) backends expose 3D buildings /
-            // terrain; the snapshot backend exposes look-ahead framing and the bitmap
-            // sharpness. Showing only the rows that affect the chosen backend keeps
-            // the panel honest (e.g. sharpness does nothing on the live map).
+            // terrain; the snapshot backend exposes the bitmap sharpness. Showing
+            // only the rows that affect the chosen backend keeps the panel honest
+            // (e.g. sharpness does nothing on the live map).
             if (uiState.mapRenderMode == MapRenderMode.SNAPSHOT) {
-                SliderRow(
-                    title = stringResource(R.string.settings_group_map_look_ahead),
-                    valueLabel = stringResource(R.string.settings_map_look_ahead_value, uiState.mapLookAheadM),
-                    value = uiState.mapLookAheadM,
-                    range = MIN_MAP_LOOK_AHEAD..MAX_MAP_LOOK_AHEAD,
-                    onValueChange = { onAction(SettingsAction.SetMapLookAhead(it)) },
-                )
                 SliderRow(
                     title = stringResource(R.string.settings_group_map_quality),
                     valueLabel = stringResource(R.string.settings_map_quality_value, uiState.mapRenderPercent),
@@ -617,10 +620,10 @@ private const val MAX_MAP_TILT = 60
 private const val MIN_MAP_ZOOM = 12
 private const val MAX_MAP_ZOOM = 19
 
-// Camera look-ahead band (metres): 0 centres the marker; larger pushes it lower,
-// toward the speed panel.
-private const val MIN_MAP_LOOK_AHEAD = 0
-private const val MAX_MAP_LOOK_AHEAD = 400
+// Marker vertical-position band (percent): 0 centres the marker; 100 drops it to
+// just above the speed panel.
+private const val MIN_MAP_MARKER_POS = 0
+private const val MAX_MAP_MARKER_POS = 100
 
 // Snapshot render resolution band (percent). The floor stays well above zero so
 // the upscaled map keeps roads legible; 100 is full panel resolution.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -25,7 +25,7 @@ internal data class SettingsUiState(
     val mapZoom: Int,
     val mapRenderPercent: Int,
     val mapRenderMode: MapRenderMode,
-    val mapLookAheadM: Int,
+    val mapMarkerPos: Int,
     val map3dBuildings: Boolean,
     val mapTerrain: Boolean,
     val showCalendar: Boolean,
@@ -50,7 +50,7 @@ internal data class SettingsUiState(
                 mapZoom = DisplaySettings.Default.mapZoom,
                 mapRenderPercent = DisplaySettings.Default.mapRenderPercent,
                 mapRenderMode = DisplaySettings.Default.mapRenderMode,
-                mapLookAheadM = DisplaySettings.Default.mapLookAheadM,
+                mapMarkerPos = DisplaySettings.Default.mapMarkerPos,
                 map3dBuildings = DisplaySettings.Default.map3dBuildings,
                 mapTerrain = DisplaySettings.Default.mapTerrain,
                 showCalendar = DisplaySettings.Default.showCalendar,
@@ -111,7 +111,7 @@ internal sealed interface SettingsAction {
         val value: MapRenderMode,
     ) : SettingsAction
 
-    data class SetMapLookAhead(
+    data class SetMapMarkerPos(
         val value: Int,
     ) : SettingsAction
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -33,7 +33,7 @@ internal class SettingsViewModel(
                 mapZoom = display.mapZoom,
                 mapRenderPercent = display.mapRenderPercent,
                 mapRenderMode = display.mapRenderMode,
-                mapLookAheadM = display.mapLookAheadM,
+                mapMarkerPos = display.mapMarkerPos,
                 map3dBuildings = display.map3dBuildings,
                 mapTerrain = display.mapTerrain,
                 showCalendar = display.showCalendar,
@@ -59,7 +59,7 @@ internal class SettingsViewModel(
                 is SettingsAction.SetMapZoom -> displayPreferences.setMapZoom(action.value)
                 is SettingsAction.SetMapRenderPercent -> displayPreferences.setMapRenderPercent(action.value)
                 is SettingsAction.SetMapRenderMode -> displayPreferences.setMapRenderMode(action.value)
-                is SettingsAction.SetMapLookAhead -> displayPreferences.setMapLookAhead(action.value)
+                is SettingsAction.SetMapMarkerPos -> displayPreferences.setMapMarkerPos(action.value)
                 is SettingsAction.SetMap3dBuildings -> displayPreferences.setMap3dBuildings(action.value)
                 is SettingsAction.SetMapTerrain -> displayPreferences.setMapTerrain(action.value)
                 is SettingsAction.SetShowCalendar -> displayPreferences.setShowCalendar(action.value)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,8 +127,8 @@
     <string name="settings_group_map_quality">Map sharpness</string>
     <string name="settings_map_quality_value">%1$d%%</string>
     <string name="settings_map_quality_desc">Lower renders the map faster but softer — useful on slow head units.</string>
-    <string name="settings_group_map_look_ahead">Marker look-ahead</string>
-    <string name="settings_map_look_ahead_value">%1$d m</string>
+    <string name="settings_group_map_marker_pos">Marker position</string>
+    <string name="settings_map_marker_pos_value">%1$d%%</string>
     <string name="settings_group_map_3d">3D buildings</string>
     <string name="settings_group_map_terrain">Terrain</string>
     <string name="settings_map_terrain_desc">3D elevation relief (Mapterhorn). Adds tile downloads; heavier on low-end GPUs.</string>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -52,7 +52,7 @@ internal class FakeDisplaySettingsStore(
 
     override suspend fun setMapRenderMode(value: MapRenderMode) = state.update { it.copy(mapRenderMode = value) }
 
-    override suspend fun setMapLookAhead(value: Int) = state.update { it.copy(mapLookAheadM = value) }
+    override suspend fun setMapMarkerPos(value: Int) = state.update { it.copy(mapMarkerPos = value) }
 
     override suspend fun setMap3dBuildings(value: Boolean) = state.update { it.copy(map3dBuildings = value) }
 

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -93,11 +93,11 @@ class SettingsViewModelTest {
         }
 
     @Test
-    fun `SetMapLookAhead writes the value to the store`() =
+    fun `SetMapMarkerPos writes the value to the store`() =
         runTest(dispatcher) {
-            viewModel().onAction(SettingsAction.SetMapLookAhead(200))
+            viewModel().onAction(SettingsAction.SetMapMarkerPos(40))
             advanceUntilIdle()
-            assertEquals(200, store.settings.first().mapLookAheadM)
+            assertEquals(40, store.settings.first().mapMarkerPos)
         }
 
     @Test


### PR DESCRIPTION
## Summary

Fifth of the dashboard UI brush-up series. The location marker was dropped low only
on the snapshot backend (a metres-based look-ahead setting) and sat dead-centre on
the live backend. This replaces look-ahead with a single **Marker position** slider
(0 = map centre, 100 = just above the speed overlay) applied to **both** backends.

## Changes

- Setting renamed end to end: `mapLookAheadM` → `mapMarkerPos` (0..100, default 70),
  surfaced as a "Marker position" slider shown for every render mode (was a
  snapshot-only look-ahead slider). DataStore key `map_look_ahead_m` → `map_marker_pos`.
- **Snapshot** (`cameraFor`): the position fraction → a camera look-ahead distance via
  the ground resolution at the current zoom/latitude (`metersPerPixel`, MapLibre
  512-px-tile web-mercator), so the same setting reads consistently across zooms; the
  marker is still placed exactly via `pixelForLatLng`.
- **Live** (`map.html`): the fraction sets the camera `padding.top` so the centred
  location renders lower; passed via `updateCamera`.

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` —
  green.
- `compose-launcher-reviewer`: no blocking findings; confirmed the live padding math
  (`2·drop·H` places the focal point at `0.5+drop` of the height). Applied the comment
  fixes it raised.
- Emulator (live): the marker now sits just above the speed panel at the default
  position.

Note: the old metres value resets to the new default rather than mis-migrating (180 m
would read as 180 % → clamped).