### PR TITLE
fix: harden resilience and surface degraded states across the launcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,9 @@ when markets diverge.
 
 ## Tech stack
 
-- Kotlin (auto-applied by AGP 9), Jetpack Compose (BOM `2026.03.00`),
+- Kotlin (auto-applied by AGP 9), Jetpack Compose (BOM `2026.05.01`),
   Material 3.
-- AGP 9.1.1, Gradle 9.3.1, JDK 21 toolchain, Java 11 source/target.
+- AGP 9.2.1, Gradle 9.5.1, JDK 21 toolchain, Java 11 source/target.
 - `minSdk = 33`, `targetSdk = 36` with `compileSdk { release(37) }`
   (compile against API 37 as `androidx.core` 1.19+ requires; the
   supported-device floor stays Android 13 / API 33).

--- a/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
@@ -27,6 +27,7 @@ internal fun fakeCalendarSnapshot(
             DayCell(LocalDate.of(2026, 5, 6), "Wed", listOf(EventItem(null, "Holiday"))),
         ),
     hasCalendarAccess: Boolean = true,
+    queryFailed: Boolean = false,
 ): CalendarSnapshot =
     CalendarSnapshot(
         today = today,
@@ -34,4 +35,5 @@ internal fun fakeCalendarSnapshot(
         monthLabel = monthLabel,
         days = days,
         hasCalendarAccess = hasCalendarAccess,
+        queryFailed = queryFailed,
     )

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
@@ -71,4 +71,21 @@ class CalendarCardTest {
                 .getString(R.string.calendar_permission_denied)
         rule.onNodeWithText(denied).assertIsDisplayed()
     }
+
+    @Test
+    fun shows_query_failed_message_when_the_provider_query_failed() {
+        rule.setContent {
+            FemtoTheme {
+                CalendarCard(snapshot = fakeCalendarSnapshot(queryFailed = true), is24Hour = true)
+            }
+        }
+        // Resolve the copy from resources so the literal stays the SSOT in
+        // strings.xml ("Calendar couldn't be read").
+        val failed =
+            InstrumentationRegistry
+                .getInstrumentation()
+                .targetContext
+                .getString(R.string.calendar_query_failed)
+        rule.onNodeWithText(failed).assertIsDisplayed()
+    }
 }

--- a/app/src/main/assets/web/map.html
+++ b/app/src/main/assets/web/map.html
@@ -36,6 +36,17 @@
       // WebGL drops, so the page never asks the host to switch away.
       function log(msg) { try { console.log("[map] " + msg); } catch (e) {} }
 
+      // JS -> Android error channel (window.femtoBridge, injected by the host via
+      // addJavascriptInterface). "fatal" = definitive never-going-to-render facts
+      // (no WebGL context, map construction threw); "error" = transient resource
+      // failures (tile / style / DEM fetch), log-only on the host. Neither kind
+      // triggers a backend switch — the no-fallback rule above still holds.
+      function report(kind, detail) {
+        try {
+          if (window.femtoBridge) window.femtoBridge.onMapEvent(kind, String(detail || ""));
+        } catch (e) {}
+      }
+
       // LIVE-only feature toggles, merged into the style via MapLibre transformStyle
       // (the official "hybrid satellite map with terrain elevation" approach, minus
       // satellite). DEM = Mapterhorn (free, no key); 3D buildings reuse the
@@ -120,7 +131,10 @@
       }
       (function () {
         const c = document.createElement("canvas");
-        if (!(c.getContext("webgl2") || c.getContext("webgl"))) log("no-webgl-context");
+        if (!(c.getContext("webgl2") || c.getContext("webgl"))) {
+          log("no-webgl-context");
+          report("fatal", "no-webgl-context");
+        }
       })();
 
       let map;
@@ -142,6 +156,22 @@
         // on that built-in restore and do not fall back to another backend.
         map.on("webglcontextlost", () => log("webglcontextlost (awaiting MapLibre restore)"));
         map.on("webglcontextrestored", () => log("webglcontextrestored"));
+
+        // Tile / style / DEM fetch failures surface here. A flaky link can fire
+        // this once per tile, so reports to the host are throttled to one per
+        // ERROR_REPORT_INTERVAL_MS; the host only logs them (transient by
+        // definition — never UI, never a backend switch).
+        var ERROR_REPORT_INTERVAL_MS = 10000;
+        var lastErrorReportMs = 0;
+        map.on("error", (e) => {
+          var detail = (e && e.error && e.error.message) || "unknown map error";
+          log("error: " + detail);
+          var now = Date.now();
+          if (now - lastErrorReportMs >= ERROR_REPORT_INTERVAL_MS) {
+            lastErrorReportMs = now;
+            report("error", String(detail).slice(0, 200));
+          }
+        });
 
         // Self-location chevron: a fixed-on-screen DOM overlay (see #self-marker CSS).
         // The camera brings the location to the chevron's spot, so the chevron stays
@@ -215,6 +245,8 @@
         window.onHostResume = function () { if (map) { map.resize(); map.triggerRepaint(); } };
       } catch (e) {
         log("exception:" + (e && e.message));
+        // The map object never came up; this page will stay blank forever.
+        report("fatal", "map-init-exception: " + (e && e.message));
       }
     </script>
   </body>

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.text.format.DateFormat
+import android.util.Log
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -379,6 +380,7 @@ class MainActivity : ComponentActivity() {
             startActivity(intent)
             true
         } catch (_: ActivityNotFoundException) {
+            Log.w(TAG, "no handler for ${intent.component?.flattenToShortString() ?: intent.action}")
             false
         }
 
@@ -410,6 +412,8 @@ private fun isProbablyEmulator(): Boolean =
         Build.PRODUCT.startsWith("sdk") ||
         Build.PRODUCT.contains("sdk_gphone") ||
         Build.BRAND.startsWith("generic")
+
+private const val TAG = "MainActivity"
 
 private const val QEMU_PROPERTY = "ro.kernel.qemu"
 

--- a/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/AppsRepository.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.pm.LauncherActivityInfo
 import android.content.pm.LauncherApps
 import android.os.Process
+import android.util.Log
 import androidx.core.content.getSystemService
 import androidx.core.graphics.drawable.toBitmap
 import kotlinx.coroutines.Dispatchers
@@ -45,8 +46,12 @@ internal class AppsRepository(
                 // Isolate per-app resolution: getIcon() can throw
                 // Resources.NotFoundException or OOM on a pathological adaptive
                 // icon. One bad package must not blank the whole grid.
-                .mapNotNull { runCatching { it.toAppEntry() }.getOrNull() }
-                .sortedBy { it.label.lowercase() }
+                .mapNotNull { info ->
+                    runCatching { info.toAppEntry() }
+                        .onFailure {
+                            Log.w(TAG, "dropping ${info.componentName.flattenToShortString()} from app grid", it)
+                        }.getOrNull()
+                }.sortedBy { it.label.lowercase() }
         }
 
     /**
@@ -79,6 +84,8 @@ internal class AppsRepository(
                 ?.componentName
         }.getOrNull()
 }
+
+private const val TAG = "AppsRepository"
 
 private const val ICON_PIXELS = 192
 

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
@@ -12,6 +12,7 @@ import android.os.Handler
 import android.os.Looper
 import android.provider.CalendarContract
 import android.text.format.DateFormat
+import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
@@ -31,6 +32,8 @@ import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.util.Locale
 
+private const val TAG = "CalendarRepository"
+
 /**
  * Calendar surface for the dashboard.
  *
@@ -45,7 +48,10 @@ import java.util.Locale
  * alone, but with `hasCalendarAccess = false` so the card renders the denial
  * message rather than a hollow strip. The calling UI treats a null snapshot
  * as "loading"; a non-null snapshot with `hasCalendarAccess = true` and an
- * empty events list means "granted but nothing scheduled".
+ * empty events list means "granted but nothing scheduled". An unexpected
+ * provider fault (anything other than the mid-stream `SecurityException`
+ * revoke) sets `queryFailed = true` so an empty list never fakes that
+ * "nothing scheduled" contract.
  */
 internal class CalendarRepository(
     private val context: Context,
@@ -63,13 +69,15 @@ internal class CalendarRepository(
 
     private fun buildSnapshot(today: LocalDate): CalendarSnapshot {
         val granted = hasPermission()
+        // null marks a provider fault (see readWindow); the days still build
+        // from the clock alone so the strip never disappears.
         val eventsByDay = if (granted) readWindow(today) else emptyMap()
         val days = (0 until WINDOW_DAYS).map { offset ->
             val date = today.plusDays(offset.toLong())
             DayCell(
                 date = date,
                 weekdayLetter = date.dayOfWeek.getDisplayName(TextStyle.SHORT, locale),
-                events = eventsByDay[date].orEmpty(),
+                events = eventsByDay?.get(date).orEmpty(),
             )
         }
         return CalendarSnapshot(
@@ -78,6 +86,7 @@ internal class CalendarRepository(
             monthLabel = monthLabelOf(today),
             days = days,
             hasCalendarAccess = granted,
+            queryFailed = eventsByDay == null,
         )
     }
 
@@ -129,10 +138,13 @@ internal class CalendarRepository(
      *
      * A mid-stream permission revoke (SecurityException) or an OEM provider
      * fault (SQLiteException) must not tear down the dashboard StateFlow, so the
-     * whole scan is guarded.
+     * whole scan is guarded. The two faults degrade differently: a revoke is the
+     * documented permission path and yields an empty map, while any other fault
+     * returns null so [buildSnapshot] can flag `queryFailed` instead of faking
+     * "granted but nothing scheduled".
      */
     @SuppressLint("MissingPermission") // Caller checks READ_CALENDAR before subscribing.
-    private fun readWindow(today: LocalDate): Map<LocalDate, List<EventItem>> =
+    private fun readWindow(today: LocalDate): Map<LocalDate, List<EventItem>>? =
         runCatching {
             val byDay = linkedMapOf<LocalDate, MutableList<EventItem>>()
             context.contentResolver
@@ -164,7 +176,15 @@ internal class CalendarRepository(
                     }
                 }
             byDay.mapValues { (_, events) -> events.toList() }
-        }.getOrDefault(emptyMap())
+        }.onFailure {
+            when (it) {
+                // Mid-stream revoke is the expected degradation path (see KDoc);
+                // anything else is a real provider fault and must be visible.
+                is SecurityException -> Log.d(TAG, "calendar window query denied", it)
+
+                else -> Log.e(TAG, "calendar window query failed", it)
+            }
+        }.getOrElse { if (it is SecurityException) emptyMap() else null }
 
     /**
      * Resolve an Instances.BEGIN epoch-millis to the local calendar day.

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarSnapshot.kt
@@ -15,6 +15,8 @@ import java.time.LocalTime
  * in-band by [hasCalendarAccess]: a non-null snapshot with
  * [hasCalendarAccess] == false tells the card to render the denial message
  * instead of an empty list plus a misleading "no upcoming events".
+ * [queryFailed] carries the third state — access granted but the provider
+ * query faulted — so an OEM provider error is never presented as a free week.
  */
 @Immutable
 data class CalendarSnapshot(
@@ -25,6 +27,10 @@ data class CalendarSnapshot(
     // false means READ_CALENDAR is denied, so the list carries no real data
     // and the card shows the denial message instead.
     val hasCalendarAccess: Boolean,
+    // true means the provider query failed unexpectedly (e.g. SQLiteException),
+    // so the empty list is a fault, not "nothing scheduled"; the card shows the
+    // failure message instead of a hollow agenda.
+    val queryFailed: Boolean = false,
 )
 
 @Immutable

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -1,16 +1,24 @@
 package io.github.seijikohara.femto.data
 
 import android.content.Context
+import android.util.Log
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import java.io.IOException
 import kotlin.enums.enumEntries
+
+private const val TAG = "DisplayPreferences"
 
 /** Light / dark / follow-system theme choice. */
 internal enum class ThemeMode { SYSTEM, LIGHT, DARK }
@@ -239,133 +247,133 @@ internal class DisplayPreferences(
     private val context: Context,
 ) : DisplaySettingsStore {
     override val settings: Flow<DisplaySettings> =
-        context.displayDataStore.data.map { prefs ->
-            DisplaySettings(
-                themeMode = prefs[THEME_KEY].toEnumOr(ThemeMode.SYSTEM),
-                accentColor = prefs[ACCENT_KEY].toEnumOr(AccentColor.DYNAMIC),
-                speedUnit = prefs[SPEED_KEY].toEnumOr(SpeedUnitSetting.AUTO),
-                temperatureUnit = prefs[TEMPERATURE_KEY].toEnumOr(TemperatureUnitSetting.AUTO),
-                clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
-                showClockSeconds = prefs[SHOW_CLOCK_SECONDS_KEY] ?: false,
-                fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.ON),
-                keepScreenOn = prefs[KEEP_SCREEN_ON_KEY] ?: true,
-                mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
-                mapSchemeLight = prefs[MAP_SCHEME_LIGHT_KEY].toEnumOr(MapColorScheme.ACCENT),
-                mapSchemeDark = prefs[MAP_SCHEME_DARK_KEY].toEnumOr(MapColorScheme.ACCENT),
-                mapTiltDeg = prefs[MAP_TILT_KEY] ?: DEFAULT_MAP_TILT_DEG,
-                mapZoom = prefs[MAP_ZOOM_KEY] ?: DEFAULT_MAP_ZOOM,
-                mapRenderPercent = prefs[MAP_QUALITY_KEY] ?: DEFAULT_MAP_RENDER_PERCENT,
-                mapRenderMode = prefs[MAP_RENDER_MODE_KEY].toMapRenderModeOr(MapRenderMode.LIVE),
-                mapMarkerPos = prefs[MAP_MARKER_POS_KEY] ?: DEFAULT_MAP_MARKER_POS,
-                map3dBuildings = prefs[MAP_3D_BUILDINGS_KEY] ?: true,
-                mapTerrain = prefs[MAP_TERRAIN_KEY] ?: true,
-                glassBlurRadius = prefs[GLASS_BLUR_KEY] ?: DEFAULT_GLASS_BLUR_DP,
-                glassTintScale = prefs[GLASS_TINT_KEY] ?: DEFAULT_GLASS_TINT_SCALE,
-                showCalendar = prefs[SHOW_CALENDAR_KEY] ?: true,
-                showWeather = prefs[SHOW_WEATHER_KEY] ?: true,
-                showMusic = prefs[SHOW_MUSIC_KEY] ?: true,
-            )
-        }
+        context.displayDataStore.data
+            .catchIoAsDefaults(TAG)
+            .map { prefs ->
+                DisplaySettings(
+                    themeMode = prefs[THEME_KEY].toEnumOr(ThemeMode.SYSTEM),
+                    accentColor = prefs[ACCENT_KEY].toEnumOr(AccentColor.DYNAMIC),
+                    speedUnit = prefs[SPEED_KEY].toEnumOr(SpeedUnitSetting.AUTO),
+                    temperatureUnit = prefs[TEMPERATURE_KEY].toEnumOr(TemperatureUnitSetting.AUTO),
+                    clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
+                    showClockSeconds = prefs[SHOW_CLOCK_SECONDS_KEY] ?: false,
+                    fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.ON),
+                    keepScreenOn = prefs[KEEP_SCREEN_ON_KEY] ?: true,
+                    mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
+                    mapSchemeLight = prefs[MAP_SCHEME_LIGHT_KEY].toEnumOr(MapColorScheme.ACCENT),
+                    mapSchemeDark = prefs[MAP_SCHEME_DARK_KEY].toEnumOr(MapColorScheme.ACCENT),
+                    mapTiltDeg = prefs[MAP_TILT_KEY] ?: DEFAULT_MAP_TILT_DEG,
+                    mapZoom = prefs[MAP_ZOOM_KEY] ?: DEFAULT_MAP_ZOOM,
+                    mapRenderPercent = prefs[MAP_QUALITY_KEY] ?: DEFAULT_MAP_RENDER_PERCENT,
+                    mapRenderMode = prefs[MAP_RENDER_MODE_KEY].toMapRenderModeOr(MapRenderMode.LIVE),
+                    mapMarkerPos = prefs[MAP_MARKER_POS_KEY] ?: DEFAULT_MAP_MARKER_POS,
+                    map3dBuildings = prefs[MAP_3D_BUILDINGS_KEY] ?: true,
+                    mapTerrain = prefs[MAP_TERRAIN_KEY] ?: true,
+                    glassBlurRadius = prefs[GLASS_BLUR_KEY] ?: DEFAULT_GLASS_BLUR_DP,
+                    glassTintScale = prefs[GLASS_TINT_KEY] ?: DEFAULT_GLASS_TINT_SCALE,
+                    showCalendar = prefs[SHOW_CALENDAR_KEY] ?: true,
+                    showWeather = prefs[SHOW_WEATHER_KEY] ?: true,
+                    showMusic = prefs[SHOW_MUSIC_KEY] ?: true,
+                )
+            }
 
-    // Block bodies (returning Unit): edit() yields Preferences, which the
-    // DisplaySettingsStore contract intentionally discards.
     override suspend fun setThemeMode(value: ThemeMode) {
-        context.displayDataStore.edit { it[THEME_KEY] = value.name }
+        context.displayDataStore.editOrLog(TAG) { it[THEME_KEY] = value.name }
     }
 
     override suspend fun setAccentColor(value: AccentColor) {
-        context.displayDataStore.edit { it[ACCENT_KEY] = value.name }
+        context.displayDataStore.editOrLog(TAG) { it[ACCENT_KEY] = value.name }
     }
 
     override suspend fun setSpeedUnit(value: SpeedUnitSetting) {
-        context.displayDataStore.edit { it[SPEED_KEY] = value.name }
+        context.displayDataStore.editOrLog(TAG) { it[SPEED_KEY] = value.name }
     }
 
     override suspend fun setTemperatureUnit(value: TemperatureUnitSetting) {
-        context.displayDataStore.edit { it[TEMPERATURE_KEY] = value.name }
+        context.displayDataStore.editOrLog(TAG) { it[TEMPERATURE_KEY] = value.name }
     }
 
     override suspend fun setClock(value: ClockSetting) {
-        context.displayDataStore.edit { it[CLOCK_KEY] = value.name }
+        context.displayDataStore.editOrLog(TAG) { it[CLOCK_KEY] = value.name }
     }
 
     override suspend fun setShowClockSeconds(value: Boolean) {
-        context.displayDataStore.edit { it[SHOW_CLOCK_SECONDS_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[SHOW_CLOCK_SECONDS_KEY] = value }
     }
 
     override suspend fun setFullscreen(value: FullscreenSetting) {
-        context.displayDataStore.edit { it[FULLSCREEN_KEY] = value.name }
+        context.displayDataStore.editOrLog(TAG) { it[FULLSCREEN_KEY] = value.name }
     }
 
     override suspend fun setKeepScreenOn(value: Boolean) {
-        context.displayDataStore.edit { it[KEEP_SCREEN_ON_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[KEEP_SCREEN_ON_KEY] = value }
     }
 
     override suspend fun setMapStyle(value: MapStyleSetting) {
-        context.displayDataStore.edit { it[MAP_STYLE_KEY] = value.name }
+        context.displayDataStore.editOrLog(TAG) { it[MAP_STYLE_KEY] = value.name }
     }
 
     override suspend fun setMapSchemeLight(value: MapColorScheme) {
-        context.displayDataStore.edit { it[MAP_SCHEME_LIGHT_KEY] = value.name }
+        context.displayDataStore.editOrLog(TAG) { it[MAP_SCHEME_LIGHT_KEY] = value.name }
     }
 
     override suspend fun setMapSchemeDark(value: MapColorScheme) {
-        context.displayDataStore.edit { it[MAP_SCHEME_DARK_KEY] = value.name }
+        context.displayDataStore.editOrLog(TAG) { it[MAP_SCHEME_DARK_KEY] = value.name }
     }
 
     override suspend fun setMapTilt(value: Int) {
-        context.displayDataStore.edit { it[MAP_TILT_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[MAP_TILT_KEY] = value }
     }
 
     override suspend fun setMapZoom(value: Int) {
-        context.displayDataStore.edit { it[MAP_ZOOM_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[MAP_ZOOM_KEY] = value }
     }
 
     override suspend fun setMapRenderPercent(value: Int) {
-        context.displayDataStore.edit { it[MAP_QUALITY_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[MAP_QUALITY_KEY] = value }
     }
 
     override suspend fun setMapRenderMode(value: MapRenderMode) {
-        context.displayDataStore.edit { it[MAP_RENDER_MODE_KEY] = value.name }
+        context.displayDataStore.editOrLog(TAG) { it[MAP_RENDER_MODE_KEY] = value.name }
     }
 
     override suspend fun setMapMarkerPos(value: Int) {
-        context.displayDataStore.edit { it[MAP_MARKER_POS_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[MAP_MARKER_POS_KEY] = value }
     }
 
     override suspend fun setMap3dBuildings(value: Boolean) {
-        context.displayDataStore.edit { it[MAP_3D_BUILDINGS_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[MAP_3D_BUILDINGS_KEY] = value }
     }
 
     override suspend fun setMapTerrain(value: Boolean) {
-        context.displayDataStore.edit { it[MAP_TERRAIN_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[MAP_TERRAIN_KEY] = value }
     }
 
     override suspend fun setGlassBlurRadius(value: Int) {
-        context.displayDataStore.edit { it[GLASS_BLUR_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[GLASS_BLUR_KEY] = value }
     }
 
     override suspend fun setGlassTintScale(value: Int) {
-        context.displayDataStore.edit { it[GLASS_TINT_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[GLASS_TINT_KEY] = value }
     }
 
     override suspend fun setShowCalendar(value: Boolean) {
-        context.displayDataStore.edit { it[SHOW_CALENDAR_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[SHOW_CALENDAR_KEY] = value }
     }
 
     override suspend fun setShowWeather(value: Boolean) {
-        context.displayDataStore.edit { it[SHOW_WEATHER_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[SHOW_WEATHER_KEY] = value }
     }
 
     override suspend fun setShowMusic(value: Boolean) {
-        context.displayDataStore.edit { it[SHOW_MUSIC_KEY] = value }
+        context.displayDataStore.editOrLog(TAG) { it[SHOW_MUSIC_KEY] = value }
     }
 
     // Clearing every key makes the read path above fall back to its per-field
     // defaults, which are kept identical to DisplaySettings.Default — so a reset
     // restores the defaults without duplicating the default literals here.
     override suspend fun resetToDefaults() {
-        context.displayDataStore.edit { it.clear() }
+        context.displayDataStore.editOrLog(TAG) { it.clear() }
     }
 
     private companion object {
@@ -408,3 +416,32 @@ private fun String?.toMapRenderModeOr(fallback: MapRenderMode): MapRenderMode =
         "LIVE_HARDWARE", "LIVE_SOFTWARE" -> MapRenderMode.LIVE
         else -> toEnumOr(fallback)
     }
+
+// DataStore surfaces an unreadable prefs file as an IOException on the read
+// flow. The launcher is the HOME app, so a corrupted file (e.g. after a power
+// loss mid-write) must degrade to defaults instead of crash-looping every cold
+// start. Shared by every preferences accessor in this package.
+internal fun Flow<Preferences>.catchIoAsDefaults(tag: String): Flow<Preferences> =
+    catch { e ->
+        if (e is IOException) {
+            Log.e(tag, "preferences read failed; falling back to defaults", e)
+            emit(emptyPreferences())
+        } else {
+            throw e
+        }
+    }
+
+// Preference writes are launched fire-and-forget, so an IOException thrown by
+// edit() would otherwise escape the launching coroutine and kill the HOME
+// process. Losing one write is acceptable; crashing the launcher is not.
+// Cancellation is rethrown to keep structured concurrency intact.
+internal suspend fun DataStore<Preferences>.editOrLog(
+    tag: String,
+    transform: suspend (MutablePreferences) -> Unit,
+) {
+    runCatching { edit(transform) }
+        .onFailure { e ->
+            if (e is CancellationException) throw e
+            Log.e(tag, "preferences write failed", e)
+        }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/data/DrawerPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DrawerPreferences.kt
@@ -3,7 +3,6 @@ package io.github.seijikohara.femto.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -30,23 +29,31 @@ internal interface DrawerSettingsStore {
 
 private val Context.drawerDataStore: DataStore<Preferences> by preferencesDataStore(name = "drawer_preferences")
 
+private const val TAG = "DrawerPreferences"
+
 internal class DrawerPreferences(
     private val context: Context,
 ) : DrawerSettingsStore {
     override val layout: Flow<DrawerLayout> =
-        context.drawerDataStore.data.map { prefs ->
-            prefs[LAYOUT_KEY]?.let { name -> DrawerLayout.entries.firstOrNull { it.name == name } } ?: DrawerLayout.GRID
-        }
+        context.drawerDataStore.data
+            .catchIoAsDefaults(TAG)
+            .map { prefs ->
+                prefs[LAYOUT_KEY]
+                    ?.let { name -> DrawerLayout.entries.firstOrNull { it.name == name } }
+                    ?: DrawerLayout.GRID
+            }
 
     override val pinned: Flow<Set<String>> =
-        context.drawerDataStore.data.map { prefs -> prefs[PINNED_KEY] ?: emptySet() }
+        context.drawerDataStore.data
+            .catchIoAsDefaults(TAG)
+            .map { prefs -> prefs[PINNED_KEY] ?: emptySet() }
 
     override suspend fun setLayout(value: DrawerLayout) {
-        context.drawerDataStore.edit { it[LAYOUT_KEY] = value.name }
+        context.drawerDataStore.editOrLog(TAG) { it[LAYOUT_KEY] = value.name }
     }
 
     override suspend fun togglePinned(flattenedComponent: String) {
-        context.drawerDataStore.edit { prefs ->
+        context.drawerDataStore.editOrLog(TAG) { prefs ->
             val current = prefs[PINNED_KEY] ?: emptySet()
             prefs[PINNED_KEY] =
                 if (flattenedComponent in current) current - flattenedComponent else current + flattenedComponent

--- a/app/src/main/java/io/github/seijikohara/femto/data/FontCache.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/FontCache.kt
@@ -61,9 +61,17 @@ internal class FontCache(
             }
         }
 
-    /** Delete the cached directories of every family outside [keep]. */
-    fun evictExcept(keep: Collection<String>) {
-        val keepDirs = keep.map { dirFor(it).name }.toSet()
+    /**
+     * Delete the cached directories of every family outside [keep].
+     * [alsoProtect] shields families whose download is still in flight — a fast
+     * re-selection cancels the previous resolve pass mid-download, and evicting
+     * its directory here would delete the file the cancelled pass is writing.
+     */
+    fun evictExcept(
+        keep: Collection<String>,
+        alsoProtect: Collection<String> = emptySet(),
+    ) {
+        val keepDirs = (keep + alsoProtect).map { dirFor(it).name }.toSet()
         root.listFiles().orEmpty().forEach { dir ->
             if (dir.isDirectory && dir.name !in keepDirs) dir.deleteRecursively()
         }

--- a/app/src/main/java/io/github/seijikohara/femto/data/FontPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/FontPreferences.kt
@@ -3,13 +3,14 @@ package io.github.seijikohara.femto.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 private val Context.fontDataStore: DataStore<Preferences> by preferencesDataStore(name = "font_preferences")
+
+private const val TAG = "FontPreferences"
 
 /**
  * DataStore-backed accessor for the user's [FontSelection].
@@ -22,9 +23,11 @@ internal class FontPreferences(
     private val context: Context,
 ) {
     val selection: Flow<FontSelection> =
-        context.fontDataStore.data.map { prefs ->
-            FontSelection(latinFamily = prefs[LATIN_KEY], cjkFamily = prefs[CJK_KEY])
-        }
+        context.fontDataStore.data
+            .catchIoAsDefaults(TAG)
+            .map { prefs ->
+                FontSelection(latinFamily = prefs[LATIN_KEY], cjkFamily = prefs[CJK_KEY])
+            }
 
     /** Persist [family] for [slot]; a null family clears the slot to system. */
     suspend fun setFamily(
@@ -32,7 +35,7 @@ internal class FontPreferences(
         family: String?,
     ) {
         val key = keyFor(slot)
-        context.fontDataStore.edit { prefs ->
+        context.fontDataStore.editOrLog(TAG) { prefs ->
             if (family == null) prefs.remove(key) else prefs[key] = family
         }
     }
@@ -40,7 +43,7 @@ internal class FontPreferences(
     // Clearing the keys makes the read path fall back to the system font,
     // mirroring DisplayPreferences.resetToDefaults.
     suspend fun resetToDefaults() {
-        context.fontDataStore.edit { it.clear() }
+        context.fontDataStore.editOrLog(TAG) { it.clear() }
     }
 
     private fun keyFor(slot: FontSlot): Preferences.Key<String> =

--- a/app/src/main/java/io/github/seijikohara/femto/data/FontRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/FontRepository.kt
@@ -5,11 +5,15 @@ import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -44,6 +48,35 @@ internal sealed interface CatalogState {
     data object Error : CatalogState
 }
 
+/** The slice of [GoogleFontsApi] the repository consumes; a seam for JVM tests. */
+internal fun interface FontCatalogSource {
+    suspend fun catalog(): List<GoogleFontFamily>?
+}
+
+/** The slice of [FontCache] the repository consumes; a seam for JVM tests. */
+internal interface FontFaceStore {
+    fun cached(family: String): CachedFont?
+
+    suspend fun ensure(family: String): CachedFont?
+
+    fun evictExcept(
+        keep: Collection<String>,
+        alsoProtect: Collection<String>,
+    )
+}
+
+/** The slice of [FontPreferences] the repository consumes; a seam for JVM tests. */
+internal interface FontSelectionStore {
+    val selection: Flow<FontSelection>
+
+    suspend fun setFamily(
+        slot: FontSlot,
+        family: String?,
+    )
+
+    suspend fun resetToDefaults()
+}
+
 /**
  * App-scoped hub for downloadable Google Fonts. Resolves the persisted
  * [FontSelection] into on-disk faces (downloading on demand), evicts the cache
@@ -51,13 +84,15 @@ internal sealed interface CatalogState {
  *
  * A singleton so [MainActivity]'s theme and the settings picker share one cache
  * and one in-flight download set. Its [scope] lives for the whole process,
- * which suits a launcher that is only ever the foreground home app.
+ * which suits a launcher that is only ever the foreground home app. The
+ * constructor stays injectable for JVM tests; production wiring goes through
+ * [get].
  */
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-internal class FontRepository private constructor(
-    private val api: GoogleFontsApi,
-    private val cache: FontCache,
-    private val preferences: FontPreferences,
+internal class FontRepository internal constructor(
+    private val api: FontCatalogSource,
+    private val cache: FontFaceStore,
+    private val preferences: FontSelectionStore,
     private val catalogFile: File,
     private val scope: CoroutineScope,
 ) {
@@ -67,25 +102,51 @@ internal class FontRepository private constructor(
     val selection: StateFlow<FontSelection> =
         preferences.selection.stateIn(scope, SharingStarted.Eagerly, FontSelection.System)
 
+    // Declared before [resolved]: the eagerly started mapLatest below reads these
+    // fields, and stateIn(Eagerly) may run the lambda while construction is still
+    // in progress.
+    private val _downloading = MutableStateFlow<Set<String>>(emptySet())
+
+    /** Families with an in-flight download, so the picker can show progress. */
+    val downloading: StateFlow<Set<String>> = _downloading.asStateFlow()
+
+    private val _downloadFailed = MutableStateFlow<Set<String>>(emptySet())
+
     /**
-     * The resolved faces, recomputed whenever the selection changes. Evicts the
-     * now-unused cache first, then ensures each selected family is downloaded —
-     * so a switch frees the previous font's bytes before fetching the new one.
+     * Families whose most recent resolve attempt failed (manifest or download
+     * unreachable), so the picker can flag the row and offer a retry. An entry
+     * clears when a later resolve succeeds or when the slot moves to another
+     * family.
+     */
+    val downloadFailed: StateFlow<Set<String>> = _downloadFailed.asStateFlow()
+
+    // DataStore skips both the disk write and the re-emission when the chosen
+    // family equals the persisted one, so re-tapping a failed family would never
+    // reach a new resolve pass. [choose] fires this trigger for unchanged
+    // selections to force a fresh pass that retries the download.
+    private val retryTrigger = MutableSharedFlow<Unit>()
+
+    /**
+     * The resolved faces, recomputed whenever the selection changes (or a retry
+     * fires). Evicts the now-unused cache first, then ensures each selected
+     * family is downloaded — so a switch frees the previous font's bytes before
+     * fetching the new one. Families still downloading are protected from
+     * eviction: a fast re-selection cancels the previous mapLatest pass while
+     * its OkHttp call is still streaming, and deleting that directory would
+     * corrupt the write.
      */
     val resolved: StateFlow<ResolvedFonts> =
-        preferences.selection
+        combine(preferences.selection, retryTrigger.onStart { emit(Unit) }) { selection, _ -> selection }
             .mapLatest { selection ->
-                cache.evictExcept(selection.families)
+                // A failed family that is no longer selected has no retry surface;
+                // drop it so the picker does not flag a stale row.
+                _downloadFailed.update { failed -> failed intersect selection.families }
+                cache.evictExcept(selection.families, alsoProtect = _downloading.value)
                 ResolvedFonts(
                     latin = resolveSlot(selection.latinFamily),
                     cjk = resolveSlot(selection.cjkFamily),
                 )
             }.stateIn(scope, SharingStarted.Eagerly, ResolvedFonts.System)
-
-    private val _downloading = MutableStateFlow<Set<String>>(emptySet())
-
-    /** Families with an in-flight download, so the picker can show progress. */
-    val downloading: StateFlow<Set<String>> = _downloading.asStateFlow()
 
     private val _catalog = MutableStateFlow<CatalogState>(CatalogState.Idle)
     val catalog: StateFlow<CatalogState> = _catalog.asStateFlow()
@@ -95,7 +156,11 @@ internal class FontRepository private constructor(
         slot: FontSlot,
         family: String?,
     ) {
-        scope.launch { preferences.setFamily(slot, family) }
+        scope.launch {
+            val unchanged = selection.value.familyFor(slot) == family
+            preferences.setFamily(slot, family)
+            if (unchanged) retryTrigger.emit(Unit)
+        }
     }
 
     fun resetToDefaults() {
@@ -104,8 +169,13 @@ internal class FontRepository private constructor(
 
     /** Load the catalog once (disk first for offline use, then refresh). */
     fun ensureCatalog() {
-        if (_catalog.value is CatalogState.Loaded || _catalog.value is CatalogState.Loading) return
-        _catalog.value = CatalogState.Loading
+        // CAS from the two launchable states (Idle on first call, Error on
+        // retry) so concurrent callers cannot both pass a check-then-set gap
+        // and double-launch the fetch.
+        val claimed =
+            _catalog.compareAndSet(CatalogState.Idle, CatalogState.Loading) ||
+                _catalog.compareAndSet(CatalogState.Error, CatalogState.Loading)
+        if (!claimed) return
         scope.launch {
             readCatalogDisk()?.let { _catalog.value = CatalogState.Loaded(it) }
             val fresh = api.catalog()
@@ -124,10 +194,20 @@ internal class FontRepository private constructor(
 
     private suspend fun resolveSlot(family: String?): CachedFont? {
         if (family == null) return null
-        cache.cached(family)?.let { return it }
+        cache.cached(family)?.let { font ->
+            _downloadFailed.update { it - family }
+            return font
+        }
         _downloading.update { it + family }
         return try {
-            cache.ensure(family)
+            cache.ensure(family).also { font ->
+                if (font == null) {
+                    Log.w(TAG, "resolve failed for $family; falling back to the system font")
+                    _downloadFailed.update { it + family }
+                } else {
+                    _downloadFailed.update { it - family }
+                }
+            }
         } finally {
             _downloading.update { it - family }
         }
@@ -161,12 +241,39 @@ internal class FontRepository private constructor(
             val api = GoogleFontsApi(client)
             val cacheRoot = File(app.filesDir, "google_fonts")
             return FontRepository(
-                api = api,
-                cache = FontCache(cacheRoot, api),
-                preferences = FontPreferences(app),
+                api = FontCatalogSource(api::catalog),
+                cache = FontCache(cacheRoot, api).asFaceStore(),
+                preferences = FontPreferences(app).asSelectionStore(),
                 catalogFile = File(app.filesDir, "google_fonts_catalog.json"),
                 scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
             )
         }
     }
 }
+
+// Adapters narrowing the concrete collaborators to the seams above. They live
+// here (not on the concrete classes) so the data layer's public surface stays
+// unchanged while the repository remains constructible from fakes in JVM tests.
+private fun FontCache.asFaceStore(): FontFaceStore =
+    object : FontFaceStore {
+        override fun cached(family: String): CachedFont? = this@asFaceStore.cached(family)
+
+        override suspend fun ensure(family: String): CachedFont? = this@asFaceStore.ensure(family)
+
+        override fun evictExcept(
+            keep: Collection<String>,
+            alsoProtect: Collection<String>,
+        ) = this@asFaceStore.evictExcept(keep, alsoProtect)
+    }
+
+private fun FontPreferences.asSelectionStore(): FontSelectionStore =
+    object : FontSelectionStore {
+        override val selection: Flow<FontSelection> = this@asSelectionStore.selection
+
+        override suspend fun setFamily(
+            slot: FontSlot,
+            family: String?,
+        ) = this@asSelectionStore.setFamily(slot, family)
+
+        override suspend fun resetToDefaults() = this@asSelectionStore.resetToDefaults()
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/data/GoogleFontsApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/GoogleFontsApi.kt
@@ -98,7 +98,15 @@ internal class GoogleFontsApi(
                     // never leaves a truncated TTF that Typeface loading would reject.
                     val tmp = File(target.parentFile, target.name + ".part")
                     tmp.outputStream().use { out -> body.byteStream().use { it.copyTo(out) } }
-                    tmp.renameTo(target)
+                    // A silently ignored rename failure would report success while the
+                    // target never appears, sending the caller into an endless
+                    // re-download loop with no log trail.
+                    tmp.renameTo(target).also { renamed ->
+                        if (!renamed) {
+                            Log.w(TAG, "rename to ${target.name} failed for $url")
+                            tmp.delete()
+                        }
+                    }
                 }
             }.onFailure { Log.w(TAG, "download failed for $url", it) }
                 .getOrDefault(false)

--- a/app/src/main/java/io/github/seijikohara/femto/data/LocationRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/LocationRepository.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.location.Location
 import android.location.LocationManager
 import android.os.Looper
+import android.util.Log
 import androidx.core.content.getSystemService
 import androidx.core.location.LocationListenerCompat
 import androidx.core.location.LocationManagerCompat
@@ -19,6 +20,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.shareIn
+
+private const val TAG = "LocationRepository"
 
 internal class LocationRepository(
     private val context: Context,
@@ -54,6 +57,7 @@ internal class LocationRepository(
                 runCatching {
                     locationManager.getLastKnownLocation(provider)
                 }.onSuccess { trySend(it) }
+                    .onFailure { logProviderFailure("getLastKnownLocation", provider, it) }
 
                 runCatching {
                     LocationManagerCompat.requestLocationUpdates(
@@ -63,7 +67,7 @@ internal class LocationRepository(
                         listener,
                         Looper.getMainLooper(),
                     )
-                }
+                }.onFailure { logProviderFailure("register", provider, it) }
             }
 
             awaitClose { locationManager.removeUpdates(listener) }
@@ -82,6 +86,17 @@ internal class LocationRepository(
     // The repository factory already builds one LocationRepository and passes the single flow
     // instance to all consumers, so returning the shared flow makes that sharing real.
     fun locationFlow(): Flow<Location?> = shared
+
+    private fun logProviderFailure(
+        stage: String,
+        provider: String,
+        error: Throwable,
+    ) = when (error) {
+        // A coarse-only grant makes GPS_PROVIDER throw SecurityException by design.
+        is SecurityException -> Log.d(TAG, "$stage $provider denied", error)
+
+        else -> Log.w(TAG, "$stage $provider failed", error)
+    }
 
     private companion object {
         const val LOCATION_INTERVAL_MS = 1_000L

--- a/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/MusicSessionRepository.kt
@@ -10,6 +10,7 @@ import android.media.session.PlaybackState
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
+import android.util.Log
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.app.NotificationManagerCompat
@@ -24,6 +25,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 
+private const val TAG = "MusicSessionRepo"
+
 internal class MusicSessionRepository(
     private val context: Context,
 ) {
@@ -32,25 +35,16 @@ internal class MusicSessionRepository(
 
     // Source-app icons keyed by package. Resolved once per package: the icon is
     // stable for the process lifetime, while the session flow re-emits on every
-    // playback tick. Touched only from the single sequential icon-resolution map
-    // (see stateFlow); coroutine dispatch provides the happens-before, so a plain
-    // map is safe even though the resolution runs on the Default pool.
+    // playback tick. The icon-resolution map runs on the Default pool, where a
+    // collector restart can land on a different thread mid-resolution, so all
+    // access is synchronized (see sourceIconOf). A plain map under a monitor is
+    // used instead of ConcurrentHashMap because a failed resolution stores null
+    // and ConcurrentHashMap forbids null values.
     private val sourceIconCache = mutableMapOf<String, ImageBitmap?>()
 
     fun stateFlow(): Flow<MusicCardState> =
         combine(permissionFlow(), activeControllersFlow()) { hasPermission, controllers ->
-            when {
-                !hasPermission -> {
-                    MusicCardState.NeedsPermission
-                }
-
-                else -> {
-                    controllers
-                        .toNowPlaying()
-                        ?.let(MusicCardState::Playing)
-                        ?: MusicCardState.NoActiveSession
-                }
-            }
+            musicCardStateOf(hasPermission) { controllers.toNowPlaying() }
         }.flowOn(Dispatchers.Main.immediate)
             // Resolve the source-app icon off Main: the PackageManager icon decode
             // is too heavy for the frame thread. The session logic stays on Main
@@ -70,7 +64,8 @@ internal class MusicSessionRepository(
         val controller =
             runCatching {
                 selectPrimaryController(sessionManager.getActiveSessions(componentName))
-            }.getOrNull() ?: return
+            }.onFailure { Log.w(TAG, "dropping $command: active-session query failed", it) }
+                .getOrNull() ?: return
         val transport = controller.transportControls
         when (command) {
             MusicCommand.PlayPause -> {
@@ -158,7 +153,12 @@ internal class MusicSessionRepository(
                 rewatch(sessionManager.getActiveSessions(componentName))
                 trySend(current)
                 sessionManager.addOnActiveSessionsChangedListener(sessionsListener, componentName)
-            }.onFailure { trySend(emptyList()) }
+            }.onFailure {
+                // Typically a SecurityException before the notification-listener
+                // grant; surface it so a silent "no music" card is diagnosable.
+                Log.w(TAG, "active-session enumeration failed; emitting empty list", it)
+                trySend(emptyList())
+            }
 
             awaitClose {
                 runCatching { watched?.unregisterCallback(watcher) }
@@ -175,29 +175,14 @@ internal class MusicSessionRepository(
                 // A granted session can briefly expose no metadata (just connected,
                 // or a metadata-less stream). Degrade to NoActiveSession upstream
                 // rather than render a blank, broken-looking card.
-                val metadata = controller.metadata ?: return@let null
-                val playbackState = controller.playbackState
-                NowPlaying(
-                    // METADATA_KEY_TITLE is empty for many podcast / radio / stream
-                    // sessions; fall back to the display title and finally the source
-                    // label so the 23sp title line is never blank.
-                    title =
-                        metadata.getString(MediaMetadata.METADATA_KEY_TITLE)?.takeIf { it.isNotBlank() }
-                            ?: metadata.getString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE)?.takeIf { it.isNotBlank() }
-                            ?: sourceLabel(controller.packageName),
-                    artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST),
-                    album = metadata.getString(MediaMetadata.METADATA_KEY_ALBUM),
-                    albumArt = metadata.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)?.asImageBitmap(),
-                    // sourceIcon is resolved downstream off Main (see stateFlow).
-                    // A paused controller renders with isPlaying=false (Play icon,
-                    // resumable), but stays on screen via selectPrimaryController.
-                    isPlaying = playbackState?.state == PlaybackState.STATE_PLAYING,
-                    positionMs = playbackState?.position ?: 0L,
-                    durationMs = metadata.getLong(MediaMetadata.METADATA_KEY_DURATION),
-                    packageName = controller.packageName,
-                    playbackSpeed = playbackState?.playbackSpeed ?: 1f,
-                    positionUpdateTimeMs = playbackState?.lastPositionUpdateTime ?: 0L,
-                )
+                controller.metadata?.let { metadata ->
+                    nowPlayingOf(
+                        metadata = metadata,
+                        playbackState = controller.playbackState,
+                        packageName = controller.packageName,
+                        fallbackTitle = { sourceLabel(controller.packageName) },
+                    )
+                }
             }
 
     // Attach the source-app icon to a Playing state, leaving the other variants
@@ -216,13 +201,18 @@ internal class MusicSessionRepository(
      * restricted), in which case the card shows a generic launch glyph.
      */
     private fun sourceIconOf(packageName: String): ImageBitmap? =
-        sourceIconCache.getOrPut(packageName) {
-            runCatching {
-                context.packageManager
-                    .getApplicationIcon(packageName)
-                    .toBitmap(width = SOURCE_ICON_PIXELS, height = SOURCE_ICON_PIXELS)
-                    .asImageBitmap()
-            }.getOrNull()
+        // The monitor spans the decode so two concurrent first lookups of the
+        // same package resolve once; the decode is small (96 px) and runs at
+        // most once per package, so the hold time is negligible.
+        synchronized(sourceIconCache) {
+            sourceIconCache.getOrPut(packageName) {
+                runCatching {
+                    context.packageManager
+                        .getApplicationIcon(packageName)
+                        .toBitmap(width = SOURCE_ICON_PIXELS, height = SOURCE_ICON_PIXELS)
+                        .asImageBitmap()
+                }.getOrNull()
+            }
         }
 
     private companion object {
@@ -233,19 +223,79 @@ internal class MusicSessionRepository(
         const val SOURCE_ICON_PIXELS = 96
 
         /**
-         * Return `true` when the state is PLAYING or PAUSED. A paused session is
-         * still resumable and must stay on the card, so the plain [isActive] check
-         * (which excludes STATE_PAUSED) is not enough here.
-         */
-        private fun PlaybackState?.isPlayingOrPaused(): Boolean =
-            this != null && (isActive() || state == PlaybackState.STATE_PAUSED)
-
-        /**
          * Pick the highest-priority controller that is playing or paused.
          * [MediaSessionManager.getActiveSessions] is priority-ordered, so the
          * first match is the session the user is most likely interacting with.
          */
         private fun selectPrimaryController(controllers: List<MediaController>): MediaController? =
-            controllers.firstOrNull { it.playbackState.isPlayingOrPaused() }
+            selectPrimarySession(controllers) { it.playbackState }
     }
 }
+
+/**
+ * Return `true` when the state is PLAYING or PAUSED. A paused session is
+ * still resumable and must stay on the card, so the plain [PlaybackState.isActive]
+ * check (which excludes STATE_PAUSED) is not enough here.
+ */
+internal fun PlaybackState?.isPlayingOrPaused(): Boolean =
+    this != null && (isActive() || state == PlaybackState.STATE_PAUSED)
+
+/**
+ * Pick the first session whose playback state is playing or paused; the caller
+ * passes sessions in priority order. Generic over the session type so the
+ * selection policy is unit-testable with plain value holders instead of
+ * [MediaController] instances, which cannot be constructed in JVM tests.
+ */
+internal fun <T> selectPrimarySession(
+    sessions: List<T>,
+    playbackStateOf: (T) -> PlaybackState?,
+): T? = sessions.firstOrNull { playbackStateOf(it).isPlayingOrPaused() }
+
+/**
+ * Collapse the permission gate and the resolved session into the card state.
+ * [nowPlaying] is a lambda so session inspection is skipped while the
+ * notification-listener permission is missing.
+ */
+internal fun musicCardStateOf(
+    hasPermission: Boolean,
+    nowPlaying: () -> NowPlaying?,
+): MusicCardState =
+    if (hasPermission) {
+        nowPlaying()?.let(MusicCardState::Playing) ?: MusicCardState.NoActiveSession
+    } else {
+        MusicCardState.NeedsPermission
+    }
+
+/**
+ * Map one session's extracted fields to the card's [NowPlaying]. Operates on
+ * plain values so the fallback branches are unit-testable without a
+ * [MediaController]; [fallbackTitle] is a lambda so the source-label lookup
+ * runs only when both metadata titles are blank.
+ */
+internal fun nowPlayingOf(
+    metadata: MediaMetadata,
+    playbackState: PlaybackState?,
+    packageName: String,
+    fallbackTitle: () -> String,
+): NowPlaying =
+    NowPlaying(
+        // METADATA_KEY_TITLE is empty for many podcast / radio / stream
+        // sessions; fall back to the display title and finally the source
+        // label so the 23sp title line is never blank.
+        title =
+            metadata.getString(MediaMetadata.METADATA_KEY_TITLE)?.takeIf { it.isNotBlank() }
+                ?: metadata.getString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE)?.takeIf { it.isNotBlank() }
+                ?: fallbackTitle(),
+        artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST),
+        album = metadata.getString(MediaMetadata.METADATA_KEY_ALBUM),
+        albumArt = metadata.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART)?.asImageBitmap(),
+        // sourceIcon is resolved downstream off Main (see stateFlow).
+        // A paused controller renders with isPlaying=false (Play icon,
+        // resumable), but stays on screen via selectPrimaryController.
+        isPlaying = playbackState?.state == PlaybackState.STATE_PLAYING,
+        positionMs = playbackState?.position ?: 0L,
+        durationMs = metadata.getLong(MediaMetadata.METADATA_KEY_DURATION),
+        packageName = packageName,
+        playbackSpeed = playbackState?.playbackSpeed ?: 1f,
+        positionUpdateTimeMs = playbackState?.lastPositionUpdateTime ?: 0L,
+    )

--- a/app/src/main/java/io/github/seijikohara/femto/data/NominatimApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/NominatimApi.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import java.util.Locale
 
 private const val TAG = "NominatimApi"
 
@@ -24,7 +25,9 @@ internal class NominatimApi(
     private val client: OkHttpClient,
     private val baseUrl: String = "https://nominatim.openstreetmap.org/",
     private val userAgent: String,
-    private val language: String = "ja",
+    // Follow the device locale by default: the launcher is multi-region and no
+    // single language may be privileged (CLAUDE.md, "multi-region distribution").
+    private val language: String = Locale.getDefault().language,
     // Token for a keyed Nominatim-compatible host (e.g. LocationIQ). Null for the
     // public keyless Nominatim service; when set it is appended as `key`.
     private val apiKey: String? = null,
@@ -57,7 +60,12 @@ internal class NominatimApi(
                         .header("User-Agent", userAgent)
                         .build()
                 client.newCall(request).execute().use { response ->
-                    if (!response.isSuccessful) return@use null
+                    if (!response.isSuccessful) {
+                        // 429 in particular signals a Nominatim usage-policy
+                        // violation and must leave a trail, not a silent null.
+                        Log.w(TAG, "reverse geocode HTTP ${response.code}")
+                        return@use null
+                    }
                     response.body?.string()?.let { body ->
                         json.decodeFromString<NominatimResponse>(body)
                     }

--- a/app/src/main/java/io/github/seijikohara/femto/data/ReverseGeocoderRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/ReverseGeocoderRepository.kt
@@ -1,6 +1,7 @@
 package io.github.seijikohara.femto.data
 
 import android.location.Location
+import android.util.Log
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -8,7 +9,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.roundToLong
+
+private const val TAG = "ReverseGeocoder"
 
 /**
  * Reverse-geocode the current location through OSM Nominatim and expose a
@@ -43,32 +49,47 @@ internal class ReverseGeocoderRepository(
     private var lastResult: ShortAddress? = null
     private var lastRequestAtMs = 0L
 
+    // Serialises resolve: the flow runs on the IO pool where overlapping
+    // collections are possible, and the throttle's read-then-update pair must
+    // be atomic or two callers can both pass the spacing check and violate
+    // Nominatim's 1 request/second policy. The lock also covers the LRU map,
+    // which is not safe under concurrent mutation.
+    private val mutex = Mutex()
+
     fun addressFlow(): Flow<ShortAddress?> =
         locationFlow
             .distinctUntilChangedByBucket()
             .map { location -> location?.let { resolve(it) } }
             .flowOn(ioDispatcher)
 
-    private suspend fun resolve(location: Location): ShortAddress? {
-        val key = bucketKey(location.latitude, location.longitude)
-        cachedAddress(key)?.let { return it }
+    private suspend fun resolve(location: Location): ShortAddress? =
+        mutex.withLock {
+            val key = bucketKey(location.latitude, location.longitude)
+            cachedAddress(key)?.let { return it }
 
-        // Nominatim's usage policy caps callers at 1 request per second; the
-        // 100 m bucket already collapses most calls, and this spacing guards
-        // the remaining boundary crossings.
-        throttle()
+            // Nominatim's usage policy caps callers at 1 request per second; the
+            // 100 m bucket already collapses most calls, and this spacing guards
+            // the remaining boundary crossings. Holding the lock across the delay
+            // and the request keeps the spacing global, not per-caller.
+            throttle()
 
-        return runCatching {
-            api.reverse(location.latitude, location.longitude)?.address?.let {
-                AddressComposer.composeAddress(it)
-            }
-        }.getOrNull()
-            ?.also {
-                cache[key] = CacheEntry(it, nowMs())
-                lastResult = it
-            }
-            ?: lastResult
-    }
+            runCatching {
+                api.reverse(location.latitude, location.longitude)?.address?.let {
+                    AddressComposer.composeAddress(it)
+                }
+            }.onFailure {
+                // runCatching also traps cancellation; rethrow so a cancelled
+                // collector propagates instead of being misread as a lookup
+                // failure that falls back to lastResult.
+                if (it is CancellationException) throw it
+                Log.w(TAG, "reverse geocode resolve failed", it)
+            }.getOrNull()
+                ?.also {
+                    cache[key] = CacheEntry(it, nowMs())
+                    lastResult = it
+                }
+                ?: lastResult
+        }
 
     // Return the cached address only while it is within the TTL window. A
     // stale entry is dropped so the next visit re-queries and can recover from

--- a/app/src/main/java/io/github/seijikohara/femto/data/VoiceRecognizer.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/VoiceRecognizer.kt
@@ -6,10 +6,13 @@ import android.os.Bundle
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
+import android.util.Log
 import io.github.seijikohara.femto.R
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+
+private const val TAG = "VoiceRecognizer"
 
 /**
  * One step of the in-launcher voice flow. [Unavailable] means the device has no
@@ -106,6 +109,9 @@ internal class VoiceRecognizer(
             }
 
             override fun onError(error: Int) {
+                // messageFor collapses codes into three strings; keep the raw
+                // platform code for diagnosis.
+                Log.w(TAG, "speech recognition error=$error")
                 _state.value = VoiceState.Failed(messageRes = messageFor(error))
             }
 
@@ -123,10 +129,10 @@ internal class VoiceRecognizer(
             ) = Unit
         }
 
-    private fun firstText(bundle: Bundle?): String? =
+    internal fun firstText(bundle: Bundle?): String? =
         bundle?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()
 
-    private fun messageFor(error: Int): Int =
+    internal fun messageFor(error: Int): Int =
         when (error) {
             SpeechRecognizer.ERROR_NO_MATCH,
             SpeechRecognizer.ERROR_SPEECH_TIMEOUT,

--- a/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -23,6 +25,10 @@ internal class WeatherRepository(
     private val clockFlow: Flow<ClockTick>,
     private val clock: Clock = Clock.systemUTC(),
 ) {
+    // Serialises refresh: merge() lets the location and clock upstreams reach
+    // refresh concurrently on the IO pool, and an unguarded check-fetch-write
+    // sequence could double-fetch or bypass the outage throttle.
+    private val mutex = Mutex()
     private var cached: WeatherSnapshot? = null
     private var lastFetchLocation: Location? = null
 
@@ -47,6 +53,12 @@ internal class WeatherRepository(
 
     private suspend fun refresh(location: Location?): WeatherSnapshot? {
         location ?: return null
+        return mutex.withLock { refreshLocked(location) }
+    }
+
+    // Runs under [mutex]: the throttle read, network call, and cache write must
+    // be one atomic step or two near-simultaneous ticks both pass shouldRefetch.
+    private suspend fun refreshLocked(location: Location): WeatherSnapshot? {
         if (!shouldRefetch(location)) return cached
         // Record the attempt before the network call so a failing call still throttles
         // subsequent outage retries via MIN_RETRY_INTERVAL.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
@@ -1,6 +1,7 @@
 package io.github.seijikohara.femto.ui.drawer
 
 import android.content.ComponentName
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -24,6 +25,9 @@ import io.github.seijikohara.femto.data.DrawerLayout
 import io.github.seijikohara.femto.data.DrawerPreferences
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
+
+private const val TAG = "AppDrawerSheet"
 
 /**
  * App drawer presented as a Material 3 [ModalBottomSheet] over the dashboard.
@@ -60,7 +64,14 @@ internal fun AppDrawerSheet(
         uiState = AppDrawerUiState.Loading
         runCatching { AppsRepository(context).queryApps() }
             .onSuccess { apps -> uiState = AppDrawerUiState.Content(apps) }
-            .onFailure { uiState = AppDrawerUiState.Error }
+            .onFailure {
+                // runCatching also traps the cancellation thrown when the sheet
+                // is dismissed or retryKey restarts the effect; rethrow so
+                // cancellation never renders as the Error state.
+                if (it is CancellationException) throw it
+                Log.e(TAG, "app query failed", it)
+                uiState = AppDrawerUiState.Error
+            }
     }
 
     // Drawer layout + pinned apps are persisted; collect them and write changes back.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerScreen.kt
@@ -48,8 +48,8 @@ private const val STATUS_KEY = "__status__"
  * Google Fonts picker for one slot. A search field filters the full catalog
  * (CJK-capable families only for the fallback slot); the leading "system
  * default" entry needs no download. Selecting a family downloads it in the
- * background — the row shows a spinner until the cache is ready and a check
- * once it backs the live theme.
+ * background — the row shows a spinner until the cache is ready, a check once
+ * it backs the live theme, and a retry hint when the download failed.
  */
 @Composable
 internal fun FontPickerScreen(
@@ -96,6 +96,7 @@ internal fun FontPickerScreen(
                     family = family,
                     selected = family.family == uiState.selectedFamily,
                     downloading = family.family in uiState.downloading,
+                    failed = family.family in uiState.downloadFailed,
                     onClick = { onAction(FontPickerAction.Choose(family.family)) },
                 )
             }
@@ -190,6 +191,7 @@ private fun SystemRow(
     subtitle = stringResource(R.string.font_picker_system_desc),
     selected = selected,
     downloading = false,
+    failed = false,
     onClick = onClick,
     modifier = modifier,
 )
@@ -199,6 +201,7 @@ private fun FontRow(
     family: GoogleFontFamily,
     selected: Boolean,
     downloading: Boolean,
+    failed: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) = PickerRow(
@@ -211,19 +214,22 @@ private fun FontRow(
         },
     selected = selected,
     downloading = downloading,
+    failed = failed,
     onClick = onClick,
     modifier = modifier,
 )
 
 // Shared row: a >= MinTouchTarget tap target with the family name, a category /
 // CJK subtitle, and a trailing slot that shows the download spinner then the
-// selected check.
+// selected check. A failed download replaces the subtitle with a retry hint:
+// tapping re-chooses the family, which routes through the repository's retry.
 @Composable
 private fun PickerRow(
     title: String,
     subtitle: String,
     selected: Boolean,
     downloading: Boolean,
+    failed: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Row(
@@ -249,9 +255,14 @@ private fun PickerRow(
             overflow = TextOverflow.Ellipsis,
         )
         Text(
-            text = subtitle,
+            text = if (failed) stringResource(R.string.font_download_failed) else subtitle,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color =
+                if (failed) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
@@ -265,7 +276,10 @@ private fun PickerRow(
             )
         }
 
-        selected -> {
+        // A failed family may still be the persisted selection, but its face is
+        // not live — suppress the check so the row does not claim a font the
+        // theme is not rendering.
+        selected && !failed -> {
             Icon(
                 imageVector = Lucide.Check,
                 contentDescription = stringResource(R.string.font_picker_selected),
@@ -343,6 +357,7 @@ private fun FontPickerScreenPreview() {
                             GoogleFontFamily("Noto Sans JP", "Sans Serif", listOf("latin", "japanese")),
                         ),
                     downloading = setOf("Roboto"),
+                    downloadFailed = setOf("Noto Sans JP"),
                     status = PickerStatus.READY,
                 ),
             onAction = {},

--- a/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerUiState.kt
@@ -21,6 +21,7 @@ internal data class FontPickerUiState(
     val selectedFamily: String? = null,
     val families: List<GoogleFontFamily> = emptyList(),
     val downloading: Set<String> = emptySet(),
+    val downloadFailed: Set<String> = emptySet(),
     val status: PickerStatus = PickerStatus.LOADING,
 )
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerViewModel.kt
@@ -19,13 +19,13 @@ import kotlinx.coroutines.flow.stateIn
  * Binds the shared [FontRepository] to one [slot]'s picker: triggers the catalog
  * load, filters it to the slot and the live search query, and forwards the
  * choice back to the repository (which downloads, swaps the theme, and evicts
- * the old font).
+ * the old font). Re-choosing a failed family routes through the same path and
+ * retries its download.
  */
 internal class FontPickerViewModel(
-    application: Application,
+    private val repository: FontRepository,
     private val slot: FontSlot,
 ) : ViewModel() {
-    private val repository = FontRepository.get(application)
     private val query = MutableStateFlow("")
 
     val uiState: StateFlow<FontPickerUiState> =
@@ -33,8 +33,9 @@ internal class FontPickerViewModel(
             repository.catalog,
             repository.selection,
             repository.downloading,
+            repository.downloadFailed,
             query,
-        ) { catalog, selection, downloading, currentQuery ->
+        ) { catalog, selection, downloading, downloadFailed, currentQuery ->
             val (families, status) = filterCatalog(catalog, currentQuery)
             FontPickerUiState(
                 slot = slot,
@@ -42,6 +43,7 @@ internal class FontPickerViewModel(
                 selectedFamily = selection.familyFor(slot),
                 families = families,
                 downloading = downloading,
+                downloadFailed = downloadFailed,
                 status = status,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FontPickerUiState(slot))
@@ -90,6 +92,6 @@ internal class FontPickerViewModelFactory(
         extras: CreationExtras,
     ): T {
         @Suppress("UNCHECKED_CAST")
-        return FontPickerViewModel(application, slot) as T
+        return FontPickerViewModel(FontRepository.get(application), slot) as T
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeUiState.kt
@@ -12,6 +12,10 @@ import io.github.seijikohara.femto.data.WeatherSnapshot
 import java.time.LocalDate
 import java.time.LocalTime
 
+// @Immutable despite android.location.Location being a mutable Java type:
+// LocationRepository emits each Location instance once and never mutates it
+// afterwards, so the immutability promise holds and Compose can skip
+// recomposition on reference equality.
 @Immutable
 internal data class HomeUiState(
     val clock: ClockTick,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.ComponentName
 import android.content.Intent
 import android.location.Location
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -28,16 +29,20 @@ import io.github.seijikohara.femto.data.TripState
 import io.github.seijikohara.femto.data.WeatherRepository
 import io.github.seijikohara.femto.data.WeatherSnapshot
 import io.github.seijikohara.femto.ui.home.components.MusicCommand
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import okhttp3.OkHttpClient
 import java.util.Locale
+
+private const val TAG = "HomeViewModel"
 
 internal class HomeViewModel(
     private val clockFlow: Flow<ClockTick>,
@@ -56,13 +61,18 @@ internal class HomeViewModel(
     // sources through a typed intermediate (CoreSignals) so the compiler enforces
     // arity and per-slot types end-to-end: a future reorder fails to compile
     // instead of silently mismapping a positional values[i] cast.
+    //
+    // Each source is caught individually: an uncaught exception in any one flow
+    // (e.g. a SecurityException when a permission is revoked between check and
+    // register) would otherwise cancel the shared combine and crash the HOME
+    // process. Catching per source degrades only that card to its initial value.
     private val coreSignals: Flow<CoreSignals> =
         combine(
-            clockFlow,
-            locationFlow,
-            addressFlow,
-            weatherFlow,
-            musicStateFlow,
+            clockFlow.catchAsDefault("clock", HomeUiState.Initial.clock),
+            locationFlow.catchAsDefault("location", HomeUiState.Initial.location),
+            addressFlow.catchAsDefault("address", HomeUiState.Initial.address),
+            weatherFlow.catchAsDefault("weather", HomeUiState.Initial.weather),
+            musicStateFlow.catchAsDefault("music", HomeUiState.Initial.musicState),
         ) { clock, location, address, weather, music ->
             CoreSignals(clock, location, address, weather, music)
         }
@@ -70,9 +80,9 @@ internal class HomeViewModel(
     val uiState: StateFlow<HomeUiState> =
         combine(
             coreSignals,
-            calendarFlow,
-            systemStatusFlow,
-            tripStateFlow,
+            calendarFlow.catchAsDefault("calendar", HomeUiState.Initial.calendar),
+            systemStatusFlow.catchAsDefault("system status", HomeUiState.Initial.systemStatus),
+            tripStateFlow.catchAsDefault("trip state", HomeUiState.Initial.tripState),
         ) { core, calendar, systemStatus, tripState ->
             HomeUiState(
                 clock = core.clock,
@@ -151,6 +161,19 @@ internal class HomeViewModel(
         }
     }
 }
+
+// Replace a source failure with that source's neutral value so one broken
+// repository degrades its own card instead of killing the launcher process.
+// Cancellation is rethrown to keep structured concurrency intact.
+private fun <T> Flow<T>.catchAsDefault(
+    source: String,
+    default: T,
+): Flow<T> =
+    catch { e ->
+        if (e is CancellationException) throw e
+        Log.e(TAG, "$source flow failed", e)
+        emit(default)
+    }
 
 // File-private holder that groups the first five sources so the two-stage
 // combine stays within Kotlin's typed (max-arity-5) combine overloads.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -164,7 +164,10 @@ internal class HomeViewModel(
 
 // Replace a source failure with that source's neutral value so one broken
 // repository degrades its own card instead of killing the launcher process.
-// Cancellation is rethrown to keep structured concurrency intact.
+// Cancellation is rethrown to keep structured concurrency intact. By design the
+// failed source then COMPLETES: its card stays at the neutral value until the
+// process restarts. No automatic retry — a broken system service would turn a
+// retry loop into a battery drain on the head unit.
 private fun <T> Flow<T>.catchAsDefault(
     source: String,
     default: T,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -73,7 +73,11 @@ internal fun CalendarCard(
 
         // A non-null snapshot with access denied carries no real data, so show the
         // denial message instead of a hollow agenda.
-        !snapshot.hasCalendarAccess -> PermissionDenied()
+        !snapshot.hasCalendarAccess -> CenteredHint(stringResource(R.string.calendar_permission_denied))
+
+        // Access is granted but the provider query faulted: the empty agenda is
+        // a read failure, not a free month, so say so rather than fake it.
+        snapshot.queryFailed -> CenteredHint(stringResource(R.string.calendar_query_failed))
 
         else -> CalendarContent(snapshot, is24Hour)
     }
@@ -260,15 +264,17 @@ private fun EventRow(
     )
 }
 
+// Shared centred hint for the no-data states (permission denied / provider
+// fault): one muted line in place of the agenda.
 @Composable
-private fun PermissionDenied() =
+private fun CenteredHint(text: String) =
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
-            text = stringResource(R.string.calendar_permission_denied),
+            text = text,
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -7,6 +7,7 @@ import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.PixelFormat
 import android.location.Location
+import android.util.Log
 import android.view.SurfaceView
 import android.view.View
 import android.view.ViewGroup
@@ -299,7 +300,10 @@ private suspend fun MapSnapshotter.render(camera: CameraPosition): Bitmap? =
         setCameraPosition(camera)
         start(
             { snapshot -> if (cont.isActive) cont.resume(snapshot.bitmap) },
-            { _ -> if (cont.isActive) cont.resume(null) },
+            { error ->
+                Log.w(TAG, "snapshot render failed: $error")
+                if (cont.isActive) cont.resume(null)
+            },
         )
         cont.invokeOnCancellation { cancel() }
     }
@@ -549,6 +553,8 @@ internal const val MAP_ZOOM = 16.5
 // produced when the fix actually moves (shouldRerender), so this just bounds the
 // re-check cadence, not the render rate.
 private const val SNAPSHOT_POLL_INTERVAL_MS = 200L
+
+private const val TAG = "MapPanel"
 
 // Re-render once a fix moves at least this far; below it the last frame is held.
 // Kept small so the map follows movement in smaller steps (smoother panning); the

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -376,7 +376,7 @@ private fun Progress(
         Text(
             text = formatMillis(livePosition),
             style =
-                MaterialTheme.typography.labelSmall.copy(
+                MaterialTheme.typography.labelMedium.copy(
                     fontSize = 11.sp,
                     fontWeight = FontWeight.Medium,
                     fontFeatureSettings = TabularFigures,
@@ -404,7 +404,7 @@ private fun Progress(
         Text(
             text = formatMillis(durationMs),
             style =
-                MaterialTheme.typography.labelSmall.copy(
+                MaterialTheme.typography.labelMedium.copy(
                     fontSize = 11.sp,
                     fontWeight = FontWeight.Medium,
                     fontFeatureSettings = TabularFigures,
@@ -561,7 +561,7 @@ private fun EmptyState() =
         Text(
             text = stringResource(R.string.music_nothing_hint),
             style =
-                MaterialTheme.typography.bodySmall.copy(
+                MaterialTheme.typography.bodyMedium.copy(
                     fontSize = 13.sp,
                     lineHeight = 18.sp,
                 ),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -23,9 +23,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -106,17 +103,24 @@ internal fun SpeedOverlay(
     //
     // The EMA accumulator is keyed off the latest fix so a new sample
     // advances the average and a null fix (no location) resets it; the
-    // first non-null sample seeds the accumulator with itself.
-    val smoothedSpeedMs = remember { mutableStateOf<Float?>(null) }
-    smoothedSpeedMs.value =
-        location?.let { emaStep(smoothedSpeedMs.value, tripState.currentSpeedMs.toFloat(), SPEED_OVERLAY_EMA_ALPHA) }
-    val currentSpeedText by remember(speedUnit) {
-        derivedStateOf {
-            smoothedSpeedMs.value
-                ?.let { "${speedUnit.fromMetersPerSecond(it).roundToInt()}" }
-                ?: NO_SPEED_PLACEHOLDER
+    // first non-null sample seeds the accumulator with itself. The
+    // accumulator lives in a remembered plain holder (cf. MapPanel's
+    // bearingHolder) rather than MutableState because writing state during
+    // composition would invalidate the composition computing it;
+    // remember(location) advances the average exactly once per fix.
+    val emaAccumulator = remember { arrayOfNulls<Float>(1) }
+    val smoothedSpeedMs =
+        remember(location) {
+            emaAccumulator[0] =
+                location?.let {
+                    emaStep(emaAccumulator[0], tripState.currentSpeedMs.toFloat(), SPEED_OVERLAY_EMA_ALPHA)
+                }
+            emaAccumulator[0]
         }
-    }
+    val currentSpeedText =
+        smoothedSpeedMs
+            ?.let { "${speedUnit.fromMetersPerSecond(it).roundToInt()}" }
+            ?: NO_SPEED_PLACEHOLDER
     val distance = speedUnit.tripDistanceFromMeters(tripState.distanceMeters)
     val avgSpeed = speedUnit.fromMetersPerSecond(tripState.avgSpeedMs.toFloat()).roundToInt()
     val shortAddress = address?.displayString().orEmpty()

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -2,28 +2,52 @@ package io.github.seijikohara.femto.ui.home.components
 
 import android.annotation.SuppressLint
 import android.location.Location
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.util.Log
+import android.view.ViewGroup
+import android.webkit.JavascriptInterface
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
+import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewClientCompat
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.MapPinOff
+import io.github.seijikohara.femto.BuildConfig
+import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.MapStyleSetting
 
 /**
@@ -44,6 +68,26 @@ import io.github.seijikohara.femto.data.MapStyleSetting
  * keeps the chosen backend regardless. The WebView renders WebGL on the GPU
  * (hardware-accelerated); a device that cannot keep a WebGL context uses the
  * SNAPSHOT backend instead.
+ *
+ * The page reports into the host over a one-method [JavascriptInterface] bridge
+ * (`window.femtoBridge.onMapEvent(kind, detail)`). Only two kinds exist: `error`
+ * for transient resource failures (tile / style / DEM fetch — logged, never UI,
+ * because the removed auto-downgrade misfired on exactly such ambiguous signals)
+ * and `fatal` for definitive never-going-to-render facts (no WebGL context, map
+ * construction threw). A `fatal` swaps the permanently-blank WebView for a static
+ * notice pointing at the Settings render-mode switch — same posture as
+ * renderer-death containment below: inform, never switch the persisted backend.
+ *
+ * Renderer-death containment is the one exception to "do nothing": without an
+ * [android.webkit.WebViewClient.onRenderProcessGone] override the platform kills
+ * the whole launcher process when the WebView renderer dies (WebGL is a classic
+ * OOM victim on weak head-unit GPUs). Death is a fact reported by the system, not
+ * a heuristic like the removed context-loss / readiness signals, so reacting to
+ * it cannot misfire on a healthy map. The reaction stays inside the LIVE backend:
+ * the first death rebuilds the WebView in place; repeated deaths within
+ * [RENDERER_DEATH_WINDOW_MS] stop the rebuild loop and show a static notice that
+ * points at the Settings render-mode switch. The persisted render mode is never
+ * rewritten.
  *
  * [ON_START][androidx.lifecycle.Lifecycle.Event.ON_START] resumes the WebView and
  * nudges the map to re-measure/repaint; the WebView is paused only on ON_STOP (a
@@ -73,8 +117,46 @@ internal fun WebMapView(
     // window.updateCamera / setStyleUrl / setFeatures and is silently dropped.
     val pageReady = remember { mutableStateOf(false) }
 
+    // Renderer-death containment state (see the KDoc): bumping the generation
+    // rebuilds the WebView after the renderer process dies; once deaths repeat
+    // inside the window the panel gives up and shows a static notice instead of
+    // crash-looping. Views whose renderer died are destroyed in the callback, so
+    // the disposal path and lifecycle observer must skip them.
+    var rendererGeneration by remember { mutableIntStateOf(0) }
+    var rendererGaveUp by remember { mutableStateOf(false) }
+    var lastRendererDeath by remember { mutableStateOf<String?>(null) }
+    val rendererDeathsMs = remember { mutableListOf<Long>() }
+    val crashedViews = remember { mutableSetOf<WebView>() }
+
+    // Set by a `fatal` bridge event (see the KDoc): the page itself determined it
+    // can never render, so a blank "working" map would be a lie. Like the
+    // renderer-death notice, this only informs — the persisted mode is untouched.
+    var liveInitFailed by remember { mutableStateOf(false) }
+    var lastFatalDetail by remember { mutableStateOf<String?>(null) }
+    // Bridge callbacks arrive on a WebView-managed background thread; Compose
+    // state writes must land on the main thread.
+    val mainHandler = remember { Handler(Looper.getMainLooper()) }
+
+    if (rendererGaveUp || liveInitFailed) {
+        Box(modifier = modifier) {
+            LiveMapNotice(
+                titleRes = if (rendererGaveUp) R.string.map_live_renderer_gone else R.string.map_live_init_failed,
+                hintRes =
+                    if (rendererGaveUp) {
+                        R.string.map_live_renderer_gone_hint
+                    } else {
+                        R.string.map_live_init_failed_hint
+                    },
+                // Why it failed is debugging detail, not driver-facing content.
+                reason = (if (rendererGaveUp) lastRendererDeath else lastFatalDetail).takeIf { BuildConfig.DEBUG },
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
+        return
+    }
+
     val webView =
-        remember {
+        remember(rendererGeneration) {
             val assetLoader =
                 WebViewAssetLoader
                     .Builder()
@@ -103,7 +185,73 @@ internal fun WebMapView(
                         ) {
                             pageReady.value = true
                         }
+
+                        // Returning true claims the renderer death; the default kills
+                        // the whole launcher process. The dead view must be detached
+                        // and destroyed here — any other call on it can crash.
+                        override fun onRenderProcessGone(
+                            view: WebView,
+                            detail: RenderProcessGoneDetail,
+                        ): Boolean {
+                            val description =
+                                if (detail.didCrash()) "renderer crashed" else "renderer killed by the system"
+                            Log.e(TAG, "WebView $description; containing")
+                            crashedViews += view
+                            (view.parent as? ViewGroup)?.removeView(view)
+                            view.destroy()
+                            pageReady.value = false
+                            lastRendererDeath = description
+                            val now = SystemClock.elapsedRealtime()
+                            rendererDeathsMs.removeAll { now - it > RENDERER_DEATH_WINDOW_MS }
+                            rendererDeathsMs += now
+                            if (rendererDeathsMs.size >= MAX_RENDERER_DEATHS) {
+                                rendererGaveUp = true
+                            } else {
+                                rendererGeneration++
+                            }
+                            return true
+                        }
                     }
+                // JS -> Kotlin error channel; registered per WebView instance so a
+                // post-crash rebuild (rendererGeneration bump) re-registers it on
+                // the fresh view. Kept minimal on purpose: one method, primitive
+                // params, and the only page that can call it is our bundled asset
+                // served through the WebViewAssetLoader above.
+                addJavascriptInterface(
+                    object {
+                        // Block body: a @JavascriptInterface method must not leak
+                        // a non-primitive return type to the JS side.
+                        @JavascriptInterface
+                        fun onMapEvent(
+                            kind: String,
+                            detail: String,
+                        ) {
+                            when (kind) {
+                                // Transient by definition (tile / style / DEM
+                                // fetch): log only. The removed auto-downgrade
+                                // misfired on exactly such ambiguous signals —
+                                // never UI here.
+                                "error" -> {
+                                    Log.w(TAG, "LIVE map transient error: $detail")
+                                }
+
+                                "fatal" -> {
+                                    Log.e(TAG, "LIVE map fatal: $detail")
+                                    // Bridge calls arrive on a background thread.
+                                    mainHandler.post {
+                                        lastFatalDetail = detail
+                                        liveInitFailed = true
+                                    }
+                                }
+
+                                else -> {
+                                    Log.w(TAG, "Unknown map event '$kind': $detail")
+                                }
+                            }
+                        }
+                    },
+                    "femtoBridge",
+                )
                 loadUrl("https://appassets.androidplatform.net/assets/web/map.html")
             }
         }
@@ -118,9 +266,11 @@ internal fun WebMapView(
     val styleRef = mapStyleRefFor(if (isDark) mapConfig.schemeDark else mapConfig.schemeLight, isDark)
     val accentColors = accentMapColors()
 
-    // Each effect keys on [pageReady] (so it fires once the page is ready), then
-    // pushes the current state to the page.
+    // Each effect keys on [pageReady] (so it fires once the page is ready) and on
+    // [webView] (so a rebuilt WebView gets the state re-pushed), then pushes the
+    // current state to the page.
     LaunchedEffect(
+        webView,
         pageReady.value,
         location.latitude,
         location.longitude,
@@ -138,7 +288,7 @@ internal fun WebMapView(
             null,
         )
     }
-    LaunchedEffect(pageReady.value, styleRef, accentColors) {
+    LaunchedEffect(webView, pageReady.value, styleRef, accentColors) {
         if (!pageReady.value) return@LaunchedEffect
         // Resolve the scheme to a URL the WebView can load (hosted, or the bundled
         // base served over appassets) plus the accent palette (empty = no recolor).
@@ -157,7 +307,7 @@ internal fun WebMapView(
     }
     // LIVE-only feature toggles (3D buildings / terrain). The page merges them into
     // the style via MapLibre transformStyle, so this re-applies the style.
-    LaunchedEffect(pageReady.value, mapConfig.buildings3d, mapConfig.terrain) {
+    LaunchedEffect(webView, pageReady.value, mapConfig.buildings3d, mapConfig.terrain) {
         if (!pageReady.value) return@LaunchedEffect
         webView.evaluateJavascript(
             "window.setFeatures && setFeatures(${mapConfig.buildings3d}, ${mapConfig.terrain})",
@@ -169,6 +319,8 @@ internal fun WebMapView(
     DisposableEffect(lifecycleOwner, webView) {
         val observer =
             LifecycleEventObserver { _, event ->
+                // A view whose renderer died is already destroyed; touching it crashes.
+                if (webView in crashedViews) return@LifecycleEventObserver
                 when (event) {
                     // Pause only when truly backgrounded (ON_STOP), not ON_PAUSE: the
                     // launcher map stays visible behind transient lifecycle dips, and
@@ -190,15 +342,21 @@ internal fun WebMapView(
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose {
             lifecycleOwner.lifecycle.removeObserver(observer)
-            webView.destroy()
+            // onRenderProcessGone already destroyed crashed views; destroying twice
+            // is undefined, so disposal only destroys views that died gracefully.
+            if (!crashedViews.remove(webView)) webView.destroy()
         }
     }
 
     Box(modifier = modifier) {
-        AndroidView(
-            modifier = Modifier.fillMaxSize().clickable { onTap() },
-            factory = { webView },
-        )
+        // Keyed on the WebView so a post-crash rebuild swaps in the fresh view
+        // (AndroidView's factory runs once per node otherwise).
+        key(webView) {
+            AndroidView(
+                modifier = Modifier.fillMaxSize().clickable { onTap() },
+                factory = { webView },
+            )
+        }
         Attribution(
             modifier = Modifier.align(Alignment.BottomStart),
             showTerrainCredit = mapConfig.terrain,
@@ -206,6 +364,58 @@ internal fun WebMapView(
     }
 }
 
+// Terminal LIVE-map state (repeated renderer deaths, or a fatal bridge event):
+// a static notice pointing at the Settings render-mode switch. Deliberately NOT
+// an automatic fallback to SNAPSHOT — an earlier auto-downgrade misfired on
+// healthy devices and silently overrode the user's chosen backend, so the user
+// stays in control here.
+@Composable
+private fun LiveMapNotice(
+    @StringRes titleRes: Int,
+    @StringRes hintRes: Int,
+    reason: String?,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier = modifier.padding(32.dp),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+) {
+    Icon(
+        imageVector = Lucide.MapPinOff,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(40.dp),
+    )
+    Text(
+        text = stringResource(titleRes),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.padding(top = 8.dp),
+    )
+    Text(
+        text = stringResource(hintRes),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = 4.dp),
+    )
+    if (reason != null) {
+        Text(
+            text = reason,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+    }
+}
+
 // A bundled asset served to the WebView over the WebViewAssetLoader https origin so
 // MapLibre's tile Worker can fetch it (and the asset's OpenFreeMap sources) cross-origin.
 private fun appAssetsUrl(asset: String): String = "https://appassets.androidplatform.net/assets/$asset"
+
+private const val TAG = "WebMapView"
+
+// One renderer death rebuilds the WebView silently (a lone death is usually the
+// system reclaiming memory, not a fault in the map); a second death inside this
+// window means a crash loop, so the rebuild stops and the notice shows instead.
+private const val RENDERER_DEATH_WINDOW_MS = 5 * 60_000L
+private const val MAX_RENDERER_DEATHS = 2

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -49,6 +49,8 @@ import com.composables.icons.lucide.MapPinOff
 import io.github.seijikohara.femto.BuildConfig
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.MapStyleSetting
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 
 /**
  * Live map backend: MapLibre GL JS (WebGL) in a WebView — the only path that renders
@@ -411,6 +413,18 @@ private fun LiveMapNotice(
 // A bundled asset served to the WebView over the WebViewAssetLoader https origin so
 // MapLibre's tile Worker can fetch it (and the asset's OpenFreeMap sources) cross-origin.
 private fun appAssetsUrl(asset: String): String = "https://appassets.androidplatform.net/assets/$asset"
+
+@PreviewLightDark
+@Composable
+private fun LiveMapNoticePreview() {
+    FemtoTheme {
+        LiveMapNotice(
+            titleRes = R.string.map_live_renderer_gone,
+            hintRes = R.string.map_live_renderer_gone_hint,
+            reason = "renderer crashed",
+        )
+    }
+}
 
 private const val TAG = "WebMapView"
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -62,6 +61,7 @@ import io.github.seijikohara.femto.data.MapStyleSetting
 import io.github.seijikohara.femto.data.SpeedUnitSetting
 import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.ThemeMode
+import io.github.seijikohara.femto.ui.theme.DynamicAccentSweep
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
@@ -783,19 +783,6 @@ private fun AccentColor.labelRes(): Int =
         AccentColor.VIOLET -> R.string.settings_accent_violet
         AccentColor.PINK -> R.string.settings_accent_pink
     }
-
-// Rainbow stops for the DYNAMIC swatch's sweep gradient; the first hue repeats at
-// the end so the sweep closes seamlessly. Signals "automatic / wallpaper-derived".
-private val DynamicAccentSweep =
-    listOf(
-        Color(0xFFEF5350),
-        Color(0xFFFFCA28),
-        Color(0xFF66BB6A),
-        Color(0xFF26C6DA),
-        Color(0xFF42A5F5),
-        Color(0xFFAB47BC),
-        Color(0xFFEF5350),
-    )
 
 // A font-slot row: the current family (or "System default") under the title,
 // opening the full Google Fonts picker on tap.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/Color.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/Color.kt
@@ -55,6 +55,22 @@ internal val LightFallback =
         outlineVariant = InkHairline,
     )
 
+// Rainbow stops for the Settings DYNAMIC accent swatch's sweep gradient; the
+// first hue repeats at the end so the sweep closes seamlessly. Decorative only
+// (signals "automatic / wallpaper-derived"), not theme color roles — they live
+// here because hardcoded hex is confined to this file and AccentColors.kt
+// (CLAUDE.md#design-system).
+internal val DynamicAccentSweep =
+    listOf(
+        Color(0xFFEF5350),
+        Color(0xFFFFCA28),
+        Color(0xFF66BB6A),
+        Color(0xFF26C6DA),
+        Color(0xFF42A5F5),
+        Color(0xFFAB47BC),
+        Color(0xFFEF5350),
+    )
+
 internal val DarkFallback =
     darkColorScheme(
         primary = Bone,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,12 @@
     <!-- Map panel -->
     <string name="map_unavailable">Map unavailable</string>
     <string name="map_permission_cta">Grant location access to enable the map and overlays.</string>
+    <string name="map_live_renderer_gone">Live map stopped</string>
+    <string name="map_live_renderer_gone_hint">The map renderer keeps crashing on this device. Switch the map mode to Snapshot in Settings.</string>
+    <string name="map_live_init_failed">Live map can\'t start</string>
+    <string name="map_live_init_failed_hint">This device can\'t render the live map. Switch the map mode to Snapshot in Settings.</string>
+    <string name="calendar_query_failed">Calendar couldn\'t be read</string>
+    <string name="font_download_failed">Download failed — tap to retry</string>
     <string name="map_attribution">© OpenStreetMap · OpenMapTiles · OpenFreeMap</string>
     <string name="map_attribution_terrain">Terrain © Mapterhorn</string>
 

--- a/app/src/test/java/io/github/seijikohara/femto/data/AppsRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/AppsRepositoryTest.kt
@@ -3,11 +3,19 @@ package io.github.seijikohara.femto.data
 import android.app.Application
 import android.content.ActivityNotFoundException
 import android.content.ComponentName
+import android.content.pm.LauncherApps
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Process
 import androidx.test.core.app.ApplicationProvider
+import io.github.seijikohara.femto.testfixtures.fakeLauncherActivityInfo
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -16,6 +24,22 @@ import kotlin.test.assertTrue
 @Config(sdk = [33])
 class AppsRepositoryTest {
     private val application: Application = ApplicationProvider.getApplicationContext()
+
+    /**
+     * Register a launcher activity with the [LauncherApps] shadow. A resolvable
+     * icon is registered too, because `queryApps` rasterizes every entry's icon
+     * and the shadowed PackageManager resolves icons from this per-package map.
+     */
+    private fun installApp(
+        packageName: String,
+        label: String,
+    ) {
+        shadowOf(application.packageManager).setUnbadgedApplicationIcon(packageName, ColorDrawable(Color.RED))
+        shadowOf(application.getSystemService(LauncherApps::class.java)).addActivity(
+            Process.myUserHandle(),
+            fakeLauncherActivityInfo(application, packageName, label = label),
+        )
+    }
 
     @Test
     fun `launch returns false and does not throw on ActivityNotFoundException`() {
@@ -37,6 +61,51 @@ class AppsRepositoryTest {
 
         assertTrue(repo.launch(STALE_COMPONENT))
     }
+
+    @Test
+    fun `queryApps resolves labels and sorts them alphabetically ignoring case`() =
+        runTest {
+            // Registered out of order, with a lowercase label that would sort
+            // last under a case-sensitive comparison.
+            installApp("com.example.zebra", label = "Zebra")
+            installApp("com.example.alpha", label = "alpha")
+            installApp("com.example.mango", label = "Mango")
+
+            val labels = AppsRepository(application).queryApps().map { it.label }
+
+            assertEquals(listOf("alpha", "Mango", "Zebra"), labels)
+        }
+
+    @Test
+    fun `queryApps maps the launcher component name`() =
+        runTest {
+            installApp("com.example.solo", label = "Solo")
+
+            val entry = AppsRepository(application).queryApps().single()
+
+            assertEquals(ComponentName("com.example.solo", "com.example.solo.MainActivity"), entry.componentName)
+        }
+
+    @Test
+    fun `queryApps drops an entry that fails to resolve and keeps the rest`() =
+        runTest {
+            installApp("com.example.good", label = "Good")
+            // No label and no ApplicationInfo: label resolution throws, which is
+            // the pathological-package case the per-app runCatching isolates.
+            shadowOf(application.getSystemService(LauncherApps::class.java)).addActivity(
+                Process.myUserHandle(),
+                fakeLauncherActivityInfo(
+                    application,
+                    "com.example.broken",
+                    label = null,
+                    hasApplicationInfo = false,
+                ),
+            )
+
+            val labels = AppsRepository(application).queryApps().map { it.label }
+
+            assertEquals(listOf("Good"), labels)
+        }
 
     private companion object {
         val STALE_COMPONENT = ComponentName("com.example", "X")

--- a/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
@@ -6,6 +6,7 @@ import android.content.ContentProvider
 import android.content.ContentValues
 import android.database.Cursor
 import android.database.MatrixCursor
+import android.database.sqlite.SQLiteException
 import android.net.Uri
 import android.provider.CalendarContract
 import android.text.format.DateFormat
@@ -62,10 +63,12 @@ class CalendarRepositoryTest {
         runTest {
             // Grant the permission so the repository attempts the provider
             // query, then make the registered provider throw to simulate a
-            // mid-stream revoke / OEM provider fault. The snapshot must still
-            // resolve with an empty events list rather than tearing down the
-            // dashboard StateFlow.
+            // mid-stream revoke. The snapshot must still resolve with an empty
+            // events list rather than tearing down the dashboard StateFlow —
+            // and a revoke is the documented permission-degradation path, so
+            // it must NOT be flagged as a provider fault.
             shadowOf(application).grantPermissions(Manifest.permission.READ_CALENDAR)
+            ThrowingCalendarProvider.failure = SecurityException("calendar permission revoked")
             Robolectric
                 .buildContentProvider(ThrowingCalendarProvider::class.java)
                 .create(CalendarContract.AUTHORITY)
@@ -79,8 +82,38 @@ class CalendarRepositoryTest {
             val snapshot = repository.snapshotFlow().first()
 
             assertNotNull(snapshot)
+            assertFalse(snapshot.queryFailed)
             assertTrue(snapshot.days.all { it.events.isEmpty() })
             assertEquals(30, snapshot.days.size)
+        }
+
+    @Test
+    fun `flags queryFailed when the provider throws an unexpected exception`() =
+        runTest {
+            // An OEM provider fault (anything other than the SecurityException
+            // revoke) must surface in-band: the empty events list is a read
+            // failure, not "granted but nothing scheduled", so the snapshot
+            // carries queryFailed = true for the card to render the failure hint.
+            shadowOf(application).grantPermissions(Manifest.permission.READ_CALENDAR)
+            ThrowingCalendarProvider.failure = SQLiteException("disk I/O error")
+            Robolectric
+                .buildContentProvider(ThrowingCalendarProvider::class.java)
+                .create(CalendarContract.AUTHORITY)
+
+            val repository =
+                CalendarRepository(
+                    application,
+                    clockFlow = flowOf(ClockTick(LocalTime.NOON, LocalDate.of(2026, 6, 3))),
+                )
+
+            val snapshot = repository.snapshotFlow().first()
+
+            assertNotNull(snapshot)
+            assertTrue(snapshot.queryFailed)
+            // Access itself is still granted: queryFailed is the orthogonal
+            // provider-fault axis, not a second denial flag.
+            assertTrue(snapshot.hasCalendarAccess)
+            assertTrue(snapshot.days.all { it.events.isEmpty() })
         }
 
     @Test
@@ -353,8 +386,10 @@ class CalendarRepositoryTest {
     }
 
     /**
-     * Stand-in calendar provider whose [query] throws [SecurityException], the
-     * fault the repository's `runCatching` guards must absorb.
+     * Stand-in calendar provider whose [query] throws [failure], the fault the
+     * repository's `runCatching` guards must absorb. [failure] is set explicitly
+     * by each test (rather than relying on a default) because Robolectric can
+     * share the companion across test methods.
      */
     class ThrowingCalendarProvider : ContentProvider() {
         override fun onCreate(): Boolean = true
@@ -365,7 +400,13 @@ class CalendarRepositoryTest {
             selection: String?,
             selectionArgs: Array<out String>?,
             sortOrder: String?,
-        ): Cursor = throw SecurityException("calendar provider unavailable")
+        ): Cursor = throw failure
+
+        companion object {
+            // SecurityException exercises the permission-degradation path;
+            // any other exception exercises the queryFailed provider-fault path.
+            var failure: RuntimeException = SecurityException("calendar provider unavailable")
+        }
 
         override fun getType(uri: Uri): String? = null
 

--- a/app/src/test/java/io/github/seijikohara/femto/data/DrawerPreferencesTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/DrawerPreferencesTest.kt
@@ -1,0 +1,40 @@
+package io.github.seijikohara.femto.data
+
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class DrawerPreferencesTest {
+    // The `preferencesDataStore` delegate behind DrawerPreferences is a
+    // process-wide singleton bound to the first Application's filesDir, while
+    // Robolectric hands each test method a fresh Application and temp dir. All
+    // round-trip steps therefore live in one test method, so the persisted file
+    // and the singleton never disagree across tests.
+    @Test
+    fun `togglePinned round-trips pin, unpin, and re-pin without touching other pins`() =
+        runTest {
+            val store = DrawerPreferences(ApplicationProvider.getApplicationContext())
+
+            store.togglePinned(OTHER)
+            store.togglePinned(COMPONENT)
+            assertEquals(setOf(OTHER, COMPONENT), store.pinned.first())
+
+            store.togglePinned(COMPONENT)
+            assertEquals(setOf(OTHER), store.pinned.first())
+
+            store.togglePinned(COMPONENT)
+            assertEquals(setOf(OTHER, COMPONENT), store.pinned.first())
+        }
+
+    private companion object {
+        const val COMPONENT = "com.example.music/.MainActivity"
+        const val OTHER = "com.example.maps/.MapsActivity"
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/FontCacheTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/FontCacheTest.kt
@@ -53,4 +53,16 @@ class FontCacheTest {
         assertTrue(File(root, "roboto").isDirectory)
         assertFalse(File(root, "lobster").exists())
     }
+
+    @Test
+    fun `evictExcept spares a protected family outside the keep set`() {
+        File(root, "roboto").mkdirs()
+        File(root, "roboto/variable.ttf").writeText("ttf")
+        File(root, "lobster").mkdirs()
+        File(root, "lobster/variable.ttf").writeText("ttf")
+
+        cache.evictExcept(listOf("Roboto"), alsoProtect = listOf("Lobster"))
+
+        assertTrue(File(root, "lobster").isDirectory)
+    }
 }

--- a/app/src/test/java/io/github/seijikohara/femto/data/FontRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/FontRepositoryTest.kt
@@ -1,0 +1,150 @@
+package io.github.seijikohara.femto.data
+
+import io.github.seijikohara.femto.testfixtures.FakeFontFaceStore
+import io.github.seijikohara.femto.testfixtures.FakeFontSelectionStore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FontRepositoryTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun `choosing a family downloads it and evicts the dropped family`() =
+        runTest {
+            val cache = FakeFontFaceStore().apply { preload("Old Face") }
+            val repository = repository(cache, FakeFontSelectionStore(FontSelection(latinFamily = "Old Face")))
+            runCurrent()
+
+            repository.choose(FontSlot.LATIN, "New Face")
+            runCurrent()
+
+            assertEquals(listOf("New Face"), cache.downloads)
+            assertFalse(cache.isCached("Old Face"))
+            assertNotNull(repository.resolved.value.latin)
+        }
+
+    @Test
+    fun `eviction never runs while a download is still in flight`() =
+        runTest {
+            val cache = FakeFontFaceStore()
+            val repository = repository(cache)
+            val gate = cache.gateDownload("Slow Face")
+            repository.choose(FontSlot.LATIN, "Slow Face")
+            runCurrent()
+            assertEquals(setOf("Slow Face"), repository.downloading.value)
+
+            // A fast re-selection cancels the resolve pass mid-download; the
+            // switch pass must not evict until the in-flight write has finished.
+            repository.choose(FontSlot.LATIN, "Other Face")
+            runCurrent()
+            assertTrue(cache.evictions.none { (keep, _) -> "Other Face" in keep })
+
+            gate.complete(Unit)
+            runCurrent()
+            assertTrue(cache.evictions.any { (keep, _) -> "Other Face" in keep })
+            assertFalse(cache.isCached("Slow Face"))
+            assertEquals(emptySet(), repository.downloading.value)
+        }
+
+    @Test
+    fun `restart loads the catalog from disk when the network is unavailable`() =
+        runTest {
+            val families = listOf(GoogleFontFamily("Inter", "Sans Serif", listOf("latin"), popularity = 1))
+            catalogFile().writeText(Json.encodeToString(ListSerializer(GoogleFontFamily.serializer()), families))
+            val repository = repository(FakeFontFaceStore())
+
+            repository.ensureCatalog()
+            val loaded = repository.catalog.first { it is CatalogState.Loaded }
+
+            assertEquals(families, (loaded as CatalogState.Loaded).families)
+        }
+
+    @Test
+    fun `restart serves a cached selection without re-downloading`() =
+        runTest {
+            val cache = FakeFontFaceStore().apply { preload("Inter") }
+            val repository = repository(cache, FakeFontSelectionStore(FontSelection(latinFamily = "Inter")))
+
+            val resolved = repository.resolved.first { it.latin != null }
+
+            assertEquals(cache.cached("Inter"), resolved.latin)
+            assertTrue(cache.downloads.isEmpty())
+        }
+
+    @Test
+    fun `a failed download adds the family to downloadFailed`() =
+        runTest {
+            val cache = FakeFontFaceStore().apply { failing += "Inter" }
+            val repository = repository(cache)
+
+            repository.choose(FontSlot.LATIN, "Inter")
+            runCurrent()
+
+            assertEquals(setOf("Inter"), repository.downloadFailed.value)
+            assertNull(repository.resolved.value.latin)
+        }
+
+    @Test
+    fun `re-choosing the failed family retries and a success clears downloadFailed`() =
+        runTest {
+            val cache = FakeFontFaceStore().apply { failing += "Inter" }
+            val repository = repository(cache)
+            repository.choose(FontSlot.LATIN, "Inter")
+            runCurrent()
+            cache.failing.clear()
+
+            // The persisted selection does not change, so without the retry
+            // trigger this second choose would never reach a new resolve pass.
+            repository.choose(FontSlot.LATIN, "Inter")
+            runCurrent()
+
+            assertEquals(listOf("Inter", "Inter"), cache.downloads)
+            assertEquals(emptySet(), repository.downloadFailed.value)
+            assertNotNull(repository.resolved.value.latin)
+        }
+
+    @Test
+    fun `choosing a different family clears the stale downloadFailed entry`() =
+        runTest {
+            val cache = FakeFontFaceStore().apply { failing += "Inter" }
+            val repository = repository(cache)
+            repository.choose(FontSlot.LATIN, "Inter")
+            runCurrent()
+
+            repository.choose(FontSlot.LATIN, "Roboto")
+            runCurrent()
+
+            assertEquals(emptySet(), repository.downloadFailed.value)
+        }
+
+    private fun TestScope.repository(
+        cache: FakeFontFaceStore,
+        preferences: FakeFontSelectionStore = FakeFontSelectionStore(),
+        catalog: List<GoogleFontFamily>? = null,
+    ): FontRepository =
+        FontRepository(
+            api = FontCatalogSource { catalog },
+            cache = cache,
+            preferences = preferences,
+            catalogFile = catalogFile(),
+            scope = backgroundScope,
+        )
+
+    private fun catalogFile(): File = File(tempFolder.root, "catalog.json")
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/GoogleFontsApiTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/GoogleFontsApiTest.kt
@@ -1,0 +1,134 @@
+package io.github.seijikohara.femto.data
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GoogleFontsApiTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        client = OkHttpClient()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `parses the catalog sorted by popularity`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(CATALOG_BODY))
+
+            val catalog = newApi().catalog()
+
+            assertEquals(listOf("Roboto", "Lobster"), catalog?.map { it.family })
+        }
+
+    @Test
+    fun `strips the xssi prefix from a guarded response`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(")]}'\n$CATALOG_BODY"))
+
+            val catalog = newApi().catalog()
+
+            assertEquals(2, catalog?.size)
+        }
+
+    @Test
+    fun `returns null on a malformed catalog body`() =
+        runTest {
+            server.enqueue(MockResponse().setBody("{ not json"))
+
+            assertNull(newApi().catalog())
+        }
+
+    @Test
+    fun `returns null on a catalog http error`() =
+        runTest {
+            server.enqueue(MockResponse().setResponseCode(500))
+
+            assertNull(newApi().catalog())
+        }
+
+    @Test
+    fun `plan prefers the upright variable font over static weights`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(MANIFEST_BODY))
+
+            val plan = newApi().plan("Roboto")
+
+            assertTrue(plan is FontDownloadPlan.Variable)
+            assertEquals("https://fonts.example/vf.ttf", plan.url)
+        }
+
+    @Test
+    fun `plan falls back to static weights without a variable font`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(STATIC_MANIFEST_BODY))
+
+            val plan = newApi().plan("Roboto")
+
+            assertTrue(plan is FontDownloadPlan.Static)
+            assertEquals(setOf(400, 700), plan.urlByWeight.keys)
+        }
+
+    @Test
+    fun `plan returns null on a malformed manifest body`() =
+        runTest {
+            server.enqueue(MockResponse().setBody("<html>not json</html>"))
+
+            assertNull(newApi().plan("Roboto"))
+        }
+
+    private fun newApi(): GoogleFontsApi = GoogleFontsApi(client, metadataBaseUrl = server.url("/").toString())
+
+    private companion object {
+        const val CATALOG_BODY = """
+            {
+              "familyMetadataList": [
+                {"family": "Lobster", "category": "Display", "subsets": ["latin"], "popularity": 42},
+                {"family": "Roboto", "category": "Sans Serif", "subsets": ["latin"], "popularity": 1}
+              ]
+            }
+        """
+
+        // The italic variable font precedes the upright one so the plan's
+        // italic exclusion is exercised, not just the VariableFont match.
+        const val MANIFEST_BODY = """
+            {
+              "manifest": {
+                "fileRefs": [
+                  {"filename": "Roboto-Italic-VariableFont_wght.ttf", "url": "https://fonts.example/italic-vf.ttf"},
+                  {"filename": "Roboto-VariableFont_wght.ttf", "url": "https://fonts.example/vf.ttf"},
+                  {"filename": "Roboto-Regular.ttf", "url": "https://fonts.example/regular.ttf"},
+                  {"filename": "Roboto-Bold.ttf", "url": "https://fonts.example/bold.ttf"}
+                ]
+              }
+            }
+        """
+
+        const val STATIC_MANIFEST_BODY = """
+            {
+              "manifest": {
+                "fileRefs": [
+                  {"filename": "Roboto-Regular.ttf", "url": "https://fonts.example/regular.ttf"},
+                  {"filename": "Roboto-Bold.ttf", "url": "https://fonts.example/bold.ttf"},
+                  {"filename": "Roboto-BoldItalic.ttf", "url": "https://fonts.example/bold-italic.ttf"}
+                ]
+              }
+            }
+        """
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/MusicSessionMappingTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/MusicSessionMappingTest.kt
@@ -1,0 +1,345 @@
+package io.github.seijikohara.femto.data
+
+import android.graphics.Bitmap
+import android.media.MediaMetadata
+import android.media.session.PlaybackState
+import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// Robolectric provides real PlaybackState / MediaMetadata builders, so the
+// extracted pure logic is exercised with genuine platform values instead of
+// mocks (MediaController itself stays out of reach — see MusicSessionRepository).
+private fun playbackState(
+    state: Int,
+    positionMs: Long = 0L,
+    speed: Float = 1f,
+    updateTimeMs: Long = 0L,
+): PlaybackState =
+    PlaybackState
+        .Builder()
+        .setState(state, positionMs, speed, updateTimeMs)
+        .build()
+
+private fun metadata(
+    title: String? = null,
+    displayTitle: String? = null,
+    artist: String? = null,
+    album: String? = null,
+    durationMs: Long = 0L,
+    albumArt: Bitmap? = null,
+): MediaMetadata =
+    MediaMetadata
+        .Builder()
+        .apply {
+            title?.let { putString(MediaMetadata.METADATA_KEY_TITLE, it) }
+            displayTitle?.let { putString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE, it) }
+            artist?.let { putString(MediaMetadata.METADATA_KEY_ARTIST, it) }
+            album?.let { putString(MediaMetadata.METADATA_KEY_ALBUM, it) }
+            putLong(MediaMetadata.METADATA_KEY_DURATION, durationMs)
+            albumArt?.let { putBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART, it) }
+        }.build()
+
+/** Plain value holder standing in for a MediaController in selection tests. */
+private data class FakeSession(
+    val name: String,
+    val playbackState: PlaybackState?,
+)
+
+private fun selectPrimary(sessions: List<FakeSession>): FakeSession? =
+    selectPrimarySession(sessions) {
+        it.playbackState
+    }
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class MusicSessionMappingTest {
+    // -- selectPrimarySession ------------------------------------------------
+
+    @Test
+    fun `selectPrimarySession returns null for an empty session list`() {
+        assertNull(selectPrimary(emptyList()))
+    }
+
+    @Test
+    fun `selectPrimarySession returns null when no session is playing or paused`() {
+        val sessions =
+            listOf(
+                FakeSession("stateless", playbackState = null),
+                FakeSession("stopped", playbackState(PlaybackState.STATE_STOPPED)),
+                FakeSession("errored", playbackState(PlaybackState.STATE_ERROR)),
+            )
+
+        assertNull(selectPrimary(sessions))
+    }
+
+    @Test
+    fun `selectPrimarySession skips inactive sessions and picks the first playing one`() {
+        val sessions =
+            listOf(
+                FakeSession("stopped", playbackState(PlaybackState.STATE_STOPPED)),
+                FakeSession("playing", playbackState(PlaybackState.STATE_PLAYING)),
+            )
+
+        assertEquals("playing", selectPrimary(sessions)?.name)
+    }
+
+    @Test
+    fun `selectPrimarySession keeps a paused session selectable so it stays resumable`() {
+        val sessions = listOf(FakeSession("paused", playbackState(PlaybackState.STATE_PAUSED)))
+
+        assertEquals("paused", selectPrimary(sessions)?.name)
+    }
+
+    @Test
+    fun `selectPrimarySession prefers the higher-priority paused session over a later playing one`() {
+        // The input list is priority-ordered by MediaSessionManager; the first
+        // playing-or-paused entry wins even when a lower-priority one is playing.
+        val sessions =
+            listOf(
+                FakeSession("paused", playbackState(PlaybackState.STATE_PAUSED)),
+                FakeSession("playing", playbackState(PlaybackState.STATE_PLAYING)),
+            )
+
+        assertEquals("paused", selectPrimary(sessions)?.name)
+    }
+
+    @Test
+    fun `a missing playback state is never playing or paused`() {
+        assertFalse((null as PlaybackState?).isPlayingOrPaused())
+    }
+
+    // -- musicCardStateOf ----------------------------------------------------
+
+    @Test
+    fun `musicCardStateOf reports NeedsPermission while the listener grant is missing`() {
+        assertEquals(
+            MusicCardState.NeedsPermission,
+            musicCardStateOf(hasPermission = false) { fakeNowPlaying() },
+        )
+    }
+
+    @Test
+    fun `musicCardStateOf does not inspect sessions while the grant is missing`() {
+        // Session enumeration throws SecurityException before the grant, so the
+        // lambda must stay unevaluated on the NeedsPermission path.
+        musicCardStateOf(hasPermission = false) { error("session inspected without permission") }
+    }
+
+    @Test
+    fun `musicCardStateOf wraps a resolved session in Playing`() {
+        val nowPlaying = fakeNowPlaying()
+
+        assertEquals(
+            MusicCardState.Playing(nowPlaying),
+            musicCardStateOf(hasPermission = true) { nowPlaying },
+        )
+    }
+
+    @Test
+    fun `musicCardStateOf falls back to NoActiveSession when nothing resolves`() {
+        assertEquals(
+            MusicCardState.NoActiveSession,
+            musicCardStateOf(hasPermission = true) { null },
+        )
+    }
+
+    // -- nowPlayingOf --------------------------------------------------------
+
+    @Test
+    fun `nowPlayingOf uses the metadata title when present`() {
+        val result =
+            nowPlayingOf(
+                metadata = metadata(title = "Strobe", displayTitle = "Display"),
+                playbackState = null,
+                packageName = PACKAGE,
+                fallbackTitle = { FALLBACK },
+            )
+
+        assertEquals("Strobe", result.title)
+    }
+
+    @Test
+    fun `nowPlayingOf falls back to the display title when the title is blank`() {
+        val result =
+            nowPlayingOf(
+                metadata = metadata(title = " ", displayTitle = "Display"),
+                playbackState = null,
+                packageName = PACKAGE,
+                fallbackTitle = { FALLBACK },
+            )
+
+        assertEquals("Display", result.title)
+    }
+
+    @Test
+    fun `nowPlayingOf falls back to the source label when both titles are blank`() {
+        val result =
+            nowPlayingOf(
+                metadata = metadata(title = "", displayTitle = " "),
+                playbackState = null,
+                packageName = PACKAGE,
+                fallbackTitle = { FALLBACK },
+            )
+
+        assertEquals(FALLBACK, result.title)
+    }
+
+    @Test
+    fun `nowPlayingOf resolves the fallback label only when needed`() {
+        // sourceLabel touches PackageManager in production, so it must stay
+        // unevaluated while a usable title exists.
+        nowPlayingOf(
+            metadata = metadata(title = "Strobe"),
+            playbackState = null,
+            packageName = PACKAGE,
+            fallbackTitle = { error("fallback resolved despite a usable title") },
+        )
+    }
+
+    @Test
+    fun `nowPlayingOf is playing only for STATE_PLAYING`() {
+        fun isPlayingFor(state: Int): Boolean =
+            nowPlayingOf(
+                metadata = metadata(title = "Strobe"),
+                playbackState = playbackState(state),
+                packageName = PACKAGE,
+                fallbackTitle = { FALLBACK },
+            ).isPlaying
+
+        assertTrue(isPlayingFor(PlaybackState.STATE_PLAYING))
+        // A paused session stays on the card but renders the Play affordance.
+        assertFalse(isPlayingFor(PlaybackState.STATE_PAUSED))
+    }
+
+    @Test
+    fun `nowPlayingOf copies position, speed, and update basis from the playback state`() {
+        val result =
+            nowPlayingOf(
+                metadata = metadata(title = "Strobe"),
+                playbackState =
+                    playbackState(
+                        PlaybackState.STATE_PLAYING,
+                        positionMs = 5_000L,
+                        speed = 1.5f,
+                        updateTimeMs = 42_000L,
+                    ),
+                packageName = PACKAGE,
+                fallbackTitle = { FALLBACK },
+            )
+
+        assertEquals(5_000L, result.positionMs)
+        assertEquals(1.5f, result.playbackSpeed)
+        assertEquals(42_000L, result.positionUpdateTimeMs)
+    }
+
+    @Test
+    fun `nowPlayingOf defaults transport fields when the playback state is null`() {
+        val result =
+            nowPlayingOf(
+                metadata = metadata(title = "Strobe"),
+                playbackState = null,
+                packageName = PACKAGE,
+                fallbackTitle = { FALLBACK },
+            )
+
+        assertFalse(result.isPlaying)
+        assertEquals(0L, result.positionMs)
+        assertEquals(1f, result.playbackSpeed)
+        assertEquals(0L, result.positionUpdateTimeMs)
+    }
+
+    @Test
+    fun `nowPlayingOf maps artist, album, duration, and package name`() {
+        val result =
+            nowPlayingOf(
+                metadata =
+                    metadata(
+                        title = "Strobe",
+                        artist = "deadmau5",
+                        album = "For Lack of a Better Name",
+                        durationMs = 632_000L,
+                    ),
+                playbackState = null,
+                packageName = PACKAGE,
+                fallbackTitle = { FALLBACK },
+            )
+
+        assertEquals("deadmau5", result.artist)
+        assertEquals("For Lack of a Better Name", result.album)
+        assertEquals(632_000L, result.durationMs)
+        assertEquals(PACKAGE, result.packageName)
+    }
+
+    @Test
+    fun `nowPlayingOf decodes the album art when present and leaves it null otherwise`() {
+        val art = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
+
+        assertNotNull(
+            nowPlayingOf(
+                metadata = metadata(title = "Strobe", albumArt = art),
+                playbackState = null,
+                packageName = PACKAGE,
+                fallbackTitle = { FALLBACK },
+            ).albumArt,
+        )
+        assertNull(
+            nowPlayingOf(
+                metadata = metadata(title = "Strobe"),
+                playbackState = null,
+                packageName = PACKAGE,
+                fallbackTitle = { FALLBACK },
+            ).albumArt,
+        )
+    }
+
+    private companion object {
+        const val PACKAGE = "com.example.music"
+        const val FALLBACK = "Now playing"
+    }
+}
+
+/**
+ * State table for [isPlayingOrPaused]: every state that keeps the card on
+ * screen (the platform `isActive` set plus STATE_PAUSED) versus the ones that
+ * release it.
+ */
+@RunWith(ParameterizedRobolectricTestRunner::class)
+@Config(sdk = [33])
+class IsPlayingOrPausedStateTest(
+    private val state: Int,
+    private val expected: Boolean,
+) {
+    @Test
+    fun `keeps the card on screen exactly for playing-or-paused states`() {
+        assertEquals(expected, playbackState(state).isPlayingOrPaused())
+    }
+
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "state={0} -> {1}")
+        fun params(): List<Array<Any>> =
+            listOf(
+                arrayOf(PlaybackState.STATE_PLAYING, true),
+                arrayOf(PlaybackState.STATE_PAUSED, true),
+                arrayOf(PlaybackState.STATE_BUFFERING, true),
+                arrayOf(PlaybackState.STATE_CONNECTING, true),
+                arrayOf(PlaybackState.STATE_FAST_FORWARDING, true),
+                arrayOf(PlaybackState.STATE_REWINDING, true),
+                arrayOf(PlaybackState.STATE_SKIPPING_TO_PREVIOUS, true),
+                arrayOf(PlaybackState.STATE_SKIPPING_TO_NEXT, true),
+                arrayOf(PlaybackState.STATE_SKIPPING_TO_QUEUE_ITEM, true),
+                arrayOf(PlaybackState.STATE_NONE, false),
+                arrayOf(PlaybackState.STATE_STOPPED, false),
+                arrayOf(PlaybackState.STATE_ERROR, false),
+            )
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/NominatimApiTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/NominatimApiTest.kt
@@ -109,6 +109,9 @@ class NominatimApiTest {
             client = client,
             baseUrl = server.url("/").toString(),
             userAgent = USER_AGENT,
+            // Pinned explicitly: the production default follows the JVM locale,
+            // which would make the accept-language assertion machine-dependent.
+            language = "ja",
         )
 
     private companion object {

--- a/app/src/test/java/io/github/seijikohara/femto/data/VoiceRecognizerMessageTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/VoiceRecognizerMessageTest.kt
@@ -1,0 +1,96 @@
+package io.github.seijikohara.femto.data
+
+import android.app.Application
+import android.os.Bundle
+import android.speech.SpeechRecognizer
+import androidx.test.core.app.ApplicationProvider
+import io.github.seijikohara.femto.R
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Mapping table for [VoiceRecognizer.messageFor]: the platform error codes
+ * collapse into three user-facing strings (no-match, network, generic), and any
+ * unknown future code must land on the generic message rather than crash.
+ */
+@RunWith(ParameterizedRobolectricTestRunner::class)
+@Config(sdk = [33])
+class VoiceRecognizerMessageTest(
+    private val errorCode: Int,
+    private val expectedMessageRes: Int,
+) {
+    @Test
+    fun `maps the recognizer error code to its user-facing message`() {
+        val recognizer = VoiceRecognizer(ApplicationProvider.getApplicationContext<Application>())
+
+        assertEquals(expectedMessageRes, recognizer.messageFor(errorCode))
+    }
+
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "error={0} -> res={1}")
+        fun params(): List<Array<Any>> =
+            listOf(
+                arrayOf(SpeechRecognizer.ERROR_NO_MATCH, R.string.assistant_voice_error_no_match),
+                arrayOf(SpeechRecognizer.ERROR_SPEECH_TIMEOUT, R.string.assistant_voice_error_no_match),
+                arrayOf(SpeechRecognizer.ERROR_NETWORK, R.string.assistant_voice_error_network),
+                arrayOf(SpeechRecognizer.ERROR_NETWORK_TIMEOUT, R.string.assistant_voice_error_network),
+                arrayOf(SpeechRecognizer.ERROR_AUDIO, R.string.assistant_voice_error_generic),
+                arrayOf(SpeechRecognizer.ERROR_CLIENT, R.string.assistant_voice_error_generic),
+                arrayOf(SpeechRecognizer.ERROR_SERVER, R.string.assistant_voice_error_generic),
+                arrayOf(SpeechRecognizer.ERROR_RECOGNIZER_BUSY, R.string.assistant_voice_error_generic),
+                arrayOf(SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS, R.string.assistant_voice_error_generic),
+                arrayOf(SpeechRecognizer.ERROR_TOO_MANY_REQUESTS, R.string.assistant_voice_error_generic),
+                arrayOf(SpeechRecognizer.ERROR_SERVER_DISCONNECTED, R.string.assistant_voice_error_generic),
+                arrayOf(SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED, R.string.assistant_voice_error_generic),
+                arrayOf(SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE, R.string.assistant_voice_error_generic),
+                arrayOf(SpeechRecognizer.ERROR_CANNOT_CHECK_SUPPORT, R.string.assistant_voice_error_generic),
+                // An unknown future platform code must degrade to the generic message.
+                arrayOf(Int.MAX_VALUE, R.string.assistant_voice_error_generic),
+            )
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class VoiceRecognizerFirstTextTest {
+    private val recognizer = VoiceRecognizer(ApplicationProvider.getApplicationContext<Application>())
+
+    @Test
+    fun `firstText returns null for a null bundle`() {
+        assertNull(recognizer.firstText(null))
+    }
+
+    @Test
+    fun `firstText returns null when the bundle lacks a results list`() {
+        assertNull(recognizer.firstText(Bundle()))
+    }
+
+    @Test
+    fun `firstText returns null when the results list is empty`() {
+        val bundle =
+            Bundle().apply {
+                putStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION, ArrayList())
+            }
+
+        assertNull(recognizer.firstText(bundle))
+    }
+
+    @Test
+    fun `firstText returns the first transcript when several are present`() {
+        val bundle =
+            Bundle().apply {
+                putStringArrayList(
+                    SpeechRecognizer.RESULTS_RECOGNITION,
+                    arrayListOf("navigate home", "navigate Rome"),
+                )
+            }
+
+        assertEquals("navigate home", recognizer.firstText(bundle))
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeCalendarSnapshot.kt
@@ -27,6 +27,7 @@ internal fun fakeCalendarSnapshot(
             DayCell(LocalDate.of(2026, 5, 6), "Wed", listOf(EventItem(null, "Holiday"))),
         ),
     hasCalendarAccess: Boolean = true,
+    queryFailed: Boolean = false,
 ): CalendarSnapshot =
     CalendarSnapshot(
         today = today,
@@ -34,4 +35,5 @@ internal fun fakeCalendarSnapshot(
         monthLabel = monthLabel,
         days = days,
         hasCalendarAccess = hasCalendarAccess,
+        queryFailed = queryFailed,
     )

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeFontFaceStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeFontFaceStore.kt
@@ -1,0 +1,58 @@
+package io.github.seijikohara.femto.testfixtures
+
+import io.github.seijikohara.femto.data.CachedFont
+import io.github.seijikohara.femto.data.FontFaceStore
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * In-memory [FontFaceStore] for repository tests. Downloads succeed instantly by
+ * default; a family in [failing] resolves to null (the offline path), and
+ * [gateDownload] holds a download in flight until the test releases it. The gate
+ * waits inside [NonCancellable] to model the real cache's blocking OkHttp write,
+ * which a cancelled resolve pass cannot interrupt mid-stream.
+ */
+internal class FakeFontFaceStore : FontFaceStore {
+    private val store = mutableMapOf<String, CachedFont>()
+    private val gates = mutableMapOf<String, CompletableDeferred<Unit>>()
+
+    /** Families whose download resolves to null, as when the network is down. */
+    val failing = mutableSetOf<String>()
+
+    /** Every family [ensure] actually tried to download (cache misses only). */
+    val downloads = mutableListOf<String>()
+
+    /** Every [evictExcept] call in order, as keep set to alsoProtect set. */
+    val evictions = mutableListOf<Pair<Set<String>, Set<String>>>()
+
+    fun preload(family: String) {
+        store[family] = fontFor(family)
+    }
+
+    fun isCached(family: String): Boolean = family in store
+
+    /** Hold the next download of [family] open until the returned gate completes. */
+    fun gateDownload(family: String): CompletableDeferred<Unit> =
+        CompletableDeferred<Unit>().also { gates[family] = it }
+
+    override fun cached(family: String): CachedFont? = store[family]
+
+    override suspend fun ensure(family: String): CachedFont? {
+        store[family]?.let { return it }
+        downloads += family
+        gates.remove(family)?.let { gate -> withContext(NonCancellable) { gate.await() } }
+        return if (family in failing) null else fontFor(family).also { store[family] = it }
+    }
+
+    override fun evictExcept(
+        keep: Collection<String>,
+        alsoProtect: Collection<String>,
+    ) {
+        evictions += keep.toSet() to alsoProtect.toSet()
+        store.keys.retainAll((keep + alsoProtect).toSet())
+    }
+
+    private fun fontFor(family: String): CachedFont = CachedFont.Variable(File("/fonts/$family/variable.ttf"))
+}

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeFontSelectionStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeFontSelectionStore.kt
@@ -1,0 +1,31 @@
+package io.github.seijikohara.femto.testfixtures
+
+import io.github.seijikohara.femto.data.FontSelection
+import io.github.seijikohara.femto.data.FontSelectionStore
+import io.github.seijikohara.femto.data.FontSlot
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * In-memory [FontSelectionStore] for repository tests. Backed by a
+ * [MutableStateFlow], which — like DataStore — skips the re-emission when an
+ * unchanged selection is written, so the repository's retry trigger for
+ * re-chosen families is exercised faithfully.
+ */
+internal class FakeFontSelectionStore(
+    initial: FontSelection = FontSelection.System,
+) : FontSelectionStore {
+    private val state = MutableStateFlow(initial)
+
+    override val selection: Flow<FontSelection> = state
+
+    override suspend fun setFamily(
+        slot: FontSlot,
+        family: String?,
+    ) = state.update { it.with(slot, family) }
+
+    override suspend fun resetToDefaults() {
+        state.value = FontSelection.System
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeLauncherActivityInfo.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeLauncherActivityInfo.kt
@@ -1,0 +1,60 @@
+package io.github.seijikohara.femto.testfixtures
+
+import android.content.Context
+import android.content.pm.ActivityInfo
+import android.content.pm.ApplicationInfo
+import android.content.pm.LauncherActivityInfo
+import android.os.Process
+import android.os.UserHandle
+import org.robolectric.util.ReflectionHelpers
+import org.robolectric.util.ReflectionHelpers.ClassParameter
+
+/**
+ * Build a real [LauncherActivityInfo] for Robolectric tests. The platform class
+ * has no public constructor, so this goes through the hidden
+ * `LauncherActivityInfoInternal` / `IncrementalStatesInfo` types reflectively,
+ * matching the API 33 constructor shapes (tests pin `@Config(sdk = [33])`).
+ *
+ * Pass `label = null` together with `hasApplicationInfo = false` to produce an
+ * entry whose label resolution throws (`ComponentInfo.loadUnsafeLabel`
+ * dereferences the missing [ApplicationInfo]); tests use that to exercise the
+ * per-app isolation path in `AppsRepository.queryApps`.
+ */
+internal fun fakeLauncherActivityInfo(
+    context: Context,
+    packageName: String,
+    className: String = "$packageName.MainActivity",
+    label: String? = packageName,
+    hasApplicationInfo: Boolean = true,
+    user: UserHandle = Process.myUserHandle(),
+): LauncherActivityInfo {
+    val activityInfo =
+        ActivityInfo().apply {
+            this.packageName = packageName
+            name = className
+            nonLocalizedLabel = label
+            if (hasApplicationInfo) {
+                applicationInfo = ApplicationInfo().also { it.packageName = packageName }
+            }
+        }
+    val statesClass = Class.forName("android.content.pm.IncrementalStatesInfo")
+    val states: Any =
+        ReflectionHelpers.callConstructor(
+            statesClass,
+            ClassParameter.from(Boolean::class.javaPrimitiveType!!, false),
+            ClassParameter.from(Float::class.javaPrimitiveType!!, 1f),
+        )
+    val internalClass = Class.forName("android.content.pm.LauncherActivityInfoInternal")
+    val internal: Any =
+        ReflectionHelpers.callConstructor(
+            internalClass,
+            ClassParameter.from(ActivityInfo::class.java, activityInfo),
+            ClassParameter.from(statesClass, states),
+        )
+    return ReflectionHelpers.callConstructor(
+        LauncherActivityInfo::class.java,
+        ClassParameter.from(Context::class.java, context),
+        ClassParameter.from(UserHandle::class.java, user),
+        ClassParameter.from(internalClass, internal),
+    )
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerViewModelTest.kt
@@ -1,0 +1,124 @@
+package io.github.seijikohara.femto.ui.fontpicker
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.test
+import io.github.seijikohara.femto.data.FontCatalogSource
+import io.github.seijikohara.femto.data.FontRepository
+import io.github.seijikohara.femto.data.FontSlot
+import io.github.seijikohara.femto.data.GoogleFontFamily
+import io.github.seijikohara.femto.testfixtures.FakeFontFaceStore
+import io.github.seijikohara.femto.testfixtures.FakeFontSelectionStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertEquals
+
+private val Catalog =
+    listOf(
+        GoogleFontFamily("Inter", "Sans Serif", listOf("latin"), popularity = 1),
+        GoogleFontFamily("Noto Sans JP", "Sans Serif", listOf("latin", "japanese"), popularity = 2),
+        GoogleFontFamily("Roboto", "Sans Serif", listOf("latin"), popularity = 3),
+    )
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FontPickerViewModelTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `latin slot lists the whole catalog`() =
+        runTest {
+            val viewModel = viewModel(FontSlot.LATIN)
+            viewModel.uiState.test {
+                val ready = awaitUntil { it.status == PickerStatus.READY }
+                assertEquals(listOf("Inter", "Noto Sans JP", "Roboto"), ready.families.map { it.family })
+            }
+        }
+
+    @Test
+    fun `cjk slot lists only cjk-capable families`() =
+        runTest {
+            val viewModel = viewModel(FontSlot.CJK)
+            viewModel.uiState.test {
+                val ready = awaitUntil { it.status == PickerStatus.READY }
+                assertEquals(listOf("Noto Sans JP"), ready.families.map { it.family })
+            }
+        }
+
+    @Test
+    fun `search filters the catalog case-insensitively`() =
+        runTest {
+            val viewModel = viewModel(FontSlot.LATIN)
+            viewModel.uiState.test {
+                awaitUntil { it.status == PickerStatus.READY }
+
+                viewModel.onAction(FontPickerAction.Search("noTO"))
+
+                val filtered = awaitUntil { it.query == "noTO" && it.status == PickerStatus.READY }
+                assertEquals(listOf("Noto Sans JP"), filtered.families.map { it.family })
+            }
+        }
+
+    @Test
+    fun `a failed download is exposed for the affected family`() =
+        runTest {
+            val cache = FakeFontFaceStore().apply { failing += "Inter" }
+            val viewModel = viewModel(FontSlot.LATIN, cache = cache)
+            viewModel.uiState.test {
+                awaitUntil { it.status == PickerStatus.READY }
+
+                viewModel.onAction(FontPickerAction.Choose("Inter"))
+
+                val failed = awaitUntil { "Inter" in it.downloadFailed }
+                assertEquals("Inter", failed.selectedFamily)
+                // The selection and failure flows recombine once more after the
+                // matched event; the trailing emission is not under test.
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    private fun TestScope.viewModel(
+        slot: FontSlot,
+        cache: FakeFontFaceStore = FakeFontFaceStore(),
+    ): FontPickerViewModel =
+        FontPickerViewModel(
+            repository =
+                FontRepository(
+                    api = FontCatalogSource { Catalog },
+                    cache = cache,
+                    preferences = FakeFontSelectionStore(),
+                    catalogFile = File(tempFolder.root, "catalog.json"),
+                    scope = backgroundScope,
+                ),
+            slot = slot,
+        )
+}
+
+// Conflated state flows may fold intermediate states into one emission, so the
+// assertions anchor on a predicate rather than a fixed emission index.
+private suspend fun <T> ReceiveTurbine<T>.awaitUntil(predicate: (T) -> Boolean): T {
+    while (true) {
+        val item = awaitItem()
+        if (predicate(item)) return item
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to a full-project review. Three themes: crash containment, concurrency correctness, and making unexpected failures visible instead of indistinguishable from healthy empty states.

### Crash containment

- **`WebMapView` overrides `onRenderProcessGone`** — without it the platform kills the whole launcher process when the WebView renderer dies (WebGL is a classic OOM victim on weak head-unit GPUs). The first death rebuilds the WebView in place; a second death within 5 minutes stops the rebuild loop and shows a static notice pointing at the Settings render-mode switch. **No auto-fallback**: renderer death is a system-reported fact (unlike the removed context-loss/readiness heuristics that misfired on healthy devices), and even then the persisted render mode is never rewritten.
- **DataStore reads catch `IOException`** (`emptyPreferences()` fallback) so a prefs file corrupted by a power cut boots the HOME app with defaults instead of crash-looping; writes are logged on failure.
- **`HomeViewModel` catches per-source flow failures** — one broken repository (e.g. a `SecurityException` from a permission revoked mid-registration) degrades its own card and the rest of the dashboard keeps updating.

### Concurrency / cancellation

- `Mutex` around `WeatherRepository.refresh` and `ReverseGeocoderRepository.resolve` (the latter also fixes a throttle race that could violate Nominatim's 1 req/s policy); synchronized icon cache in `MusicSessionRepository`; CAS-based `FontRepository.ensureCatalog`.
- `CancellationException` is rethrown wherever `runCatching` wrapped a suspend call (app drawer dismissal no longer renders as an error).

### Degraded-state visibility

- `CalendarSnapshot.queryFailed` distinguishes a provider fault from an empty schedule; the card says "Calendar couldn't be read" instead of faking "no events".
- `map.html` reports through a minimal JS bridge (`femtoBridge.onMapEvent`): transient tile/style errors are **logged only** (never UI — that ambiguous signal class caused the old false fallbacks); definitive fatal conditions (no WebGL, map construction threw) show a static notice.
- `FontRepository.downloadFailed` drives a tap-to-retry state on font picker rows; re-choosing the same family retries the download. `GoogleFontsApi` verifies the post-download rename; `FontCache` eviction protects in-flight downloads.
- Silent `runCatching` sites across Calendar/Location/Apps/Voice/MainActivity/MapSnapshotter now log.

### Conventions

Banned typography roles replaced in `MusicCard`; `DynamicAccentSweep` hex moved to `Color.kt`; `SpeedOverlay` no longer writes state during composition; `NominatimApi` default language follows the device locale (multi-region rule); CLAUDE.md tech-stack versions synced to the catalog.

### Tests

New JVM suites: `FontRepositoryTest` (evict-on-switch contract, in-flight protection, offline restart, failure/retry), `GoogleFontsApiTest` (MockWebServer), `FontPickerViewModelTest`, `MusicSessionMappingTest`, `VoiceRecognizerMessageTest`, `DrawerPreferencesTest`, plus extended `AppsRepositoryTest`, `CalendarRepositoryTest`, `FontCacheTest`, and a `CalendarCardTest` UI case. `FontPickerViewModel` is now constructor-injected (factory pattern mirrors `HomeViewModel`).

## Test plan

- `./gradlew spotlessCheck assembleDebug` — BUILD SUCCESSFUL
- `./gradlew test` — 250+ JVM tests green
- `./gradlew lint` — 0 errors
- Deployed to the TBox-Mock emulator (800x480@150dpi): LIVE map renders with marker/address overlays, calendar/weather/footer normal, no fatal exceptions in logcat, and no false notices — the new containment reacts only to definitive failures.
- `connectedAndroidTest` not run (the new `CalendarCardTest` case rides the existing suite).