### PR TITLE
feat(music): add album line and leading meta icons

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeNowPlaying.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeNowPlaying.kt
@@ -5,6 +5,7 @@ import io.github.seijikohara.femto.data.NowPlaying
 internal fun fakeNowPlaying(
     title: String = "Strobe",
     artist: String? = "deadmau5",
+    album: String? = "For Lack of a Better Name",
     isPlaying: Boolean = true,
     positionMs: Long = 232_000L,
     durationMs: Long = 632_000L,
@@ -13,6 +14,7 @@ internal fun fakeNowPlaying(
     NowPlaying(
         title = title,
         artist = artist,
+        album = album,
         albumArt = null,
         isPlaying = isPlaying,
         positionMs = positionMs,

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicCardTest.kt
@@ -35,6 +35,21 @@ class MusicCardTest {
     }
 
     @Test
+    fun renders_album_when_present() {
+        rule.setContent {
+            FemtoTheme {
+                MusicCard(
+                    state = MusicCardState.Playing(fakeNowPlaying(album = "For Lack of a Better Name")),
+                    onCommand = {},
+                    onConnect = {},
+                    onLaunchSource = {},
+                )
+            }
+        }
+        rule.onNodeWithText("For Lack of a Better Name").assertIsDisplayed()
+    }
+
+    @Test
     fun keeps_paused_session_on_screen_instead_of_collapsing_to_empty() {
         rule.setContent {
             FemtoTheme {

--- a/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
@@ -186,6 +186,7 @@ internal class MusicSessionRepository(
                             ?: metadata.getString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE)?.takeIf { it.isNotBlank() }
                             ?: sourceLabel(controller.packageName),
                     artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST),
+                    album = metadata.getString(MediaMetadata.METADATA_KEY_ALBUM),
                     albumArt = metadata.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)?.asImageBitmap(),
                     // sourceIcon is resolved downstream off Main (see stateFlow).
                     // A paused controller renders with isPlaying=false (Play icon,

--- a/app/src/main/java/io/github/seijikohara/femto/data/NowPlaying.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/NowPlaying.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 internal data class NowPlaying(
     val title: String,
     val artist: String?,
+    val album: String?,
     val albumArt: ImageBitmap?,
     val isPlaying: Boolean,
     val positionMs: Long,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -38,6 +39,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -45,12 +47,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import com.composables.icons.lucide.Disc
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Music
 import com.composables.icons.lucide.Pause
 import com.composables.icons.lucide.Play
 import com.composables.icons.lucide.SkipBack
 import com.composables.icons.lucide.SkipForward
+import com.composables.icons.lucide.User
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.data.NowPlaying
@@ -142,6 +146,7 @@ private fun PlayingState(
                     sourceIcon = nowPlaying.sourceIcon,
                     title = nowPlaying.title,
                     artist = nowPlaying.artist,
+                    album = nowPlaying.album,
                 )
                 Progress(
                     positionMs = nowPlaying.positionMs,
@@ -214,63 +219,110 @@ private fun Meta(
     sourceIcon: ImageBitmap?,
     title: String,
     artist: String?,
+    album: String?,
     modifier: Modifier = Modifier,
-) = Column(
-    modifier = modifier.fillMaxWidth(),
-    horizontalAlignment = Alignment.Start,
-    verticalArrangement = Arrangement.spacedBy(2.dp),
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        // The source app's own icon precedes its name; fall back to a generic music
-        // glyph when the icon could not be resolved (rare).
-        if (sourceIcon != null) {
-            Image(
-                bitmap = sourceIcon,
-                contentDescription = null,
-                modifier = Modifier.size(14.dp).clip(RoundedCornerShape(4.dp)),
-            )
-        } else {
-            Icon(
-                imageVector = Lucide.Music,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(12.dp),
-            )
-        }
-        Text(
-            text = source.uppercase(),
-            style = MaterialTheme.typography.sectionLabel(10, 0.16f),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-        )
-    }
-    Text(
-        text = title,
-        style =
-            MaterialTheme.typography.titleLarge.copy(
+    // Title, artist and album styles derive from the M3 type roles once and are
+    // remembered so a track-change recomposition doesn't reallocate them.
+    val typography = MaterialTheme.typography
+    val titleStyle =
+        remember(typography) {
+            typography.titleLarge.copy(
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold,
                 letterSpacing = (-0.02f).em,
                 lineHeight = 23.sp,
-            ),
-        color = MaterialTheme.colorScheme.onSurface,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-    )
-    Text(
-        // Radio / stream tracks often carry no artist; show an em dash so the line
-        // height stays stable rather than the title jumping down.
-        text = artist?.takeUnless { it.isBlank() } ?: "—",
-        style =
-            MaterialTheme.typography.bodyMedium.copy(
+            )
+        }
+    val secondaryStyle =
+        remember(typography) {
+            typography.bodyMedium.copy(
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Medium,
                 lineHeight = 16.sp,
-            ),
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.Start,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            // The source app's own icon precedes its name; fall back to a generic
+            // music glyph when the icon could not be resolved (rare).
+            if (sourceIcon != null) {
+                Image(
+                    bitmap = sourceIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp).clip(RoundedCornerShape(4.dp)),
+                )
+            } else {
+                Icon(
+                    imageVector = Lucide.Music,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(12.dp),
+                )
+            }
+            Text(
+                text = source.uppercase(),
+                style = MaterialTheme.typography.sectionLabel(10, 0.16f),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+        MetaLine(
+            icon = Lucide.Music,
+            text = title,
+            style = titleStyle,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        MetaLine(
+            icon = Lucide.User,
+            // Radio / stream tracks often carry no artist; show an em dash so the
+            // line height stays stable rather than the title jumping down.
+            text = artist?.takeUnless { it.isBlank() } ?: "—",
+            style = secondaryStyle,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        // Album is absent for many radio / stream sessions; drop the whole line
+        // rather than show a placeholder, so the block stays compact without it.
+        if (!album.isNullOrBlank()) {
+            MetaLine(
+                icon = Lucide.Disc,
+                text = album,
+                style = secondaryStyle,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MetaLine(
+    icon: ImageVector,
+    text: String,
+    style: TextStyle,
+    color: Color,
+    modifier: Modifier = Modifier,
+) = Row(
+    modifier = modifier,
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+) {
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = color,
+        modifier = Modifier.size(14.dp),
+    )
+    Text(
+        text = text,
+        style = style,
+        color = color,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
     )
@@ -542,6 +594,7 @@ private fun MusicCardPlayingPreview() {
                         NowPlaying(
                             title = "Sunset Lover",
                             artist = "Petit Biscuit",
+                            album = "Petit Biscuit",
                             albumArt = null,
                             isPlaying = true,
                             positionMs = 98_000,

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeNowPlaying.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeNowPlaying.kt
@@ -5,6 +5,7 @@ import io.github.seijikohara.femto.data.NowPlaying
 internal fun fakeNowPlaying(
     title: String = "Strobe",
     artist: String? = "deadmau5",
+    album: String? = "For Lack of a Better Name",
     isPlaying: Boolean = true,
     positionMs: Long = 232_000L,
     durationMs: Long = 632_000L,
@@ -13,6 +14,7 @@ internal fun fakeNowPlaying(
     NowPlaying(
         title = title,
         artist = artist,
+        album = album,
         albumArt = null,
         isPlaying = isPlaying,
         positionMs = positionMs,


### PR DESCRIPTION
## Summary

Two music-panel goals:

1. **Album name** — shown beneath the artist, resolved from `MediaMetadata.METADATA_KEY_ALBUM`. The line is omitted entirely when the session reports no album (radio / streams), so the meta block stays compact.
2. **Leading meta icons** — each metadata line now carries a leading Lucide glyph so the three fields read at a glance: a music note for the title, a person for the artist, and a disc for the album.

### Changes

- `data/NowPlaying.kt` — new `album: String?`.
- `data/MusicSessionRepository.kt` — populate `album` from `METADATA_KEY_ALBUM`.
- `ui/home/components/MusicCard.kt` — `Meta` renders title/artist/album through a new `MetaLine(icon, text, style, color)` helper; styles are `remember`ed from the M3 type roles; the album line is conditional on a non-blank value.
- testfixtures (both source sets) + `MusicCardTest` — `album` fixture param and a `renders_album_when_present` test.

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — all green
- `compose-launcher-reviewer` — no blocking findings; two suggestions applied (`remember` the derived styles; `MetaLine` tints the glyph with the line colour)
- Installed on the emulator (no crash; the playing-state visual needs a live media session — verify on device while music plays)