### PR TITLE
feat(drawer): add app search and wider grid tiles

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import io.github.seijikohara.femto.data.DrawerLayout
 import io.github.seijikohara.femto.testfixtures.fakeAppEntry
@@ -119,6 +120,48 @@ class AppDrawerScreenTest {
             }
         }
         rule.onNodeWithText("No apps installed").assertIsDisplayed()
+    }
+
+    @Test
+    fun search_filters_apps_by_label() {
+        val maps = fakeAppEntry(packageName = "com.maps", className = ".Main", label = "Maps")
+        val music = fakeAppEntry(packageName = "com.music", className = ".Main", label = "Music")
+        rule.setContent {
+            FemtoTheme {
+                AppDrawerScreen(
+                    uiState = AppDrawerUiState.Content(listOf(maps, music)),
+                    layout = DrawerLayout.LIST,
+                    pinned = emptySet(),
+                    onLaunch = {},
+                    onTogglePin = {},
+                    onToggleLayout = {},
+                    onRetry = {},
+                )
+            }
+        }
+        rule.onNodeWithTag(APP_DRAWER_SEARCH_TEST_TAG).performTextInput("mu")
+        rule.onNodeWithText("Music").assertIsDisplayed()
+        rule.onNodeWithText("Maps").assertDoesNotExist()
+    }
+
+    @Test
+    fun search_with_no_match_shows_no_matches_message() {
+        val maps = fakeAppEntry(packageName = "com.maps", className = ".Main", label = "Maps")
+        rule.setContent {
+            FemtoTheme {
+                AppDrawerScreen(
+                    uiState = AppDrawerUiState.Content(listOf(maps)),
+                    layout = DrawerLayout.LIST,
+                    pinned = emptySet(),
+                    onLaunch = {},
+                    onTogglePin = {},
+                    onToggleLayout = {},
+                    onRetry = {},
+                )
+            }
+        }
+        rule.onNodeWithTag(APP_DRAWER_SEARCH_TEST_TAG).performTextInput("zzz")
+        rule.onNodeWithText("No apps match your search").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,6 +25,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -42,6 +44,8 @@ import com.composables.icons.lucide.LayoutList
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Pin
 import com.composables.icons.lucide.PinOff
+import com.composables.icons.lucide.Search
+import com.composables.icons.lucide.X
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.data.DrawerLayout
@@ -51,9 +55,12 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 
-private val MinTileWidth = 96.dp
+// 120 dp (up from 96) yields ~5 columns on the 853 dp-wide reference head unit,
+// giving each tile room for a 64 dp icon plus its label without crowding.
+private val MinTileWidth = 120.dp
 
 internal const val APP_DRAWER_PROGRESS_TEST_TAG = "app-drawer-progress"
+internal const val APP_DRAWER_SEARCH_TEST_TAG = "app-drawer-search"
 
 @Composable
 internal fun AppDrawerScreen(
@@ -107,29 +114,71 @@ private fun ContentState(
     onToggleLayout: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(modifier = modifier.fillMaxSize()) {
-    LayoutToggleBar(layout = layout, onToggleLayout = onToggleLayout)
+    var query by remember { mutableStateOf("") }
+    DrawerTopBar(
+        query = query,
+        onQueryChange = { query = it },
+        layout = layout,
+        onToggleLayout = onToggleLayout,
+    )
     if (apps.isEmpty()) {
         CenteredMessage(text = stringResource(R.string.drawer_no_apps))
         return@Column
     }
+    // Filter by the search query (label substring, case-insensitive); an empty query
+    // shows everything.
+    val trimmed = query.trim()
+    val matched =
+        if (trimmed.isEmpty()) {
+            apps
+        } else {
+            apps.filter { it.label.contains(trimmed, ignoreCase = true) }
+        }
+    if (matched.isEmpty()) {
+        CenteredMessage(text = stringResource(R.string.drawer_no_matches))
+        return@Column
+    }
     // Split into the pinned section and the rest (both keep the shared label sort).
-    val pinnedApps = apps.filter { it.componentName.flattenToString() in pinned }
-    val otherApps = apps.filterNot { it.componentName.flattenToString() in pinned }
+    val pinnedApps = matched.filter { it.componentName.flattenToString() in pinned }
+    val otherApps = matched.filterNot { it.componentName.flattenToString() in pinned }
     when (layout) {
         DrawerLayout.GRID -> GridApps(pinnedApps, otherApps, onLaunch, onTogglePin)
         DrawerLayout.LIST -> ListApps(pinnedApps, otherApps, onLaunch, onTogglePin)
     }
 }
 
+// Search field + layout toggle. Filtering by app name is the main usability win on a
+// head unit with a long app list; the layout toggle stays at the trailing edge.
 @Composable
-private fun LayoutToggleBar(
+private fun DrawerTopBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
     layout: DrawerLayout,
     onToggleLayout: () -> Unit,
     modifier: Modifier = Modifier,
-) = Box(
+) = Row(
     modifier = modifier.fillMaxWidth().padding(horizontal = FemtoDimens.ScreenPadding, vertical = 4.dp),
-    contentAlignment = Alignment.CenterEnd,
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
 ) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = Modifier.weight(1f).testTag(APP_DRAWER_SEARCH_TEST_TAG),
+        textStyle = MaterialTheme.typography.bodyLarge.copy(fontSize = FemtoDimens.MinBodyTextSize),
+        placeholder = {
+            Text(text = stringResource(R.string.drawer_search_hint), fontSize = FemtoDimens.MinBodyTextSize)
+        },
+        leadingIcon = { Icon(imageVector = Lucide.Search, contentDescription = null) },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(imageVector = Lucide.X, contentDescription = stringResource(R.string.drawer_search_clear))
+                }
+            }
+        },
+        singleLine = true,
+    )
     // The icon shows the layout the tap switches TO.
     IconButton(onClick = onToggleLayout, modifier = Modifier.size(FemtoDimens.MinTouchTarget)) {
         Icon(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,9 @@
     <string name="drawer_section_apps">Apps</string>
     <string name="drawer_pin">Pin</string>
     <string name="drawer_unpin">Unpin</string>
+    <string name="drawer_search_hint">Search apps</string>
+    <string name="drawer_search_clear">Clear search</string>
+    <string name="drawer_no_matches">No apps match your search</string>
 
     <!-- Assistant sheet -->
     <string name="assistant_sheet_title">Voice assistant</string>


### PR DESCRIPTION
## Summary

Implements goal #8: make the app-list bottom sheet more usable on a head unit.

- **Search field**: the top bar now pairs an OutlinedTextField (filter apps by name, case-insensitive) with the existing layout toggle. Leading search icon, a clear (X) button when non-empty, single line, 18sp text. An empty query shows everything; a no-match query shows a dedicated 'No apps match your search' message. Both the pinned and all-apps sections filter from the same matched list.
- **Wider grid tiles**: the tile floor goes 96 to 120 dp, so the 853 dp reference unit lands ~5 roomy columns with space for the 64 dp icon plus its label.

The motion-state policy allows passenger operation, so the keyboard search field needs no global gate.

## Verification

- spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin — all green; two new AppDrawerScreenTest cases (filter shows only matches; no-match shows the message)
- Verified on the emulator: the drawer opens with the search bar + layout toggle and the PINNED/APPS sections.