### PR TITLE
refactor(theme): drop Bold Minimal flat-elevation token for M3 default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,11 @@ with automotive overrides on top.
   the seed colors in `ui/theme/AccentColors.kt` are the only hardcoded
   hex outside `Color.kt`.
 - Shape: M3 default `Shapes` (squircles). Do not customise.
+- Elevation: M3 standard — express surface hierarchy with the
+  `surfaceContainer*` color roles (cards sit on `surfaceContainer`,
+  nested emphasis on `surfaceContainerHigh`); do not pass a non-zero
+  `tonalElevation` / `shadowElevation` to a `Surface` / `Card`. No
+  dedicated elevation token exists.
 - Typography: Bold Minimal on M3 roles, tuned **one weight notch
   lighter** than the original scale after on-device review found the
   heavy display/headline weights too dense on the head unit (display
@@ -95,7 +100,6 @@ with automotive overrides on top.
 | --- | --- | --- | --- |
 | Tap target | 48 dp | **≥ 64 dp** | `FemtoDimens.MinTouchTarget` |
 | Body text on the head-unit dashboard | flexible | **≥ 18 sp**, never `bodySmall` / `labelSmall` (cards may relax this for glance-metadata strip / metrics / progress when the design SSOT specifies it — see `docs/design/dashboard-v2-mockup.html`) | `FemtoDimens.MinBodyTextSize` |
-| Card / Surface elevation | tonal | **0 dp** (Bold Minimal: flat) | `FemtoDimens.CardElevation` |
 
 When the value lives in code, the symbol on the right is the SSOT —
 not a magic number in another file.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -56,7 +56,6 @@ internal fun CalendarCard(
     modifier = modifier,
     shape = MaterialTheme.shapes.large,
     color = MaterialTheme.colorScheme.surfaceContainer,
-    tonalElevation = FemtoDimens.CardElevation,
 ) {
     when {
         // null is the loading frame: render nothing rather than a denial the

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -134,7 +134,6 @@ internal fun MapPanel(
     modifier = modifier,
     shape = MaterialTheme.shapes.large,
     color = MaterialTheme.colorScheme.surfaceContainer,
-    tonalElevation = FemtoDimens.CardElevation,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         // A location fix is the only gate: with it we have permission and a

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -97,7 +97,6 @@ internal fun MusicCard(
     modifier = modifier,
     shape = MaterialTheme.shapes.large,
     color = MaterialTheme.colorScheme.surfaceContainer,
-    tonalElevation = FemtoDimens.CardElevation,
 ) {
     when (state) {
         MusicCardState.NeedsPermission -> ConnectState(onConnect = onConnect)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -77,7 +77,6 @@ internal fun WeatherCard(
     modifier = modifier,
     shape = MaterialTheme.shapes.large,
     color = MaterialTheme.colorScheme.surfaceContainer,
-    tonalElevation = FemtoDimens.CardElevation,
 ) {
     if (snapshot != null) {
         // verticalScroll is a safety net: fillMaxWidth (not fillMaxSize) lets the

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -351,7 +351,6 @@ private fun SettingsSection(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surfaceContainer,
-        tonalElevation = FemtoDimens.CardElevation,
     ) {
         Column(content = content)
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -21,9 +21,6 @@ object FemtoDimens {
     /** Spacing between tiles in a launcher grid. */
     val GridGutter = 16.dp
 
-    /** Default card elevation. Bold Minimal keeps surfaces flat. */
-    val CardElevation = 0.dp
-
     /** Hero-block icon size for dashboard cards (e.g., the weather summary). */
     val HeroIconSize = 36.dp
 


### PR DESCRIPTION
## Summary

Second step of the approved plan to standardise the launcher's look on plain **Material 3 + Material You** and retire the bespoke *Bold Minimal* deviations.

Material 3 expresses surface hierarchy through the `surfaceContainer*` **color roles**, not shadow / tonal elevation overlays — and the M3 `Surface` already defaults `tonalElevation` to `0.dp`. The launcher already places cards on `surfaceContainer` and nested emphasis on `surfaceContainerHigh`, so the explicit `tonalElevation = FemtoDimens.CardElevation` (0.dp) on every card was redundant and only encoded the Bold Minimal "keep surfaces flat" identity.

- Removed the redundant `tonalElevation` argument from CalendarCard, WeatherCard, MusicCard, MapPanel, and SettingsScreen (Surface default is already 0.dp).
- Deleted the now-unused `FemtoDimens.CardElevation` constant.
- **CLAUDE.md**: added an *Elevation: M3 standard* rule to `#design-system` (express hierarchy via `surfaceContainer*`; never pass a non-zero `tonalElevation`/`shadowElevation`), and dropped the *Card / Surface elevation* row from the `#automotive-overrides` table — elevation now **follows** the M3 standard rather than overriding it.

**No visual change**: the rendered elevation was already 0.dp; this removes the bespoke token and defers to the M3 default.

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — all green
- `compose-launcher-reviewer` — no blocking findings (two CLAUDE.md wording suggestions applied)