### PR TITLE
build(webmap): add Biome linting/formatting and Vitest unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,7 +34,9 @@ val buildWebMap =
         pnpmCommand.set(listOf("run", "build"))
         inputs.dir("../webmap/src")
         inputs.files(
+            "../webmap/biome.json",
             "../webmap/map.html",
+            "../webmap/no-let.grit",
             "../webmap/package.json",
             "../webmap/pnpm-lock.yaml",
             "../webmap/tsconfig.json",

--- a/webmap/biome.json
+++ b/webmap/biome.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true,
+		"root": ".."
+	},
+	"files": {
+		"includes": ["**"]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"suspicious": {
+				"noVar": "error"
+			},
+			"style": {
+				"useConst": "error"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	},
+	"plugins": ["./no-let.grit"]
+}

--- a/webmap/map.html
+++ b/webmap/map.html
@@ -31,7 +31,8 @@
     <div id="map"></div>
     <div id="style-fade"><img alt="" /></div>
     <div id="self-marker">
-      <svg width="34" height="34" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
+      <!-- Decorative self-location chevron; the host UI owns the accessible name. -->
+      <svg width="34" height="34" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <path d="M15 0 L30 30 L15 21.6 L0 30 Z" fill="#3367D6" stroke="#FFFFFF" stroke-width="1.5" stroke-linejoin="round"/>
       </svg>
     </div>

--- a/webmap/no-let.grit
+++ b/webmap/no-let.grit
@@ -1,0 +1,14 @@
+language js
+
+// `let` is forbidden alongside `var` (lint/suspicious/noVar in biome.json):
+// every binding is a const, and mutable state lives in fields of a const
+// holder object (see the `state` holder in src/main.ts).
+//
+// Biome's GritQL bridge exposes declarations as tree-sitter style
+// `variable_declaration` nodes for every kind (var/let/const) and does not
+// surface the kind as a queryable field, so the kind keyword is matched on
+// the declaration's source text instead.
+variable_declaration() as $decl where {
+	$decl <: r"let\b[\s\S]*",
+	register_diagnostic(span=$decl, message="let is forbidden: use const, and keep mutable state in fields of a const holder.", severity="error")
+}

--- a/webmap/package.json
+++ b/webmap/package.json
@@ -1,18 +1,23 @@
 {
-  "name": "femto-webmap",
-  "private": true,
-  "type": "module",
-  "packageManager": "pnpm@11.5.2",
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc --noEmit && vite build",
-    "check": "tsc --noEmit"
-  },
-  "dependencies": {
-    "maplibre-gl": "^5.24.0"
-  },
-  "devDependencies": {
-    "typescript": "~6.0.3",
-    "vite": "^8.0.16"
-  }
+	"name": "femto-webmap",
+	"private": true,
+	"type": "module",
+	"packageManager": "pnpm@11.5.2",
+	"scripts": {
+		"dev": "vite",
+		"build": "pnpm run check && vite build",
+		"check": "biome check . && tsc --noEmit && vitest run",
+		"test": "vitest run",
+		"lint": "biome check .",
+		"format": "biome format --write ."
+	},
+	"dependencies": {
+		"maplibre-gl": "^5.24.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.16",
+		"typescript": "~6.0.3",
+		"vite": "^8.0.16",
+		"vitest": "^4.1.8"
+	}
 }

--- a/webmap/pnpm-lock.yaml
+++ b/webmap/pnpm-lock.yaml
@@ -12,14 +12,77 @@ importers:
         specifier: ^5.24.0
         version: 5.24.0
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.16
+        version: 2.4.16
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.0.16
         version: 8.0.16
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(vite@8.0.16)
 
 packages:
+
+  '@biomejs/biome@2.4.16':
+    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.16':
+    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.16':
+    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.16':
+    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.16':
+    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.16':
+    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -29,6 +92,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@mapbox/jsonlint-lines-primitives@2.0.2':
     resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
@@ -173,11 +239,63 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -185,6 +303,16 @@ packages:
 
   earcut@3.0.2:
     resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -283,6 +411,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   maplibre-gl@5.24.0:
     resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
@@ -297,6 +428,13 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pbf@4.0.2:
     resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
@@ -334,9 +472,25 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -344,6 +498,10 @@ packages:
 
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -396,7 +554,88 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
 snapshots:
+
+  '@biomejs/biome@2.4.16':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.16
+      '@biomejs/cli-darwin-x64': 2.4.16
+      '@biomejs/cli-linux-arm64': 2.4.16
+      '@biomejs/cli-linux-arm64-musl': 2.4.16
+      '@biomejs/cli-linux-x64': 2.4.16
+      '@biomejs/cli-linux-x64-musl': 2.4.16
+      '@biomejs/cli-win32-arm64': 2.4.16
+      '@biomejs/cli-win32-x64': 2.4.16
+
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.16':
+    optional: true
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -413,6 +652,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@mapbox/jsonlint-lines-primitives@2.0.2': {}
 
@@ -515,16 +756,82 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/geojson@7946.0.16': {}
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.16)':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
 
   detect-libc@2.1.2: {}
 
   earcut@3.0.2: {}
+
+  es-module-lexer@2.1.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -588,6 +895,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   maplibre-gl@5.24.0:
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
@@ -615,6 +926,10 @@ snapshots:
   murmurhash-js@1.0.0: {}
 
   nanoid@3.3.12: {}
+
+  obug@2.1.2: {}
+
+  pathe@2.0.3: {}
 
   pbf@4.0.2:
     dependencies:
@@ -665,7 +980,17 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -673,6 +998,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinyqueue@3.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   tslib@2.8.1:
     optional: true
@@ -688,3 +1015,33 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
+
+  vitest@4.1.8(vite@8.0.16):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16)
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/webmap/src/main.ts
+++ b/webmap/src/main.ts
@@ -1,29 +1,36 @@
-// LIVE map page logic, bundled into assets/web/ and hosted in the launcher's
+// LIVE map page wiring, bundled into assets/web/ and hosted in the launcher's
 // WebView (see WebMapView.kt for the host side of every contract in this file).
+// Pure style logic lives in style.ts; this module owns the DOM, the MapLibre
+// instance, and the Android bridge.
 import maplibregl from "maplibre-gl";
-import type { LayerSpecification, StyleSpecification } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
+import {
+	type AccentColors,
+	injectFeatures,
+	MAX_MARKER_DROP,
+	markerPadTop,
+} from "./style";
 
 // Android -> JS surface, called by the host through evaluateJavascript. Every
 // function is feature-detected on the Kotlin side (`window.updateCamera && ...`),
 // so the names below are a compatibility contract — never rename without
 // updating WebMapView.kt.
 declare global {
-  interface Window {
-    femtoBridge?: { onMapEvent(kind: string, detail: string): void };
-    updateCamera: (
-      lat: number,
-      lon: number,
-      bearing: number,
-      zoom: number,
-      tilt: number,
-      markerPos: number,
-      markerColor: string,
-    ) => void;
-    setStyleUrl: (url: string, bg: string, water: string, land: string) => void;
-    setFeatures: (buildings: boolean, terrain: boolean) => void;
-    onHostResume: () => void;
-  }
+	interface Window {
+		femtoBridge?: { onMapEvent(kind: string, detail: string): void };
+		updateCamera: (
+			lat: number,
+			lon: number,
+			bearing: number,
+			zoom: number,
+			tilt: number,
+			markerPos: number,
+			markerColor: string,
+		) => void;
+		setStyleUrl: (url: string, bg: string, water: string, land: string) => void;
+		setFeatures: (buildings: boolean, terrain: boolean) => void;
+		onHostResume: () => void;
+	}
 }
 
 // Diagnostic logging only (visible via chrome://inspect or the debug PoC's
@@ -31,11 +38,11 @@ declare global {
 // is kept as-is, and MapLibre's own context-loss restore handles transient
 // WebGL drops, so the page never asks the host to switch away.
 function log(msg: string): void {
-  try {
-    console.log("[map] " + msg);
-  } catch {
-    // Logging must never break the page.
-  }
+	try {
+		console.log(`[map] ${msg}`);
+	} catch {
+		// Logging must never break the page.
+	}
 }
 
 // JS -> Android error channel (window.femtoBridge, injected by the host via
@@ -44,112 +51,39 @@ function log(msg: string): void {
 // failures (tile / style / DEM fetch), log-only on the host. Neither kind
 // triggers a backend switch — the no-fallback rule above still holds.
 function report(kind: "fatal" | "error", detail: unknown): void {
-  try {
-    window.femtoBridge?.onMapEvent(kind, String(detail ?? ""));
-  } catch {
-    // The bridge may be absent outside the launcher (e.g. desktop dev server).
-  }
+	try {
+		window.femtoBridge?.onMapEvent(kind, String(detail ?? ""));
+	} catch {
+		// The bridge may be absent outside the launcher (e.g. desktop dev server).
+	}
 }
 
-// LIVE-only feature toggles, merged into the style via MapLibre transformStyle
-// (the official "hybrid satellite map with terrain elevation" approach, minus
-// satellite). DEM = Mapterhorn (free, no key); 3D buildings reuse the
-// OpenMapTiles building layer's render_height. The terrain provider's required
-// credit is shown by the host's Compose attribution overlay when active.
-const MAPTERHORN_DEM_URL = "https://tiles.mapterhorn.com/tilejson.json";
-
-interface AccentColors {
-  background: string;
-  water: string;
-  land: string;
-}
-
-let featureState = { buildings: false, terrain: false };
-let currentStyleUrl = "https://tiles.openfreemap.org/styles/positron";
-// Set by setStyleUrl for the ACCENT scheme, or null for a plain style.
-// Recoloured in injectFeatures (mirrors the Kotlin recolorAccent in
-// MapPanel.kt — keep the layer groups in sync).
-let accentColors: AccentColors | null = null;
-const ACCENT_LAND = ["landcover", "landuse", "park"];
-
-let map: maplibregl.Map | undefined;
-
-// The first vector source id in a style (the OpenMapTiles source), so 3D
-// buildings work across positron / the bundled dark.json without hard-coding.
-function vectorSourceId(style: StyleSpecification): string | undefined {
-  const sources = style.sources ?? {};
-  return Object.keys(sources).find((id) => sources[id].type === "vector");
-}
-
-// Style-spec paint maps are per-layer-type unions; this helper funnels the few
-// dynamic recolour writes through one narrow cast.
-function setPaint(layer: LayerSpecification, key: string, value: unknown): void {
-  const mutable = layer as { paint?: Record<string, unknown> };
-  mutable.paint = mutable.paint ?? {};
-  mutable.paint[key] = value;
-}
-
-// MapLibre transformStyle: merge the active feature layers/sources into a
-// freshly-loaded base style. OFF features are simply not injected, so toggling
-// off and re-setting the style removes them cleanly.
-function injectFeatures(
-  _previousStyle: StyleSpecification | undefined,
-  nextStyle: StyleSpecification,
-): StyleSpecification {
-  nextStyle.sources = nextStyle.sources ?? {};
-  nextStyle.layers = nextStyle.layers ?? [];
-  // Idempotent: strip any of OUR previously-injected layers/sources first, so a
-  // re-applied style (toggle change, or a setStyle that races the initial load
-  // and reuses the current style) never produces a duplicate-id error.
-  nextStyle.layers = nextStyle.layers.filter((l) => l.id !== "femto-3d-buildings");
-  // Only strip terrain if WE injected it (terrainSource present), so a base
-  // style that ever ships its own terrain is left intact.
-  if (nextStyle.sources.terrainSource) {
-    delete nextStyle.sources.terrainSource;
-    delete nextStyle.terrain;
-  }
-  // ACCENT scheme: recolour background / water / land fills with the accent
-  // palette, leaving roads + labels legible against the base.
-  const accent = accentColors;
-  if (accent) {
-    nextStyle.layers.forEach((l) => {
-      const sourceLayer = (l as { "source-layer"?: string })["source-layer"];
-      if (l.type === "background") setPaint(l, "background-color", accent.background);
-      else if (l.type === "fill" && sourceLayer === "water") setPaint(l, "fill-color", accent.water);
-      else if (l.type === "fill" && sourceLayer !== undefined && ACCENT_LAND.includes(sourceLayer))
-        setPaint(l, "fill-color", accent.land);
-    });
-  }
-  const src = vectorSourceId(nextStyle);
-  if (featureState.buildings && src) {
-    // Insert beneath the first label (symbol) layer so labels stay on top.
-    const firstSymbol = nextStyle.layers.find((l) => l.type === "symbol");
-    const buildings = {
-      id: "femto-3d-buildings",
-      source: src,
-      "source-layer": "building",
-      type: "fill-extrusion",
-      minzoom: 14,
-      filter: ["!=", ["get", "hide_3d"], true],
-      paint: {
-        "fill-extrusion-color": "#c2c8d0",
-        "fill-extrusion-height": ["interpolate", ["linear"], ["zoom"], 14, 0, 16, ["get", "render_height"]],
-        "fill-extrusion-base": ["interpolate", ["linear"], ["zoom"], 14, 0, 16, ["get", "render_min_height"]],
-        "fill-extrusion-opacity": 0.85,
-      },
-    } as LayerSpecification;
-    if (firstSymbol) nextStyle.layers.splice(nextStyle.layers.indexOf(firstSymbol), 0, buildings);
-    else nextStyle.layers.push(buildings);
-  }
-  if (featureState.terrain) {
-    nextStyle.sources.terrainSource = { type: "raster-dem", url: MAPTERHORN_DEM_URL };
-    nextStyle.terrain = { source: "terrainSource", exaggeration: 1.0 };
-  }
-  return nextStyle;
-}
+// Mutable page state in one const holder (let/var are banned — see biome.json
+// and no-let.grit). Camera pushes, style swaps, and error throttling all read
+// and write through here.
+const state = {
+	map: undefined as maplibregl.Map | undefined,
+	currentStyleUrl: "https://tiles.openfreemap.org/styles/positron",
+	// Set by setStyleUrl for the ACCENT scheme, or null for a plain style.
+	accentColors: null as AccentColors | null,
+	buildings: false,
+	terrain: false,
+	styleFadeGen: 0,
+	firstCamera: true,
+	lastErrorReportMs: 0,
+};
 
 function applyStyle(): void {
-  if (map && currentStyleUrl) map.setStyle(currentStyleUrl, { transformStyle: injectFeatures });
+	if (state.map && state.currentStyleUrl) {
+		state.map.setStyle(state.currentStyleUrl, {
+			transformStyle: (_previous, next) =>
+				injectFeatures(next, {
+					buildings: state.buildings,
+					terrain: state.terrain,
+					accent: state.accentColors,
+				}),
+		});
+	}
 }
 
 // Cross-fade a style swap: capture the outgoing style's last frame from the
@@ -160,193 +94,195 @@ function applyStyle(): void {
 // swap's pending callbacks.
 const STYLE_FADE_MS = 500;
 const STYLE_FADE_MAX_WAIT_MS = 4000;
-let styleFadeGen = 0;
 function applyStyleWithFade(): void {
-  const liveMap = map;
-  if (!liveMap) return;
-  // Nothing rendered yet (initial load): swap without a fade.
-  if (!liveMap.isStyleLoaded()) {
-    applyStyle();
-    return;
-  }
-  const gen = ++styleFadeGen;
-  const el = document.getElementById("style-fade") as HTMLElement;
-  const img = el.querySelector("img") as HTMLImageElement;
-  // The GL buffer is only valid synchronously inside a render event, so the
-  // capture happens there (no preserveDrawingBuffer cost) — but the style
-  // swap itself is deferred OUT of the render loop: a setStyle issued
-  // mid-render leaves the presented frame stale on a static camera, so the
-  // new scheme only appeared as the camera moved.
-  liveMap.once("render", () => {
-    if (gen !== styleFadeGen) return;
-    try {
-      img.src = liveMap.getCanvas().toDataURL("image/jpeg", 0.85);
-      el.style.transition = "none";
-      el.style.opacity = "1";
-      el.style.display = "block";
-    } catch (e) {
-      log("style-fade capture failed: " + (e instanceof Error ? e.message : e));
-    }
-    setTimeout(() => {
-      if (gen !== styleFadeGen) return;
-      applyStyle();
-      let faded = false;
-      const fadeOut = (): void => {
-        if (faded || gen !== styleFadeGen) return;
-        faded = true;
-        el.style.transition = "opacity " + STYLE_FADE_MS + "ms ease";
-        el.style.opacity = "0";
-        setTimeout(() => {
-          if (gen === styleFadeGen) el.style.display = "none";
-        }, STYLE_FADE_MS + 100);
-      };
-      // Fade once the swapped-in style has loaded and a frame with it has
-      // been rendered (the same readiness signal the host uses); "idle"
-      // would be nicer but never fires while the GPS camera keeps easing.
-      const check = (): void => {
-        if (gen !== styleFadeGen) {
-          liveMap.off("render", check);
-          return;
-        }
-        if (liveMap.isStyleLoaded()) {
-          liveMap.off("render", check);
-          fadeOut();
-        }
-      };
-      liveMap.on("render", check);
-      setTimeout(fadeOut, STYLE_FADE_MAX_WAIT_MS);
-      liveMap.triggerRepaint();
-    }, 0);
-  });
-  liveMap.triggerRepaint();
+	const liveMap = state.map;
+	if (!liveMap) return;
+	// Nothing rendered yet (initial load): swap without a fade.
+	if (!liveMap.isStyleLoaded()) {
+		applyStyle();
+		return;
+	}
+	state.styleFadeGen += 1;
+	const gen = state.styleFadeGen;
+	const el = document.getElementById("style-fade") as HTMLElement;
+	const img = el.querySelector("img") as HTMLImageElement;
+	// The GL buffer is only valid synchronously inside a render event, so the
+	// capture happens there (no preserveDrawingBuffer cost) — but the style
+	// swap itself is deferred OUT of the render loop: a setStyle issued
+	// mid-render leaves the presented frame stale on a static camera, so the
+	// new scheme only appeared as the camera moved.
+	liveMap.once("render", () => {
+		if (gen !== state.styleFadeGen) return;
+		try {
+			img.src = liveMap.getCanvas().toDataURL("image/jpeg", 0.85);
+			el.style.transition = "none";
+			el.style.opacity = "1";
+			el.style.display = "block";
+		} catch (e) {
+			log(`style-fade capture failed: ${e instanceof Error ? e.message : e}`);
+		}
+		setTimeout(() => {
+			if (gen !== state.styleFadeGen) return;
+			applyStyle();
+			const fade = { done: false };
+			const fadeOut = (): void => {
+				if (fade.done || gen !== state.styleFadeGen) return;
+				fade.done = true;
+				el.style.transition = `opacity ${STYLE_FADE_MS}ms ease`;
+				el.style.opacity = "0";
+				setTimeout(() => {
+					if (gen === state.styleFadeGen) el.style.display = "none";
+				}, STYLE_FADE_MS + 100);
+			};
+			// Fade once the swapped-in style has loaded and a frame with it has
+			// been rendered (the same readiness signal the host uses); "idle"
+			// would be nicer but never fires while the GPS camera keeps easing.
+			const check = (): void => {
+				if (gen !== state.styleFadeGen) {
+					liveMap.off("render", check);
+					return;
+				}
+				if (liveMap.isStyleLoaded()) {
+					liveMap.off("render", check);
+					fadeOut();
+				}
+			};
+			liveMap.on("render", check);
+			setTimeout(fadeOut, STYLE_FADE_MAX_WAIT_MS);
+			liveMap.triggerRepaint();
+		}, 0);
+	});
+	liveMap.triggerRepaint();
 }
 
 (() => {
-  const c = document.createElement("canvas");
-  if (!(c.getContext("webgl2") || c.getContext("webgl"))) {
-    log("no-webgl-context");
-    report("fatal", "no-webgl-context");
-  }
+	const c = document.createElement("canvas");
+	if (!(c.getContext("webgl2") || c.getContext("webgl"))) {
+		log("no-webgl-context");
+		report("fatal", "no-webgl-context");
+	}
 })();
 
 try {
-  const liveMap = new maplibregl.Map({
-    container: "map",
-    style: "https://tiles.openfreemap.org/styles/positron",
-    center: [0, 0],
-    zoom: 1,
-    attributionControl: false,
-  });
-  map = liveMap;
-  liveMap.on("render", () => {
-    if (liveMap.isStyleLoaded()) log("rendered");
-  });
-  liveMap.on("load", () => log("load"));
+	const liveMap = new maplibregl.Map({
+		container: "map",
+		style: "https://tiles.openfreemap.org/styles/positron",
+		center: [0, 0],
+		zoom: 1,
+		attributionControl: false,
+	});
+	state.map = liveMap;
+	liveMap.on("render", () => {
+		if (liveMap.isStyleLoaded()) log("rendered");
+	});
+	liveMap.on("load", () => log("load"));
 
-  // WebGL context loss is usually TRANSIENT on mobile / WebView GPUs, and
-  // MapLibre auto-recovers: it preventDefault()s the loss, saves the style,
-  // and on webglcontextrestored rebuilds the painter and re-renders (see
-  // map.ts _contextLost / _contextRestored, re-fired as Map events). We rely
-  // on that built-in restore and do not fall back to another backend.
-  liveMap.on("webglcontextlost", () => log("webglcontextlost (awaiting MapLibre restore)"));
-  liveMap.on("webglcontextrestored", () => log("webglcontextrestored"));
+	// WebGL context loss is usually TRANSIENT on mobile / WebView GPUs, and
+	// MapLibre auto-recovers: it preventDefault()s the loss, saves the style,
+	// and on webglcontextrestored rebuilds the painter and re-renders (see
+	// map.ts _contextLost / _contextRestored, re-fired as Map events). We rely
+	// on that built-in restore and do not fall back to another backend.
+	liveMap.on("webglcontextlost", () =>
+		log("webglcontextlost (awaiting MapLibre restore)"),
+	);
+	liveMap.on("webglcontextrestored", () => log("webglcontextrestored"));
 
-  // Tile / style / DEM fetch failures surface here. A flaky link can fire
-  // this once per tile, so reports to the host are throttled to one per
-  // ERROR_REPORT_INTERVAL_MS; the host only logs them (transient by
-  // definition — never UI, never a backend switch).
-  const ERROR_REPORT_INTERVAL_MS = 10000;
-  let lastErrorReportMs = 0;
-  liveMap.on("error", (e) => {
-    const detail = e?.error?.message || "unknown map error";
-    log("error: " + detail);
-    const now = Date.now();
-    if (now - lastErrorReportMs >= ERROR_REPORT_INTERVAL_MS) {
-      lastErrorReportMs = now;
-      report("error", String(detail).slice(0, 200));
-    }
-  });
+	// Tile / style / DEM fetch failures surface here. A flaky link can fire
+	// this once per tile, so reports to the host are throttled to one per
+	// ERROR_REPORT_INTERVAL_MS; the host only logs them (transient by
+	// definition — never UI, never a backend switch).
+	const ERROR_REPORT_INTERVAL_MS = 10000;
+	liveMap.on("error", (e) => {
+		const detail = e?.error?.message || "unknown map error";
+		log(`error: ${detail}`);
+		const now = Date.now();
+		if (now - state.lastErrorReportMs >= ERROR_REPORT_INTERVAL_MS) {
+			state.lastErrorReportMs = now;
+			report("error", String(detail).slice(0, 200));
+		}
+	});
 
-  // Self-location chevron: a fixed-on-screen DOM overlay (see #self-marker CSS).
-  // The camera brings the location to the chevron's spot, so the chevron stays
-  // still and the map slides + rotates beneath it (car-nav style) rather than a
-  // geo-anchored marker sliding to catch the eased camera. It is heading-UP: the
-  // chevron always points to the top of the frame and the map rotates to the
-  // travel bearing; rotateX lays it onto the tilted ground plane.
-  const markerEl = document.getElementById("self-marker") as HTMLElement;
-  const markerPath = markerEl.querySelector("path");
+	// Self-location chevron: a fixed-on-screen DOM overlay (see #self-marker CSS).
+	// The camera brings the location to the chevron's spot, so the chevron stays
+	// still and the map slides + rotates beneath it (car-nav style) rather than a
+	// geo-anchored marker sliding to catch the eased camera. It is heading-UP: the
+	// chevron always points to the top of the frame and the map rotates to the
+	// travel bearing; rotateX lays it onto the tilted ground plane.
+	const markerEl = document.getElementById("self-marker") as HTMLElement;
+	const markerPath = markerEl.querySelector("path");
 
-  // The lowest the marker drops below centre, as a fraction of map height, at
-  // markerPos = 100 (mirrors MAX_MARKER_DROP in MapPanel.kt).
-  const MAX_MARKER_DROP = 0.32;
-
-  // Top camera padding (px) that places the centred location at the height the
-  // marker-position setting asks for. padTop shifts the focal point down, so
-  // the location (and its marker) sits lower in the frame; markerPos 0 keeps it
-  // centred, 100 drops it MAX_MARKER_DROP of the height toward the speed panel.
-  function markerPadTop(markerPos: number): number {
-    const pos = Math.max(0, Math.min(100, markerPos || 0));
-    const drop = (pos / 100) * MAX_MARKER_DROP;
-    return 2 * drop * (liveMap.getContainer().clientHeight || 0);
-  }
-
-  // Android -> JS: smooth heading-up camera follow (easeTo interpolates between
-  // sparse GPS fixes). The first fix jumps (no fly-in from [0,0]); the rest ease.
-  // The chevron is pinned on screen (not geo-anchored), so only the camera moves
-  // and the chevron stays put while the map slides + rotates beneath it. The map
-  // rotates to the travel bearing, so the fixed chevron always reads as forward;
-  // rotateX lays it onto the tilted ground plane to match the map pitch. The
-  // chevron's screen height tracks markerPos, matching the camera padding so the
-  // location renders right under it. [markerColor] (Material primary) self-heals
-  // if the first push raced page load.
-  let firstCamera = true;
-  window.updateCamera = (lat, lon, bearing, zoom, tilt, markerPos, markerColor) => {
-    if (!map) return;
-    const heading = bearing || 0;
-    if (markerColor && markerPath) markerPath.setAttribute("fill", markerColor);
-    const pos = Math.max(0, Math.min(100, markerPos || 0));
-    markerEl.style.top = 50 + (pos / 100) * MAX_MARKER_DROP * 100 + "%";
-    markerEl.style.transform = "translate(-50%, -50%) perspective(600px) rotateX(" + (tilt || 0) + "deg)";
-    markerEl.style.display = "block";
-    const opts = {
-      center: [lon, lat] as [number, number],
-      bearing: heading,
-      zoom: zoom || 16,
-      pitch: tilt || 0,
-      padding: { top: markerPadTop(markerPos), bottom: 0, left: 0, right: 0 },
-    };
-    if (firstCamera) {
-      firstCamera = false;
-      liveMap.jumpTo(opts);
-    } else {
-      liveMap.easeTo({ ...opts, duration: 1000, essential: true });
-    }
-  };
-  // Android -> JS: switch the base style and (for the ACCENT scheme) its
-  // recolour palette; empty colour args mean a plain, non-accent style.
-  window.setStyleUrl = (url, bg, water, land) => {
-    if (!url) return;
-    currentStyleUrl = url;
-    accentColors = bg ? { background: bg, water: water, land: land } : null;
-    applyStyleWithFade();
-  };
-  // Android -> JS: flip the LIVE feature toggles, then re-apply the style so
-  // transformStyle injects (or omits) the matching layers/sources.
-  window.setFeatures = (buildings, terrain) => {
-    featureState = { buildings: !!buildings, terrain: !!terrain };
-    applyStyleWithFade();
-  };
-  // Host (Android) calls this on lifecycle resume so the map re-measures and
-  // repaints after the WebView was paused / not visible (guards a stale GL
-  // surface): map.resize() + triggerRepaint().
-  window.onHostResume = () => {
-    if (map) {
-      liveMap.resize();
-      liveMap.triggerRepaint();
-    }
-  };
+	// Android -> JS: smooth heading-up camera follow (easeTo interpolates between
+	// sparse GPS fixes). The first fix jumps (no fly-in from [0,0]); the rest ease.
+	// The chevron is pinned on screen (not geo-anchored), so only the camera moves
+	// and the chevron stays put while the map slides + rotates beneath it. The map
+	// rotates to the travel bearing, so the fixed chevron always reads as forward;
+	// rotateX lays it onto the tilted ground plane to match the map pitch. The
+	// chevron's screen height tracks markerPos, matching the camera padding so the
+	// location renders right under it. [markerColor] (Material primary) self-heals
+	// if the first push raced page load.
+	window.updateCamera = (
+		lat,
+		lon,
+		bearing,
+		zoom,
+		tilt,
+		markerPos,
+		markerColor,
+	) => {
+		if (!state.map) return;
+		const heading = bearing || 0;
+		if (markerColor && markerPath) markerPath.setAttribute("fill", markerColor);
+		const pos = Math.max(0, Math.min(100, markerPos || 0));
+		markerEl.style.top = `${50 + (pos / 100) * MAX_MARKER_DROP * 100}%`;
+		markerEl.style.transform = `translate(-50%, -50%) perspective(600px) rotateX(${tilt || 0}deg)`;
+		markerEl.style.display = "block";
+		const opts = {
+			center: [lon, lat] as [number, number],
+			bearing: heading,
+			zoom: zoom || 16,
+			pitch: tilt || 0,
+			padding: {
+				top: markerPadTop(markerPos, liveMap.getContainer().clientHeight || 0),
+				bottom: 0,
+				left: 0,
+				right: 0,
+			},
+		};
+		if (state.firstCamera) {
+			state.firstCamera = false;
+			liveMap.jumpTo(opts);
+		} else {
+			liveMap.easeTo({ ...opts, duration: 1000, essential: true });
+		}
+	};
+	// Android -> JS: switch the base style and (for the ACCENT scheme) its
+	// recolour palette; empty colour args mean a plain, non-accent style.
+	window.setStyleUrl = (url, bg, water, land) => {
+		if (!url) return;
+		state.currentStyleUrl = url;
+		state.accentColors = bg
+			? { background: bg, water: water, land: land }
+			: null;
+		applyStyleWithFade();
+	};
+	// Android -> JS: flip the LIVE feature toggles, then re-apply the style so
+	// transformStyle injects (or omits) the matching layers/sources.
+	window.setFeatures = (buildings, terrain) => {
+		state.buildings = !!buildings;
+		state.terrain = !!terrain;
+		applyStyleWithFade();
+	};
+	// Host (Android) calls this on lifecycle resume so the map re-measures and
+	// repaints after the WebView was paused / not visible (guards a stale GL
+	// surface): map.resize() + triggerRepaint().
+	window.onHostResume = () => {
+		if (state.map) {
+			liveMap.resize();
+			liveMap.triggerRepaint();
+		}
+	};
 } catch (e) {
-  log("exception:" + (e instanceof Error ? e.message : e));
-  // The map object never came up; this page will stay blank forever.
-  report("fatal", "map-init-exception: " + (e instanceof Error ? e.message : e));
+	log(`exception:${e instanceof Error ? e.message : e}`);
+	// The map object never came up; this page will stay blank forever.
+	report("fatal", `map-init-exception: ${e instanceof Error ? e.message : e}`);
 }

--- a/webmap/src/style.test.ts
+++ b/webmap/src/style.test.ts
@@ -1,0 +1,166 @@
+import type { StyleSpecification } from "maplibre-gl";
+import { describe, expect, it } from "vitest";
+import {
+	injectFeatures,
+	MAPTERHORN_DEM_URL,
+	MAX_MARKER_DROP,
+	markerPadTop,
+	vectorSourceId,
+} from "./style";
+
+const OFF = { buildings: false, terrain: false, accent: null };
+
+function baseStyle(): StyleSpecification {
+	return {
+		version: 8,
+		sources: {
+			openmaptiles: { type: "vector", url: "https://example.test/tiles.json" },
+			rasterdem: { type: "raster-dem", url: "https://example.test/dem.json" },
+		},
+		layers: [
+			{ id: "bg", type: "background" },
+			{
+				id: "water",
+				type: "fill",
+				source: "openmaptiles",
+				"source-layer": "water",
+			},
+			{
+				id: "park",
+				type: "fill",
+				source: "openmaptiles",
+				"source-layer": "park",
+			},
+			{
+				id: "road",
+				type: "fill",
+				source: "openmaptiles",
+				"source-layer": "transportation",
+			},
+			{
+				id: "labels",
+				type: "symbol",
+				source: "openmaptiles",
+				"source-layer": "place",
+			},
+		],
+	} as StyleSpecification;
+}
+
+describe("vectorSourceId", () => {
+	it("returns the first vector source id", () => {
+		expect(vectorSourceId(baseStyle())).toBe("openmaptiles");
+	});
+
+	it("returns undefined when the style has no vector source", () => {
+		const style = baseStyle();
+		style.sources = { rasterOnly: { type: "raster", tiles: [] } };
+		expect(vectorSourceId(style)).toBeUndefined();
+	});
+});
+
+describe("injectFeatures: 3D buildings", () => {
+	it("inserts the extrusion layer beneath the first symbol layer", () => {
+		const style = injectFeatures(baseStyle(), { ...OFF, buildings: true });
+		const ids = style.layers.map((l) => l.id);
+		expect(ids.indexOf("femto-3d-buildings")).toBe(ids.indexOf("labels") - 1);
+	});
+
+	it("appends the extrusion layer when the style has no symbol layer", () => {
+		const style = baseStyle();
+		style.layers = style.layers.filter((l) => l.type !== "symbol");
+		const out = injectFeatures(style, { ...OFF, buildings: true });
+		expect(out.layers.at(-1)?.id).toBe("femto-3d-buildings");
+	});
+
+	it("does not inject without a vector source", () => {
+		const style = baseStyle();
+		style.sources = {};
+		const out = injectFeatures(style, { ...OFF, buildings: true });
+		expect(out.layers.some((l) => l.id === "femto-3d-buildings")).toBe(false);
+	});
+
+	it("is idempotent across re-application", () => {
+		const once = injectFeatures(baseStyle(), { ...OFF, buildings: true });
+		const twice = injectFeatures(once, { ...OFF, buildings: true });
+		expect(
+			twice.layers.filter((l) => l.id === "femto-3d-buildings"),
+		).toHaveLength(1);
+	});
+
+	it("removes a previously injected layer when toggled off", () => {
+		const on = injectFeatures(baseStyle(), { ...OFF, buildings: true });
+		const off = injectFeatures(on, OFF);
+		expect(off.layers.some((l) => l.id === "femto-3d-buildings")).toBe(false);
+	});
+});
+
+describe("injectFeatures: terrain", () => {
+	it("injects the DEM source and terrain when enabled", () => {
+		const style = injectFeatures(baseStyle(), { ...OFF, terrain: true });
+		expect(style.sources.terrainSource).toEqual({
+			type: "raster-dem",
+			url: MAPTERHORN_DEM_URL,
+		});
+		expect(style.terrain).toEqual({
+			source: "terrainSource",
+			exaggeration: 1.0,
+		});
+	});
+
+	it("strips our terrain when toggled off but keeps foreign DEM sources", () => {
+		const on = injectFeatures(baseStyle(), { ...OFF, terrain: true });
+		const off = injectFeatures(on, OFF);
+		expect(off.sources.terrainSource).toBeUndefined();
+		expect(off.terrain).toBeUndefined();
+		expect(off.sources.rasterdem).toBeDefined();
+	});
+});
+
+describe("injectFeatures: accent recolour", () => {
+	const accent = { background: "#101010", water: "#202020", land: "#303030" };
+
+	it("recolours background, water, and land fills", () => {
+		const style = injectFeatures(baseStyle(), { ...OFF, accent });
+		const paintOf = (id: string) =>
+			(
+				style.layers.find((l) => l.id === id) as {
+					paint?: Record<string, unknown>;
+				}
+			).paint;
+		expect(paintOf("bg")?.["background-color"]).toBe(accent.background);
+		expect(paintOf("water")?.["fill-color"]).toBe(accent.water);
+		expect(paintOf("park")?.["fill-color"]).toBe(accent.land);
+	});
+
+	it("leaves road fills untouched", () => {
+		const style = injectFeatures(baseStyle(), { ...OFF, accent });
+		const road = style.layers.find((l) => l.id === "road") as {
+			paint?: Record<string, unknown>;
+		};
+		expect(road.paint?.["fill-color"]).toBeUndefined();
+	});
+
+	it("applies no recolour for a plain (non-accent) style", () => {
+		const style = injectFeatures(baseStyle(), OFF);
+		const bg = style.layers.find((l) => l.id === "bg") as {
+			paint?: Record<string, unknown>;
+		};
+		expect(bg.paint).toBeUndefined();
+	});
+});
+
+describe("markerPadTop", () => {
+	it("keeps the focal point centred at markerPos 0", () => {
+		expect(markerPadTop(0, 480)).toBe(0);
+	});
+
+	it("drops the focal point by 2 * MAX_MARKER_DROP of the height at markerPos 100", () => {
+		expect(markerPadTop(100, 480)).toBeCloseTo(2 * MAX_MARKER_DROP * 480);
+	});
+
+	it("clamps out-of-range positions", () => {
+		expect(markerPadTop(250, 480)).toBe(markerPadTop(100, 480));
+		expect(markerPadTop(-5, 480)).toBe(0);
+	});
+});

--- a/webmap/src/style.ts
+++ b/webmap/src/style.ts
@@ -1,0 +1,151 @@
+// Pure style-transformation logic, kept free of MapLibre runtime and DOM state
+// so it is unit-testable (see style.test.ts); main.ts owns the page wiring.
+import type { LayerSpecification, StyleSpecification } from "maplibre-gl";
+
+export interface AccentColors {
+	background: string;
+	water: string;
+	land: string;
+}
+
+// The feature merge is parameterised on the page state instead of reading it,
+// so a test can exercise every combination without touching globals.
+export interface MapFeatures {
+	buildings: boolean;
+	terrain: boolean;
+	accent: AccentColors | null;
+}
+
+// DEM = Mapterhorn (free, no key); the provider's required credit is shown by
+// the host's Compose attribution overlay when terrain is active.
+export const MAPTERHORN_DEM_URL = "https://tiles.mapterhorn.com/tilejson.json";
+
+const ACCENT_LAND = ["landcover", "landuse", "park"];
+
+// The lowest the self-marker drops below centre, as a fraction of map height,
+// at markerPos = 100 (mirrors MAX_MARKER_DROP in MapPanel.kt).
+export const MAX_MARKER_DROP = 0.32;
+
+// Top camera padding (px) that places the centred location at the height the
+// marker-position setting asks for. padTop shifts the focal point down, so the
+// location (and its marker) sits lower in the frame; markerPos 0 keeps it
+// centred, 100 drops it MAX_MARKER_DROP of the height toward the speed panel.
+export function markerPadTop(
+	markerPos: number,
+	containerHeight: number,
+): number {
+	const pos = Math.max(0, Math.min(100, markerPos || 0));
+	const drop = (pos / 100) * MAX_MARKER_DROP;
+	return 2 * drop * containerHeight;
+}
+
+// The first vector source id in a style (the OpenMapTiles source), so 3D
+// buildings work across positron / the bundled dark.json without hard-coding.
+export function vectorSourceId(style: StyleSpecification): string | undefined {
+	const sources = style.sources ?? {};
+	return Object.keys(sources).find((id) => sources[id].type === "vector");
+}
+
+// Style-spec paint maps are per-layer-type unions; this helper funnels the few
+// dynamic recolour writes through one narrow cast.
+function setPaint(
+	layer: LayerSpecification,
+	key: string,
+	value: unknown,
+): void {
+	const mutable = layer as { paint?: Record<string, unknown> };
+	mutable.paint = mutable.paint ?? {};
+	mutable.paint[key] = value;
+}
+
+// MapLibre transformStyle body: merge the active feature layers/sources into a
+// freshly-loaded base style. OFF features are simply not injected, so toggling
+// off and re-setting the style removes them cleanly.
+export function injectFeatures(
+	nextStyle: StyleSpecification,
+	features: MapFeatures,
+): StyleSpecification {
+	nextStyle.sources = nextStyle.sources ?? {};
+	nextStyle.layers = nextStyle.layers ?? [];
+	// Idempotent: strip any of OUR previously-injected layers/sources first, so a
+	// re-applied style (toggle change, or a setStyle that races the initial load
+	// and reuses the current style) never produces a duplicate-id error.
+	nextStyle.layers = nextStyle.layers.filter(
+		(l) => l.id !== "femto-3d-buildings",
+	);
+	// Only strip terrain if WE injected it (terrainSource present), so a base
+	// style that ever ships its own terrain is left intact.
+	if (nextStyle.sources.terrainSource) {
+		delete nextStyle.sources.terrainSource;
+		delete nextStyle.terrain;
+	}
+	// ACCENT scheme: recolour background / water / land fills with the accent
+	// palette, leaving roads + labels legible against the base. Mirrors the
+	// Kotlin recolorAccent in MapPanel.kt — keep the layer groups in sync.
+	const accent = features.accent;
+	if (accent) {
+		for (const l of nextStyle.layers) {
+			const sourceLayer = (l as { "source-layer"?: string })["source-layer"];
+			if (l.type === "background")
+				setPaint(l, "background-color", accent.background);
+			else if (l.type === "fill" && sourceLayer === "water")
+				setPaint(l, "fill-color", accent.water);
+			else if (
+				l.type === "fill" &&
+				sourceLayer !== undefined &&
+				ACCENT_LAND.includes(sourceLayer)
+			)
+				setPaint(l, "fill-color", accent.land);
+		}
+	}
+	const src = vectorSourceId(nextStyle);
+	if (features.buildings && src) {
+		// Insert beneath the first label (symbol) layer so labels stay on top.
+		const firstSymbol = nextStyle.layers.find((l) => l.type === "symbol");
+		const buildings = {
+			id: "femto-3d-buildings",
+			source: src,
+			"source-layer": "building",
+			type: "fill-extrusion",
+			minzoom: 14,
+			filter: ["!=", ["get", "hide_3d"], true],
+			paint: {
+				"fill-extrusion-color": "#c2c8d0",
+				"fill-extrusion-height": [
+					"interpolate",
+					["linear"],
+					["zoom"],
+					14,
+					0,
+					16,
+					["get", "render_height"],
+				],
+				"fill-extrusion-base": [
+					"interpolate",
+					["linear"],
+					["zoom"],
+					14,
+					0,
+					16,
+					["get", "render_min_height"],
+				],
+				"fill-extrusion-opacity": 0.85,
+			},
+		} as LayerSpecification;
+		if (firstSymbol)
+			nextStyle.layers.splice(
+				nextStyle.layers.indexOf(firstSymbol),
+				0,
+				buildings,
+			);
+		else nextStyle.layers.push(buildings);
+	}
+	if (features.terrain) {
+		nextStyle.sources.terrainSource = {
+			type: "raster-dem",
+			url: MAPTERHORN_DEM_URL,
+		};
+		nextStyle.terrain = { source: "terrainSource", exaggeration: 1.0 };
+	}
+	return nextStyle;
+}

--- a/webmap/tsconfig.json
+++ b/webmap/tsconfig.json
@@ -1,18 +1,18 @@
 {
-  "compilerOptions": {
-    // ES2022 is fully supported by Chromium 109, the factory WebView of the
-    // Android 13 floor (aftermarket AI boxes without Play may never update it).
-    // The actual syntax floor is enforced by Vite's build.target ("chrome109");
-    // this target only governs type-checking.
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "strict": true,
-    "noEmit": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "types": ["vite/client"]
-  },
-  "include": ["src"]
+	"compilerOptions": {
+		// ES2022 is fully supported by Chromium 109, the factory WebView of the
+		// Android 13 floor (aftermarket AI boxes without Play may never update it).
+		// The actual syntax floor is enforced by Vite's build.target ("chrome109");
+		// this target only governs type-checking.
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"strict": true,
+		"noEmit": true,
+		"isolatedModules": true,
+		"skipLibCheck": true,
+		"types": ["vite/client"]
+	},
+	"include": ["src"]
 }

--- a/webmap/vite.config.ts
+++ b/webmap/vite.config.ts
@@ -1,20 +1,26 @@
 import { resolve } from "node:path";
-import { defineConfig } from "vite";
+// vitest/config re-exports Vite's defineConfig with the `test` block typed.
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  // Relative asset URLs: the page is served from
-  // https://appassets.androidplatform.net/assets/web/map.html, so absolute
-  // "/assets/..." URLs would escape the web/ asset subtree.
-  base: "./",
-  build: {
-    // Android 13's factory WebView is Chromium 109; aftermarket AI boxes
-    // without Play Services may never update it, so never emit newer syntax.
-    target: "chrome109",
-    // dist/web/ mirrors the assets/web/ layout the Kotlin host expects; the
-    // whole dist/ directory is wired into the Android assets source set.
-    outDir: "dist/web",
-    rollupOptions: {
-      input: resolve(import.meta.dirname, "map.html"),
-    },
-  },
+	// Relative asset URLs: the page is served from
+	// https://appassets.androidplatform.net/assets/web/map.html, so absolute
+	// "/assets/..." URLs would escape the web/ asset subtree.
+	base: "./",
+	build: {
+		// Android 13's factory WebView is Chromium 109; aftermarket AI boxes
+		// without Play Services may never update it, so never emit newer syntax.
+		target: "chrome109",
+		// dist/web/ mirrors the assets/web/ layout the Kotlin host expects; the
+		// whole dist/ directory is wired into the Android assets source set.
+		outDir: "dist/web",
+		rollupOptions: {
+			input: resolve(import.meta.dirname, "map.html"),
+		},
+	},
+	test: {
+		// style.ts is pure data transformation; no DOM environment needed.
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+	},
 });


### PR DESCRIPTION
## Summary
- **Biome 2.4** with the recommended rules, formatter, and import organizer. `var`/`let` are both banned: `lint/suspicious/noVar` + `lint/style/useConst` as errors, and a **GritQL plugin (`no-let.grit`)** that rejects every `let` declaration (Biome has no built-in no-let rule; the plugin matches the kind keyword on `variable_declaration` text since the bridge does not expose the kind as a field). Verified by probe: a reassigned `let` — which `useConst` does not catch — is rejected with "let is forbidden".
- `src/main.ts` refactored to const-only: all mutable page state lives in one `const state = { ... }` holder. Behavior unchanged (same bridge contract, same fade logic).
- **Vitest 4** unit tests: pure style logic extracted from `main.ts` into `src/style.ts` (`injectFeatures`, `vectorSourceId`, `markerPadTop`) — 15 cases covering 3D-building injection order/idempotency/cleanup, terrain source handling (ours vs foreign DEM), accent recolour targets, and camera-padding math.
- `pnpm run build` = `biome check` + `tsc --noEmit` + `vitest run` + `vite build`, so `./gradlew assembleDebug` / CI fail on lint, type, or test errors with no workflow changes. Config files added to `buildWebMap` inputs.

## Test plan
- `pnpm run check` — Biome clean, tsc clean, 15/15 tests pass.
- Probe files confirmed `noVar` and the no-let plugin fire (and are clean after removal).
- `./gradlew assembleDebug` — buildWebMap green; APK carries the rebuilt bundle.
- Emulator (TBox-Mock): map renders from the new bundle (`[map] load` + continuous `[map] rendered`), 3D buildings + overlays live.