### PR TITLE
fix(map): pin the chevron on screen so the map pans beneath it

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,61 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/src/main/assets/web/map.html
+++ b/app/src/main/assets/web/map.html
@@ -11,10 +11,24 @@
          0 px tall); fixed/inset fills the WebView viewport reliably. */
       #map { position: fixed; inset: 0; }
       .maplibregl-ctrl-attrib, .maplibregl-ctrl-logo { display: none; }
+      /* Self-location chevron pinned at a fixed screen spot (centre X, markerPos
+         height). The camera brings the location to it, so the chevron stays put and
+         the map slides / rotates beneath it (car-nav style) instead of the marker
+         sliding to catch the eased camera. */
+      #self-marker {
+        position: fixed; left: 50%; top: 50%;
+        transform: translate(-50%, -50%);
+        pointer-events: none; display: none; will-change: top, transform;
+      }
     </style>
   </head>
   <body>
     <div id="map"></div>
+    <div id="self-marker">
+      <svg width="34" height="34" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 0 L30 30 L15 21.6 L0 30 Z" fill="#3367D6" stroke="#FFFFFF" stroke-width="1.5" stroke-linejoin="round"/>
+      </svg>
+    </div>
     <script>
       // Diagnostic logging only (visible via chrome://inspect or the debug PoC's
       // WebChromeClient). There is NO host fallback path: the chosen render backend
@@ -129,20 +143,14 @@
         map.on("webglcontextlost", () => log("webglcontextlost (awaiting MapLibre restore)"));
         map.on("webglcontextrestored", () => log("webglcontextrestored"));
 
-        // Self-location puck: a heading-up nav chevron that mirrors the SNAPSHOT
-        // backend's marker so the two render the same. rotationAlignment "map" +
-        // pitchAlignment "map" rotate it to the travel bearing and lay it flat on
-        // the tilted ground plane (the heading-up camera then points it toward the
-        // top of the frame). It is a DOM Marker, so it survives setStyle. The fill
-        // is set from the host's Material primary via updateCamera's last argument;
-        // the inline default only shows for the first frame before the host pushes.
-        var markerEl = document.createElement("div");
-        markerEl.innerHTML =
-          '<svg width="34" height="34" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">' +
-          '<path d="M15 0 L30 30 L15 21.6 L0 30 Z" fill="#3367D6" stroke="#FFFFFF" ' +
-          'stroke-width="1.5" stroke-linejoin="round"/></svg>';
-        var marker = new maplibregl.Marker({ element: markerEl, rotationAlignment: "map", pitchAlignment: "map" });
-        var markerAdded = false;
+        // Self-location chevron: a fixed-on-screen DOM overlay (see #self-marker CSS).
+        // The camera brings the location to the chevron's spot, so the chevron stays
+        // still and the map slides + rotates beneath it (car-nav style) rather than a
+        // geo-anchored marker sliding to catch the eased camera. It is heading-UP: the
+        // chevron always points to the top of the frame and the map rotates to the
+        // travel bearing; rotateX lays it onto the tilted ground plane.
+        var markerEl = document.getElementById("self-marker");
+        var markerPath = markerEl.querySelector("path");
 
         // The lowest the marker drops below centre, as a fraction of map height, at
         // markerPos = 100 (mirrors MAX_MARKER_DROP in MapPanel.kt).
@@ -158,21 +166,25 @@
           return 2 * drop * (map.getContainer().clientHeight || 0);
         }
 
-        // Android -> JS: smooth heading-up camera follow (this is how #2 smooth
-        // movement is achieved — easeTo interpolates between sparse GPS fixes). The
-        // first fix jumps (no dramatic fly-in from the [0,0] start); the rest ease.
-        // The marker rides the same fixes; [markerColor] (Material primary, "#rrggbb")
-        // is applied here so it self-heals if the first push raced page load.
+        // Android -> JS: smooth heading-up camera follow (easeTo interpolates between
+        // sparse GPS fixes). The first fix jumps (no fly-in from [0,0]); the rest ease.
+        // The chevron is pinned on screen (not geo-anchored), so only the camera moves
+        // and the chevron stays put while the map slides + rotates beneath it. The map
+        // rotates to the travel bearing, so the fixed chevron always reads as forward;
+        // rotateX lays it onto the tilted ground plane to match the map pitch. The
+        // chevron's screen height tracks markerPos, matching the camera padding so the
+        // location renders right under it. [markerColor] (Material primary) self-heals
+        // if the first push raced page load.
         let firstCamera = true;
         window.updateCamera = function (lat, lon, bearing, zoom, tilt, markerPos, markerColor) {
           if (!map) return;
           var heading = bearing || 0;
-          if (markerColor) {
-            var path = markerEl.querySelector("path");
-            if (path) path.setAttribute("fill", markerColor);
-          }
-          marker.setLngLat([lon, lat]).setRotation(heading);
-          if (!markerAdded) { marker.addTo(map); markerAdded = true; }
+          if (markerColor && markerPath) markerPath.setAttribute("fill", markerColor);
+          var pos = Math.max(0, Math.min(100, markerPos || 0));
+          markerEl.style.top = (50 + (pos / 100) * MAX_MARKER_DROP * 100) + "%";
+          markerEl.style.transform =
+            "translate(-50%, -50%) perspective(600px) rotateX(" + (tilt || 0) + "deg)";
+          markerEl.style.display = "block";
           const opts = {
             center: [lon, lat],
             bearing: heading,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -188,11 +188,14 @@ private fun SnapshotMap(
     val renderPercent = mapConfig.renderPercent.coerceIn(1, 100)
     val renderWidthPx = (widthPx * renderPercent / 100).coerceAtLeast(1)
     val renderHeightPx = (heightPx * renderPercent / 100).coerceAtLeast(1)
-    // The snapshot pixels are upscaled to layout pixels by this factor, so the
-    // marker (placed in layout pixels) scales the snapshot pixel it rendered at.
-    val markerScale = widthPx.toFloat() / renderWidthPx
+    // The chevron sits at a fixed on-screen spot — centre X, markerPos height — and
+    // the camera look-ahead aims the location there, so the map slides beneath a
+    // still marker (car-nav style) rather than the marker drifting per frame.
+    val dropFraction = markerDropFraction(mapConfig.markerPos)
+    val markerXPx = widthPx / 2f
+    val markerYPx = (heightPx * (0.5 + dropFraction)).toFloat()
 
-    var frame by remember { mutableStateOf<MapFrame?>(null) }
+    var frame by remember { mutableStateOf<Bitmap?>(null) }
     var failed by remember { mutableStateOf(false) }
     // Carry the last non-zero bearing so a stopped vehicle (GPS bearing 0) keeps
     // the heading-up rotation instead of snapping back to north.
@@ -245,7 +248,7 @@ private fun SnapshotMap(
                             markerPos = mapConfig.markerPos,
                             renderHeightPx = renderHeightPx,
                         )
-                    val rendered = snap.render(camera, LatLng(loc.latitude, loc.longitude), markerScale)
+                    val rendered = snap.render(camera)
                     if (rendered != null) {
                         frame = rendered
                         failed = false
@@ -268,12 +271,12 @@ private fun SnapshotMap(
     when {
         current != null -> {
             Image(
-                bitmap = current.bitmap.asImageBitmap(),
+                bitmap = current.asImageBitmap(),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize().clickable { onTap() },
             )
-            LocationMarker(xPx = current.markerX, yPx = current.markerY, tiltDeg = mapConfig.tiltDeg)
+            LocationMarker(xPx = markerXPx, yPx = markerYPx, tiltDeg = mapConfig.tiltDeg)
         }
 
         failed -> {
@@ -286,34 +289,24 @@ private fun SnapshotMap(
     }
 }
 
-// A rendered frame plus the pixel where the current location landed, so the
-// marker overlay sits exactly on it regardless of the look-ahead camera offset.
-private class MapFrame(
-    val bitmap: Bitmap,
-    val markerX: Float,
-    val markerY: Float,
-)
-
 // Render one frame off-screen. Suspends until the snapshotter's callback fires,
 // keeping the caller single-flight; cancelling the coroutine cancels the render.
-private suspend fun MapSnapshotter.render(
-    camera: CameraPosition,
-    markerLatLng: LatLng,
-    markerScale: Float,
-): MapFrame? =
+// The marker is NOT placed from pixelForLatLng: the camera look-ahead already aims
+// the location at the fixed on-screen marker spot, so the chevron stays put and the
+// map slides beneath it (car-nav style) rather than drifting per frame.
+private suspend fun MapSnapshotter.render(camera: CameraPosition): Bitmap? =
     suspendCancellableCoroutine { cont ->
         setCameraPosition(camera)
         start(
-            { snapshot ->
-                // pixelForLatLng is in snapshot (render-bitmap) pixels; scale to the
-                // layout pixels the upscaled Image occupies so the marker lands true.
-                val p = snapshot.pixelForLatLng(markerLatLng)
-                if (cont.isActive) cont.resume(MapFrame(snapshot.bitmap, p.x * markerScale, p.y * markerScale))
-            },
+            { snapshot -> if (cont.isActive) cont.resume(snapshot.bitmap) },
             { _ -> if (cont.isActive) cont.resume(null) },
         )
         cont.invokeOnCancellation { cancel() }
     }
+
+// The marker's drop below centre as a fraction of the map height, shared by the
+// camera look-ahead and the fixed on-screen marker spot so the two always agree.
+private fun markerDropFraction(markerPos: Int): Double = (markerPos.coerceIn(0, 100) / 100.0) * MAX_MARKER_DROP
 
 private fun cameraFor(
     location: Location,
@@ -325,13 +318,15 @@ private fun cameraFor(
 ): CameraPosition {
     val bearing = location.carriedBearing(bearingHolder).toDouble()
     // Aim the camera ahead of the current position (along the heading) so the
-    // location renders low in the frame (nav-style framing). [markerPos] (0..100)
-    // picks the marker's screen height: 0 keeps it centred, 100 drops it just above
-    // the speed overlay. Convert that to a look-ahead distance via the ground
-    // resolution at this zoom/latitude so the same setting reads consistently across
-    // zooms (the tilt makes this approximate; pixelForLatLng still places the marker
-    // exactly where the location renders).
-    val dropFraction = (markerPos.coerceIn(0, 100) / 100.0) * MAX_MARKER_DROP
+    // location renders low in the frame, under the fixed on-screen chevron
+    // (nav-style framing). [markerPos] (0..100) picks the chevron's screen height: 0
+    // keeps it centred, 100 drops it just above the speed overlay. The look-ahead is
+    // computed in render-bitmap pixels (renderHeightPx); the bitmap is Crop-upscaled
+    // to the layout at the same aspect, so the location lands at the same layout
+    // fraction the chevron is pinned to regardless of renderPercent. The tilt makes
+    // this approximate, but a fixed chevron stays steady rather than drifting with
+    // the per-frame estimate.
+    val dropFraction = markerDropFraction(markerPos)
     val lookAheadM = dropFraction * renderHeightPx * metersPerPixel(zoom, location.latitude)
     val target = LatLng(location.latitude, location.longitude).offsetForward(bearing, lookAheadM)
     return CameraPosition
@@ -470,13 +465,12 @@ internal fun Attribution(
     )
 }
 
-// Current-location puck: a heading-up navigation chevron, positioned by the pixel
-// the location rendered at (see MapFrame). The map is heading-up, so the chevron
-// always points toward the top of the frame (forward); rotationX lays it onto the
-// oblique ground plane so it matches the map's tilt and reads as a nav arrow
-// resting on the road rather than a flat sticker. offset {} takes layout pixels;
-// MapFrame already scaled the snapshot pixel to layout space, so an upscaled
-// (sub-100%) render still lands the marker on the true position.
+// Current-location puck: a heading-up navigation chevron at a fixed on-screen spot
+// (the camera look-ahead keeps the location there, so the chevron stays still while
+// the map slides beneath it). The map is heading-up, so the chevron always points
+// toward the top of the frame (forward); rotationX lays it onto the oblique ground
+// plane so it matches the map's tilt and reads as a nav arrow resting on the road
+// rather than a flat sticker.
 @Composable
 private fun LocationMarker(
     xPx: Float,


### PR DESCRIPTION
## Summary

Implements goal #3: the self-position chevron must stay fixed on screen while the map pans beneath it (car-nav style), instead of drifting as the vehicle moves.

The SNAPSHOT backend placed the chevron from pixelForLatLng every frame. The look-ahead camera framing is approximate under the oblique tilt, so the computed pixel jittered/drifted frame to frame. Now the chevron is pinned at a fixed on-screen spot (centre X, markerPos height); the camera look-ahead already aims the location there, so the location renders under a steady chevron and the map slides beneath it.

- MapSnapshotter.render returns the Bitmap directly; pixelForLatLng, markerScale and the MapFrame holder are removed.
- New markerDropFraction(markerPos) is the single source of the drop fraction, shared by the fixed marker spot and cameraFor's look-ahead.
- The LIVE (WebView) backend already keeps the marker steady via easeTo and is unchanged.

### On the renderHeightPx vs heightPx question
The look-ahead is computed in render-bitmap pixels (renderHeightPx) while the chevron is pinned in layout pixels (heightPx). These agree at any renderPercent: the bitmap is ContentScale.Crop-upscaled to the layout at the same aspect ratio, so the location lands at the same layout fraction (0.5 + dropFraction) the chevron is pinned to. (Reviewer flagged this as a possible unit mismatch; it cancels out via the upscale.)

## Verification

- spotlessCheck test lint assembleDebug compileDebugAndroidTestKotlin — green (the change is geometric + a comment; MapSnapshotRenderTest uses MapSnapshotter directly and is unaffected)
- Emulator map tiles render unreliably, so the moving-chevron visual is best confirmed on the device.