### PR TITLE
refactor(theme): route card shapes to M3 shape roles

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -55,7 +54,7 @@ internal fun CalendarCard(
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
-    shape = RoundedCornerShape(FemtoDimens.CardCorner),
+    shape = MaterialTheme.shapes.large,
     color = MaterialTheme.colorScheme.surfaceContainer,
     tonalElevation = FemtoDimens.CardElevation,
 ) {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -132,7 +132,7 @@ internal fun MapPanel(
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
-    shape = RoundedCornerShape(FemtoDimens.CardCorner),
+    shape = MaterialTheme.shapes.large,
     color = MaterialTheme.colorScheme.surfaceContainer,
     tonalElevation = FemtoDimens.CardElevation,
 ) {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -95,7 +95,7 @@ internal fun MusicCard(
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
-    shape = RoundedCornerShape(FemtoDimens.CardCorner),
+    shape = MaterialTheme.shapes.large,
     color = MaterialTheme.colorScheme.surfaceContainer,
     tonalElevation = FemtoDimens.CardElevation,
 ) {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -76,7 +75,7 @@ internal fun WeatherCard(
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
-    shape = RoundedCornerShape(FemtoDimens.CardCorner),
+    shape = MaterialTheme.shapes.large,
     color = MaterialTheme.colorScheme.surfaceContainer,
     tonalElevation = FemtoDimens.CardElevation,
 ) {
@@ -225,7 +224,7 @@ private fun ForecastChip(
     Column(
         modifier =
             modifier
-                .clip(RoundedCornerShape(FemtoDimens.ChipCorner))
+                .clip(MaterialTheme.shapes.small)
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 .padding(vertical = 8.dp, horizontal = 4.dp),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -349,7 +349,7 @@ private fun SettingsSection(
     )
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(FemtoDimens.CardCorner),
+        shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = FemtoDimens.CardElevation,
     ) {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -114,14 +114,8 @@ object FemtoDimens {
     val CardPaddingCompact = 10.dp
     val CardSectionGapCompact = 6.dp
 
-    /** Corner radius for dashboard cards. Mockup legend: card radius 16 dp (Shapes.large). */
-    val CardCorner = 16.dp
-
     /** Corner radius for the calendar day-strip cells. Mockup `.day-cell`: 10 px. */
     val DayCellCorner = 10.dp
-
-    /** Corner radius for the weather forecast chips. Mockup `.chip`: 8 px. */
-    val ChipCorner = 8.dp
 
     /** Corner radius for the music album-art block. Mockup `.music-card .art`: 14 px. */
     val ArtCorner = 14.dp


### PR DESCRIPTION
## Summary

First step of the approved plan to standardise the launcher's look on plain **Material 3 + Material You** and retire the bespoke *Bold Minimal* deviations (keeping the automotive safety floors).

Replaces the hardcoded corner literals with the standard M3 shape roles:

- `shape = RoundedCornerShape(FemtoDimens.CardCorner)` → `shape = MaterialTheme.shapes.large` (CalendarCard, WeatherCard, MusicCard, MapPanel, SettingsScreen)
- `.clip(RoundedCornerShape(FemtoDimens.ChipCorner))` → `.clip(MaterialTheme.shapes.small)` (WeatherCard forecast chip)
- Removed the now-unused `FemtoDimens.CardCorner` (16 dp) and `FemtoDimens.ChipCorner` (8 dp) constants and their dead `RoundedCornerShape` imports.

`CardCorner` (16 dp) == M3 `shapes.large` and `ChipCorner` (8 dp) == M3 `shapes.small`, so this is a **no-visual-change** idiom alignment.

Design-specific corner values that map to no M3 role (`OverlayCorner`, `SpeedOverlayCorner`, `ArtCorner`, `DayCellCorner`) stay as `FemtoDimens` tokens — out of scope here.

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — all green
- `compose-launcher-reviewer` — no blocking findings