### PR TITLE
feat(settings): add reset to defaults

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -26,6 +26,8 @@ class SettingsScreenTest {
     private val darkLabel = context.getString(R.string.settings_theme_dark)
     private val showSecondsLabel = context.getString(R.string.settings_group_clock_seconds)
     private val tealAccentLabel = context.getString(R.string.settings_accent_teal)
+    private val resetLabel = context.getString(R.string.settings_reset_to_defaults)
+    private val resetConfirmLabel = context.getString(R.string.settings_reset_confirm)
 
     @Test
     fun renders_fullscreen_row() {
@@ -72,6 +74,17 @@ class SettingsScreenTest {
         rule.onNodeWithText(themeLabel).performClick()
         rule.onNodeWithText(darkLabel).performClick()
         assertEquals(listOf(SettingsAction.SetThemeMode(ThemeMode.DARK)), actions)
+    }
+
+    @Test
+    fun confirming_reset_dispatches_reset_to_defaults() {
+        val actions = mutableListOf<SettingsAction>()
+        setScreen(onAction = { actions += it })
+        // The reset row sits at the bottom (System section); scroll it in, tap to
+        // open the confirm dialog, then tap Reset to confirm.
+        rule.onNodeWithText(resetLabel).performScrollTo().performClick()
+        rule.onNodeWithText(resetConfirmLabel).performClick()
+        assertEquals(listOf(SettingsAction.ResetToDefaults), actions)
     }
 
     private fun setScreen(onAction: (SettingsAction) -> Unit = {}) {

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -203,6 +203,9 @@ internal interface DisplaySettingsStore {
     suspend fun setShowWeather(value: Boolean)
 
     suspend fun setShowMusic(value: Boolean)
+
+    /** Restore every display setting to [DisplaySettings.Default]. */
+    suspend fun resetToDefaults()
 }
 
 /**
@@ -321,6 +324,13 @@ internal class DisplayPreferences(
 
     override suspend fun setShowMusic(value: Boolean) {
         context.displayDataStore.edit { it[SHOW_MUSIC_KEY] = value }
+    }
+
+    // Clearing every key makes the read path above fall back to its per-field
+    // defaults, which are kept identical to DisplaySettings.Default — so a reset
+    // restores the defaults without duplicating the default literals here.
+    override suspend fun resetToDefaults() {
+        context.displayDataStore.edit { it.clear() }
     }
 
     private companion object {

--- a/app/src/main/java/io/github/seijikohara/femto/data/FontPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/FontPreferences.kt
@@ -31,6 +31,12 @@ internal class FontPreferences(
         context.fontDataStore.edit { it[KEY] = theme.name }
     }
 
+    // Clearing the key makes the read path fall back to the FontTheme.INTER
+    // default, mirroring DisplayPreferences.resetToDefaults.
+    suspend fun resetToDefaults() {
+        context.fontDataStore.edit { it.clear() }
+    }
+
     private companion object {
         val KEY = stringPreferencesKey("font_theme")
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -49,6 +49,7 @@ import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.ChevronRight
 import com.composables.icons.lucide.ExternalLink
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.RotateCcw
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
@@ -296,6 +297,7 @@ internal fun SettingsScreen(
                 title = stringResource(R.string.settings_open_system_settings),
                 onClick = onOpenSystemSettings,
             )
+            ResetRow(onConfirm = { onAction(SettingsAction.ResetToDefaults) })
         }
     }
 }
@@ -591,6 +593,52 @@ private fun ActionRow(
 ) {
     TrailingIcon(Lucide.ExternalLink)
 }
+
+// A destructive row: resetting every setting to its default. Tapping opens a
+// confirm dialog — the only destructive action in Settings — so a stray tap on
+// the head unit never wipes the user's configuration.
+@Composable
+private fun ResetRow(
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var dialogOpen by remember { mutableStateOf(false) }
+    SettingRow(
+        title = stringResource(R.string.settings_reset_to_defaults),
+        modifier = modifier.clickable { dialogOpen = true },
+    ) {
+        TrailingIcon(Lucide.RotateCcw)
+    }
+    if (dialogOpen) {
+        ResetConfirmDialog(
+            onConfirm = {
+                onConfirm()
+                dialogOpen = false
+            },
+            onDismiss = { dialogOpen = false },
+        )
+    }
+}
+
+@Composable
+private fun ResetConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) = AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text(text = stringResource(R.string.settings_reset_confirm_title)) },
+    text = { Text(text = stringResource(R.string.settings_reset_confirm_message)) },
+    confirmButton = {
+        TextButton(onClick = onConfirm) {
+            Text(text = stringResource(R.string.settings_reset_confirm))
+        }
+    },
+    dismissButton = {
+        TextButton(onClick = onDismiss) {
+            Text(text = stringResource(R.string.settings_cancel))
+        }
+    },
+)
 
 // Shared row scaffold: a tap target ≥ MinTouchTarget with a title, optional
 // summary, and a trailing slot. The caller supplies the interaction (clickable /

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -151,4 +151,7 @@ internal sealed interface SettingsAction {
     data class SetFontTheme(
         val value: FontTheme,
     ) : SettingsAction
+
+    /** Restore every display + font setting to its default value. */
+    data object ResetToDefaults : SettingsAction
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -49,27 +49,94 @@ internal class SettingsViewModel(
         // Each branch is a single suspending write; launch once and dispatch.
         viewModelScope.launch {
             when (action) {
-                is SettingsAction.SetThemeMode -> displayPreferences.setThemeMode(action.value)
-                is SettingsAction.SetAccentColor -> displayPreferences.setAccentColor(action.value)
-                is SettingsAction.SetSpeedUnit -> displayPreferences.setSpeedUnit(action.value)
-                is SettingsAction.SetTemperatureUnit -> displayPreferences.setTemperatureUnit(action.value)
-                is SettingsAction.SetClock -> displayPreferences.setClock(action.value)
-                is SettingsAction.SetShowClockSeconds -> displayPreferences.setShowClockSeconds(action.value)
-                is SettingsAction.SetFullscreen -> displayPreferences.setFullscreen(action.value)
-                is SettingsAction.SetMapStyle -> displayPreferences.setMapStyle(action.value)
-                is SettingsAction.SetMapSchemeLight -> displayPreferences.setMapSchemeLight(action.value)
-                is SettingsAction.SetMapSchemeDark -> displayPreferences.setMapSchemeDark(action.value)
-                is SettingsAction.SetMapTilt -> displayPreferences.setMapTilt(action.value)
-                is SettingsAction.SetMapZoom -> displayPreferences.setMapZoom(action.value)
-                is SettingsAction.SetMapRenderPercent -> displayPreferences.setMapRenderPercent(action.value)
-                is SettingsAction.SetMapRenderMode -> displayPreferences.setMapRenderMode(action.value)
-                is SettingsAction.SetMapMarkerPos -> displayPreferences.setMapMarkerPos(action.value)
-                is SettingsAction.SetMap3dBuildings -> displayPreferences.setMap3dBuildings(action.value)
-                is SettingsAction.SetMapTerrain -> displayPreferences.setMapTerrain(action.value)
-                is SettingsAction.SetShowCalendar -> displayPreferences.setShowCalendar(action.value)
-                is SettingsAction.SetShowWeather -> displayPreferences.setShowWeather(action.value)
-                is SettingsAction.SetShowMusic -> displayPreferences.setShowMusic(action.value)
-                is SettingsAction.SetFontTheme -> fontPreferences.setFontTheme(action.value)
+                is SettingsAction.SetThemeMode -> {
+                    displayPreferences.setThemeMode(action.value)
+                }
+
+                is SettingsAction.SetAccentColor -> {
+                    displayPreferences.setAccentColor(action.value)
+                }
+
+                is SettingsAction.SetSpeedUnit -> {
+                    displayPreferences.setSpeedUnit(action.value)
+                }
+
+                is SettingsAction.SetTemperatureUnit -> {
+                    displayPreferences.setTemperatureUnit(action.value)
+                }
+
+                is SettingsAction.SetClock -> {
+                    displayPreferences.setClock(action.value)
+                }
+
+                is SettingsAction.SetShowClockSeconds -> {
+                    displayPreferences.setShowClockSeconds(action.value)
+                }
+
+                is SettingsAction.SetFullscreen -> {
+                    displayPreferences.setFullscreen(action.value)
+                }
+
+                is SettingsAction.SetMapStyle -> {
+                    displayPreferences.setMapStyle(action.value)
+                }
+
+                is SettingsAction.SetMapSchemeLight -> {
+                    displayPreferences.setMapSchemeLight(action.value)
+                }
+
+                is SettingsAction.SetMapSchemeDark -> {
+                    displayPreferences.setMapSchemeDark(action.value)
+                }
+
+                is SettingsAction.SetMapTilt -> {
+                    displayPreferences.setMapTilt(action.value)
+                }
+
+                is SettingsAction.SetMapZoom -> {
+                    displayPreferences.setMapZoom(action.value)
+                }
+
+                is SettingsAction.SetMapRenderPercent -> {
+                    displayPreferences.setMapRenderPercent(action.value)
+                }
+
+                is SettingsAction.SetMapRenderMode -> {
+                    displayPreferences.setMapRenderMode(action.value)
+                }
+
+                is SettingsAction.SetMapMarkerPos -> {
+                    displayPreferences.setMapMarkerPos(action.value)
+                }
+
+                is SettingsAction.SetMap3dBuildings -> {
+                    displayPreferences.setMap3dBuildings(action.value)
+                }
+
+                is SettingsAction.SetMapTerrain -> {
+                    displayPreferences.setMapTerrain(action.value)
+                }
+
+                is SettingsAction.SetShowCalendar -> {
+                    displayPreferences.setShowCalendar(action.value)
+                }
+
+                is SettingsAction.SetShowWeather -> {
+                    displayPreferences.setShowWeather(action.value)
+                }
+
+                is SettingsAction.SetShowMusic -> {
+                    displayPreferences.setShowMusic(action.value)
+                }
+
+                is SettingsAction.SetFontTheme -> {
+                    fontPreferences.setFontTheme(action.value)
+                }
+
+                is SettingsAction.ResetToDefaults -> {
+                    displayPreferences.resetToDefaults()
+                    fontPreferences.resetToDefaults()
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,4 +152,8 @@
     <string name="settings_group_panel_music">Music panel</string>
     <string name="settings_open_notification_access">Notification access</string>
     <string name="settings_open_system_settings">System settings</string>
+    <string name="settings_reset_to_defaults">Reset to defaults</string>
+    <string name="settings_reset_confirm_title">Reset all settings?</string>
+    <string name="settings_reset_confirm_message">This restores every display, unit, map, panel and font setting to its default value.</string>
+    <string name="settings_reset_confirm">Reset</string>
 </resources>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -68,4 +68,6 @@ internal class FakeDisplaySettingsStore(
     override suspend fun setShowWeather(value: Boolean) = state.update { it.copy(showWeather = value) }
 
     override suspend fun setShowMusic(value: Boolean) = state.update { it.copy(showMusic = value) }
+
+    override suspend fun resetToDefaults() = state.update { DisplaySettings.Default }
 }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package io.github.seijikohara.femto.ui.settings
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import io.github.seijikohara.femto.data.AccentColor
+import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.MapColorScheme
@@ -131,6 +132,21 @@ class SettingsViewModelTest {
             viewModel().onAction(SettingsAction.SetMapTerrain(true))
             advanceUntilIdle()
             assertEquals(true, store.settings.first().mapTerrain)
+        }
+
+    @Test
+    fun `ResetToDefaults restores display settings to their defaults`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            // Move a representative field of each persisted type off its default.
+            vm.onAction(SettingsAction.SetFullscreen(FullscreenSetting.ON))
+            vm.onAction(SettingsAction.SetAccentColor(AccentColor.TEAL))
+            vm.onAction(SettingsAction.SetShowMusic(false))
+            vm.onAction(SettingsAction.SetMapTilt(10))
+            advanceUntilIdle()
+            vm.onAction(SettingsAction.ResetToDefaults)
+            advanceUntilIdle()
+            assertEquals(DisplaySettings.Default, store.settings.first())
         }
 
     private fun viewModel() = SettingsViewModel(store, FontPreferences(application))


### PR DESCRIPTION
## Summary

Implements goal #4: a **Reset to defaults** action in Settings.

A destructive row in the **System** section opens a confirm dialog (Reset / Cancel) before restoring every display, unit, map, panel and font setting to its default value — so a stray tap on the head unit never wipes the user's configuration.

### Design

- `DisplaySettingsStore.resetToDefaults()` / `FontPreferences.resetToDefaults()` clear each preference DataStore. The read path's per-field fallbacks are kept identical to `DisplaySettings.Default` (and `FontTheme.INTER`), so clearing restores the defaults **without duplicating the default literals** (SSOT/DRY). All 20 display fields verified to match.
- `SettingsAction.ResetToDefaults` (data object) → VM calls both stores.
- `ResetRow` + `ResetConfirmDialog` in `SettingsScreen`, mirroring the existing `ChoiceRow` dialog-state pattern; the row uses a `Lucide.RotateCcw` glyph.

### Tests

- `SettingsViewModelTest`: moves a representative field of each type off-default, then asserts the store equals `DisplaySettings.Default` after reset.
- `SettingsScreenTest`: scroll to the row, tap, confirm, assert `ResetToDefaults` dispatched.

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — all green
- `compose-launcher-reviewer` — no blocking findings; clear()-relies-on-defaults verified correct (all 20 fields match). Test name/coverage suggestions applied. The row's semantics role mirrors the existing `ActionRow` (left consistent; a separate change if revisited).
- Installed on the emulator.