### PR TITLE
chore(renovate): enable rebase + automerge and migrate config to JSON5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,12 +16,14 @@ plugins {
 // nor CI need a system Node.
 node {
     download = true
+    // renovate: datasource=node-version depName=node
     version = "22.13.1"
     // null suppresses the plugin's own repository registration; the Node.js
     // ivy repository lives in settings.gradle.kts (FAIL_ON_PROJECT_REPOS).
     distBaseUrl = null
     // Mirrors webmap/package.json "packageManager" (the pin pnpm itself reads
     // when invoked directly); this copy provisions the Gradle-managed install.
+    // renovate: datasource=npm depName=pnpm
     pnpmVersion = "11.5.2"
     nodeProjectDir = file("../webmap")
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,49 @@
+// Renovate configuration, in JSON5 so each policy can be annotated in place.
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    // Maintainer-recommended superset of config:recommended: pins GitHub Action
+    // digests, enables config migration, and keeps dependencies pinned where
+    // the ecosystem supports it.
+    'config:best-practices',
+    // Conventional Commits subjects (fix(deps)/chore(deps)) to match the repo.
+    ':semanticCommits',
+  ],
+  timezone: 'Asia/Tokyo',
+  // Keep update branches rebased whenever they fall behind main.
+  rebaseWhen: 'behind-base-branch',
+  // Renovate merges by itself (squash, matching the repo's linear history) on
+  // the first run after the Validate check passes. Platform auto-merge stays
+  // off so the merge method never depends on the repository's GitHub merge
+  // settings.
+  platformAutomerge: false,
+  automergeStrategy: 'squash',
+  // Weekly pnpm-lock.yaml refresh for webmap/, automerged like any other
+  // non-major update.
+  lockFileMaintenance: {
+    enabled: true,
+    automerge: true,
+  },
+  packageRules: [
+    {
+      description: 'Automerge non-major updates once CI is green; majors stay manual',
+      matchUpdateTypes: ['minor', 'patch', 'pin', 'pinDigest', 'digest'],
+      automerge: true,
+    },
+    {
+      description: 'Cooldown so a hijacked npm release cannot ride automerge on day zero',
+      matchDatasources: ['npm'],
+      minimumReleaseAge: '3 days',
+    },
+  ],
+  customManagers: [
+    {
+      customType: 'regex',
+      description: 'Node / pnpm pins in the node-gradle block, annotated with renovate comments',
+      managerFilePatterns: ['/(^|/)build\\.gradle\\.kts$/'],
+      matchStrings: [
+        '// renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s*\\n\\s*\\w+ = "(?<currentValue>[^"]+)"',
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- Migrates `renovate.json` to **`renovate.json5`** with inline rationale per policy.
- `config:best-practices` (pinned GitHub Action digests, config migration) + `:semanticCommits`.
- **Rebase**: `rebaseWhen: behind-base-branch` keeps update branches rebased onto main.
- **Automerge**: non-major updates (`minor` / `patch` / `pin` / `pinDigest` / `digest`) and weekly `lockFileMaintenance` automerge once the Validate check is green. Majors stay manual. Merging is done by Renovate itself with `automergeStrategy: squash` (matches the repo's linear history; independent of GitHub merge settings).
- **Supply-chain guard**: npm packages get a 3-day `minimumReleaseAge` cooldown so a hijacked release cannot ride automerge immediately.
- **Custom manager**: tracks the Node / pnpm pins inside the `node {}` block of `app/build.gradle.kts` via `// renovate:` annotations.

## Test plan
- `renovate-config-validator renovate.json5` — config validated successfully.
- CI Validate must pass (the Gradle annotations are comments only — no build behavior change).