### PR TITLE
feat: add tunable location precision and theme/map cross-fades

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -33,6 +33,7 @@ class SettingsScreenTest {
     private val lightSchemeLabel = context.getString(R.string.settings_group_map_scheme_light)
     private val darkSchemeLabel = context.getString(R.string.settings_group_map_scheme_dark)
     private val glassBlurLabel = context.getString(R.string.settings_group_glass_blur)
+    private val locationIntervalLabel = context.getString(R.string.settings_group_location_interval)
 
     @Test
     fun renders_fullscreen_row() {
@@ -102,6 +103,12 @@ class SettingsScreenTest {
     fun glass_blur_row_is_shown() {
         setScreen()
         rule.onNodeWithText(glassBlurLabel).performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun location_interval_row_is_shown() {
+        setScreen()
+        rule.onNodeWithText(locationIntervalLabel).performScrollTo().assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/assets/web/map.html
+++ b/app/src/main/assets/web/map.html
@@ -20,10 +20,18 @@
         transform: translate(-50%, -50%);
         pointer-events: none; display: none; will-change: top, transform;
       }
+      /* Style-swap cross-fade: a frozen capture of the outgoing style pinned over
+         the map, faded out once the incoming style has rendered. */
+      #style-fade {
+        position: fixed; inset: 0; z-index: 10;
+        pointer-events: none; display: none; opacity: 0;
+      }
+      #style-fade img { width: 100%; height: 100%; }
     </style>
   </head>
   <body>
     <div id="map"></div>
+    <div id="style-fade"><img alt="" /></div>
     <div id="self-marker">
       <svg width="34" height="34" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
         <path d="M15 0 L30 30 L15 21.6 L0 30 Z" fill="#3367D6" stroke="#FFFFFF" stroke-width="1.5" stroke-linejoin="round"/>
@@ -129,6 +137,61 @@
       function applyStyle() {
         if (map && currentStyleUrl) map.setStyle(currentStyleUrl, { transformStyle: injectFeatures });
       }
+
+      // Cross-fade a style swap: capture the outgoing style's last frame from the
+      // GL canvas, pin it over the map, apply the new style, then fade the capture
+      // out once the new style has loaded and presented a frame. A timeout guard
+      // fades anyway so a style that never loads (offline) cannot pin the stale
+      // capture; the generation counter lets a rapid second swap cancel the first
+      // swap's pending callbacks.
+      var STYLE_FADE_MS = 500;
+      var STYLE_FADE_MAX_WAIT_MS = 4000;
+      var styleFadeGen = 0;
+      function applyStyleWithFade() {
+        if (!map) return;
+        // Nothing rendered yet (initial load): swap without a fade.
+        if (!map.isStyleLoaded()) { applyStyle(); return; }
+        var gen = ++styleFadeGen;
+        var el = document.getElementById("style-fade");
+        var img = el.querySelector("img");
+        // The GL buffer is only valid synchronously inside a render event, so the
+        // capture happens there (no preserveDrawingBuffer cost) — but the style
+        // swap itself is deferred OUT of the render loop: a setStyle issued
+        // mid-render leaves the presented frame stale on a static camera, so the
+        // new scheme only appeared as the camera moved.
+        map.once("render", function () {
+          if (gen !== styleFadeGen) return;
+          try {
+            img.src = map.getCanvas().toDataURL("image/jpeg", 0.85);
+            el.style.transition = "none";
+            el.style.opacity = "1";
+            el.style.display = "block";
+          } catch (e) { log("style-fade capture failed: " + (e && e.message)); }
+          setTimeout(function () {
+            if (gen !== styleFadeGen) return;
+            applyStyle();
+            var faded = false;
+            function fadeOut() {
+              if (faded || gen !== styleFadeGen) return;
+              faded = true;
+              el.style.transition = "opacity " + STYLE_FADE_MS + "ms ease";
+              el.style.opacity = "0";
+              setTimeout(function () { if (gen === styleFadeGen) el.style.display = "none"; }, STYLE_FADE_MS + 100);
+            }
+            // Fade once the swapped-in style has loaded and a frame with it has
+            // been rendered (the same readiness signal the host uses); "idle"
+            // would be nicer but never fires while the GPS camera keeps easing.
+            function check() {
+              if (gen !== styleFadeGen) { map.off("render", check); return; }
+              if (map.isStyleLoaded()) { map.off("render", check); fadeOut(); }
+            }
+            map.on("render", check);
+            setTimeout(fadeOut, STYLE_FADE_MAX_WAIT_MS);
+            map.triggerRepaint();
+          }, 0);
+        });
+        map.triggerRepaint();
+      }
       (function () {
         const c = document.createElement("canvas");
         if (!(c.getContext("webgl2") || c.getContext("webgl"))) {
@@ -231,13 +294,13 @@
           if (!url) return;
           currentStyleUrl = url;
           accentColors = bg ? { background: bg, water: water, land: land } : null;
-          applyStyle();
+          applyStyleWithFade();
         };
         // Android -> JS: flip the LIVE feature toggles, then re-apply the style so
         // transformStyle injects (or omits) the matching layers/sources.
         window.setFeatures = function (buildings, terrain) {
           featureState = { buildings: !!buildings, terrain: !!terrain };
-          applyStyle();
+          applyStyleWithFade();
         };
         // Host (Android) calls this on lifecycle resume so the map re-measures and
         // repaints after the WebView was paused / not visible (guards a stale GL

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -405,7 +405,8 @@ internal class DisplayPreferences(
 
 // Decode a stored enum name to [T], falling back to [fallback] for a missing or
 // unrecognised value so the read never throws on a downgrade / renamed entry.
-private inline fun <reified T : Enum<T>> String?.toEnumOr(fallback: T): T =
+// Shared by every preferences accessor in this package.
+internal inline fun <reified T : Enum<T>> String?.toEnumOr(fallback: T): T =
     this?.let { name -> enumEntries<T>().firstOrNull { it.name == name } } ?: fallback
 
 // Decode the render mode, migrating the short-lived three-mode values

--- a/app/src/main/java/io/github/seijikohara/femto/data/LocationPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/LocationPreferences.kt
@@ -1,0 +1,112 @@
+package io.github.seijikohara.femto.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private const val TAG = "LocationPreferences"
+
+/**
+ * GNSS request quality, mirroring `LocationRequestCompat.QUALITY_*`. Defaults to
+ * [HIGH_ACCURACY]: the head unit runs on vehicle power, so there is no battery
+ * budget to trade away; the lower tiers exist for hardware that struggles to keep
+ * up with a high-accuracy duty cycle.
+ */
+internal enum class LocationQualitySetting { HIGH_ACCURACY, BALANCED, LOW_POWER }
+
+/**
+ * Default location-request interval (ms). 250 ms asks for fixes faster than the
+ * common 1 Hz GNSS cadence so chips capable of more deliver more; a 1 Hz-capped
+ * chip simply keeps emitting at 1 Hz.
+ */
+internal const val DEFAULT_LOCATION_INTERVAL_MS = 250L
+
+/** Default minimum distance (m) between fixes; 0 delivers every fix. */
+internal const val DEFAULT_LOCATION_MIN_DISTANCE_M = 0
+
+/**
+ * User-tunable location request parameters. The defaults ask for maximum
+ * precision; Settings exposes each knob so the user can dial the request back
+ * when the head-unit hardware struggles at chip-native rates.
+ */
+internal data class LocationSettings(
+    val quality: LocationQualitySetting,
+    val intervalMillis: Long,
+    val minUpdateDistanceMeters: Int,
+) {
+    companion object {
+        val Default =
+            LocationSettings(
+                quality = LocationQualitySetting.HIGH_ACCURACY,
+                intervalMillis = DEFAULT_LOCATION_INTERVAL_MS,
+                minUpdateDistanceMeters = DEFAULT_LOCATION_MIN_DISTANCE_M,
+            )
+    }
+}
+
+/**
+ * Read/write surface for [LocationSettings]. [LocationPreferences] is the
+ * DataStore-backed production implementation; tests substitute an in-memory fake
+ * so consumers can be exercised without real DataStore IO.
+ */
+internal interface LocationSettingsStore {
+    val settings: Flow<LocationSettings>
+
+    suspend fun setQuality(value: LocationQualitySetting)
+
+    suspend fun setIntervalMillis(value: Long)
+
+    suspend fun setMinUpdateDistanceMeters(value: Int)
+
+    /** Restore every location setting to [LocationSettings.Default]. */
+    suspend fun resetToDefaults()
+}
+
+private val Context.locationDataStore: DataStore<Preferences> by preferencesDataStore(name = "location_preferences")
+
+/** DataStore-backed accessor for [LocationSettings]. Modelled on [DisplayPreferences]. */
+internal class LocationPreferences(
+    private val context: Context,
+) : LocationSettingsStore {
+    override val settings: Flow<LocationSettings> =
+        context.locationDataStore.data
+            .catchIoAsDefaults(TAG)
+            .map { prefs ->
+                LocationSettings(
+                    quality = prefs[QUALITY_KEY].toEnumOr(LocationQualitySetting.HIGH_ACCURACY),
+                    intervalMillis = prefs[INTERVAL_KEY] ?: DEFAULT_LOCATION_INTERVAL_MS,
+                    minUpdateDistanceMeters = prefs[MIN_DISTANCE_KEY] ?: DEFAULT_LOCATION_MIN_DISTANCE_M,
+                )
+            }
+
+    override suspend fun setQuality(value: LocationQualitySetting) {
+        context.locationDataStore.editOrLog(TAG) { it[QUALITY_KEY] = value.name }
+    }
+
+    override suspend fun setIntervalMillis(value: Long) {
+        context.locationDataStore.editOrLog(TAG) { it[INTERVAL_KEY] = value }
+    }
+
+    override suspend fun setMinUpdateDistanceMeters(value: Int) {
+        context.locationDataStore.editOrLog(TAG) { it[MIN_DISTANCE_KEY] = value }
+    }
+
+    // Clearing every key makes the read path fall back to its per-field defaults,
+    // which are kept identical to LocationSettings.Default — so a reset restores
+    // the defaults without duplicating the default literals here.
+    override suspend fun resetToDefaults() {
+        context.locationDataStore.editOrLog(TAG) { it.clear() }
+    }
+
+    private companion object {
+        val QUALITY_KEY = stringPreferencesKey("location_quality")
+        val INTERVAL_KEY = longPreferencesKey("location_interval_ms")
+        val MIN_DISTANCE_KEY = intPreferencesKey("location_min_distance_m")
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/data/LocationRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/LocationRepository.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package io.github.seijikohara.femto.data
 
 import android.annotation.SuppressLint
@@ -12,12 +14,15 @@ import androidx.core.location.LocationManagerCompat
 import androidx.core.location.LocationRequestCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.shareIn
 
@@ -25,6 +30,9 @@ private const val TAG = "LocationRepository"
 
 internal class LocationRepository(
     private val context: Context,
+    // User-tunable request parameters (see [LocationSettings]); a change while
+    // collectors are live tears down and re-registers the platform listener.
+    private val settings: Flow<LocationSettings>,
     // Repository-scoped scope owns the single shared GPS subscription. The default keeps
     // production wiring trivial; tests inject their own scope to drive shareIn deterministically.
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
@@ -48,7 +56,7 @@ internal class LocationRepository(
     // never disturbs the other. A per-provider failure is dropped (no null emission) so a
     // working provider is never blanked by the other's absence.
     @SuppressLint("MissingPermission") // Caller checks fine or coarse location before subscribing.
-    private fun rawLocationFlow(): Flow<Location?> =
+    private fun rawLocationFlow(settings: LocationSettings): Flow<Location?> =
         callbackFlow {
             // One listener shared across both registrations; each fix is forwarded verbatim.
             val listener = LocationListenerCompat { location -> trySend(location) }
@@ -63,7 +71,7 @@ internal class LocationRepository(
                     LocationManagerCompat.requestLocationUpdates(
                         locationManager,
                         provider,
-                        LocationRequestCompat.Builder(LOCATION_INTERVAL_MS).build(),
+                        settings.toLocationRequest(),
                         listener,
                         Looper.getMainLooper(),
                     )
@@ -73,15 +81,24 @@ internal class LocationRepository(
             awaitClose { locationManager.removeUpdates(listener) }
         }.flowOn(Dispatchers.Main.immediate)
 
-    // Single hot fan-out of the cold raw flow. On an always-on head unit the four consumers
-    // (ViewModel combine, ReverseGeocoder, Weather, Trip) collect the same instance, so they
-    // share one platform GPS registration + one getLastKnownLocation instead of four each.
-    // WhileSubscribed(5_000) gates that single registration: it starts on the first collector,
-    // and stops ~5s after the last collector leaves (the grace window avoids tearing down and
-    // re-registering GPS across brief recomposition / config-change gaps). replay = 1 hands a
-    // late subscriber the most recent fix immediately rather than waiting for the next update.
+    // Single hot fan-out of the cold raw flow. On an always-on head unit the consumers
+    // (ViewModel combine, ReverseGeocoder, Weather, Trip, SystemStatus) collect the same
+    // instance, so they share one platform GPS registration + one getLastKnownLocation
+    // instead of one each. WhileSubscribed(5_000) gates that single registration: it starts
+    // on the first collector, and stops ~5s after the last collector leaves (the grace
+    // window avoids tearing down and re-registering GPS across brief recomposition /
+    // config-change gaps). replay = 1 hands a late subscriber the most recent fix
+    // immediately rather than waiting for the next update.
+    //
+    // flatMapLatest re-runs the raw flow when the user changes a location setting: the
+    // cancelled inner flow's awaitClose removes the old listener, the new one re-registers
+    // with the new request and re-seeds getLastKnownLocation, and replay = 1 bridges
+    // subscribers across the swap so nobody observes a gap.
     private val shared: SharedFlow<Location?> =
-        rawLocationFlow().shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 1)
+        settings
+            .distinctUntilChanged()
+            .flatMapLatest { rawLocationFlow(it) }
+            .shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 1)
 
     // The repository factory already builds one LocationRepository and passes the single flow
     // instance to all consumers, so returning the shared flow makes that sharing real.
@@ -97,8 +114,23 @@ internal class LocationRepository(
 
         else -> Log.w(TAG, "$stage $provider failed", error)
     }
-
-    private companion object {
-        const val LOCATION_INTERVAL_MS = 1_000L
-    }
 }
+
+private fun LocationSettings.toLocationRequest(): LocationRequestCompat =
+    LocationRequestCompat
+        .Builder(intervalMillis)
+        .setQuality(quality.toCompatQuality())
+        // The head unit runs on vehicle power: never throttle below the requested
+        // interval — let the GNSS chip deliver fixes as fast as it emits them. The
+        // interval itself is the user-facing rate knob, so a separate min-interval
+        // setting would only duplicate it.
+        .setMinUpdateIntervalMillis(0L)
+        .setMinUpdateDistanceMeters(minUpdateDistanceMeters.toFloat())
+        .build()
+
+private fun LocationQualitySetting.toCompatQuality(): Int =
+    when (this) {
+        LocationQualitySetting.HIGH_ACCURACY -> LocationRequestCompat.QUALITY_HIGH_ACCURACY
+        LocationQualitySetting.BALANCED -> LocationRequestCompat.QUALITY_BALANCED_POWER_ACCURACY
+        LocationQualitySetting.LOW_POWER -> LocationRequestCompat.QUALITY_LOW_POWER
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/data/TripRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/TripRepository.kt
@@ -53,8 +53,11 @@ import kotlinx.coroutines.flow.merge
  * only when `deltaSeconds` is at least `MIN_TRUSTWORTHY_DELTA_SECONDS`.
  * A sub-second gap (two near-simultaneous fixes) would divide a real
  * position delta into an absurd speed, so below that floor the
- * position-derived path yields no reading and the fix contributes
- * nothing.
+ * position-derived path yields no reading and the fix *defers*: the
+ * anchor stays put, the delta keeps growing across subsequent fixes,
+ * and accrual happens in one step once the accumulated delta clears
+ * the floor. (Advancing the anchor instead would reset the delta on
+ * every fix and freeze distance forever at sub-second cadence.)
  *
  * The accumulators ([lastLocation], [totalMeters], [totalSeconds]) live
  * on the instance, not inside the cold `flow {}`. Under
@@ -142,27 +145,37 @@ internal class TripRepository(
     // upstream in stateFlow so they never advance the anchor.
     private fun accrue(current: Location) {
         val previous = lastLocation
-        if (previous != null) {
-            val deltaSeconds =
-                (current.elapsedRealtimeNanos - previous.elapsedRealtimeNanos) / NANOS_PER_SECOND
-            if (deltaSeconds in MIN_DELTA_SECONDS..MAX_GAP_SECONDS) {
-                val speed = effectiveSpeed(previous, current, deltaSeconds)
-                // Drop implausible speeds (teleport jumps, bad chip reports,
-                // sub-second gaps): do not publish or accrue them.
-                if (speed != null && speed <= MAX_PLAUSIBLE_SPEED_MS) {
-                    currentSpeedMs = speed
-                    // Count every tracked interval toward the average's time base,
-                    // including time spent stopped, so AVG is the overall trip
-                    // average (distance / elapsed) rather than a moving-only average.
-                    // Long gaps are already excluded by the deltaSeconds window above.
-                    totalSeconds += deltaSeconds
-                    if (speed >= MIN_MOVING_SPEED_MS) {
-                        totalMeters += previous.distanceTo(current).toDouble()
-                    }
-                }
+        if (previous == null) {
+            lastLocation = current
+            return
+        }
+        val deltaSeconds =
+            (current.elapsedRealtimeNanos - previous.elapsedRealtimeNanos) / NANOS_PER_SECOND
+        if (deltaSeconds !in MIN_DELTA_SECONDS..MAX_GAP_SECONDS) {
+            // Non-advancing clock or a long gap (parked, lost fix, tunnel):
+            // re-anchor without accruing — we do not interpolate across it.
+            lastLocation = current
+            return
+        }
+        // A speed-less fix below the trust floor keeps the anchor: the delta then
+        // keeps growing toward MIN_TRUSTWORTHY_DELTA_SECONDS instead of resetting
+        // on every fix. Without this, a sub-second fix cadence (interval < 500 ms
+        // on a chip that never reports speed) would freeze distance forever.
+        val speed = effectiveSpeed(previous, current, deltaSeconds) ?: return
+        lastLocation = current
+        // Drop implausible speeds (teleport jumps, bad chip reports): re-anchor
+        // but do not publish or accrue them.
+        if (speed <= MAX_PLAUSIBLE_SPEED_MS) {
+            currentSpeedMs = speed
+            // Count every tracked interval toward the average's time base,
+            // including time spent stopped, so AVG is the overall trip
+            // average (distance / elapsed) rather than a moving-only average.
+            // Long gaps are already excluded by the deltaSeconds window above.
+            totalSeconds += deltaSeconds
+            if (speed >= MIN_MOVING_SPEED_MS) {
+                totalMeters += previous.distanceTo(current).toDouble()
             }
         }
-        lastLocation = current
     }
 
     // The chip's reported speed when it has one; otherwise the position-derived

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import io.github.seijikohara.femto.data.CalendarRepository
 import io.github.seijikohara.femto.data.CalendarSnapshot
 import io.github.seijikohara.femto.data.ClockRepository
 import io.github.seijikohara.femto.data.ClockTick
+import io.github.seijikohara.femto.data.LocationPreferences
 import io.github.seijikohara.femto.data.LocationRepository
 import io.github.seijikohara.femto.data.MusicCardState
 import io.github.seijikohara.femto.data.MusicSessionRepository
@@ -195,7 +196,7 @@ internal class HomeViewModelFactory(
         modelClass: Class<T>,
         extras: CreationExtras,
     ): T {
-        val location = LocationRepository(application)
+        val location = LocationRepository(application, LocationPreferences(application).settings)
         val locationFlow = location.locationFlow()
         val clock = ClockRepository(application)
         val clockFlow = clock.tickFlow()

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -11,6 +11,8 @@ import android.util.Log
 import android.view.SurfaceView
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -198,6 +200,29 @@ private fun SnapshotMap(
 
     var frame by remember { mutableStateOf<Bitmap?>(null) }
     var failed by remember { mutableStateOf(false) }
+
+    // Cross-fade a scheme/style swap: when the style key changes, freeze the
+    // outgoing style's last frame underneath and drop the top layer to alpha 0
+    // (both layers still show the old bitmap, so nothing flashes); the incoming
+    // style's first frame then fades in over the frozen capture. Movement
+    // re-renders replace the bitmap directly — only a style swap animates.
+    val styleKey = styleRef to accentColors
+    var fadeFrom by remember { mutableStateOf<Bitmap?>(null) }
+    var lastStyleKey by remember { mutableStateOf<Any?>(null) }
+    val fadeIn = remember { Animatable(1f) }
+    LaunchedEffect(styleKey) {
+        if (lastStyleKey != null && lastStyleKey != styleKey && frame != null) {
+            fadeFrom = frame
+            fadeIn.snapTo(0f)
+        }
+        lastStyleKey = styleKey
+    }
+    LaunchedEffect(frame) {
+        if (fadeFrom != null && frame != null && frame !== fadeFrom) {
+            fadeIn.animateTo(1f, tween(STYLE_FADE_MS))
+            fadeFrom = null
+        }
+    }
     // Carry the last non-zero bearing so a stopped vehicle (GPS bearing 0) keeps
     // the heading-up rotation instead of snapping back to north.
     val bearingHolder = remember { floatArrayOf(0f) }
@@ -271,11 +296,23 @@ private fun SnapshotMap(
     val current = frame
     when {
         current != null -> {
+            fadeFrom?.let { outgoing ->
+                Image(
+                    bitmap = outgoing.asImageBitmap(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
             Image(
                 bitmap = current.asImageBitmap(),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize().clickable { onTap() },
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .graphicsLayer { alpha = fadeIn.value }
+                        .clickable { onTap() },
             )
             LocationMarker(xPx = markerXPx, yPx = markerYPx, tiltDeg = mapConfig.tiltDeg)
         }
@@ -553,6 +590,10 @@ internal const val MAP_ZOOM = 16.5
 // produced when the fix actually moves (shouldRerender), so this just bounds the
 // re-check cadence, not the render rate.
 private const val SNAPSHOT_POLL_INTERVAL_MS = 200L
+
+// How long a snapshot style swap takes to cross-fade (mirrors STYLE_FADE_MS in
+// assets/web/map.html so both map backends transition at the same pace).
+private const val STYLE_FADE_MS = 500
 
 private const val TAG = "MapPanel"
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -51,6 +51,7 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.MapStyleSetting
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+import kotlinx.coroutines.delay
 
 /**
  * Live map backend: MapLibre GL JS (WebGL) in a WebView — the only path that renders
@@ -292,6 +293,11 @@ internal fun WebMapView(
     }
     LaunchedEffect(webView, pageReady.value, styleRef, accentColors) {
         if (!pageReady.value) return@LaunchedEffect
+        // The theme cross-fade animates MaterialTheme colours, so accentColors
+        // churns once per frame for the fade duration after a theme change. Each
+        // push restarts the page's style swap, so debounce: every churn cancels
+        // this effect and only the settled palette reaches the page.
+        delay(STYLE_PUSH_DEBOUNCE_MS)
         // Resolve the scheme to a URL the WebView can load (hosted, or the bundled
         // base served over appassets) plus the accent palette (empty = no recolor).
         val url =
@@ -427,6 +433,11 @@ private fun LiveMapNoticePreview() {
 }
 
 private const val TAG = "WebMapView"
+
+// Settle window for style pushes: longer than one animation frame (so a churning
+// theme fade keeps cancelling the push) but short enough to feel immediate once
+// the colours stop moving.
+private const val STYLE_PUSH_DEBOUNCE_MS = 150L
 
 // One renderer death rebuilds the WebView silently (a lone death is usually the
 // system reclaiming memory, not a fault in the map); a second death inside this

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.FontSlot
 import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.data.LocationQualitySetting
 import io.github.seijikohara.femto.data.MapColorScheme
 import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.data.MapStyleSetting
@@ -308,6 +309,43 @@ internal fun SettingsScreen(
                 value = uiState.mapMarkerPos,
                 range = MIN_MAP_MARKER_POS..MAX_MAP_MARKER_POS,
                 onValueChange = { onAction(SettingsAction.SetMapMarkerPos(it)) },
+            )
+        }
+
+        SettingsSection(title = stringResource(R.string.settings_section_location)) {
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_location_quality),
+                options =
+                    listOf(
+                        LocationQualitySetting.HIGH_ACCURACY to
+                            stringResource(R.string.settings_location_quality_high),
+                        LocationQualitySetting.BALANCED to
+                            stringResource(R.string.settings_location_quality_balanced),
+                        LocationQualitySetting.LOW_POWER to
+                            stringResource(R.string.settings_location_quality_low),
+                    ),
+                selected = uiState.locationQuality,
+                onSelect = { onAction(SettingsAction.SetLocationQuality(it)) },
+            )
+            // The slider works in 250 ms steps so the knob lands on round values;
+            // the persisted value stays in milliseconds.
+            SliderRow(
+                title = stringResource(R.string.settings_group_location_interval),
+                valueLabel =
+                    stringResource(R.string.settings_location_interval_value, uiState.locationIntervalMillis),
+                value = (uiState.locationIntervalMillis / LOCATION_INTERVAL_STEP_MS).toInt(),
+                range = MIN_LOCATION_INTERVAL_STEPS..MAX_LOCATION_INTERVAL_STEPS,
+                onValueChange = { onAction(SettingsAction.SetLocationIntervalMillis(it * LOCATION_INTERVAL_STEP_MS)) },
+                description = stringResource(R.string.settings_location_interval_desc),
+            )
+            SliderRow(
+                title = stringResource(R.string.settings_group_location_min_distance),
+                valueLabel =
+                    stringResource(R.string.settings_location_min_distance_value, uiState.locationMinDistanceMeters),
+                value = uiState.locationMinDistanceMeters,
+                range = MIN_LOCATION_MIN_DISTANCE..MAX_LOCATION_MIN_DISTANCE,
+                onValueChange = { onAction(SettingsAction.SetLocationMinDistance(it)) },
+                description = stringResource(R.string.settings_location_min_distance_desc),
             )
         }
 
@@ -766,6 +804,14 @@ private const val MIN_GLASS_BLUR = 0
 private const val MAX_GLASS_BLUR = 40
 private const val MIN_GLASS_OPACITY = 0
 private const val MAX_GLASS_OPACITY = 150
+
+// Location-request interval slider, in 250 ms steps (250 ms – 2 s); the persisted
+// value is milliseconds. Minimum-distance band in metres; 0 delivers every fix.
+private const val LOCATION_INTERVAL_STEP_MS = 250L
+private const val MIN_LOCATION_INTERVAL_STEPS = 1
+private const val MAX_LOCATION_INTERVAL_STEPS = 8
+private const val MIN_LOCATION_MIN_DISTANCE = 0
+private const val MAX_LOCATION_MIN_DISTANCE = 25
 
 private fun Boolean.toFullscreen(): FullscreenSetting = if (this) FullscreenSetting.ON else FullscreenSetting.OFF
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -4,6 +4,8 @@ import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.data.LocationQualitySetting
+import io.github.seijikohara.femto.data.LocationSettings
 import io.github.seijikohara.femto.data.MapColorScheme
 import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.data.MapStyleSetting
@@ -39,6 +41,9 @@ internal data class SettingsUiState(
     // The chosen Google Fonts families per slot; null means the system font.
     val latinFont: String?,
     val cjkFont: String?,
+    val locationQuality: LocationQualitySetting,
+    val locationIntervalMillis: Long,
+    val locationMinDistanceMeters: Int,
 ) {
     companion object {
         // Seeded from the persistence defaults so the default values live in one
@@ -70,6 +75,9 @@ internal data class SettingsUiState(
                 showMusic = DisplaySettings.Default.showMusic,
                 latinFont = null,
                 cjkFont = null,
+                locationQuality = LocationSettings.Default.quality,
+                locationIntervalMillis = LocationSettings.Default.intervalMillis,
+                locationMinDistanceMeters = LocationSettings.Default.minUpdateDistanceMeters,
             )
     }
 }
@@ -168,6 +176,18 @@ internal sealed interface SettingsAction {
         val value: Boolean,
     ) : SettingsAction
 
-    /** Restore every display + font setting to its default value. */
+    data class SetLocationQuality(
+        val value: LocationQualitySetting,
+    ) : SettingsAction
+
+    data class SetLocationIntervalMillis(
+        val value: Long,
+    ) : SettingsAction
+
+    data class SetLocationMinDistance(
+        val value: Int,
+    ) : SettingsAction
+
+    /** Restore every display + font + location setting to its default value. */
     data object ResetToDefaults : SettingsAction
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import io.github.seijikohara.femto.data.DisplayPreferences
 import io.github.seijikohara.femto.data.DisplaySettingsStore
 import io.github.seijikohara.femto.data.FontPreferences
+import io.github.seijikohara.femto.data.LocationPreferences
+import io.github.seijikohara.femto.data.LocationSettingsStore
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -17,9 +19,14 @@ import kotlinx.coroutines.launch
 internal class SettingsViewModel(
     private val displayPreferences: DisplaySettingsStore,
     private val fontPreferences: FontPreferences,
+    private val locationPreferences: LocationSettingsStore,
 ) : ViewModel() {
     val uiState: StateFlow<SettingsUiState> =
-        combine(displayPreferences.settings, fontPreferences.selection) { display, font ->
+        combine(
+            displayPreferences.settings,
+            fontPreferences.selection,
+            locationPreferences.settings,
+        ) { display, font, location ->
             SettingsUiState(
                 themeMode = display.themeMode,
                 accentColor = display.accentColor,
@@ -46,6 +53,9 @@ internal class SettingsViewModel(
                 showMusic = display.showMusic,
                 latinFont = font.latinFamily,
                 cjkFont = font.cjkFamily,
+                locationQuality = location.quality,
+                locationIntervalMillis = location.intervalMillis,
+                locationMinDistanceMeters = location.minUpdateDistanceMeters,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState.Initial)
 
@@ -145,8 +155,21 @@ internal class SettingsViewModel(
                     displayPreferences.setShowMusic(action.value)
                 }
 
+                is SettingsAction.SetLocationQuality -> {
+                    locationPreferences.setQuality(action.value)
+                }
+
+                is SettingsAction.SetLocationIntervalMillis -> {
+                    locationPreferences.setIntervalMillis(action.value)
+                }
+
+                is SettingsAction.SetLocationMinDistance -> {
+                    locationPreferences.setMinUpdateDistanceMeters(action.value)
+                }
+
                 is SettingsAction.ResetToDefaults -> {
                     displayPreferences.resetToDefaults()
+                    locationPreferences.resetToDefaults()
                     fontPreferences.resetToDefaults()
                 }
             }
@@ -165,6 +188,7 @@ internal class SettingsViewModelFactory(
         return SettingsViewModel(
             displayPreferences = DisplayPreferences(application),
             fontPreferences = FontPreferences(application),
+            locationPreferences = LocationPreferences(application),
         ) as T
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoTheme.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoTheme.kt
@@ -1,10 +1,14 @@
 package io.github.seijikohara.femto.ui.theme
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontFamily
@@ -17,7 +21,8 @@ import io.github.seijikohara.femto.data.AccentColor
  * Color: [AccentColor.DYNAMIC] (the default) uses Material You wallpaper-derived
  * color (always available because minSdk = 33); any other [accent] generates the
  * Material 3 scheme from a fixed preset seed. Falls back to a Bold Minimal
- * monochrome scheme inside Compose previews when on the dynamic path.
+ * monochrome scheme inside Compose previews when on the dynamic path. Scheme
+ * changes (Light <-> Dark, accent, wallpaper) cross-fade rather than snap.
  *
  * Typography: Bold Minimal weights and automotive sizing on top of M3 roles.
  * [fontFamily] is the resolved typeface — the system default, or the user's
@@ -38,22 +43,77 @@ fun FemtoTheme(
     val context = LocalContext.current
     val inPreview = LocalInspectionMode.current
     val seed = accent.accentSeedColor()
+    val target =
+        when {
+            // A fixed preset seed generates a full M3 scheme and works without a
+            // context (so it also previews), so it takes precedence everywhere.
+            seed != null -> rememberDynamicColorScheme(seedColor = seed, isDark = darkTheme)
+
+            inPreview && darkTheme -> DarkFallback
+
+            inPreview -> LightFallback
+
+            darkTheme -> dynamicDarkColorScheme(context)
+
+            else -> dynamicLightColorScheme(context)
+        }
     MaterialTheme(
-        colorScheme =
-            when {
-                // A fixed preset seed generates a full M3 scheme and works without a
-                // context (so it also previews), so it takes precedence everywhere.
-                seed != null -> rememberDynamicColorScheme(seedColor = seed, isDark = darkTheme)
-
-                inPreview && darkTheme -> DarkFallback
-
-                inPreview -> LightFallback
-
-                darkTheme -> dynamicDarkColorScheme(context)
-
-                else -> dynamicLightColorScheme(context)
-            },
+        colorScheme = target.animated(),
         typography = femtoTypography(fontFamily),
         content = content,
     )
 }
+
+// How long a theme change (Light <-> Dark, accent, wallpaper) takes to cross-fade.
+private const val THEME_FADE_MILLIS = 500
+
+/**
+ * Animate every colour role toward this target scheme so a theme switch
+ * cross-fades instead of snapping. The first composition starts at the target
+ * (animateColorAsState has no separate initial value), so cold start renders
+ * instantly. The rarely-used fixed-* roles are left to snap — nothing in the
+ * launcher reads them.
+ */
+@Composable
+private fun ColorScheme.animated(): ColorScheme =
+    copy(
+        primary = primary.fade(),
+        onPrimary = onPrimary.fade(),
+        primaryContainer = primaryContainer.fade(),
+        onPrimaryContainer = onPrimaryContainer.fade(),
+        inversePrimary = inversePrimary.fade(),
+        secondary = secondary.fade(),
+        onSecondary = onSecondary.fade(),
+        secondaryContainer = secondaryContainer.fade(),
+        onSecondaryContainer = onSecondaryContainer.fade(),
+        tertiary = tertiary.fade(),
+        onTertiary = onTertiary.fade(),
+        tertiaryContainer = tertiaryContainer.fade(),
+        onTertiaryContainer = onTertiaryContainer.fade(),
+        background = background.fade(),
+        onBackground = onBackground.fade(),
+        surface = surface.fade(),
+        onSurface = onSurface.fade(),
+        surfaceVariant = surfaceVariant.fade(),
+        onSurfaceVariant = onSurfaceVariant.fade(),
+        surfaceTint = surfaceTint.fade(),
+        inverseSurface = inverseSurface.fade(),
+        inverseOnSurface = inverseOnSurface.fade(),
+        error = error.fade(),
+        onError = onError.fade(),
+        errorContainer = errorContainer.fade(),
+        onErrorContainer = onErrorContainer.fade(),
+        outline = outline.fade(),
+        outlineVariant = outlineVariant.fade(),
+        scrim = scrim.fade(),
+        surfaceBright = surfaceBright.fade(),
+        surfaceDim = surfaceDim.fade(),
+        surfaceContainer = surfaceContainer.fade(),
+        surfaceContainerHigh = surfaceContainerHigh.fade(),
+        surfaceContainerHighest = surfaceContainerHighest.fade(),
+        surfaceContainerLow = surfaceContainerLow.fade(),
+        surfaceContainerLowest = surfaceContainerLowest.fade(),
+    )
+
+@Composable
+private fun Color.fade(): Color = animateColorAsState(this, tween(THEME_FADE_MILLIS), label = "themeColor").value

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="settings_section_display">Display</string>
     <string name="settings_section_units">Units</string>
     <string name="settings_section_map">Map</string>
+    <string name="settings_section_location">Location</string>
     <string name="settings_section_panels">Panels</string>
     <string name="settings_subheader_screen">Screen</string>
     <string name="settings_subheader_glass">Glass</string>
@@ -189,6 +190,16 @@
     <string name="settings_group_map_3d">3D buildings</string>
     <string name="settings_group_map_terrain">Terrain</string>
     <string name="settings_map_terrain_desc">3D elevation relief (Mapterhorn). Adds tile downloads; heavier on low-end GPUs.</string>
+    <string name="settings_group_location_quality">Accuracy</string>
+    <string name="settings_location_quality_high">High accuracy</string>
+    <string name="settings_location_quality_balanced">Balanced</string>
+    <string name="settings_location_quality_low">Low power</string>
+    <string name="settings_group_location_interval">Update interval</string>
+    <string name="settings_location_interval_value">%1$d ms</string>
+    <string name="settings_location_interval_desc">How often position updates are requested. Shorter is smoother; longer reduces load on slow head units. Many GNSS chips cap at one update per second regardless.</string>
+    <string name="settings_group_location_min_distance">Minimum distance</string>
+    <string name="settings_location_min_distance_value">%1$d m</string>
+    <string name="settings_location_min_distance_desc">Skip updates closer than this to the last position; 0 delivers every fix.</string>
     <string name="settings_group_panel_calendar">Calendar panel</string>
     <string name="settings_group_panel_weather">Weather panel</string>
     <string name="settings_group_panel_music">Music panel</string>
@@ -196,6 +207,6 @@
     <string name="settings_open_system_settings">System settings</string>
     <string name="settings_reset_to_defaults">Reset to defaults</string>
     <string name="settings_reset_confirm_title">Reset all settings?</string>
-    <string name="settings_reset_confirm_message">This restores every display, unit, map, panel and font setting to its default value.</string>
+    <string name="settings_reset_confirm_message">This restores every display, unit, map, location, panel and font setting to its default value.</string>
     <string name="settings_reset_confirm">Reset</string>
 </resources>

--- a/app/src/test/java/io/github/seijikohara/femto/data/LocationRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/LocationRepositoryTest.kt
@@ -11,8 +11,10 @@ import io.github.seijikohara.femto.testfixtures.fakeLocation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -54,7 +56,12 @@ class LocationRepositoryTest {
             val seedFix = fakeLocation()
             seedLastKnown(LocationManager.GPS_PROVIDER, seedFix)
 
-            val repository = LocationRepository(application, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+            val repository =
+                LocationRepository(
+                    application,
+                    flowOf(LocationSettings.Default),
+                    CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+                )
 
             // The first non-null fix arrives before any live update exists, proving
             // the stale cache is forwarded on subscribe rather than the flow blocking
@@ -74,7 +81,12 @@ class LocationRepositoryTest {
             val seedFix = fakeLocation()
             seedLastKnown(LocationManager.NETWORK_PROVIDER, seedFix)
 
-            val repository = LocationRepository(application, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+            val repository =
+                LocationRepository(
+                    application,
+                    flowOf(LocationSettings.Default),
+                    CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+                )
 
             val emitted = repository.locationFlow().filterNotNull().first()
 
@@ -89,13 +101,60 @@ class LocationRepositoryTest {
             val seedFix = fakeLocation()
             seedLastKnown(LocationManager.GPS_PROVIDER, seedFix)
 
-            val repository = LocationRepository(application, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+            val repository =
+                LocationRepository(
+                    application,
+                    flowOf(LocationSettings.Default),
+                    CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+                )
 
             repository.locationFlow().filterNotNull().test {
                 assertEquals(seedFix.latitude, awaitItem().latitude, 0.0)
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    @Test
+    fun `keeps delivering live fixes after a settings change re-registers the listener`() =
+        runTest {
+            val settings = MutableStateFlow(LocationSettings.Default)
+            val repository =
+                LocationRepository(
+                    application,
+                    settings,
+                    CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+                )
+
+            repository.locationFlow().filterNotNull().test {
+                simulateFix(fakeLocation(latitude = 10.0))
+                assertEquals(10.0, awaitItem().latitude, 0.0)
+
+                // Swap the request parameters mid-collection: flatMapLatest must tear
+                // down the old registration and bring up a new one without dropping
+                // the subscriber.
+                settings.value = LocationSettings.Default.copy(intervalMillis = 1_000L)
+
+                simulateFix(fakeLocation(latitude = 20.0))
+                // The swap re-runs the getLastKnownLocation seed, which may replay
+                // the previous fix first; the live fix from the new registration
+                // must follow it.
+                var item = awaitItem()
+                while (item.latitude != 20.0) item = awaitItem()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // Dispatch a live fix to whatever listeners are currently registered for the
+    // fix's provider (GPS here, matching the repository's GPS_PROVIDER registration).
+    // The shadow posts the callback to the registration's main Looper, so idle it
+    // to run the delivery (the coroutine Main override does not drive that Handler).
+    private fun simulateFix(location: android.location.Location) {
+        val locationManager = checkNotNull(application.getSystemService<LocationManager>())
+        shadowOf(locationManager).simulateLocation(
+            android.location.Location(location).apply { provider = LocationManager.GPS_PROVIDER },
+        )
+        shadowOf(android.os.Looper.getMainLooper()).idle()
+    }
 
     // ShadowLocationManager.setLastKnownLocation is the only seeding hook the shadow
     // exposes; its @Deprecated marker mirrors the platform setter and has no

--- a/app/src/test/java/io/github/seijikohara/femto/data/TripRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/TripRepositoryTest.kt
@@ -383,6 +383,71 @@ class TripRepositoryTest {
             }
         }
 
+    @Test
+    fun `defers speed-less sub-floor fixes until the accumulated delta clears the floor`() =
+        runTest {
+            // Speed-less fixes 250 ms apart — a sub-second request interval on a
+            // chip that never reports speed. Each individual delta is below the
+            // trust floor, so the anchor must hold (distance stays 0 after the
+            // second fix) until the accumulated delta reaches 0.5 s, then accrue
+            // in one step. Advancing the anchor per fix would freeze distance
+            // forever at this cadence.
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, hasSpeed = false, elapsedRealtimeNanos = 0L),
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + SMALL_STEP,
+                        hasSpeed = false,
+                        elapsedRealtimeNanos = quarterSecond(1),
+                    ),
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 2 * SMALL_STEP,
+                        hasSpeed = false,
+                        elapsedRealtimeNanos = quarterSecond(2),
+                    ),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix (anchor only)
+                assertEquals(0.0, awaitItem().distanceMeters, 0.0) // deferred sub-floor fix
+                assertTrue(awaitItem().distanceMeters > 0.0) // accumulated delta clears the floor
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `re-anchors on an implausible speed without accruing`() =
+        runTest {
+            // The implausible middle fix must not accrue, but it must advance the
+            // anchor: the next normal fix then accrues one step from the glitch
+            // position, not the ten-step span back to the origin.
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 10 * STEP,
+                        speedMps = 5_000f,
+                        elapsedRealtimeNanos = tenSeconds(1),
+                    ),
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 11 * STEP,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(2),
+                    ),
+                )
+
+            TripRepository(flow).stateFlow().test {
+                skipItems(2) // initial snapshot + first fix
+                assertEquals(0.0, awaitItem().distanceMeters, 0.0) // implausible fix dropped
+                val final = awaitItem()
+                // One ~111 m step from the re-anchored position; the ~1.2 km span
+                // from the origin would mean the glitch fix failed to re-anchor.
+                assertTrue(final.distanceMeters > 0.0)
+                assertTrue(final.distanceMeters < 300.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private companion object {
         const val ORIGIN_LAT = 35.6580
 
@@ -390,7 +455,14 @@ class TripRepositoryTest {
         // the moving-speed floor.
         const val STEP = 0.001
 
+        // ~5.5 m; over 250 ms a plausible vehicle step (~22 m/s once the
+        // accumulated delta clears the trust floor).
+        const val SMALL_STEP = STEP / 20
+
         // n * 10 s expressed in boot-clock nanoseconds.
         fun tenSeconds(n: Long): Long = n * 10_000_000_000L
+
+        // n * 250 ms expressed in boot-clock nanoseconds.
+        fun quarterSecond(n: Long): Long = n * 250_000_000L
     }
 }

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeLocationSettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeLocationSettingsStore.kt
@@ -1,0 +1,31 @@
+package io.github.seijikohara.femto.testfixtures
+
+import io.github.seijikohara.femto.data.LocationQualitySetting
+import io.github.seijikohara.femto.data.LocationSettings
+import io.github.seijikohara.femto.data.LocationSettingsStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * In-memory [LocationSettingsStore] for view-model tests: every setter mutates a
+ * [MutableStateFlow] synchronously, so a test sees the write with no DataStore IO
+ * and no cross-dispatcher timing. Defaults match [LocationSettings.Default].
+ */
+internal class FakeLocationSettingsStore(
+    initial: LocationSettings = LocationSettings.Default,
+) : LocationSettingsStore {
+    private val state = MutableStateFlow(initial)
+    override val settings: Flow<LocationSettings> = state
+
+    override suspend fun setQuality(value: LocationQualitySetting) = state.update { it.copy(quality = value) }
+
+    override suspend fun setIntervalMillis(value: Long) = state.update { it.copy(intervalMillis = value) }
+
+    override suspend fun setMinUpdateDistanceMeters(value: Int) =
+        state.update {
+            it.copy(minUpdateDistanceMeters = value)
+        }
+
+    override suspend fun resetToDefaults() = state.update { LocationSettings.Default }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -6,9 +6,12 @@ import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.data.LocationQualitySetting
+import io.github.seijikohara.femto.data.LocationSettings
 import io.github.seijikohara.femto.data.MapColorScheme
 import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.testfixtures.FakeDisplaySettingsStore
+import io.github.seijikohara.femto.testfixtures.FakeLocationSettingsStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -34,6 +37,7 @@ import kotlin.test.assertEquals
 class SettingsViewModelTest {
     private val application: Application = ApplicationProvider.getApplicationContext()
     private val store = FakeDisplaySettingsStore()
+    private val locationStore = FakeLocationSettingsStore()
     private val dispatcher = StandardTestDispatcher()
 
     @Before
@@ -143,6 +147,30 @@ class SettingsViewModelTest {
         }
 
     @Test
+    fun `SetLocationQuality writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetLocationQuality(LocationQualitySetting.LOW_POWER))
+            advanceUntilIdle()
+            assertEquals(LocationQualitySetting.LOW_POWER, locationStore.settings.first().quality)
+        }
+
+    @Test
+    fun `SetLocationIntervalMillis writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetLocationIntervalMillis(1_000L))
+            advanceUntilIdle()
+            assertEquals(1_000L, locationStore.settings.first().intervalMillis)
+        }
+
+    @Test
+    fun `SetLocationMinDistance writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetLocationMinDistance(5))
+            advanceUntilIdle()
+            assertEquals(5, locationStore.settings.first().minUpdateDistanceMeters)
+        }
+
+    @Test
     fun `ResetToDefaults restores display settings to their defaults`() =
         runTest(dispatcher) {
             val vm = viewModel()
@@ -151,10 +179,12 @@ class SettingsViewModelTest {
             vm.onAction(SettingsAction.SetAccentColor(AccentColor.TEAL))
             vm.onAction(SettingsAction.SetShowMusic(false))
             vm.onAction(SettingsAction.SetMapTilt(10))
+            vm.onAction(SettingsAction.SetLocationIntervalMillis(2_000L))
             advanceUntilIdle()
             vm.onAction(SettingsAction.ResetToDefaults)
             advanceUntilIdle()
             assertEquals(DisplaySettings.Default, store.settings.first())
+            assertEquals(LocationSettings.Default, locationStore.settings.first())
         }
 
     @Test
@@ -181,5 +211,5 @@ class SettingsViewModelTest {
             assertEquals(60, store.settings.first().glassTintScale)
         }
 
-    private fun viewModel() = SettingsViewModel(store, FontPreferences(application))
+    private fun viewModel() = SettingsViewModel(store, FontPreferences(application), locationStore)
 }


### PR DESCRIPTION
## Summary

### Location precision (Settings > Location)
- Default location request is now maximum precision: `QUALITY_HIGH_ACCURACY`, 250 ms interval, `minUpdateIntervalMillis = 0` (vehicle-powered head unit; a 1 Hz-capped GNSS chip simply keeps emitting at 1 Hz).
- New `LocationPreferences` DataStore (`location_preferences`) with a `LocationSettingsStore` interface; new Settings section exposes accuracy (High accuracy / Balanced / Low power), update interval (250–2000 ms), and minimum distance (0–25 m) so weak hardware can be dialed back.
- `LocationRepository` rebuilds the request via `flatMapLatest` on a settings change — the listener re-registers live with no app restart, and the five consumers keep sharing one platform registration.
- `TripRepository` regression fix: a speed-less fix below the 0.5 s trust floor now keeps the derivation anchor (deferring accrual) instead of advancing it, so distance can no longer freeze forever at sub-second fix cadence.

### Cross-fades
- `FemtoTheme` animates all Material color roles (500 ms), so Light <-> Dark, accent, and wallpaper changes fade instead of snapping.
- LIVE map (`map.html`): a style swap captures the outgoing style's last GL frame, pins it over the map, and fades it out once the new style has rendered. The `setStyle` call is deferred out of the render loop — issuing it mid-render left the presented frame stale on a static camera (scheme only appeared while moving).
- SNAPSHOT map: the incoming style's first bitmap alpha-fades over the outgoing style's last frame; movement re-renders still swap directly.
- WebView style pushes are debounced (150 ms) because the theme fade churns the accent palette once per frame.

## Test plan
- `./gradlew spotlessCheck test lint assembleDebug` — all green (243 JVM tests).
- New tests: live listener re-registration on settings change, deferred sub-floor accrual / implausible-speed re-anchor, Settings ViewModel actions + reset, Location section rendering (androidTest).
- Emulator (TBox-Mock): fixes flow with the new request; Settings interval change applies without restart; theme toggle fades UI and map; map scheme swaps on a static camera (the original WebView bug repro) in both directions.