### PR TITLE
feat(settings): present settings as a bottom sheet

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -44,7 +44,7 @@ import io.github.seijikohara.femto.ui.home.HomeRoute
 import io.github.seijikohara.femto.ui.home.components.MapConfig
 import io.github.seijikohara.femto.ui.home.components.PanelVisibility
 import io.github.seijikohara.femto.ui.locale.resolved
-import io.github.seijikohara.femto.ui.settings.SettingsRoute
+import io.github.seijikohara.femto.ui.settings.SettingsSheet
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.FontTheme
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -103,69 +103,68 @@ class MainActivity : ComponentActivity() {
                 applyFullscreen(display.fullscreen)
             }
             FemtoTheme(fontTheme = fontTheme, accent = display.accentColor, darkTheme = darkTheme) {
-                // The dashboard stays composed; the app drawer and assistant are
-                // bottom-sheet overlays and settings is a full destination over it.
+                // The dashboard stays composed; the app drawer, assistant, and
+                // settings are all bottom-sheet overlays that slide up over it.
                 var showDrawer by rememberSaveable { mutableStateOf(false) }
                 var showAssistant by rememberSaveable { mutableStateOf(false) }
                 var showSettings by rememberSaveable { mutableStateOf(false) }
+                HomeRoute(
+                    is24Hour = resolveIs24Hour(display.clock),
+                    showClockSeconds = display.showClockSeconds,
+                    speedUnit = display.speedUnit.resolved(),
+                    temperatureUnit = display.temperatureUnit.resolved(),
+                    mapConfig =
+                        MapConfig(
+                            style = display.mapStyle,
+                            schemeLight = display.mapSchemeLight,
+                            schemeDark = display.mapSchemeDark,
+                            tiltDeg = display.mapTiltDeg,
+                            zoom = display.mapZoom,
+                            renderPercent = display.mapRenderPercent,
+                            renderMode = display.mapRenderMode,
+                            markerPos = display.mapMarkerPos,
+                            buildings3d = display.map3dBuildings,
+                            terrain = display.mapTerrain,
+                        ),
+                    panels =
+                        PanelVisibility(
+                            calendar = display.showCalendar,
+                            weather = display.showWeather,
+                            music = display.showMusic,
+                        ),
+                    onEvent = { event ->
+                        handleHomeEvent(
+                            event = event,
+                            setShowDrawer = { showDrawer = it },
+                            setShowAssistant = { showAssistant = it },
+                            setShowSettings = { showSettings = it },
+                        )
+                    },
+                )
+                if (showDrawer) {
+                    AppDrawerSheet(
+                        onLaunch = { component ->
+                            appsRepository.launch(component)
+                            showDrawer = false
+                        },
+                        onDismiss = { showDrawer = false },
+                    )
+                }
+                if (showAssistant) {
+                    AssistantSheet(
+                        onLaunchOption = { option ->
+                            launchAssistantOption(option)
+                            showAssistant = false
+                        },
+                        onDismiss = { showAssistant = false },
+                    )
+                }
                 if (showSettings) {
-                    SettingsRoute(
-                        onBack = { showSettings = false },
+                    SettingsSheet(
                         onOpenNotificationAccess = ::openNotificationListenerSettings,
                         onOpenSystemSettings = ::openSystemSettings,
+                        onDismiss = { showSettings = false },
                     )
-                } else {
-                    HomeRoute(
-                        is24Hour = resolveIs24Hour(display.clock),
-                        showClockSeconds = display.showClockSeconds,
-                        speedUnit = display.speedUnit.resolved(),
-                        temperatureUnit = display.temperatureUnit.resolved(),
-                        mapConfig =
-                            MapConfig(
-                                style = display.mapStyle,
-                                schemeLight = display.mapSchemeLight,
-                                schemeDark = display.mapSchemeDark,
-                                tiltDeg = display.mapTiltDeg,
-                                zoom = display.mapZoom,
-                                renderPercent = display.mapRenderPercent,
-                                renderMode = display.mapRenderMode,
-                                markerPos = display.mapMarkerPos,
-                                buildings3d = display.map3dBuildings,
-                                terrain = display.mapTerrain,
-                            ),
-                        panels =
-                            PanelVisibility(
-                                calendar = display.showCalendar,
-                                weather = display.showWeather,
-                                music = display.showMusic,
-                            ),
-                        onEvent = { event ->
-                            handleHomeEvent(
-                                event = event,
-                                setShowDrawer = { showDrawer = it },
-                                setShowAssistant = { showAssistant = it },
-                                setShowSettings = { showSettings = it },
-                            )
-                        },
-                    )
-                    if (showDrawer) {
-                        AppDrawerSheet(
-                            onLaunch = { component ->
-                                appsRepository.launch(component)
-                                showDrawer = false
-                            },
-                            onDismiss = { showDrawer = false },
-                        )
-                    }
-                    if (showAssistant) {
-                        AssistantSheet(
-                            onLaunchOption = { option ->
-                                launchAssistantOption(option)
-                                showAssistant = false
-                            },
-                            onDismiss = { showAssistant = false },
-                        )
-                    }
                 }
             }
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -88,7 +88,9 @@ internal fun SettingsScreen(
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier.fillMaxSize(),
-    color = MaterialTheme.colorScheme.background,
+    // Hosted in the settings bottom sheet: match the M3 sheet container colour so the
+    // surface reads as the sheet rather than painting the opaque app background.
+    color = MaterialTheme.colorScheme.surfaceContainerLow,
 ) {
     Column(
         modifier =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
@@ -1,0 +1,53 @@
+package io.github.seijikohara.femto.ui.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+
+/**
+ * Settings presented as a Material 3 [ModalBottomSheet] over the dashboard,
+ * mirroring [io.github.seijikohara.femto.ui.drawer.AppDrawerSheet]: the dashboard
+ * stays composed underneath, so settings read as an overlay the user dismisses by
+ * swiping down, tapping the scrim, or the header back button — rather than a
+ * full-screen swap. The sheet height is the same viewport fraction as the drawer so
+ * the dashboard stays visible behind it. [SettingsRoute] supplies the content inside
+ * the height-bounded [Box] so its sections scroll within the sheet.
+ *
+ * No standalone preview: a [ModalBottomSheet] renders in a popup window Compose
+ * previews do not capture, so [SettingsScreen]'s own @PreviewLightDark covers the
+ * settings content.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SettingsSheet(
+    onOpenNotificationAccess: () -> Unit,
+    onOpenSystemSettings: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(sheetHeight),
+        ) {
+            SettingsRoute(
+                onBack = onDismiss,
+                onOpenNotificationAccess = onOpenNotificationAccess,
+                onOpenSystemSettings = onOpenSystemSettings,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements goal #7: convert Settings from a full-screen replacement to a Material 3 **ModalBottomSheet** over the dashboard, mirroring the app drawer and assistant sheets.

- The dashboard (and its map / WebView) stays composed underneath, so dismissing settings no longer rebuilds it. Settings read as an overlay the user dismisses by swiping down, tapping the scrim, or the header back.
- New `SettingsSheet` hosts `SettingsRoute` inside the shared sheet height (`DrawerSheetHeightFraction`).
- `MainActivity` drops the exclusive `if (showSettings) … else …` branch and composes `HomeRoute` **always**, with drawer, assistant, and settings as three conditional sheet overlays.
- `SettingsScreen`'s surface now uses the M3 sheet container colour (`surfaceContainerLow`) instead of the opaque app background.

## Verification

- `./gradlew spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin` — all green
- `compose-launcher-reviewer` — no blocking findings; the surface-colour suggestion is applied. The header back-arrow is kept as an explicit large close target for the head unit; a shared sheet-height helper is left for a follow-up since the drawer/assistant use the same inline pattern.
- Verified on the emulator: the sheet opens over the dashboard with scrim, drag handle, and scrolling sections.