### PR TITLE
fix(dashboard): respect the 12/24-hour clock in calendar & weather card times

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -59,6 +59,7 @@ import java.time.format.DateTimeFormatter
 @Composable
 internal fun CalendarCard(
     snapshot: CalendarSnapshot?,
+    is24Hour: Boolean,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
@@ -74,31 +75,33 @@ internal fun CalendarCard(
         // denial message instead of a hollow agenda.
         !snapshot.hasCalendarAccess -> PermissionDenied()
 
-        else -> CalendarContent(snapshot)
+        else -> CalendarContent(snapshot, is24Hour)
     }
 }
 
 @Composable
-private fun CalendarContent(snapshot: CalendarSnapshot) =
-    Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                // Tighter than the shared card padding/gap: the head-unit info-pane
-                // card is short, so pack the head and the list to avoid a clip.
-                .padding(FemtoDimens.CardPaddingCompact),
-        verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGapCompact),
+private fun CalendarContent(
+    snapshot: CalendarSnapshot,
+    is24Hour: Boolean,
+) = Column(
+    modifier =
+        Modifier
+            .fillMaxSize()
+            // Tighter than the shared card padding/gap: the head-unit info-pane
+            // card is short, so pack the head and the list to avoid a clip.
+            .padding(FemtoDimens.CardPaddingCompact),
+    verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGapCompact),
+) {
+    Head(snapshot)
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth().weight(1f),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Head(snapshot)
-        LazyColumn(
-            modifier = Modifier.fillMaxWidth().weight(1f),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            items(items = snapshot.days, key = { it.date.toString() }) { day ->
-                DayRow(day = day, isToday = day.date == snapshot.today)
-            }
+        items(items = snapshot.days, key = { it.date.toString() }) { day ->
+            DayRow(day = day, isToday = day.date == snapshot.today, is24Hour = is24Hour)
         }
     }
+}
 
 @Composable
 private fun Head(snapshot: CalendarSnapshot) =
@@ -142,6 +145,7 @@ private fun Head(snapshot: CalendarSnapshot) =
 private fun DayRow(
     day: DayCell,
     isToday: Boolean,
+    is24Hour: Boolean,
 ) = Row(
     modifier = Modifier.fillMaxWidth(),
     horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -206,7 +210,11 @@ private fun DayRow(
                     // A timed event leads with a clock; an all-day event (null time)
                     // leads with a sun so it reads as "all day" at a glance.
                     icon = if (event.time != null) Lucide.Clock else Lucide.Sun,
-                    time = event.time?.format(EventTimeFormatter) ?: stringResource(R.string.calendar_all_day),
+                    // Event times honour the user's 12/24-hour clock setting, matching
+                    // the dashboard clock rather than always printing 24-hour.
+                    time =
+                        event.time?.format(eventTimeFormatter(is24Hour))
+                            ?: stringResource(R.string.calendar_all_day),
                     title = event.title,
                 )
             }
@@ -268,7 +276,13 @@ private fun PermissionDenied() =
 
 private const val NO_EVENTS_PLACEHOLDER = "—"
 
-private val EventTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+// 24-hour "14:30" or compact 12-hour "2:30 PM"; the latter stays short enough to
+// keep the narrow agenda row from clipping the event title.
+private val EventTimeFormatter24: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+private val EventTimeFormatter12: DateTimeFormatter = DateTimeFormatter.ofPattern("h:mm a")
+
+private fun eventTimeFormatter(is24Hour: Boolean): DateTimeFormatter =
+    if (is24Hour) EventTimeFormatter24 else EventTimeFormatter12
 
 // Sized to the head-unit binding: each top-row card is ~165 x 207 dp (half the
 // info pane on the 853 x 512 dp / 5:3 projection). Wider panels only add slack.
@@ -309,6 +323,7 @@ private fun CalendarCardPreview() {
                         ),
                     hasCalendarAccess = true,
                 ),
+            is24Hour = true,
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -125,6 +125,7 @@ internal fun DashboardScaffold(
                         speedUnit = speedUnit,
                         panels = panels,
                         paneGap = paneGap,
+                        is24Hour = is24Hour,
                         onAction = onAction,
                         modifier = Modifier.weight(1f).fillMaxWidth(),
                     )
@@ -154,6 +155,7 @@ internal fun DashboardScaffold(
                         speedUnit = speedUnit,
                         panels = panels,
                         paneGap = paneGap,
+                        is24Hour = is24Hour,
                         onAction = onAction,
                         modifier = Modifier.weight(1f).fillMaxHeight(),
                     )
@@ -218,6 +220,7 @@ private fun InfoPane(
     speedUnit: SpeedUnit,
     panels: PanelVisibility,
     paneGap: Dp,
+    is24Hour: Boolean,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(
@@ -239,6 +242,7 @@ private fun InfoPane(
             if (panels.calendar) {
                 CalendarCard(
                     snapshot = uiState.calendar,
+                    is24Hour = is24Hour,
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                 )
             }
@@ -247,6 +251,7 @@ private fun InfoPane(
                     snapshot = uiState.weather,
                     temperatureUnit = temperatureUnit,
                     speedUnit = speedUnit,
+                    is24Hour = is24Hour,
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                 )
             }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -75,6 +75,7 @@ internal fun WeatherCard(
     snapshot: WeatherSnapshot?,
     temperatureUnit: TemperatureUnit,
     speedUnit: SpeedUnit,
+    is24Hour: Boolean,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
@@ -98,7 +99,7 @@ internal fun WeatherCard(
         ) {
             Head(snapshot, temperatureUnit)
             Metrics(snapshot, temperatureUnit, speedUnit)
-            Forecast(snapshot.hourly, snapshot.sunrise, snapshot.sunset, temperatureUnit)
+            Forecast(snapshot.hourly, snapshot.sunrise, snapshot.sunset, temperatureUnit, is24Hour)
         }
     } else {
         EmptyState()
@@ -216,6 +217,7 @@ private fun Forecast(
     sunrise: LocalTime?,
     sunset: LocalTime?,
     temperatureUnit: TemperatureUnit,
+    is24Hour: Boolean,
 ) {
     val next = hourly.take(3)
     if (next.isEmpty()) return
@@ -225,7 +227,7 @@ private fun Forecast(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             next.forEach { hour ->
-                ForecastChip(hour, sunrise, sunset, temperatureUnit, modifier = Modifier.weight(1f))
+                ForecastChip(hour, sunrise, sunset, temperatureUnit, is24Hour, modifier = Modifier.weight(1f))
             }
         }
     }
@@ -237,6 +239,7 @@ private fun ForecastChip(
     sunrise: LocalTime?,
     sunset: LocalTime?,
     temperatureUnit: TemperatureUnit,
+    is24Hour: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val glyphs = weatherGlyphs()
@@ -251,7 +254,7 @@ private fun ForecastChip(
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         Text(
-            text = "%02dh".format(forecast.time.hour),
+            text = forecastHourLabel(forecast.time, is24Hour),
             style = MaterialTheme.typography.sectionLabel(10, 0.08f),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
@@ -293,6 +296,21 @@ private fun EmptyState() =
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(48.dp),
         )
+    }
+
+// Forecast hour label honouring the user's clock setting: compact 24-hour "09h"
+// or 12-hour "9a" / "2p" so the tiny chip never widens. Midnight reads "12a",
+// noon "12p".
+private fun forecastHourLabel(
+    time: LocalTime,
+    is24Hour: Boolean,
+): String =
+    if (is24Hour) {
+        "%02dh".format(time.hour)
+    } else {
+        val hour12 = ((time.hour + 11) % 12) + 1
+        val meridiem = if (time.hour < 12) "a" else "p"
+        "$hour12$meridiem"
     }
 
 // Day/night drives the sun-vs-moon glyph for CLEAR. Use the snapshot's real
@@ -391,6 +409,7 @@ private fun WeatherCardPreview() {
                 ),
             temperatureUnit = TemperatureUnit.CELSIUS,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            is24Hour = true,
         )
     }
 }


### PR DESCRIPTION
## Summary

Detail polish for the calendar and weather panels (goal item 10): their
times ignored the user's clock-format setting.

- **Calendar** event times printed a fixed 24-hour `HH:mm`.
- **Weather** forecast hours printed a fixed `09h`.

Both now thread the existing `is24Hour` preference (already resolved in
`DashboardScaffold`) into `CalendarCard` / `WeatherCard`, so under a
12-hour clock event times read `2:30 PM` and forecast hours read `2p`,
matching the dashboard clock. The 12-hour forms are kept compact
(`2p`, not `2 PM`) so the narrow ~165 dp info-pane cards never clip.

## Verification

- `./gradlew spotlessCheck` — passed
- `./gradlew compileDebugKotlin` — passed
- `./gradlew test` — passed