### PR TITLE
feat(settings): reorganize the settings bottom sheet

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/assistant/AssistantScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/assistant/AssistantScreenTest.kt
@@ -1,7 +1,7 @@
 package io.github.seijikohara.femto.ui.assistant
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
@@ -2,7 +2,7 @@ package io.github.seijikohara.femto.ui.drawer
 
 import android.content.ComponentName
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
@@ -19,7 +19,7 @@ class CalendarCardTest {
     fun renders_each_days_events_in_the_agenda_list() {
         rule.setContent {
             FemtoTheme {
-                CalendarCard(snapshot = fakeCalendarSnapshot())
+                CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true)
             }
         }
         // The agenda lists every day, so events from different days all render
@@ -32,7 +32,7 @@ class CalendarCardTest {
     fun shows_a_placeholder_for_days_without_events() {
         rule.setContent {
             FemtoTheme {
-                CalendarCard(snapshot = fakeCalendarSnapshot())
+                CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true)
             }
         }
         // The fixture has free days (e.g. 2026-05-02), each shown with the em-dash
@@ -45,7 +45,7 @@ class CalendarCardTest {
     fun shows_today_number_for_granted_snapshot() {
         rule.setContent {
             FemtoTheme {
-                CalendarCard(snapshot = fakeCalendarSnapshot())
+                CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true)
             }
         }
         // The hero head renders the day-of-month of the fixture's `today`
@@ -59,7 +59,7 @@ class CalendarCardTest {
     fun shows_permission_denied_message_when_access_is_denied() {
         rule.setContent {
             FemtoTheme {
-                CalendarCard(snapshot = fakeCalendarSnapshot(hasCalendarAccess = false))
+                CalendarCard(snapshot = fakeCalendarSnapshot(hasCalendarAccess = false), is24Hour = true)
             }
         }
         // Resolve the copy from resources so the literal stays the SSOT in

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
@@ -1,7 +1,7 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardFooterTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardFooterTest.kt
@@ -2,7 +2,7 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
@@ -1,7 +1,7 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import io.github.seijikohara.femto.data.ClockTick

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicCardTest.kt
@@ -1,7 +1,7 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayTest.kt
@@ -2,7 +2,7 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
@@ -24,6 +24,7 @@ class WeatherCardTest {
                     snapshot = fakeWeatherSnapshot(tempC = 18.0),
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
                 )
             }
         }
@@ -39,6 +40,7 @@ class WeatherCardTest {
                     snapshot = null,
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
                 )
             }
         }
@@ -55,6 +57,7 @@ class WeatherCardTest {
                     snapshot = fakeWeatherSnapshot(code = WeatherCode.PARTLY_CLOUDY),
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
                 )
             }
         }
@@ -71,6 +74,7 @@ class WeatherCardTest {
                     snapshot = fakeWeatherSnapshot(),
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
                 )
             }
         }
@@ -89,6 +93,7 @@ class WeatherCardTest {
                     snapshot = fakeWeatherSnapshot(),
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
                 )
             }
         }

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
@@ -1,7 +1,7 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import io.github.seijikohara.femto.data.WeatherCode

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -1,7 +1,7 @@
 package io.github.seijikohara.femto.ui.settings
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.data.MapStyleSetting
 import io.github.seijikohara.femto.data.ThemeMode
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Assert.assertEquals
@@ -28,6 +29,9 @@ class SettingsScreenTest {
     private val tealAccentLabel = context.getString(R.string.settings_accent_teal)
     private val resetLabel = context.getString(R.string.settings_reset_to_defaults)
     private val resetConfirmLabel = context.getString(R.string.settings_reset_confirm)
+    private val keepScreenOnLabel = context.getString(R.string.settings_keep_screen_on)
+    private val lightSchemeLabel = context.getString(R.string.settings_group_map_scheme_light)
+    private val darkSchemeLabel = context.getString(R.string.settings_group_map_scheme_dark)
 
     @Test
     fun renders_fullscreen_row() {
@@ -87,15 +91,49 @@ class SettingsScreenTest {
         assertEquals(listOf(SettingsAction.ResetToDefaults), actions)
     }
 
-    private fun setScreen(onAction: (SettingsAction) -> Unit = {}) {
+    @Test
+    fun keep_screen_on_row_is_shown() {
+        setScreen()
+        rule.onNodeWithText(keepScreenOnLabel).performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun auto_map_style_shows_both_scheme_rows() {
+        // AUTO can use either scheme (the system theme decides), so both rows show.
+        setScreen(uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.AUTO))
+        rule.onNodeWithText(lightSchemeLabel).performScrollTo().assertIsDisplayed()
+        rule.onNodeWithText(darkSchemeLabel).performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun light_map_style_hides_the_dark_scheme_row() {
+        // A fixed LIGHT style never uses the dark scheme, so that row is hidden.
+        setScreen(uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.LIGHT))
+        rule.onNodeWithText(lightSchemeLabel).performScrollTo().assertIsDisplayed()
+        rule.onNodeWithText(darkSchemeLabel).assertDoesNotExist()
+    }
+
+    @Test
+    fun dark_map_style_hides_the_light_scheme_row() {
+        // A fixed DARK style never uses the light scheme, so that row is hidden.
+        setScreen(uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.DARK))
+        rule.onNodeWithText(darkSchemeLabel).performScrollTo().assertIsDisplayed()
+        rule.onNodeWithText(lightSchemeLabel).assertDoesNotExist()
+    }
+
+    private fun setScreen(
+        uiState: SettingsUiState = SettingsUiState.Initial,
+        onAction: (SettingsAction) -> Unit = {},
+    ) {
         rule.setContent {
             FemtoTheme {
                 SettingsScreen(
-                    uiState = SettingsUiState.Initial,
+                    uiState = uiState,
                     onAction = onAction,
                     onBack = {},
                     onOpenNotificationAccess = {},
                     onOpenSystemSettings = {},
+                    onOpenFontPicker = {},
                 )
             }
         }

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.text.format.DateFormat
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -108,6 +109,9 @@ class MainActivity : ComponentActivity() {
             // focus-regain case.
             LaunchedEffect(display.fullscreen) {
                 applyFullscreen(display.fullscreen)
+            }
+            LaunchedEffect(display.keepScreenOn) {
+                applyKeepScreenOn(display.keepScreenOn)
             }
             FemtoTheme(fontFamily = fontFamily, accent = display.accentColor, darkTheme = darkTheme) {
                 // The dashboard stays composed; the app drawer, assistant, and
@@ -214,6 +218,16 @@ class MainActivity : ComponentActivity() {
             FullscreenSetting.OFF -> {
                 controller.show(WindowInsetsCompat.Type.systemBars())
             }
+        }
+    }
+
+    // Keep the panel lit while the launcher is foreground. Unlike the system bars
+    // this survives focus changes, so it needs no onWindowFocusChanged re-apply.
+    private fun applyKeepScreenOn(enabled: Boolean) {
+        if (enabled) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }
 

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -101,6 +101,9 @@ internal data class DisplaySettings(
     // per-minute instead of per-second.
     val showClockSeconds: Boolean,
     val fullscreen: FullscreenSetting,
+    // Whether to keep the screen awake while the launcher is foreground. Defaults
+    // to true: the head unit runs on vehicle power, so the dashboard should stay lit.
+    val keepScreenOn: Boolean,
     val mapStyle: MapStyleSetting,
     // Independent colour schemes for the light and dark map contexts (which one
     // applies follows [mapStyle] / the system theme). Both default to ACCENT.
@@ -137,6 +140,7 @@ internal data class DisplaySettings(
                 clock = ClockSetting.AUTO,
                 showClockSeconds = true,
                 fullscreen = FullscreenSetting.OFF,
+                keepScreenOn = true,
                 mapStyle = MapStyleSetting.AUTO,
                 mapSchemeLight = MapColorScheme.ACCENT,
                 mapSchemeDark = MapColorScheme.ACCENT,
@@ -177,6 +181,8 @@ internal interface DisplaySettingsStore {
     suspend fun setShowClockSeconds(value: Boolean)
 
     suspend fun setFullscreen(value: FullscreenSetting)
+
+    suspend fun setKeepScreenOn(value: Boolean)
 
     suspend fun setMapStyle(value: MapStyleSetting)
 
@@ -228,6 +234,7 @@ internal class DisplayPreferences(
                 clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
                 showClockSeconds = prefs[SHOW_CLOCK_SECONDS_KEY] ?: true,
                 fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.OFF),
+                keepScreenOn = prefs[KEEP_SCREEN_ON_KEY] ?: true,
                 mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
                 mapSchemeLight = prefs[MAP_SCHEME_LIGHT_KEY].toEnumOr(MapColorScheme.ACCENT),
                 mapSchemeDark = prefs[MAP_SCHEME_DARK_KEY].toEnumOr(MapColorScheme.ACCENT),
@@ -272,6 +279,10 @@ internal class DisplayPreferences(
 
     override suspend fun setFullscreen(value: FullscreenSetting) {
         context.displayDataStore.edit { it[FULLSCREEN_KEY] = value.name }
+    }
+
+    override suspend fun setKeepScreenOn(value: Boolean) {
+        context.displayDataStore.edit { it[KEEP_SCREEN_ON_KEY] = value }
     }
 
     override suspend fun setMapStyle(value: MapStyleSetting) {
@@ -341,6 +352,7 @@ internal class DisplayPreferences(
         val CLOCK_KEY = stringPreferencesKey("clock")
         val SHOW_CLOCK_SECONDS_KEY = booleanPreferencesKey("show_clock_seconds")
         val FULLSCREEN_KEY = stringPreferencesKey("fullscreen")
+        val KEEP_SCREEN_ON_KEY = booleanPreferencesKey("keep_screen_on")
         val MAP_STYLE_KEY = stringPreferencesKey("map_style")
         val MAP_SCHEME_LIGHT_KEY = stringPreferencesKey("map_scheme_light")
         val MAP_SCHEME_DARK_KEY = stringPreferencesKey("map_scheme_dark")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerScreen.kt
@@ -73,6 +73,14 @@ internal fun FontPickerScreen(
             query = uiState.query,
             onQueryChange = { onAction(FontPickerAction.Search(it)) },
         )
+        // The catalog is served most-popular-first; name the order so it does not
+        // read as arbitrary. Static label — sorting is not user-switchable.
+        Text(
+            text = stringResource(R.string.font_picker_sort_popular),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
         LazyColumn(
             modifier = Modifier.fillMaxWidth().weight(1f),
             verticalArrangement = Arrangement.spacedBy(2.dp),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -18,10 +18,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewClientCompat
 import io.github.seijikohara.femto.data.MapStyleSetting

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -184,9 +184,7 @@ internal fun WebMapView(
                         webView.onPause()
                     }
 
-                    else -> {
-                        Unit
-                    }
+                    else -> {}
                 }
             }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.ui.settings
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -119,6 +120,18 @@ internal fun SettingsScreen(
                 selected = uiState.accentColor,
                 onSelect = { onAction(SettingsAction.SetAccentColor(it)) },
             )
+            SettingsSubheader(stringResource(R.string.settings_subheader_screen))
+            SwitchRow(
+                title = stringResource(R.string.settings_group_fullscreen),
+                checked = uiState.fullscreen == FullscreenSetting.ON,
+                onCheckedChange = { onAction(SettingsAction.SetFullscreen(it.toFullscreen())) },
+            )
+            SwitchRow(
+                title = stringResource(R.string.settings_keep_screen_on),
+                checked = uiState.keepScreenOn,
+                onCheckedChange = { onAction(SettingsAction.SetKeepScreenOn(it)) },
+            )
+            SettingsSubheader(stringResource(R.string.settings_subheader_fonts))
             FontRow(
                 title = stringResource(R.string.settings_group_font_latin),
                 family = uiState.latinFont,
@@ -128,11 +141,6 @@ internal fun SettingsScreen(
                 title = stringResource(R.string.settings_group_font_cjk),
                 family = uiState.cjkFont,
                 onClick = { onOpenFontPicker(FontSlot.CJK) },
-            )
-            SwitchRow(
-                title = stringResource(R.string.settings_group_fullscreen),
-                checked = uiState.fullscreen == FullscreenSetting.ON,
-                onCheckedChange = { onAction(SettingsAction.SetFullscreen(it.toFullscreen())) },
             )
         }
 
@@ -178,6 +186,7 @@ internal fun SettingsScreen(
         }
 
         SettingsSection(title = stringResource(R.string.settings_section_map)) {
+            SettingsSubheader(stringResource(R.string.settings_subheader_map_rendering))
             ChoiceRow(
                 title = stringResource(R.string.settings_group_map_rendering),
                 options =
@@ -188,6 +197,36 @@ internal fun SettingsScreen(
                 selected = uiState.mapRenderMode,
                 onSelect = { onAction(SettingsAction.SetMapRenderMode(it)) },
             )
+            // Snapshot exposes bitmap sharpness; the live (WebGL) backend exposes 3D
+            // buildings + terrain. Each row sits directly under the rendering parent
+            // and slides in/out, so the swap reads as a result of the mode change. A
+            // hidden row keeps its stored value; only the layout changes.
+            AnimatedVisibility(visible = uiState.mapRenderMode == MapRenderMode.SNAPSHOT) {
+                SliderRow(
+                    title = stringResource(R.string.settings_group_map_quality),
+                    valueLabel = stringResource(R.string.settings_map_quality_value, uiState.mapRenderPercent),
+                    value = uiState.mapRenderPercent,
+                    range = MIN_MAP_QUALITY..MAX_MAP_QUALITY,
+                    onValueChange = { onAction(SettingsAction.SetMapRenderPercent(it)) },
+                    description = stringResource(R.string.settings_map_quality_desc),
+                )
+            }
+            AnimatedVisibility(visible = uiState.mapRenderMode == MapRenderMode.LIVE) {
+                Column {
+                    SwitchRow(
+                        title = stringResource(R.string.settings_group_map_3d),
+                        checked = uiState.map3dBuildings,
+                        onCheckedChange = { onAction(SettingsAction.SetMap3dBuildings(it)) },
+                    )
+                    SwitchRow(
+                        title = stringResource(R.string.settings_group_map_terrain),
+                        checked = uiState.mapTerrain,
+                        onCheckedChange = { onAction(SettingsAction.SetMapTerrain(it)) },
+                        summary = stringResource(R.string.settings_map_terrain_desc),
+                    )
+                }
+            }
+            SettingsSubheader(stringResource(R.string.settings_subheader_map_appearance))
             ChoiceRow(
                 title = stringResource(R.string.settings_group_map_style),
                 options =
@@ -199,32 +238,39 @@ internal fun SettingsScreen(
                 selected = uiState.mapStyle,
                 onSelect = { onAction(SettingsAction.SetMapStyle(it)) },
             )
-            // Independent colour schemes for the light and dark contexts. ACCENT is
-            // the adaptive accent-tinted default; the rest are fixed OpenFreeMap styles.
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_map_scheme_light),
-                options =
-                    listOf(
-                        MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
-                        MapColorScheme.POSITRON to stringResource(R.string.settings_map_scheme_positron),
-                        MapColorScheme.BRIGHT to stringResource(R.string.settings_map_scheme_bright),
-                        MapColorScheme.LIBERTY to stringResource(R.string.settings_map_scheme_liberty),
-                    ),
-                selected = uiState.mapSchemeLight,
-                onSelect = { onAction(SettingsAction.SetMapSchemeLight(it)) },
-            )
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_map_scheme_dark),
-                options =
-                    listOf(
-                        MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
-                        MapColorScheme.DARK_MATTER to stringResource(R.string.settings_map_scheme_dark_matter),
-                        MapColorScheme.DARK to stringResource(R.string.settings_map_scheme_dark),
-                        MapColorScheme.FIORD to stringResource(R.string.settings_map_scheme_fiord),
-                    ),
-                selected = uiState.mapSchemeDark,
-                onSelect = { onAction(SettingsAction.SetMapSchemeDark(it)) },
-            )
+            // Light scheme applies for AUTO + LIGHT, Dark scheme for AUTO + DARK. AUTO
+            // can use either (the system theme decides), so AUTO shows both; a fixed
+            // LIGHT / DARK hides the scheme it never uses. Independent colour schemes:
+            // ACCENT is the adaptive accent-tinted default, the rest fixed OpenFreeMap.
+            AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.DARK) {
+                ChoiceRow(
+                    title = stringResource(R.string.settings_group_map_scheme_light),
+                    options =
+                        listOf(
+                            MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
+                            MapColorScheme.POSITRON to stringResource(R.string.settings_map_scheme_positron),
+                            MapColorScheme.BRIGHT to stringResource(R.string.settings_map_scheme_bright),
+                            MapColorScheme.LIBERTY to stringResource(R.string.settings_map_scheme_liberty),
+                        ),
+                    selected = uiState.mapSchemeLight,
+                    onSelect = { onAction(SettingsAction.SetMapSchemeLight(it)) },
+                )
+            }
+            AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.LIGHT) {
+                ChoiceRow(
+                    title = stringResource(R.string.settings_group_map_scheme_dark),
+                    options =
+                        listOf(
+                            MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
+                            MapColorScheme.DARK_MATTER to stringResource(R.string.settings_map_scheme_dark_matter),
+                            MapColorScheme.DARK to stringResource(R.string.settings_map_scheme_dark),
+                            MapColorScheme.FIORD to stringResource(R.string.settings_map_scheme_fiord),
+                        ),
+                    selected = uiState.mapSchemeDark,
+                    onSelect = { onAction(SettingsAction.SetMapSchemeDark(it)) },
+                )
+            }
+            SettingsSubheader(stringResource(R.string.settings_subheader_map_camera))
             SliderRow(
                 title = stringResource(R.string.settings_group_map_tilt),
                 valueLabel = stringResource(R.string.settings_map_tilt_value, uiState.mapTiltDeg),
@@ -240,8 +286,7 @@ internal fun SettingsScreen(
                 onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
             )
             // Marker vertical position applies to both backends (0 = map centre,
-            // 100 = just above the speed overlay), so it sits outside the
-            // mode-specific block below.
+            // 100 = just above the speed overlay).
             SliderRow(
                 title = stringResource(R.string.settings_group_map_marker_pos),
                 valueLabel = stringResource(R.string.settings_map_marker_pos_value, uiState.mapMarkerPos),
@@ -249,32 +294,6 @@ internal fun SettingsScreen(
                 range = MIN_MAP_MARKER_POS..MAX_MAP_MARKER_POS,
                 onValueChange = { onAction(SettingsAction.SetMapMarkerPos(it)) },
             )
-            // Mode-specific rows: the live (WebGL) backends expose 3D buildings /
-            // terrain; the snapshot backend exposes the bitmap sharpness. Showing
-            // only the rows that affect the chosen backend keeps the panel honest
-            // (e.g. sharpness does nothing on the live map).
-            if (uiState.mapRenderMode == MapRenderMode.SNAPSHOT) {
-                SliderRow(
-                    title = stringResource(R.string.settings_group_map_quality),
-                    valueLabel = stringResource(R.string.settings_map_quality_value, uiState.mapRenderPercent),
-                    value = uiState.mapRenderPercent,
-                    range = MIN_MAP_QUALITY..MAX_MAP_QUALITY,
-                    onValueChange = { onAction(SettingsAction.SetMapRenderPercent(it)) },
-                    description = stringResource(R.string.settings_map_quality_desc),
-                )
-            } else {
-                SwitchRow(
-                    title = stringResource(R.string.settings_group_map_3d),
-                    checked = uiState.map3dBuildings,
-                    onCheckedChange = { onAction(SettingsAction.SetMap3dBuildings(it)) },
-                )
-                SwitchRow(
-                    title = stringResource(R.string.settings_group_map_terrain),
-                    checked = uiState.mapTerrain,
-                    onCheckedChange = { onAction(SettingsAction.SetMapTerrain(it)) },
-                    summary = stringResource(R.string.settings_map_terrain_desc),
-                )
-            }
         }
 
         SettingsSection(title = stringResource(R.string.settings_section_panels)) {
@@ -364,6 +383,21 @@ private fun SettingsSection(
         Column(content = content)
     }
 }
+
+// A sub-group label inside a section card, separating related rows under a
+// section heading. Same 18sp as the section heading but muted (onSurfaceVariant
+// vs the section's primary) and indented to align with row content, so it reads
+// as a child cluster rather than a new section.
+@Composable
+private fun SettingsSubheader(
+    title: String,
+    modifier: Modifier = Modifier,
+) = Text(
+    text = title,
+    style = MaterialTheme.typography.labelLarge,
+    color = MaterialTheme.colorScheme.onSurfaceVariant,
+    modifier = modifier.padding(start = 20.dp, top = 14.dp, bottom = 2.dp),
+)
 
 // The accent picker: a title over a horizontally-scrolling row of color swatches.
 // Selecting a swatch applies its seed immediately, so the picker (and the whole

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -20,6 +20,7 @@ internal data class SettingsUiState(
     val clock: ClockSetting,
     val showClockSeconds: Boolean,
     val fullscreen: FullscreenSetting,
+    val keepScreenOn: Boolean,
     val mapStyle: MapStyleSetting,
     val mapSchemeLight: MapColorScheme,
     val mapSchemeDark: MapColorScheme,
@@ -49,6 +50,7 @@ internal data class SettingsUiState(
                 clock = DisplaySettings.Default.clock,
                 showClockSeconds = DisplaySettings.Default.showClockSeconds,
                 fullscreen = DisplaySettings.Default.fullscreen,
+                keepScreenOn = DisplaySettings.Default.keepScreenOn,
                 mapStyle = DisplaySettings.Default.mapStyle,
                 mapSchemeLight = DisplaySettings.Default.mapSchemeLight,
                 mapSchemeDark = DisplaySettings.Default.mapSchemeDark,
@@ -96,6 +98,10 @@ internal sealed interface SettingsAction {
 
     data class SetFullscreen(
         val value: FullscreenSetting,
+    ) : SettingsAction
+
+    data class SetKeepScreenOn(
+        val value: Boolean,
     ) : SettingsAction
 
     data class SetMapStyle(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -28,6 +28,7 @@ internal class SettingsViewModel(
                 clock = display.clock,
                 showClockSeconds = display.showClockSeconds,
                 fullscreen = display.fullscreen,
+                keepScreenOn = display.keepScreenOn,
                 mapStyle = display.mapStyle,
                 mapSchemeLight = display.mapSchemeLight,
                 mapSchemeDark = display.mapSchemeDark,
@@ -76,6 +77,10 @@ internal class SettingsViewModel(
 
                 is SettingsAction.SetFullscreen -> {
                     displayPreferences.setFullscreen(action.value)
+                }
+
+                is SettingsAction.SetKeepScreenOn -> {
+                    displayPreferences.setKeepScreenOn(action.value)
                 }
 
                 is SettingsAction.SetMapStyle -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,12 +107,17 @@
     <string name="settings_section_units">Units</string>
     <string name="settings_section_map">Map</string>
     <string name="settings_section_panels">Panels</string>
+    <string name="settings_subheader_screen">Screen</string>
+    <string name="settings_subheader_fonts">Fonts</string>
+    <string name="settings_subheader_map_rendering">Rendering</string>
+    <string name="settings_subheader_map_appearance">Appearance</string>
+    <string name="settings_subheader_map_camera">Camera</string>
     <string name="settings_group_theme">Theme</string>
     <string name="settings_group_speed">Speed &amp; distance</string>
     <string name="settings_group_temperature">Temperature</string>
     <string name="settings_group_clock">Clock</string>
     <string name="settings_group_font_latin">Latin font</string>
-    <string name="settings_group_font_cjk">Japanese / CJK fallback</string>
+    <string name="settings_group_font_cjk">CJK fallback</string>
     <string name="settings_font_system">System default</string>
     <string name="settings_group_system">System</string>
     <string name="font_picker_search_hint">Search Google Fonts</string>
@@ -125,6 +130,7 @@
     <string name="font_picker_error">Could not load the font list. Check the connection and reopen.</string>
     <string name="font_picker_empty">No fonts available.</string>
     <string name="font_picker_no_matches">No fonts match the search.</string>
+    <string name="font_picker_sort_popular">Most popular first</string>
     <string name="settings_option_auto">Auto</string>
     <string name="settings_theme_light">Light</string>
     <string name="settings_theme_dark">Dark</string>
@@ -146,6 +152,7 @@
     <string name="settings_clock_24">24-hour</string>
     <string name="settings_group_clock_seconds">Show seconds</string>
     <string name="settings_group_fullscreen">Fullscreen</string>
+    <string name="settings_keep_screen_on">Keep screen on</string>
     <string name="settings_group_map_rendering">Map rendering</string>
     <string name="settings_map_mode_live">Live</string>
     <string name="settings_map_mode_snapshot">Snapshot</string>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -43,6 +43,8 @@ internal class FakeDisplaySettingsStore(
 
     override suspend fun setFullscreen(value: FullscreenSetting) = state.update { it.copy(fullscreen = value) }
 
+    override suspend fun setKeepScreenOn(value: Boolean) = state.update { it.copy(keepScreenOn = value) }
+
     override suspend fun setMapStyle(value: MapStyleSetting) = state.update { it.copy(mapStyle = value) }
 
     override suspend fun setMapSchemeLight(value: MapColorScheme) = state.update { it.copy(mapSchemeLight = value) }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -55,6 +55,14 @@ class SettingsViewModelTest {
         }
 
     @Test
+    fun `SetKeepScreenOn writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetKeepScreenOn(false))
+            advanceUntilIdle()
+            assertEquals(false, store.settings.first().keepScreenOn)
+        }
+
+    @Test
     fun `SetAccentColor writes the value to the store`() =
         runTest(dispatcher) {
             viewModel().onAction(SettingsAction.SetAccentColor(AccentColor.TEAL))

--- a/docs/superpowers/plans/2026-06-10-settings-sheet-reorganization.md
+++ b/docs/superpowers/plans/2026-06-10-settings-sheet-reorganization.md
@@ -1,0 +1,574 @@
+# Settings Bottom Sheet Reorganization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reorganize the settings bottom sheet so dependencies are visible (hide rows that cannot apply, nested under their driver), related rows are grouped under sub-headings, a `Keep screen on` toggle exists, and the two font rows are clarified.
+
+**Architecture:** Pure additive changes. `keepScreenOn` flows through the existing DataStore → `DisplaySettings` → `SettingsUiState` → `SettingsViewModel` chain and is applied as a window flag in `MainActivity` exactly like `Fullscreen`. The sheet layout (`SettingsScreen.kt`) gains a `SettingsSubheader` and wraps dependent rows in `AnimatedVisibility`. No persisted key or enum type for an existing setting changes.
+
+**Tech Stack:** Kotlin, Jetpack Compose (Material 3), DataStore, JUnit4 + `runTest` + Turbine, Compose `createComposeRule`.
+
+Spec: `docs/superpowers/specs/2026-06-10-settings-sheet-reorganization-design.md`.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `data/DisplayPreferences.kt` | Persistence SSOT for display settings | Add `keepScreenOn` field/default/key/setter |
+| `ui/settings/SettingsUiState.kt` | Settings state + actions | Add `keepScreenOn` field + `SetKeepScreenOn` |
+| `ui/settings/SettingsViewModel.kt` | UDF binding | Map + handle `keepScreenOn` |
+| `ui/settings/SettingsScreen.kt` | Sheet UI | `SettingsSubheader`; regroup Display + Map; disclosure |
+| `MainActivity.kt` | Window-flag application | Apply `FLAG_KEEP_SCREEN_ON` |
+| `ui/fontpicker/FontPickerScreen.kt` | Picker UI | Sort-order label |
+| `res/values/strings.xml` | Strings SSOT | CJK label edit + new strings |
+| `…/testfixtures/FakeDisplaySettingsStore.kt` | Test fake of the store | Implement `setKeepScreenOn` |
+| `…/ui/settings/SettingsViewModelTest.kt` | VM tests | `keepScreenOn` default/toggle/reset |
+| `…/ui/settings/SettingsScreenTest.kt` | UI tests | Scheme disclosure + keep-screen-on row |
+
+---
+
+## Task 1: `keepScreenOn` end-to-end (data → state → view-model)
+
+**Files:**
+- Modify: `app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt`
+- Modify: `app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt`
+- Modify: `app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt`
+- Modify: `app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt`
+- Test: `app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt`
+
+- [ ] **Step 1: Read the existing VM test + fake to match their style**
+
+Read `SettingsViewModelTest.kt` and `FakeDisplaySettingsStore.kt` fully so the new test and the fake setter copy the established pattern (e.g. how an existing boolean like `showClockSeconds` is tested and faked).
+
+- [ ] **Step 2: Write the failing VM test**
+
+Add to `SettingsViewModelTest.kt`, mirroring the existing `showClockSeconds`-style cases (use the same fake-construction + collection helper the file already uses):
+
+```kotlin
+@Test
+fun keepScreenOn_defaults_to_true() = runTest {
+    val viewModel = SettingsViewModel(FakeDisplaySettingsStore(), FakeFontPreferences())
+    assertTrue(viewModel.uiState.value.keepScreenOn)
+}
+
+@Test
+fun setKeepScreenOn_updates_state() = runTest {
+    val viewModel = SettingsViewModel(FakeDisplaySettingsStore(), FakeFontPreferences())
+    viewModel.onAction(SettingsAction.SetKeepScreenOn(false))
+    runCurrent()
+    assertFalse(viewModel.uiState.value.keepScreenOn)
+}
+```
+
+(Match the file's actual VM-construction and dispatcher pattern; the snippet shows intent, not necessarily the exact constructor call. If the file uses Turbine, use the same `.test {}` collection it already uses.)
+
+- [ ] **Step 3: Run the test — expect a compile failure**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*SettingsViewModelTest*"`
+Expected: FAILS to compile — `keepScreenOn` / `SetKeepScreenOn` unresolved.
+
+- [ ] **Step 4: Add the field to `DisplaySettings` + default + key + setter**
+
+In `DisplayPreferences.kt`:
+- Add to `DisplaySettings` (next to `fullscreen`, since both are window flags):
+  ```kotlin
+  // Whether to keep the screen awake while the launcher is foreground. Defaults
+  // to true: the head unit runs on vehicle power, so the dashboard should stay lit.
+  val keepScreenOn: Boolean,
+  ```
+- Add to `DisplaySettings.Default`: `keepScreenOn = true,`
+- Add to the `settings` read map: `keepScreenOn = prefs[KEEP_SCREEN_ON_KEY] ?: true,`
+- Add the interface method to `DisplaySettingsStore`: `suspend fun setKeepScreenOn(value: Boolean)`
+- Add the impl:
+  ```kotlin
+  override suspend fun setKeepScreenOn(value: Boolean) {
+      context.displayDataStore.edit { it[KEEP_SCREEN_ON_KEY] = value }
+  }
+  ```
+- Add the key to the companion: `val KEEP_SCREEN_ON_KEY = booleanPreferencesKey("keep_screen_on")`
+
+`resetToDefaults()` already clears all keys, so the read fallback `?: true` restores the default — no extra reset code.
+
+- [ ] **Step 5: Add the field to `SettingsUiState` + the action**
+
+In `SettingsUiState.kt`:
+- Add `val keepScreenOn: Boolean,` to the data class (next to `fullscreen`).
+- Add to `Initial`: `keepScreenOn = DisplaySettings.Default.keepScreenOn,`
+- Add the action:
+  ```kotlin
+  data class SetKeepScreenOn(
+      val value: Boolean,
+  ) : SettingsAction
+  ```
+
+- [ ] **Step 6: Wire the view-model**
+
+In `SettingsViewModel.kt`:
+- In the `combine` mapping add `keepScreenOn = display.keepScreenOn,` (next to `fullscreen`).
+- In `onAction`'s `when`, add:
+  ```kotlin
+  is SettingsAction.SetKeepScreenOn -> {
+      displayPreferences.setKeepScreenOn(action.value)
+  }
+  ```
+
+- [ ] **Step 7: Implement `setKeepScreenOn` in the fake**
+
+In `FakeDisplaySettingsStore.kt`, mirror the existing boolean setter pattern (the fake holds a `MutableStateFlow<DisplaySettings>`; copy how `setShowClockSeconds` updates it):
+
+```kotlin
+override suspend fun setKeepScreenOn(value: Boolean) {
+    state.update { it.copy(keepScreenOn = value) }
+}
+```
+
+(Use the fake's actual backing-field name and update idiom.)
+
+- [ ] **Step 8: Run the test — expect PASS**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*SettingsViewModelTest*"`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt \
+        app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt \
+        app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt \
+        app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt \
+        app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+git commit -m "feat(settings): add keep-screen-on setting through the state chain
+
+Persist a keepScreenOn flag (default on) and expose it through
+SettingsUiState / SettingsAction so the sheet can toggle it. The window
+flag itself is applied in MainActivity in a later commit."
+```
+
+---
+
+## Task 2: Apply `FLAG_KEEP_SCREEN_ON` in `MainActivity`
+
+**Files:**
+- Modify: `app/src/main/java/io/github/seijikohara/femto/MainActivity.kt`
+
+No automated test — window flags need an instrumented host; verified on the emulator in Task 6.
+
+- [ ] **Step 1: Add the import**
+
+Add `import android.view.WindowManager` to the import block.
+
+- [ ] **Step 2: Drive the flag from the persisted value**
+
+In `setContent`, next to the existing `LaunchedEffect(display.fullscreen) { applyFullscreen(display.fullscreen) }`, add:
+
+```kotlin
+LaunchedEffect(display.keepScreenOn) {
+    applyKeepScreenOn(display.keepScreenOn)
+}
+```
+
+- [ ] **Step 3: Add the apply helper**
+
+Next to `applyFullscreen`, add:
+
+```kotlin
+// Keep the panel lit while the launcher is foreground. Unlike the system bars
+// this survives focus changes, so it needs no onWindowFocusChanged re-apply.
+private fun applyKeepScreenOn(enabled: Boolean) {
+    if (enabled) {
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    } else {
+        window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    }
+}
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+git commit -m "feat(settings): keep the screen awake when keepScreenOn is on
+
+Apply FLAG_KEEP_SCREEN_ON from the persisted setting, mirroring how the
+fullscreen choice drives the system bars. No permission is required."
+```
+
+---
+
+## Task 3: Strings — CJK label, keep-screen-on, sub-headings, picker sort label
+
+**Files:**
+- Modify: `app/src/main/res/values/strings.xml`
+
+- [ ] **Step 1: Edit the CJK label (line 115)**
+
+Change:
+```xml
+<string name="settings_group_font_cjk">Japanese / CJK fallback</string>
+```
+to:
+```xml
+<string name="settings_group_font_cjk">CJK fallback</string>
+```
+
+- [ ] **Step 2: Add the new strings**
+
+Add in the `<!-- Settings -->` block (keep keys grouped logically — sub-headers near the section strings, the keep-screen-on row near `settings_group_fullscreen`):
+
+```xml
+<string name="settings_keep_screen_on">Keep screen on</string>
+<string name="settings_subheader_screen">Screen</string>
+<string name="settings_subheader_fonts">Fonts</string>
+<string name="settings_subheader_map_rendering">Rendering</string>
+<string name="settings_subheader_map_appearance">Appearance</string>
+<string name="settings_subheader_map_camera">Camera</string>
+```
+
+Add near the `font_picker_*` strings:
+```xml
+<string name="font_picker_sort_popular">Most popular first</string>
+```
+
+- [ ] **Step 3: Verify resources compile**
+
+Run: `./gradlew :app:processDebugResources`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/res/values/strings.xml
+git commit -m "feat(settings): add strings for sub-headings, keep-screen-on, sort label
+
+Also simplify the CJK font row label to \"CJK fallback\" (the slot is
+already named CJK, so \"Japanese\" over-specified the multibyte fallback)."
+```
+
+---
+
+## Task 4: `SettingsScreen` — sub-headings, regrouping, disclosure
+
+**Files:**
+- Modify: `app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt`
+- Test: `app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt`
+
+- [ ] **Step 1: Read the existing UI test to match its style**
+
+Read `SettingsScreenTest.kt` fully (how it builds `SettingsScreen` inside `FemtoTheme`, drives `uiState`, and asserts node existence) so the new assertions match.
+
+- [ ] **Step 2: Add a `SettingsSubheader` composable**
+
+Add near `SettingsSection` (verify the style against `Type.kt`: it must read one notch below the `titleSmall` section heading and must NOT be `labelSmall`):
+
+```kotlin
+// A sub-group label inside a section card, separating related rows under a
+// section. Sits one notch below the section heading (primary, indented to align
+// with row content) so a card can carry two or three labelled clusters.
+@Composable
+private fun SettingsSubheader(
+    title: String,
+    modifier: Modifier = Modifier,
+) = Text(
+    text = title,
+    style = MaterialTheme.typography.labelLarge,
+    color = MaterialTheme.colorScheme.primary,
+    modifier = modifier.padding(start = 20.dp, top = 14.dp, bottom = 2.dp),
+)
+```
+
+- [ ] **Step 3: Regroup the Display section**
+
+Replace the Display `SettingsSection` body so the order is Theme, Accent, `[Screen]` Fullscreen + Keep screen on, `[Fonts]` Latin + CJK:
+
+```kotlin
+SettingsSection(title = stringResource(R.string.settings_section_display)) {
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_theme),
+        options =
+            listOf(
+                ThemeMode.SYSTEM to stringResource(R.string.settings_option_auto),
+                ThemeMode.LIGHT to stringResource(R.string.settings_theme_light),
+                ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
+            ),
+        selected = uiState.themeMode,
+        onSelect = { onAction(SettingsAction.SetThemeMode(it)) },
+    )
+    AccentRow(
+        selected = uiState.accentColor,
+        onSelect = { onAction(SettingsAction.SetAccentColor(it)) },
+    )
+    SettingsSubheader(stringResource(R.string.settings_subheader_screen))
+    SwitchRow(
+        title = stringResource(R.string.settings_group_fullscreen),
+        checked = uiState.fullscreen == FullscreenSetting.ON,
+        onCheckedChange = { onAction(SettingsAction.SetFullscreen(it.toFullscreen())) },
+    )
+    SwitchRow(
+        title = stringResource(R.string.settings_keep_screen_on),
+        checked = uiState.keepScreenOn,
+        onCheckedChange = { onAction(SettingsAction.SetKeepScreenOn(it)) },
+    )
+    SettingsSubheader(stringResource(R.string.settings_subheader_fonts))
+    FontRow(
+        title = stringResource(R.string.settings_group_font_latin),
+        family = uiState.latinFont,
+        onClick = { onOpenFontPicker(FontSlot.LATIN) },
+    )
+    FontRow(
+        title = stringResource(R.string.settings_group_font_cjk),
+        family = uiState.cjkFont,
+        onClick = { onOpenFontPicker(FontSlot.CJK) },
+    )
+}
+```
+
+- [ ] **Step 4: Regroup the Map section with disclosure**
+
+Replace the Map `SettingsSection` body. Add `import androidx.compose.animation.AnimatedVisibility`. Order: `[Rendering]` rendering + conditional rows, `[Appearance]` style + scheme disclosure, `[Camera]` tilt/zoom/marker:
+
+```kotlin
+SettingsSection(title = stringResource(R.string.settings_section_map)) {
+    SettingsSubheader(stringResource(R.string.settings_subheader_map_rendering))
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_map_rendering),
+        options =
+            listOf(
+                MapRenderMode.LIVE to stringResource(R.string.settings_map_mode_live),
+                MapRenderMode.SNAPSHOT to stringResource(R.string.settings_map_mode_snapshot),
+            ),
+        selected = uiState.mapRenderMode,
+        onSelect = { onAction(SettingsAction.SetMapRenderMode(it)) },
+    )
+    // Snapshot exposes bitmap sharpness; the live backend exposes 3D + terrain.
+    // Hidden rows keep their stored value; only the layout changes.
+    AnimatedVisibility(visible = uiState.mapRenderMode == MapRenderMode.SNAPSHOT) {
+        SliderRow(
+            title = stringResource(R.string.settings_group_map_quality),
+            valueLabel = stringResource(R.string.settings_map_quality_value, uiState.mapRenderPercent),
+            value = uiState.mapRenderPercent,
+            range = MIN_MAP_QUALITY..MAX_MAP_QUALITY,
+            onValueChange = { onAction(SettingsAction.SetMapRenderPercent(it)) },
+            description = stringResource(R.string.settings_map_quality_desc),
+        )
+    }
+    AnimatedVisibility(visible = uiState.mapRenderMode == MapRenderMode.LIVE) {
+        Column {
+            SwitchRow(
+                title = stringResource(R.string.settings_group_map_3d),
+                checked = uiState.map3dBuildings,
+                onCheckedChange = { onAction(SettingsAction.SetMap3dBuildings(it)) },
+            )
+            SwitchRow(
+                title = stringResource(R.string.settings_group_map_terrain),
+                checked = uiState.mapTerrain,
+                onCheckedChange = { onAction(SettingsAction.SetMapTerrain(it)) },
+                summary = stringResource(R.string.settings_map_terrain_desc),
+            )
+        }
+    }
+    SettingsSubheader(stringResource(R.string.settings_subheader_map_appearance))
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_map_style),
+        options =
+            listOf(
+                MapStyleSetting.AUTO to stringResource(R.string.settings_option_auto),
+                MapStyleSetting.LIGHT to stringResource(R.string.settings_theme_light),
+                MapStyleSetting.DARK to stringResource(R.string.settings_theme_dark),
+            ),
+        selected = uiState.mapStyle,
+        onSelect = { onAction(SettingsAction.SetMapStyle(it)) },
+    )
+    // Light scheme applies for AUTO + LIGHT; Dark scheme for AUTO + DARK. AUTO
+    // can use either (system theme decides), so AUTO shows both.
+    AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.DARK) {
+        ChoiceRow(
+            title = stringResource(R.string.settings_group_map_scheme_light),
+            options =
+                listOf(
+                    MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
+                    MapColorScheme.POSITRON to stringResource(R.string.settings_map_scheme_positron),
+                    MapColorScheme.BRIGHT to stringResource(R.string.settings_map_scheme_bright),
+                    MapColorScheme.LIBERTY to stringResource(R.string.settings_map_scheme_liberty),
+                ),
+            selected = uiState.mapSchemeLight,
+            onSelect = { onAction(SettingsAction.SetMapSchemeLight(it)) },
+        )
+    }
+    AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.LIGHT) {
+        ChoiceRow(
+            title = stringResource(R.string.settings_group_map_scheme_dark),
+            options =
+                listOf(
+                    MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
+                    MapColorScheme.DARK_MATTER to stringResource(R.string.settings_map_scheme_dark_matter),
+                    MapColorScheme.DARK to stringResource(R.string.settings_map_scheme_dark),
+                    MapColorScheme.FIORD to stringResource(R.string.settings_map_scheme_fiord),
+                ),
+            selected = uiState.mapSchemeDark,
+            onSelect = { onAction(SettingsAction.SetMapSchemeDark(it)) },
+        )
+    }
+    SettingsSubheader(stringResource(R.string.settings_subheader_map_camera))
+    SliderRow(
+        title = stringResource(R.string.settings_group_map_tilt),
+        valueLabel = stringResource(R.string.settings_map_tilt_value, uiState.mapTiltDeg),
+        value = uiState.mapTiltDeg,
+        range = MIN_MAP_TILT..MAX_MAP_TILT,
+        onValueChange = { onAction(SettingsAction.SetMapTilt(it)) },
+    )
+    SliderRow(
+        title = stringResource(R.string.settings_group_map_zoom),
+        valueLabel = stringResource(R.string.settings_map_zoom_value, uiState.mapZoom),
+        value = uiState.mapZoom,
+        range = MIN_MAP_ZOOM..MAX_MAP_ZOOM,
+        onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
+    )
+    SliderRow(
+        title = stringResource(R.string.settings_group_map_marker_pos),
+        valueLabel = stringResource(R.string.settings_map_marker_pos_value, uiState.mapMarkerPos),
+        value = uiState.mapMarkerPos,
+        range = MIN_MAP_MARKER_POS..MAX_MAP_MARKER_POS,
+        onValueChange = { onAction(SettingsAction.SetMapMarkerPos(it)) },
+    )
+}
+```
+
+- [ ] **Step 5: Add UI tests for disclosure + the new row**
+
+In `SettingsScreenTest.kt`, following the file's existing pattern, add tests that:
+- with `mapStyle = AUTO`, both `Light scheme` and `Dark scheme` rows exist;
+- with `mapStyle = LIGHT`, `Dark scheme` does not exist;
+- with `mapStyle = DARK`, `Light scheme` does not exist;
+- the `Keep screen on` row exists.
+
+Use `SettingsUiState.Initial.copy(mapStyle = …)` and `composeTestRule.onNodeWithText(…).assert{Exists,DoesNotExist}` matching the file's helpers. Example shape:
+
+```kotlin
+@Test
+fun lightStyle_hides_darkScheme() {
+    composeTestRule.setContent {
+        FemtoTheme {
+            SettingsScreen(
+                uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.LIGHT),
+                onAction = {}, onBack = {},
+                onOpenNotificationAccess = {}, onOpenSystemSettings = {}, onOpenFontPicker = {},
+            )
+        }
+    }
+    composeTestRule.onNodeWithText("Dark scheme").assertDoesNotExist()
+    composeTestRule.onNodeWithText("Light scheme").assertExists()
+}
+```
+
+- [ ] **Step 6: Run the UI tests**
+
+Run: `./gradlew :app:connectedDebugAndroidTest --tests "*SettingsScreenTest*"` (needs the emulator from Task 6; if not yet booted, run after Step in Task 6 and before the PR).
+Expected: PASS. If the emulator is not up yet, defer this run to Task 6 and continue.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt \
+        app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+git commit -m "feat(settings): group rows under sub-headings and disclose by dependency
+
+Split Display into Screen/Fonts and Map into Rendering/Appearance/Camera
+sub-groups, place each dependent row under its driver, and hide rows that
+cannot apply (snapshot vs live; the scheme not selected by Map style),
+animating them in and out."
+```
+
+---
+
+## Task 5: Font picker sort-order label
+
+**Files:**
+- Modify: `app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerScreen.kt`
+
+- [ ] **Step 1: Add the label between the search field and the list**
+
+After `SearchField(...)` and before `LazyColumn(...)` in `FontPickerScreen`, add:
+
+```kotlin
+Text(
+    text = stringResource(R.string.font_picker_sort_popular),
+    style = MaterialTheme.typography.labelLarge,
+    color = MaterialTheme.colorScheme.onSurfaceVariant,
+    modifier = Modifier.padding(horizontal = 4.dp),
+)
+```
+
+(Use `labelLarge`, not `labelSmall`, per `CLAUDE.md#automotive-overrides`.)
+
+- [ ] **Step 2: Build to verify**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerScreen.kt
+git commit -m "feat(fontpicker): label the catalog's popularity ordering
+
+The picker lists families most-popular-first but never said so, making the
+order read as arbitrary. Surface a static 'Most popular first' label."
+```
+
+---
+
+## Task 6: Verify, run on emulator, PR, merge
+
+- [ ] **Step 1: Format**
+
+Run: `./gradlew spotlessApply` then review the diff.
+
+- [ ] **Step 2: Full verification** (the `verify-android-build` skill)
+
+Run: `./gradlew :app:assembleDebug :app:lintDebug :app:testDebugUnitTest spotlessCheck`
+Expected: all green. Fix any failure before proceeding.
+
+- [ ] **Step 3: Boot an emulator and install**
+
+Start an AVD, then `./gradlew :app:installDebug` and launch.
+
+- [ ] **Step 4: Run the instrumented UI tests**
+
+Run: `./gradlew :app:connectedDebugAndroidTest --tests "*SettingsScreenTest*"`
+Expected: PASS.
+
+- [ ] **Step 5: Manual check on the emulator**
+
+Open Settings and confirm:
+- Display shows `Screen` (Fullscreen + Keep screen on) and `Fonts` (Latin + `CJK fallback`) sub-groups.
+- Toggling `Keep screen on` off then on does not crash; left on, the screen does not dim while the launcher is foreground.
+- Map: switching `Map style` Auto→Light hides `Dark scheme`; Auto→Dark hides `Light scheme`. Switching `Map rendering` swaps Sharpness ↔ 3D/Terrain, each under its parent.
+- Font picker shows `Most popular first` above the list.
+Capture a screenshot of the reorganized sheet.
+
+- [ ] **Step 6: Push and open the PR**
+
+```bash
+git push -u origin feat/settings-sheet-reorganization
+gh pr create --fill --base main
+```
+PR body summarizes the four changes and notes no new permission.
+
+- [ ] **Step 7: Merge once green**
+
+After CI passes and the manual check is clean, merge the PR.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** disclosure (Task 4), sub-grouping (Task 4 + 3), keep-screen-on (Tasks 1–3), CJK label (Task 3), picker order (Tasks 3 + 5), testing (Tasks 1, 4, 6) — all mapped.
+- **Type consistency:** `keepScreenOn: Boolean` and `SetKeepScreenOn(value: Boolean)` used identically across `DisplaySettings`, `DisplaySettingsStore`, `SettingsUiState`, `SettingsAction`, `SettingsViewModel`, the fake, and the screen. Key `keep_screen_on`. String keys `settings_subheader_*`, `settings_keep_screen_on`, `font_picker_sort_popular` used consistently between Task 3 and Tasks 4–5.
+- **Open items:** sub-heading typography (`labelLarge` proposed; confirm against `Type.kt` in Task 4 Step 2) and picker label wording (`Most popular first`).

--- a/docs/superpowers/specs/2026-06-10-settings-sheet-reorganization-design.md
+++ b/docs/superpowers/specs/2026-06-10-settings-sheet-reorganization-design.md
@@ -1,0 +1,211 @@
+# Settings Bottom Sheet Reorganization — Design
+
+## Overview
+
+The settings bottom sheet has grown to ~23 rows in five flat sections.
+Some rows silently depend on other settings, and the relationship is not
+visible. This design reorganizes the sheet around two ideas: **group
+related rows under sub-headings** so a setting's location is
+predictable, and **hide rows that cannot apply** (disclosure) so the
+sheet only ever shows controls that currently matter. It also adds a
+`Keep screen on` toggle and clarifies the two font rows.
+
+Scope follows the agreed priority: dependency visibility first, the font
+fixes second, overall length reduction as a side effect.
+
+## Problem
+
+1. **Hidden dependencies.** `Map style` (Auto / Light / Dark) silently
+   decides whether `Light scheme` or `Dark scheme` is used
+   (`WebMapView.kt:62-67`), yet both rows are always shown. `Map
+   rendering` (Snapshot / Live) already swaps `Sharpness` for `3D
+   buildings` + `Terrain` (`SettingsScreen.kt:256-277`), but the swap
+   reads as rows randomly appearing rather than as a parent-child
+   relationship.
+2. **Length and grouping.** The `Map` section alone holds 7 base rows
+   plus the mode-dependent rows — over half the sheet — in one flat
+   list, so locating a control means scanning.
+3. **Font rows are unclear.** The CJK row label over-specifies:
+   `settings_group_font_cjk = "Japanese / CJK fallback"`
+   (`strings.xml:115`). The picker lists families in popularity order
+   (`GoogleFontsApi.kt:34`, `.sortedBy { it.popularity }`) but never
+   labels that order, so it reads as arbitrary.
+4. **New requirement.** The launcher should be able to keep the screen
+   awake while it is in the foreground.
+
+## Goals
+
+- Make each setting's dependency visible by hiding rows that cannot
+  apply, placing every dependent row directly under its driver.
+- Group related rows under sub-headings so location is predictable.
+- Add a `Keep screen on` toggle (default on).
+- Clarify the two font rows: simplify the CJK label and surface the
+  picker's sort order.
+
+## Non-goals
+
+- Font picker A–Z / category sorting. This design only **labels** the
+  existing popularity order; a sort switch is future work.
+- Sub-grouping the `Units`, `Panels`, or `System` sections — they stay
+  flat.
+- Advanced keep-awake policies (charge-only, timeout, motion).
+- Changing persisted enum types or DataStore keys for existing
+  settings. Only additive changes.
+
+## Design
+
+### Section structure (after)
+
+Sub-headings (the `[bracketed]` rows) are visual groupings inside a
+section card, not new sections.
+
+```
+Display
+  Theme
+  Accent color
+  [Screen]
+    Fullscreen
+    Keep screen on            ← new, default ON
+  [Fonts]
+    Latin font
+    CJK fallback              ← label simplified
+Units                          (unchanged, flat)
+  Speed & distance
+  Temperature
+  Clock
+  Show seconds
+Map
+  [Rendering]
+    Map rendering             (Snapshot / Live)
+      Sharpness               ← shown only when Snapshot
+      3D buildings            ← shown only when Live
+      Terrain                 ← shown only when Live
+  [Appearance]
+    Map style                 (Auto / Light / Dark)
+      Light scheme            ← shown when Auto or Light
+      Dark scheme             ← shown when Auto or Dark
+  [Camera]
+    Tilt
+    Zoom
+    Marker position
+Panels                         (unchanged, flat)
+  Calendar
+  Weather
+  Music
+System                         (unchanged, flat)
+  Notification access
+  System settings
+  Reset to defaults
+```
+
+### Dependency disclosure
+
+There are two kinds of dependency. Both hide the inactive rows; both
+keep the dependent rows **directly under their driver** and animate them
+in and out so the change reads as a consequence of the parent.
+
+| Driver | Dependent rows | Visible when |
+| --- | --- | --- |
+| `Map rendering` | Sharpness | `Snapshot` |
+| `Map rendering` | 3D buildings, Terrain | `Live` |
+| `Map style` | Light scheme | `Auto` or `Light` |
+| `Map style` | Dark scheme | `Auto` or `Dark` |
+
+- **Conditional rows** (`rendering` → sharpness / 3D / terrain) are
+  fully inert in the other mode. This is the existing behaviour
+  (`SettingsScreen.kt:256-277`); the change is to nest them visually
+  under `Map rendering` and animate the swap.
+- **Active-scheme rows** (`style` → schemes) carry a meaningful value in
+  every mode, but only the matching scheme is used at a time. `Auto` can
+  use either depending on the system theme, so `Auto` shows **both**
+  scheme rows; `Light` and `Dark` show only the matching one. This row
+  was previously always shown — making it disclosure is the core fix.
+
+Both swaps use `AnimatedVisibility` with a slide so a row entering or
+leaving reads as "I just changed the parent," not "a row flickered."
+
+### Keep screen on (new)
+
+- A boolean setting, default **on** (the head unit runs on vehicle
+  power, so keeping the screen awake while the launcher is foreground is
+  the expected default).
+- Applied by setting `FLAG_KEEP_SCREEN_ON` on the Activity window,
+  driven from the persisted value through the **same path
+  `Fullscreen` already uses** in `MainActivity`. The exact mechanism is
+  confirmed during planning.
+- **No permission required.** `FLAG_KEEP_SCREEN_ON` needs none;
+  `WAKE_LOCK` is not used. The `add-launcher-permission` skill and the
+  `CLAUDE.md#permissions` audit table are therefore untouched.
+- Lives in `Display ▸ Screen`, next to `Fullscreen`, rendered with the
+  existing `SwitchRow`.
+
+Modelled as `Boolean` rather than a `FullscreenSetting`-style enum: the
+sheet's other on/off rows (`showClockSeconds`, `map3dBuildings`,
+`mapTerrain`, `showCalendar`, …) are already `Boolean`, so `Boolean` is
+the majority convention; `FullscreenSetting` is the outlier.
+
+### Font adjustments
+
+1. **CJK label.** Change the value of `settings_group_font_cjk` from
+   `"Japanese / CJK fallback"` to `"CJK fallback"`. The key is unchanged,
+   so every reference (`SettingsScreen.kt:128`) keeps working. No
+   locale-specific override exists today, so only the base string
+   changes.
+2. **Picker sort order.** Surface a short, non-interactive label in the
+   font picker (`ui/fontpicker/`) that names the existing order
+   (popularity, most popular first). Behaviour is unchanged; the label
+   only removes the "why is it in this order?" confusion. A real sort
+   switch (A–Z, by category) is out of scope (see Non-goals).
+
+## Detailed changes by file
+
+| File | Change |
+| --- | --- |
+| `ui/settings/SettingsScreen.kt` | Add a private `SettingsSubheader` composable. Re-lay `Display` (Screen / Fonts groups, `Keep screen on` row) and `Map` (Rendering / Appearance / Camera groups). Wrap conditional rows and each scheme row in `AnimatedVisibility`; pick scheme visibility with `when (mapStyle)`. |
+| `ui/settings/SettingsUiState.kt` | Add `keepScreenOn: Boolean` to `SettingsUiState`; add `SetKeepScreenOn(value: Boolean)` to `SettingsAction`. |
+| `ui/settings/SettingsViewModel.kt` | Map `keepScreenOn` from the store into `SettingsUiState`; handle `SetKeepScreenOn`; include it in the `ResetToDefaults` path. |
+| `data/DisplayPreferences.kt` | Add `KEEP_SCREEN_ON_KEY` (`booleanPreferencesKey("keep_screen_on")`, default `true`); add `keepScreenOn` to `DisplaySettings`; read/write/reset it. |
+| `MainActivity.kt` | Collect `keepScreenOn` and add/clear `FLAG_KEEP_SCREEN_ON` through the same window-flag path as `Fullscreen`. |
+| `res/values/strings.xml` | Edit `settings_group_font_cjk`. Add `settings_keep_screen_on` and the sub-heading strings (`settings_subgroup_screen`, `settings_subgroup_fonts`, `settings_group_map_rendering`, `settings_group_map_appearance`, `settings_group_map_camera`). |
+| `ui/fontpicker/` (picker screen) | Render the popularity-order label above the list. |
+
+All literals stay in their SSOT: dimensions from `FemtoDimens`, colors
+from `MaterialTheme.colorScheme.*`, type from `MaterialTheme.typography`
+(`CLAUDE.md#design-system`). Sub-headings reuse the existing section
+heading style one notch down rather than introducing a new token;
+confirmed against `Type.kt` during implementation.
+
+## Behaviour specifics
+
+- **Scheme visibility:** `Auto` → both scheme rows; `Light` → Light
+  scheme only; `Dark` → Dark scheme only. The hidden scheme keeps its
+  persisted value; switching back reveals it unchanged.
+- **Reset to defaults** sets `keepScreenOn = true` alongside the
+  existing resets.
+- **Disclosure is presentation only.** Hiding a row never clears its
+  stored value; it only removes it from the layout while inactive.
+
+## Testing
+
+Following `CLAUDE.md#testing`:
+
+- **ViewModel (JVM, `app/src/test`):** with `FakeDisplaySettingsStore`
+  (the interface fake, never a real DataStore under `runTest`), assert
+  `keepScreenOn` default is `true`, `SetKeepScreenOn` flips it, and
+  `ResetToDefaults` restores `true`.
+- **Compose UI (`app/src/androidTest`, `createComposeRule`, wrapped in
+  `FemtoTheme`):** assert that switching `Map style` shows/hides the
+  scheme rows (Auto → both, Light → Light only), that switching `Map
+  rendering` swaps Sharpness ↔ 3D/Terrain, and that the `Keep screen on`
+  row renders in the Screen group.
+
+The window-flag effect itself is left to manual on-device verification;
+the unit/UI tests cover state and layout.
+
+## Open items to confirm in review
+
+- Sub-heading typography — the intent is "existing section heading, one
+  notch lighter/smaller." Final style is matched to `Type.kt` during
+  implementation, not invented.
+- Font picker order label wording (e.g. "Popular first" vs "Sorted by
+  popularity").


### PR DESCRIPTION
## Summary

Reorganize the settings bottom sheet so dependencies are visible and related
rows are grouped, add a **Keep screen on** toggle, and clarify the two font
rows. Also resolve standing deprecations at the source (no `@Suppress`).

Design and plan:
- `docs/superpowers/specs/2026-06-10-settings-sheet-reorganization-design.md`
- `docs/superpowers/plans/2026-06-10-settings-sheet-reorganization.md`

## Changes

### Settings sheet
- **Sub-headings** group related rows: Display → `Screen` / `Fonts`; the
  oversized Map section → `Rendering` / `Appearance` / `Camera`.
- **Dependency disclosure** — each dependent row sits directly under its
  driver and hides when it cannot apply, animated in/out:
  - `Map rendering` → `Sharpness` (Snapshot) vs `3D buildings` + `Terrain` (Live).
  - `Map style` → `Light scheme` (Auto/Light) vs `Dark scheme` (Auto/Dark);
    `Auto` shows both. This was the invisible dependency: both scheme rows used
    to show unconditionally while `Map style` silently picked one.
- **Keep screen on** (new): boolean, default on, applies `FLAG_KEEP_SCREEN_ON`
  through the same window path as Fullscreen. No new permission (the flag needs
  none; `WAKE_LOCK` is not used).
- **Fonts**: CJK row label simplified `Japanese / CJK fallback` → `CJK fallback`;
  the font picker now labels its order (`Most popular first`).

### Deprecation cleanup
- Migrate every instrumented test to `androidx.compose.ui.test.junit4.v2.createComposeRule`
  (StandardTestDispatcher); verified all tests still pass under the new dispatcher.
- Move `WebMapView` to `androidx.lifecycle.compose.LocalLifecycleOwner`.
- Drop a redundant `Unit` expression the compiler flagged as unused.
- Repair androidTest compilation (Calendar/Weather card tests were missing the
  required `is24Hour` argument).

## Verification
- `assembleDebug` + `lintDebug` + `testDebugUnitTest` + `spotlessCheck`: green, **zero compiler warnings**.
- `connectedAndroidTest` on a head-unit AVD (800x480 / 150 dpi): **61/61 passed**.
- Manual on device: sub-headings, the `Keep screen on` toggle (default on), and
  the `Map style` scheme disclosure render correctly.
