### PR TITLE
feat(drawer): grid/list layout toggle and app pinning

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
@@ -3,9 +3,13 @@ package io.github.seijikohara.femto.ui.drawer
 import android.content.ComponentName
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import io.github.seijikohara.femto.data.DrawerLayout
 import io.github.seijikohara.femto.testfixtures.fakeAppEntry
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Assert.assertEquals
@@ -20,7 +24,15 @@ class AppDrawerScreenTest {
     fun loading_renders_progress_indicator() {
         rule.setContent {
             FemtoTheme {
-                AppDrawerScreen(uiState = AppDrawerUiState.Loading, onLaunch = {}, onRetry = {})
+                AppDrawerScreen(
+                    uiState = AppDrawerUiState.Loading,
+                    layout = DrawerLayout.GRID,
+                    pinned = emptySet(),
+                    onLaunch = {},
+                    onTogglePin = {},
+                    onToggleLayout = {},
+                    onRetry = {},
+                )
             }
         }
         rule.onNodeWithTag(APP_DRAWER_PROGRESS_TEST_TAG).assertIsDisplayed()
@@ -34,7 +46,11 @@ class AppDrawerScreenTest {
             FemtoTheme {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Content(listOf(maps)),
+                    layout = DrawerLayout.GRID,
+                    pinned = emptySet(),
                     onLaunch = { launched = it },
+                    onTogglePin = {},
+                    onToggleLayout = {},
                     onRetry = {},
                 )
             }
@@ -44,12 +60,60 @@ class AppDrawerScreenTest {
     }
 
     @Test
+    fun long_press_dispatches_pin_for_an_unpinned_app() {
+        var pinned: ComponentName? = null
+        val maps = fakeAppEntry(packageName = "com.maps", className = ".Main", label = "Maps")
+        rule.setContent {
+            FemtoTheme {
+                AppDrawerScreen(
+                    uiState = AppDrawerUiState.Content(listOf(maps)),
+                    layout = DrawerLayout.GRID,
+                    pinned = emptySet(),
+                    onLaunch = {},
+                    onTogglePin = { pinned = it },
+                    onToggleLayout = {},
+                    onRetry = {},
+                )
+            }
+        }
+        rule.onNodeWithText("Maps").performTouchInput { longClick() }
+        rule.onNodeWithText("Pin").assertIsDisplayed().performClick()
+        assertEquals(maps.componentName, pinned)
+    }
+
+    @Test
+    fun layout_toggle_dispatches() {
+        var toggled = false
+        val maps = fakeAppEntry(packageName = "com.maps", className = ".Main", label = "Maps")
+        rule.setContent {
+            FemtoTheme {
+                AppDrawerScreen(
+                    uiState = AppDrawerUiState.Content(listOf(maps)),
+                    layout = DrawerLayout.GRID,
+                    pinned = emptySet(),
+                    onLaunch = {},
+                    onTogglePin = {},
+                    onToggleLayout = { toggled = true },
+                    onRetry = {},
+                )
+            }
+        }
+        // In grid layout the toggle offers the list layout.
+        rule.onNodeWithContentDescription("List layout").performClick()
+        assert(toggled)
+    }
+
+    @Test
     fun empty_content_shows_no_apps_message() {
         rule.setContent {
             FemtoTheme {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Content(emptyList()),
+                    layout = DrawerLayout.GRID,
+                    pinned = emptySet(),
                     onLaunch = {},
+                    onTogglePin = {},
+                    onToggleLayout = {},
                     onRetry = {},
                 )
             }
@@ -64,7 +128,11 @@ class AppDrawerScreenTest {
             FemtoTheme {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Error,
+                    layout = DrawerLayout.GRID,
+                    pinned = emptySet(),
                     onLaunch = {},
+                    onTogglePin = {},
+                    onToggleLayout = {},
                     onRetry = { retried = true },
                 )
             }

--- a/app/src/main/java/io/github/seijikohara/femto/data/DrawerPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DrawerPreferences.kt
@@ -1,0 +1,60 @@
+package io.github.seijikohara.femto.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/** App-drawer tile layout. */
+internal enum class DrawerLayout { GRID, LIST }
+
+/**
+ * Persisted app-drawer preferences: the tile [layout] and the set of [pinned] apps
+ * (each a flattened [android.content.ComponentName]). Pinned apps surface in a
+ * section at the top of the drawer.
+ */
+internal interface DrawerSettingsStore {
+    val layout: Flow<DrawerLayout>
+    val pinned: Flow<Set<String>>
+
+    suspend fun setLayout(value: DrawerLayout)
+
+    /** Add the component if absent, remove it if present. */
+    suspend fun togglePinned(flattenedComponent: String)
+}
+
+private val Context.drawerDataStore: DataStore<Preferences> by preferencesDataStore(name = "drawer_preferences")
+
+internal class DrawerPreferences(
+    private val context: Context,
+) : DrawerSettingsStore {
+    override val layout: Flow<DrawerLayout> =
+        context.drawerDataStore.data.map { prefs ->
+            prefs[LAYOUT_KEY]?.let { name -> DrawerLayout.entries.firstOrNull { it.name == name } } ?: DrawerLayout.GRID
+        }
+
+    override val pinned: Flow<Set<String>> =
+        context.drawerDataStore.data.map { prefs -> prefs[PINNED_KEY] ?: emptySet() }
+
+    override suspend fun setLayout(value: DrawerLayout) {
+        context.drawerDataStore.edit { it[LAYOUT_KEY] = value.name }
+    }
+
+    override suspend fun togglePinned(flattenedComponent: String) {
+        context.drawerDataStore.edit { prefs ->
+            val current = prefs[PINNED_KEY] ?: emptySet()
+            prefs[PINNED_KEY] =
+                if (flattenedComponent in current) current - flattenedComponent else current + flattenedComponent
+        }
+    }
+
+    private companion object {
+        val LAYOUT_KEY = stringPreferencesKey("drawer_layout")
+        val PINNED_KEY = stringSetPreferencesKey("drawer_pinned")
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -8,24 +8,44 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.LayoutGrid
+import com.composables.icons.lucide.LayoutList
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Pin
+import com.composables.icons.lucide.PinOff
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.AppEntry
+import io.github.seijikohara.femto.data.DrawerLayout
+import io.github.seijikohara.femto.ui.home.components.AppListRow
 import io.github.seijikohara.femto.ui.home.components.AppTile
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -38,7 +58,11 @@ internal const val APP_DRAWER_PROGRESS_TEST_TAG = "app-drawer-progress"
 @Composable
 internal fun AppDrawerScreen(
     uiState: AppDrawerUiState,
+    layout: DrawerLayout,
+    pinned: Set<String>,
     onLaunch: (ComponentName) -> Unit,
+    onTogglePin: (ComponentName) -> Unit,
+    onToggleLayout: () -> Unit,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
@@ -46,9 +70,24 @@ internal fun AppDrawerScreen(
     color = MaterialTheme.colorScheme.background,
 ) {
     when (uiState) {
-        AppDrawerUiState.Loading -> LoadingState()
-        is AppDrawerUiState.Content -> ContentState(apps = uiState.apps, onLaunch = onLaunch)
-        AppDrawerUiState.Error -> ErrorState(onRetry = onRetry)
+        AppDrawerUiState.Loading -> {
+            LoadingState()
+        }
+
+        is AppDrawerUiState.Content -> {
+            ContentState(
+                apps = uiState.apps,
+                layout = layout,
+                pinned = pinned,
+                onLaunch = onLaunch,
+                onTogglePin = onTogglePin,
+                onToggleLayout = onToggleLayout,
+            )
+        }
+
+        AppDrawerUiState.Error -> {
+            ErrorState(onRetry = onRetry)
+        }
     }
 }
 
@@ -61,23 +100,153 @@ private fun LoadingState(modifier: Modifier = Modifier) =
 @Composable
 private fun ContentState(
     apps: List<AppEntry>,
+    layout: DrawerLayout,
+    pinned: Set<String>,
     onLaunch: (ComponentName) -> Unit,
+    onTogglePin: (ComponentName) -> Unit,
+    onToggleLayout: () -> Unit,
     modifier: Modifier = Modifier,
-) = if (apps.isEmpty()) {
-    CenteredMessage(text = stringResource(R.string.drawer_no_apps), modifier = modifier)
-} else {
-    LazyVerticalGrid(
-        modifier = modifier,
-        columns = GridCells.Adaptive(minSize = MinTileWidth),
-        contentPadding = PaddingValues(FemtoDimens.ScreenPadding),
-        horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
-        verticalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
-    ) {
-        items(items = apps, key = { it.componentName.flattenToString() }) { entry ->
-            AppTile(entry = entry, onClick = { onLaunch(entry.componentName) })
+) = Column(modifier = modifier.fillMaxSize()) {
+    LayoutToggleBar(layout = layout, onToggleLayout = onToggleLayout)
+    if (apps.isEmpty()) {
+        CenteredMessage(text = stringResource(R.string.drawer_no_apps))
+        return@Column
+    }
+    // Split into the pinned section and the rest (both keep the shared label sort).
+    val pinnedApps = apps.filter { it.componentName.flattenToString() in pinned }
+    val otherApps = apps.filterNot { it.componentName.flattenToString() in pinned }
+    when (layout) {
+        DrawerLayout.GRID -> GridApps(pinnedApps, otherApps, onLaunch, onTogglePin)
+        DrawerLayout.LIST -> ListApps(pinnedApps, otherApps, onLaunch, onTogglePin)
+    }
+}
+
+@Composable
+private fun LayoutToggleBar(
+    layout: DrawerLayout,
+    onToggleLayout: () -> Unit,
+    modifier: Modifier = Modifier,
+) = Box(
+    modifier = modifier.fillMaxWidth().padding(horizontal = FemtoDimens.ScreenPadding, vertical = 4.dp),
+    contentAlignment = Alignment.CenterEnd,
+) {
+    // The icon shows the layout the tap switches TO.
+    IconButton(onClick = onToggleLayout, modifier = Modifier.size(FemtoDimens.MinTouchTarget)) {
+        Icon(
+            imageVector = if (layout == DrawerLayout.GRID) Lucide.LayoutList else Lucide.LayoutGrid,
+            contentDescription =
+                stringResource(
+                    if (layout == DrawerLayout.GRID) R.string.drawer_layout_list else R.string.drawer_layout_grid,
+                ),
+            tint = MaterialTheme.colorScheme.onBackground,
+        )
+    }
+}
+
+@Composable
+private fun GridApps(
+    pinnedApps: List<AppEntry>,
+    otherApps: List<AppEntry>,
+    onLaunch: (ComponentName) -> Unit,
+    onTogglePin: (ComponentName) -> Unit,
+    modifier: Modifier = Modifier,
+) = LazyVerticalGrid(
+    modifier = modifier,
+    columns = GridCells.Adaptive(minSize = MinTileWidth),
+    contentPadding = PaddingValues(FemtoDimens.ScreenPadding),
+    horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
+    verticalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
+) {
+    if (pinnedApps.isNotEmpty()) {
+        item(span = { GridItemSpan(maxLineSpan) }) { SectionHeader(stringResource(R.string.drawer_section_pinned)) }
+        items(items = pinnedApps, key = { it.componentName.flattenToString() }) { entry ->
+            DrawerAppItem(entry, DrawerLayout.GRID, isPinned = true, onLaunch, onTogglePin)
+        }
+        item(span = { GridItemSpan(maxLineSpan) }) { SectionHeader(stringResource(R.string.drawer_section_apps)) }
+    }
+    // otherApps are non-pinned by construction (filterNot), so isPinned = false.
+    items(items = otherApps, key = { it.componentName.flattenToString() }) { entry ->
+        DrawerAppItem(entry, DrawerLayout.GRID, isPinned = false, onLaunch, onTogglePin)
+    }
+}
+
+@Composable
+private fun ListApps(
+    pinnedApps: List<AppEntry>,
+    otherApps: List<AppEntry>,
+    onLaunch: (ComponentName) -> Unit,
+    onTogglePin: (ComponentName) -> Unit,
+    modifier: Modifier = Modifier,
+) = LazyColumn(modifier = modifier, contentPadding = PaddingValues(vertical = FemtoDimens.GridGutter)) {
+    if (pinnedApps.isNotEmpty()) {
+        item { SectionHeader(stringResource(R.string.drawer_section_pinned)) }
+        items(items = pinnedApps, key = { it.componentName.flattenToString() }) { entry ->
+            DrawerAppItem(entry, DrawerLayout.LIST, isPinned = true, onLaunch, onTogglePin)
+        }
+        item { SectionHeader(stringResource(R.string.drawer_section_apps)) }
+    }
+    // otherApps are non-pinned by construction (filterNot), so isPinned = false.
+    items(items = otherApps, key = { it.componentName.flattenToString() }) { entry ->
+        DrawerAppItem(entry, DrawerLayout.LIST, isPinned = false, onLaunch, onTogglePin)
+    }
+}
+
+// One app entry (grid tile or list row) wrapping a long-press pin / unpin menu.
+@Composable
+private fun DrawerAppItem(
+    entry: AppEntry,
+    layout: DrawerLayout,
+    isPinned: Boolean,
+    onLaunch: (ComponentName) -> Unit,
+    onTogglePin: (ComponentName) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    Box(modifier = modifier) {
+        when (layout) {
+            DrawerLayout.GRID -> {
+                AppTile(
+                    entry = entry,
+                    onClick = { onLaunch(entry.componentName) },
+                    onLongClick = { menuOpen = true },
+                )
+            }
+
+            DrawerLayout.LIST -> {
+                AppListRow(
+                    entry = entry,
+                    onClick = { onLaunch(entry.componentName) },
+                    onLongClick = { menuOpen = true },
+                )
+            }
+        }
+        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+            DropdownMenuItem(
+                text = {
+                    Text(stringResource(if (isPinned) R.string.drawer_unpin else R.string.drawer_pin))
+                },
+                leadingIcon = {
+                    Icon(imageVector = if (isPinned) Lucide.PinOff else Lucide.Pin, contentDescription = null)
+                },
+                onClick = {
+                    onTogglePin(entry.componentName)
+                    menuOpen = false
+                },
+            )
         }
     }
 }
+
+@Composable
+private fun SectionHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+) = Text(
+    text = text.uppercase(),
+    style = MaterialTheme.typography.titleSmall,
+    color = MaterialTheme.colorScheme.primary,
+    modifier = modifier.padding(horizontal = FemtoDimens.ScreenPadding, vertical = 8.dp),
+)
 
 @Composable
 private fun ErrorState(
@@ -141,7 +310,11 @@ private fun AppDrawerContentPreview() {
                             AppEntry(ComponentName("com.phone", ".Main"), "Phone", icon),
                         ),
                 ),
+            layout = DrawerLayout.GRID,
+            pinned = setOf("com.maps/.Main"),
             onLaunch = {},
+            onTogglePin = {},
+            onToggleLayout = {},
             onRetry = {},
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
@@ -12,13 +12,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.seijikohara.femto.data.AppsRepository
+import io.github.seijikohara.femto.data.DrawerLayout
+import io.github.seijikohara.femto.data.DrawerPreferences
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import kotlinx.coroutines.launch
 
 /**
  * App drawer presented as a Material 3 [ModalBottomSheet] over the dashboard.
@@ -57,6 +62,13 @@ internal fun AppDrawerSheet(
             .onSuccess { apps -> uiState = AppDrawerUiState.Content(apps) }
             .onFailure { uiState = AppDrawerUiState.Error }
     }
+
+    // Drawer layout + pinned apps are persisted; collect them and write changes back.
+    val drawerPreferences = remember { DrawerPreferences(context) }
+    val layout by drawerPreferences.layout.collectAsStateWithLifecycle(initialValue = DrawerLayout.GRID)
+    val pinned by drawerPreferences.pinned.collectAsStateWithLifecycle(initialValue = emptySet())
+    val scope = rememberCoroutineScope()
+
     val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -70,7 +82,19 @@ internal fun AppDrawerSheet(
         ) {
             AppDrawerScreen(
                 uiState = uiState,
+                layout = layout,
+                pinned = pinned,
                 onLaunch = onLaunch,
+                onTogglePin = { component ->
+                    scope.launch { drawerPreferences.togglePinned(component.flattenToString()) }
+                },
+                onToggleLayout = {
+                    scope.launch {
+                        drawerPreferences.setLayout(
+                            if (layout == DrawerLayout.GRID) DrawerLayout.LIST else DrawerLayout.GRID,
+                        )
+                    }
+                },
                 onRetry = { retryKey++ },
             )
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppListRow.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppListRow.kt
@@ -4,10 +4,9 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
@@ -16,51 +15,48 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
-private val IconSize = 64.dp
-private val IconLabelGap = 8.dp
-private val TilePadding = 8.dp
+private val ListIconSize = 40.dp
 
 /**
- * A single app tile in the launcher grid: icon + label, ≥ 64 dp
- * tap target enforced by [FemtoDimens.MinTouchTarget]. [onLongClick] opens the
- * drawer's pin / unpin menu.
+ * A single app row in the drawer's list layout: a small icon beside the label, the
+ * whole row a ≥ 64 dp tap target. [onLongClick] opens the pin / unpin menu.
  */
 @Composable
-internal fun AppTile(
+internal fun AppListRow(
     entry: AppEntry,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     onLongClick: (() -> Unit)? = null,
-) = Column(
+) = Row(
     modifier =
         modifier
-            .defaultMinSize(minWidth = FemtoDimens.MinTouchTarget, minHeight = FemtoDimens.MinTouchTarget)
+            .fillMaxWidth()
+            .heightIn(min = FemtoDimens.MinTouchTarget)
             .combinedClickable(onClick = onClick, onLongClick = onLongClick)
-            .padding(TilePadding),
-    horizontalAlignment = Alignment.CenterHorizontally,
-    verticalArrangement = Arrangement.Center,
+            .padding(horizontal = FemtoDimens.ScreenPadding, vertical = 8.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(16.dp),
 ) {
     Icon(
         painter = BitmapPainter(entry.icon.asImageBitmap()),
         contentDescription = entry.label,
-        tint = androidx.compose.ui.graphics.Color.Unspecified,
-        modifier = Modifier.size(IconSize),
+        tint = Color.Unspecified,
+        modifier = Modifier.size(ListIconSize),
     )
-    Spacer(Modifier.height(IconLabelGap))
     Text(
         text = entry.label,
-        style = MaterialTheme.typography.labelLarge,
+        style = MaterialTheme.typography.bodyLarge,
         color = MaterialTheme.colorScheme.onBackground,
+        fontSize = FemtoDimens.MinBodyTextSize,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
-        textAlign = TextAlign.Center,
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,12 @@
     <string name="drawer_no_apps">No apps installed</string>
     <string name="drawer_load_error">Couldn\'t load apps</string>
     <string name="drawer_retry">Retry</string>
+    <string name="drawer_layout_grid">Grid layout</string>
+    <string name="drawer_layout_list">List layout</string>
+    <string name="drawer_section_pinned">Pinned</string>
+    <string name="drawer_section_apps">Apps</string>
+    <string name="drawer_pin">Pin</string>
+    <string name="drawer_unpin">Unpin</string>
 
     <!-- Assistant sheet -->
     <string name="assistant_sheet_title">Voice assistant</string>


### PR DESCRIPTION
## Summary

Sixth of the dashboard UI brush-up series — the app drawer.

## Changes

- **Layout toggle**: a header button switches between the existing grid and a new
  **list** layout (`AppListRow`: small icon + label). The choice persists.
- **Pinning**: long-press an app → Pin / Unpin menu (`combinedClickable` +
  `DropdownMenu`). Pinned apps surface in a top **Pinned** section, the rest under
  **Apps**. The pinned set persists.
- New `DrawerPreferences` (DataStore "drawer_preferences"): `DrawerLayout` enum +
  `pinned: Set<String>` (flattened ComponentNames) with `setLayout` / `togglePinned`
  (atomic read-modify-write). Uninstalled pinned apps drop out automatically (the set
  is intersected with the live query).
- `AppDrawerSheet` collects the prefs and writes changes; the drawer stays VM-less,
  matching the existing in-sheet app-query pattern.

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` —
  green. Drawer UI tests updated/added: tap launches, long-press dispatches pin,
  layout toggle dispatches.
- `compose-launcher-reviewer`: applied its findings (modifier params on the new
  content composables, `isPinned = false` for the already-filtered non-pinned list,
  file-level `@OptIn`).
- Emulator: grid↔list toggle persists; long-press → Pin; pinning moves the app into a
  top "Pinned" section.