### PR TITLE
fix(weather): keep metric values from clipping on the narrow card

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
@@ -74,9 +74,11 @@ class WeatherCardTest {
                 )
             }
         }
-        rule.onNodeWithText("FEELS").assertIsDisplayed()
-        rule.onNodeWithText("WIND").assertIsDisplayed()
-        rule.onNodeWithText("HUMID.").assertIsDisplayed()
+        // Each metric is now a Lucide glyph; its text label survives as the icon's
+        // content description for TalkBack.
+        rule.onNodeWithContentDescription("FEELS").assertIsDisplayed()
+        rule.onNodeWithContentDescription("WIND").assertIsDisplayed()
+        rule.onNodeWithContentDescription("HUMID.").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -185,24 +185,17 @@ private fun Metric(
     label: String,
     value: String,
     modifier: Modifier = Modifier,
-) = Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(3.dp),
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(11.dp),
-        )
-        Text(
-            text = label,
-            style = MaterialTheme.typography.sectionLabel(10, 0.1f),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-        )
-    }
+) = Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(3.dp)) {
+    // The Lucide glyph stands in for the metric label (thermometer = feels-like,
+    // wind, droplet = humidity); the text label moves to the icon's content
+    // description so the value keeps the full column width and never clips on the
+    // narrow head-unit card.
+    Icon(
+        imageVector = icon,
+        contentDescription = label,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(16.dp),
+    )
     Text(
         text = value,
         style =


### PR DESCRIPTION
## Summary

Follow-up to #107. The weather metric icons added there sat before the label in a row, which pushed the third metric (humidity) past the ~165dp card width and clipped its label and value on the head unit (observed on the emulator as FEELS->FEE, HUMID.->HU).

Fix: replace the metric label **text** with the Lucide glyph itself (thermometer / wind / droplet) stacked over the value, and move the text label to the icon's contentDescription. Each metric is now a glyph over its value, so the value keeps the full equal-weight column width and never clips — even for longer values like 11 km/h.

## Verification

- spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin — all green (WeatherCardTest's metric test now asserts the labels via content description)
- The label text is preserved for TalkBack via contentDescription.