### PR TITLE
feat(drawer): pinned dock, icon size presets, and search polish

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
@@ -4,12 +4,15 @@ import android.content.ComponentName
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onLast
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
+import io.github.seijikohara.femto.data.DrawerIconSize
 import io.github.seijikohara.femto.data.DrawerLayout
 import io.github.seijikohara.femto.testfixtures.fakeAppEntry
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -28,7 +31,8 @@ class AppDrawerScreenTest {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Loading,
                     layout = DrawerLayout.GRID,
-                    pinned = emptySet(),
+                    iconSize = DrawerIconSize.MEDIUM,
+                    pinned = emptyList(),
                     onLaunch = {},
                     onTogglePin = {},
                     onToggleLayout = {},
@@ -48,7 +52,8 @@ class AppDrawerScreenTest {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Content(listOf(maps)),
                     layout = DrawerLayout.GRID,
-                    pinned = emptySet(),
+                    iconSize = DrawerIconSize.MEDIUM,
+                    pinned = emptyList(),
                     onLaunch = { launched = it },
                     onTogglePin = {},
                     onToggleLayout = {},
@@ -69,7 +74,8 @@ class AppDrawerScreenTest {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Content(listOf(maps)),
                     layout = DrawerLayout.GRID,
-                    pinned = emptySet(),
+                    iconSize = DrawerIconSize.MEDIUM,
+                    pinned = emptyList(),
                     onLaunch = {},
                     onTogglePin = { pinned = it },
                     onToggleLayout = {},
@@ -91,7 +97,8 @@ class AppDrawerScreenTest {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Content(listOf(maps)),
                     layout = DrawerLayout.GRID,
-                    pinned = emptySet(),
+                    iconSize = DrawerIconSize.MEDIUM,
+                    pinned = emptyList(),
                     onLaunch = {},
                     onTogglePin = {},
                     onToggleLayout = { toggled = true },
@@ -111,7 +118,8 @@ class AppDrawerScreenTest {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Content(emptyList()),
                     layout = DrawerLayout.GRID,
-                    pinned = emptySet(),
+                    iconSize = DrawerIconSize.MEDIUM,
+                    pinned = emptyList(),
                     onLaunch = {},
                     onTogglePin = {},
                     onToggleLayout = {},
@@ -131,7 +139,8 @@ class AppDrawerScreenTest {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Content(listOf(maps, music)),
                     layout = DrawerLayout.LIST,
-                    pinned = emptySet(),
+                    iconSize = DrawerIconSize.MEDIUM,
+                    pinned = emptyList(),
                     onLaunch = {},
                     onTogglePin = {},
                     onToggleLayout = {},
@@ -152,7 +161,8 @@ class AppDrawerScreenTest {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Content(listOf(maps)),
                     layout = DrawerLayout.LIST,
-                    pinned = emptySet(),
+                    iconSize = DrawerIconSize.MEDIUM,
+                    pinned = emptyList(),
                     onLaunch = {},
                     onTogglePin = {},
                     onToggleLayout = {},
@@ -165,6 +175,31 @@ class AppDrawerScreenTest {
     }
 
     @Test
+    fun pinned_apps_render_in_the_dock_and_launch_on_tap() {
+        var launched: ComponentName? = null
+        val maps = fakeAppEntry(packageName = "com.maps", className = ".Main", label = "Maps")
+        val music = fakeAppEntry(packageName = "com.music", className = ".Main", label = "Music")
+        rule.setContent {
+            FemtoTheme {
+                AppDrawerScreen(
+                    uiState = AppDrawerUiState.Content(listOf(maps, music)),
+                    layout = DrawerLayout.GRID,
+                    iconSize = DrawerIconSize.MEDIUM,
+                    pinned = listOf(music.componentName.flattenToString()),
+                    onLaunch = { launched = it },
+                    onTogglePin = {},
+                    onToggleLayout = {},
+                    onRetry = {},
+                )
+            }
+        }
+        // The pinned app appears twice: once in the grid, once in the dock.
+        assertEquals(2, rule.onAllNodesWithText("Music").fetchSemanticsNodes().size)
+        rule.onAllNodesWithText("Music").onLast().performClick()
+        assertEquals(music.componentName, launched)
+    }
+
+    @Test
     fun error_shows_retry_and_dispatches_on_tap() {
         var retried = false
         rule.setContent {
@@ -172,7 +207,8 @@ class AppDrawerScreenTest {
                 AppDrawerScreen(
                     uiState = AppDrawerUiState.Error,
                     layout = DrawerLayout.GRID,
-                    pinned = emptySet(),
+                    iconSize = DrawerIconSize.MEDIUM,
+                    pinned = emptyList(),
                     onLaunch = {},
                     onTogglePin = {},
                     onToggleLayout = {},

--- a/app/src/main/java/io/github/seijikohara/femto/data/DrawerPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DrawerPreferences.kt
@@ -12,20 +12,44 @@ import kotlinx.coroutines.flow.map
 /** App-drawer tile layout. */
 internal enum class DrawerLayout { GRID, LIST }
 
+/** App-drawer icon size preset; MEDIUM matches the pre-preset dimensions. */
+internal enum class DrawerIconSize { SMALL, MEDIUM, LARGE }
+
 /**
- * Persisted app-drawer preferences: the tile [layout] and the set of [pinned] apps
- * (each a flattened [android.content.ComponentName]). Pinned apps surface in a
- * section at the top of the drawer.
+ * Persisted app-drawer preferences: the tile [layout], the [iconSize] preset, and
+ * the [pinned] apps (each a flattened [android.content.ComponentName]) in the
+ * order they were pinned. Pinned apps surface in the dock fixed at the bottom of
+ * the drawer sheet.
  */
 internal interface DrawerSettingsStore {
     val layout: Flow<DrawerLayout>
-    val pinned: Flow<Set<String>>
+    val iconSize: Flow<DrawerIconSize>
+    val pinned: Flow<List<String>>
 
     suspend fun setLayout(value: DrawerLayout)
 
-    /** Add the component if absent, remove it if present. */
+    suspend fun setIconSize(value: DrawerIconSize)
+
+    /** Append the component if absent, remove it if present. */
     suspend fun togglePinned(flattenedComponent: String)
 }
+
+// A flattened ComponentName ("package/class") can never contain a newline, so it
+// is a safe join separator for the ordered pin list.
+private const val PIN_SEPARATOR = "\n"
+
+/**
+ * Resolve the ordered pin list from the persisted [order] string, falling back to
+ * the legacy unordered [legacy] set (sorted for determinism) written by versions
+ * that pinned into a section instead of the dock.
+ */
+internal fun resolvePinnedOrder(
+    order: String?,
+    legacy: Set<String>?,
+): List<String> =
+    order?.split(PIN_SEPARATOR)?.filter { it.isNotEmpty() }
+        ?: legacy?.sorted()
+        ?: emptyList()
 
 private val Context.drawerDataStore: DataStore<Preferences> by preferencesDataStore(name = "drawer_preferences")
 
@@ -43,25 +67,43 @@ internal class DrawerPreferences(
                     ?: DrawerLayout.GRID
             }
 
-    override val pinned: Flow<Set<String>> =
+    override val iconSize: Flow<DrawerIconSize> =
         context.drawerDataStore.data
             .catchIoAsDefaults(TAG)
-            .map { prefs -> prefs[PINNED_KEY] ?: emptySet() }
+            .map { prefs ->
+                prefs[ICON_SIZE_KEY]
+                    ?.let { name -> DrawerIconSize.entries.firstOrNull { it.name == name } }
+                    ?: DrawerIconSize.MEDIUM
+            }
+
+    override val pinned: Flow<List<String>> =
+        context.drawerDataStore.data
+            .catchIoAsDefaults(TAG)
+            .map { prefs -> resolvePinnedOrder(prefs[PINNED_ORDER_KEY], prefs[LEGACY_PINNED_KEY]) }
 
     override suspend fun setLayout(value: DrawerLayout) {
         context.drawerDataStore.editOrLog(TAG) { it[LAYOUT_KEY] = value.name }
     }
 
+    override suspend fun setIconSize(value: DrawerIconSize) {
+        context.drawerDataStore.editOrLog(TAG) { it[ICON_SIZE_KEY] = value.name }
+    }
+
     override suspend fun togglePinned(flattenedComponent: String) {
         context.drawerDataStore.editOrLog(TAG) { prefs ->
-            val current = prefs[PINNED_KEY] ?: emptySet()
-            prefs[PINNED_KEY] =
+            val current = resolvePinnedOrder(prefs[PINNED_ORDER_KEY], prefs[LEGACY_PINNED_KEY])
+            val updated =
                 if (flattenedComponent in current) current - flattenedComponent else current + flattenedComponent
+            prefs[PINNED_ORDER_KEY] = updated.joinToString(PIN_SEPARATOR)
+            // The ordered key is authoritative from the first write on.
+            prefs.remove(LEGACY_PINNED_KEY)
         }
     }
 
     private companion object {
         val LAYOUT_KEY = stringPreferencesKey("drawer_layout")
-        val PINNED_KEY = stringSetPreferencesKey("drawer_pinned")
+        val ICON_SIZE_KEY = stringPreferencesKey("drawer_icon_size")
+        val PINNED_ORDER_KEY = stringPreferencesKey("drawer_pinned_order")
+        val LEGACY_PINNED_KEY = stringSetPreferencesKey("drawer_pinned")
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
@@ -38,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.LayoutGrid
 import com.composables.icons.lucide.LayoutList
@@ -48,16 +48,31 @@ import com.composables.icons.lucide.Search
 import com.composables.icons.lucide.X
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.AppEntry
+import io.github.seijikohara.femto.data.DrawerIconSize
 import io.github.seijikohara.femto.data.DrawerLayout
+import io.github.seijikohara.femto.ui.drawer.components.PinnedDock
 import io.github.seijikohara.femto.ui.home.components.AppListRow
 import io.github.seijikohara.femto.ui.home.components.AppTile
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 
-// 120 dp (up from 96) yields ~5 columns on the 853 dp-wide reference head unit,
-// giving each tile room for a 64 dp icon plus its label without crowding.
-private val MinTileWidth = 120.dp
+// Per-preset drawer dimensions. MEDIUM matches the pre-preset values: a 120 dp
+// minimum tile yields ~5 columns on the 853 dp-wide reference head unit, giving
+// each tile room for a 64 dp icon plus its label without crowding. Every preset
+// keeps tiles and rows above FemtoDimens.MinTouchTarget.
+private data class DrawerDimensions(
+    val minTileWidth: Dp,
+    val gridIconSize: Dp,
+    val listIconSize: Dp,
+)
+
+private fun DrawerIconSize.dimensions(): DrawerDimensions =
+    when (this) {
+        DrawerIconSize.SMALL -> DrawerDimensions(minTileWidth = 96.dp, gridIconSize = 48.dp, listIconSize = 32.dp)
+        DrawerIconSize.MEDIUM -> DrawerDimensions(minTileWidth = 120.dp, gridIconSize = 64.dp, listIconSize = 40.dp)
+        DrawerIconSize.LARGE -> DrawerDimensions(minTileWidth = 160.dp, gridIconSize = 88.dp, listIconSize = 56.dp)
+    }
 
 internal const val APP_DRAWER_PROGRESS_TEST_TAG = "app-drawer-progress"
 internal const val APP_DRAWER_SEARCH_TEST_TAG = "app-drawer-search"
@@ -66,7 +81,8 @@ internal const val APP_DRAWER_SEARCH_TEST_TAG = "app-drawer-search"
 internal fun AppDrawerScreen(
     uiState: AppDrawerUiState,
     layout: DrawerLayout,
-    pinned: Set<String>,
+    iconSize: DrawerIconSize,
+    pinned: List<String>,
     onLaunch: (ComponentName) -> Unit,
     onTogglePin: (ComponentName) -> Unit,
     onToggleLayout: () -> Unit,
@@ -85,6 +101,7 @@ internal fun AppDrawerScreen(
             ContentState(
                 apps = uiState.apps,
                 layout = layout,
+                iconSize = iconSize,
                 pinned = pinned,
                 onLaunch = onLaunch,
                 onTogglePin = onTogglePin,
@@ -108,7 +125,8 @@ private fun LoadingState(modifier: Modifier = Modifier) =
 private fun ContentState(
     apps: List<AppEntry>,
     layout: DrawerLayout,
-    pinned: Set<String>,
+    iconSize: DrawerIconSize,
+    pinned: List<String>,
     onLaunch: (ComponentName) -> Unit,
     onTogglePin: (ComponentName) -> Unit,
     onToggleLayout: () -> Unit,
@@ -125,25 +143,34 @@ private fun ContentState(
         CenteredMessage(text = stringResource(R.string.drawer_no_apps))
         return@Column
     }
-    // Filter by the search query (label substring, case-insensitive); an empty query
-    // shows everything.
-    val trimmed = query.trim()
-    val matched =
-        if (trimmed.isEmpty()) {
-            apps
+    val pinnedSet = remember(pinned) { pinned.toSet() }
+    // Prefix matches rank before substring matches; an empty query shows everything.
+    val matched = filterAndRank(apps, query) { it.label }
+    Box(modifier = Modifier.weight(1f)) {
+        if (matched.isEmpty()) {
+            CenteredMessage(text = stringResource(R.string.drawer_no_matches))
         } else {
-            apps.filter { it.label.contains(trimmed, ignoreCase = true) }
+            val dimensions = iconSize.dimensions()
+            // A query forces the list layout so labels stay readable while searching.
+            when (effectiveLayout(layout, query)) {
+                DrawerLayout.GRID -> GridApps(matched, pinnedSet, dimensions, onLaunch, onTogglePin)
+                DrawerLayout.LIST -> ListApps(matched, pinnedSet, dimensions, onLaunch, onTogglePin)
+            }
         }
-    if (matched.isEmpty()) {
-        CenteredMessage(text = stringResource(R.string.drawer_no_matches))
-        return@Column
     }
-    // Split into the pinned section and the rest (both keep the shared label sort).
-    val pinnedApps = matched.filter { it.componentName.flattenToString() in pinned }
-    val otherApps = matched.filterNot { it.componentName.flattenToString() in pinned }
-    when (layout) {
-        DrawerLayout.GRID -> GridApps(pinnedApps, otherApps, onLaunch, onTogglePin)
-        DrawerLayout.LIST -> ListApps(pinnedApps, otherApps, onLaunch, onTogglePin)
+    // The dock renders pins in pin order, unaffected by the search query, and is
+    // skipped entirely when nothing is pinned.
+    val dockApps =
+        remember(apps, pinned) {
+            val byComponent = apps.associateBy { it.componentName.flattenToString() }
+            pinned.mapNotNull { byComponent[it] }
+        }
+    if (dockApps.isNotEmpty()) {
+        PinnedDock(
+            apps = dockApps,
+            onLaunch = onLaunch,
+            onUnpin = onTogglePin,
+        )
     }
 }
 
@@ -194,49 +221,49 @@ private fun DrawerTopBar(
 
 @Composable
 private fun GridApps(
-    pinnedApps: List<AppEntry>,
-    otherApps: List<AppEntry>,
+    apps: List<AppEntry>,
+    pinnedSet: Set<String>,
+    dimensions: DrawerDimensions,
     onLaunch: (ComponentName) -> Unit,
     onTogglePin: (ComponentName) -> Unit,
     modifier: Modifier = Modifier,
 ) = LazyVerticalGrid(
     modifier = modifier,
-    columns = GridCells.Adaptive(minSize = MinTileWidth),
+    columns = GridCells.Adaptive(minSize = dimensions.minTileWidth),
     contentPadding = PaddingValues(FemtoDimens.ScreenPadding),
     horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
     verticalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
 ) {
-    if (pinnedApps.isNotEmpty()) {
-        item(span = { GridItemSpan(maxLineSpan) }) { SectionHeader(stringResource(R.string.drawer_section_pinned)) }
-        items(items = pinnedApps, key = { it.componentName.flattenToString() }) { entry ->
-            DrawerAppItem(entry, DrawerLayout.GRID, isPinned = true, onLaunch, onTogglePin)
-        }
-        item(span = { GridItemSpan(maxLineSpan) }) { SectionHeader(stringResource(R.string.drawer_section_apps)) }
-    }
-    // otherApps are non-pinned by construction (filterNot), so isPinned = false.
-    items(items = otherApps, key = { it.componentName.flattenToString() }) { entry ->
-        DrawerAppItem(entry, DrawerLayout.GRID, isPinned = false, onLaunch, onTogglePin)
+    items(items = apps, key = { it.componentName.flattenToString() }) { entry ->
+        DrawerAppItem(
+            entry = entry,
+            layout = DrawerLayout.GRID,
+            dimensions = dimensions,
+            isPinned = entry.componentName.flattenToString() in pinnedSet,
+            onLaunch = onLaunch,
+            onTogglePin = onTogglePin,
+        )
     }
 }
 
 @Composable
 private fun ListApps(
-    pinnedApps: List<AppEntry>,
-    otherApps: List<AppEntry>,
+    apps: List<AppEntry>,
+    pinnedSet: Set<String>,
+    dimensions: DrawerDimensions,
     onLaunch: (ComponentName) -> Unit,
     onTogglePin: (ComponentName) -> Unit,
     modifier: Modifier = Modifier,
 ) = LazyColumn(modifier = modifier, contentPadding = PaddingValues(vertical = FemtoDimens.GridGutter)) {
-    if (pinnedApps.isNotEmpty()) {
-        item { SectionHeader(stringResource(R.string.drawer_section_pinned)) }
-        items(items = pinnedApps, key = { it.componentName.flattenToString() }) { entry ->
-            DrawerAppItem(entry, DrawerLayout.LIST, isPinned = true, onLaunch, onTogglePin)
-        }
-        item { SectionHeader(stringResource(R.string.drawer_section_apps)) }
-    }
-    // otherApps are non-pinned by construction (filterNot), so isPinned = false.
-    items(items = otherApps, key = { it.componentName.flattenToString() }) { entry ->
-        DrawerAppItem(entry, DrawerLayout.LIST, isPinned = false, onLaunch, onTogglePin)
+    items(items = apps, key = { it.componentName.flattenToString() }) { entry ->
+        DrawerAppItem(
+            entry = entry,
+            layout = DrawerLayout.LIST,
+            dimensions = dimensions,
+            isPinned = entry.componentName.flattenToString() in pinnedSet,
+            onLaunch = onLaunch,
+            onTogglePin = onTogglePin,
+        )
     }
 }
 
@@ -245,6 +272,7 @@ private fun ListApps(
 private fun DrawerAppItem(
     entry: AppEntry,
     layout: DrawerLayout,
+    dimensions: DrawerDimensions,
     isPinned: Boolean,
     onLaunch: (ComponentName) -> Unit,
     onTogglePin: (ComponentName) -> Unit,
@@ -258,6 +286,8 @@ private fun DrawerAppItem(
                     entry = entry,
                     onClick = { onLaunch(entry.componentName) },
                     onLongClick = { menuOpen = true },
+                    iconSize = dimensions.gridIconSize,
+                    isPinned = isPinned,
                 )
             }
 
@@ -266,6 +296,8 @@ private fun DrawerAppItem(
                     entry = entry,
                     onClick = { onLaunch(entry.componentName) },
                     onLongClick = { menuOpen = true },
+                    iconSize = dimensions.listIconSize,
+                    isPinned = isPinned,
                 )
             }
         }
@@ -285,17 +317,6 @@ private fun DrawerAppItem(
         }
     }
 }
-
-@Composable
-private fun SectionHeader(
-    text: String,
-    modifier: Modifier = Modifier,
-) = Text(
-    text = text.uppercase(),
-    style = MaterialTheme.typography.titleSmall,
-    color = MaterialTheme.colorScheme.primary,
-    modifier = modifier.padding(horizontal = FemtoDimens.ScreenPadding, vertical = 8.dp),
-)
 
 @Composable
 private fun ErrorState(
@@ -360,7 +381,8 @@ private fun AppDrawerContentPreview() {
                         ),
                 ),
             layout = DrawerLayout.GRID,
-            pinned = setOf("com.maps/.Main"),
+            iconSize = DrawerIconSize.MEDIUM,
+            pinned = listOf("com.maps/.Main"),
             onLaunch = {},
             onTogglePin = {},
             onToggleLayout = {},

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -145,7 +145,7 @@ private fun ContentState(
     }
     val pinnedSet = remember(pinned) { pinned.toSet() }
     // Prefix matches rank before substring matches; an empty query shows everything.
-    val matched = filterAndRank(apps, query) { it.label }
+    val matched = remember(apps, query) { filterAndRank(apps, query) { it.label } }
     Box(modifier = Modifier.weight(1f)) {
         if (matched.isEmpty()) {
             CenteredMessage(text = stringResource(R.string.drawer_no_matches))

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSearch.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSearch.kt
@@ -1,0 +1,33 @@
+package io.github.seijikohara.femto.ui.drawer
+
+import io.github.seijikohara.femto.data.DrawerLayout
+
+/**
+ * Filter [items] by [query] against [labelOf], ranking prefix matches before
+ * substring matches (both case-insensitive, both keeping input order) so one
+ * typed letter surfaces the apps starting with it. A blank query returns
+ * [items] unchanged.
+ */
+internal fun <T> filterAndRank(
+    items: List<T>,
+    query: String,
+    labelOf: (T) -> String,
+): List<T> {
+    val trimmed = query.trim()
+    if (trimmed.isEmpty()) return items
+    val (prefix, substring) =
+        items
+            .filter { labelOf(it).contains(trimmed, ignoreCase = true) }
+            .partition { labelOf(it).startsWith(trimmed, ignoreCase = true) }
+    return prefix + substring
+}
+
+/**
+ * Return the layout the drawer should render: the list layout while a query is
+ * active (labels are the primary signal when searching), otherwise the
+ * [persisted] preference. Never writes the persisted value.
+ */
+internal fun effectiveLayout(
+    persisted: DrawerLayout,
+    query: String,
+): DrawerLayout = if (query.isBlank()) persisted else DrawerLayout.LIST

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.seijikohara.femto.data.AppsRepository
+import io.github.seijikohara.femto.data.DrawerIconSize
 import io.github.seijikohara.femto.data.DrawerLayout
 import io.github.seijikohara.femto.data.DrawerPreferences
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
@@ -77,7 +78,8 @@ internal fun AppDrawerSheet(
     // Drawer layout + pinned apps are persisted; collect them and write changes back.
     val drawerPreferences = remember { DrawerPreferences(context) }
     val layout by drawerPreferences.layout.collectAsStateWithLifecycle(initialValue = DrawerLayout.GRID)
-    val pinned by drawerPreferences.pinned.collectAsStateWithLifecycle(initialValue = emptySet())
+    val iconSize by drawerPreferences.iconSize.collectAsStateWithLifecycle(initialValue = DrawerIconSize.MEDIUM)
+    val pinned by drawerPreferences.pinned.collectAsStateWithLifecycle(initialValue = emptyList())
     val scope = rememberCoroutineScope()
 
     val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
@@ -94,6 +96,7 @@ internal fun AppDrawerSheet(
             AppDrawerScreen(
                 uiState = uiState,
                 layout = layout,
+                iconSize = iconSize,
                 pinned = pinned,
                 onLaunch = onLaunch,
                 onTogglePin = { component ->

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
@@ -1,5 +1,3 @@
-@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
-
 package io.github.seijikohara.femto.ui.drawer.components
 
 import android.content.ComponentName
@@ -10,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -94,6 +93,7 @@ private fun DockTile(
             modifier =
                 Modifier
                     .width(DockTileWidth)
+                    .defaultMinSize(minHeight = FemtoDimens.MinTouchTarget)
                     .combinedClickable(
                         onClick = { onLaunch(entry.componentName) },
                         onLongClick = { menuOpen = true },

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
@@ -1,0 +1,150 @@
+@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+
+package io.github.seijikohara.femto.ui.drawer.components
+
+import android.content.ComponentName
+import android.graphics.Bitmap
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.PinOff
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.AppEntry
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+
+// Wide enough for a readable one-line 18 sp label while keeping several pins
+// visible at once on the 853 dp-wide reference head unit.
+private val DockTileWidth = 96.dp
+private val DockIconSize = 64.dp
+private val DockIconLabelGap = 4.dp
+private val DockVerticalPadding = 8.dp
+
+/**
+ * Pinned-apps dock fixed at the bottom of the drawer sheet: a horizontally
+ * scrolling row of icon + label tiles in pin order, visually separated from the
+ * scrolling app grid by a divider on a raised container colour. Tap launches;
+ * long-press offers Unpin. Callers skip composing the dock when [apps] is empty.
+ */
+@Composable
+internal fun PinnedDock(
+    apps: List<AppEntry>,
+    onLaunch: (ComponentName) -> Unit,
+    onUnpin: (ComponentName) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(modifier = modifier.fillMaxWidth()) {
+    HorizontalDivider()
+    Surface(color = MaterialTheme.colorScheme.surfaceContainerHigh) {
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding =
+                PaddingValues(horizontal = FemtoDimens.ScreenPadding, vertical = DockVerticalPadding),
+            horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
+        ) {
+            items(items = apps, key = { it.componentName.flattenToString() }) { entry ->
+                DockTile(entry = entry, onLaunch = onLaunch, onUnpin = onUnpin)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DockTile(
+    entry: AppEntry,
+    onLaunch: (ComponentName) -> Unit,
+    onUnpin: (ComponentName) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    Box(modifier = modifier) {
+        Column(
+            modifier =
+                Modifier
+                    .width(DockTileWidth)
+                    .combinedClickable(
+                        onClick = { onLaunch(entry.componentName) },
+                        onLongClick = { menuOpen = true },
+                    ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                painter = BitmapPainter(entry.icon.asImageBitmap()),
+                contentDescription = entry.label,
+                tint = Color.Unspecified,
+                modifier = Modifier.size(DockIconSize),
+            )
+            Spacer(Modifier.height(DockIconLabelGap))
+            Text(
+                text = entry.label,
+                style = MaterialTheme.typography.bodyLarge,
+                fontSize = FemtoDimens.MinBodyTextSize,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.drawer_unpin)) },
+                leadingIcon = { Icon(imageVector = Lucide.PinOff, contentDescription = null) },
+                onClick = {
+                    onUnpin(entry.componentName)
+                    menuOpen = false
+                },
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun PinnedDockPreview() {
+    val icon = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+    FemtoTheme {
+        PinnedDock(
+            apps =
+                listOf(
+                    AppEntry(ComponentName("com.maps", ".Main"), "Maps", icon),
+                    AppEntry(ComponentName("com.music", ".Main"), "Music", icon),
+                    AppEntry(ComponentName("com.phone", ".Main"), "Phone", icon),
+                ),
+            onLaunch = {},
+            onUnpin = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppListRow.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppListRow.kt
@@ -1,5 +1,3 @@
-@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
-
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.combinedClickable

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppListRow.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppListRow.kt
@@ -19,15 +19,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Pin
 import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
-private val ListIconSize = 40.dp
+private val DefaultListIconSize = 40.dp
+private val PinIndicatorSize = 20.dp
 
 /**
  * A single app row in the drawer's list layout: a small icon beside the label, the
- * whole row a ≥ 64 dp tap target. [onLongClick] opens the pin / unpin menu.
+ * whole row a ≥ 64 dp tap target. [onLongClick] opens the pin / unpin menu;
+ * [isPinned] shows a trailing pin indicator.
  */
 @Composable
 internal fun AppListRow(
@@ -35,6 +40,8 @@ internal fun AppListRow(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     onLongClick: (() -> Unit)? = null,
+    iconSize: Dp = DefaultListIconSize,
+    isPinned: Boolean = false,
 ) = Row(
     modifier =
         modifier
@@ -49,7 +56,7 @@ internal fun AppListRow(
         painter = BitmapPainter(entry.icon.asImageBitmap()),
         contentDescription = entry.label,
         tint = Color.Unspecified,
-        modifier = Modifier.size(ListIconSize),
+        modifier = Modifier.size(iconSize),
     )
     Text(
         text = entry.label,
@@ -58,5 +65,14 @@ internal fun AppListRow(
         fontSize = FemtoDimens.MinBodyTextSize,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.weight(1f),
     )
+    if (isPinned) {
+        Icon(
+            imageVector = Lucide.Pin,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(PinIndicatorSize),
+        )
+    }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppTile.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppTile.kt
@@ -1,5 +1,3 @@
-@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
-
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppTile.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppTile.kt
@@ -2,36 +2,45 @@
 
 package io.github.seijikohara.femto.ui.home.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Pin
 import io.github.seijikohara.femto.data.AppEntry
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
-private val IconSize = 64.dp
+private val DefaultIconSize = 64.dp
 private val IconLabelGap = 8.dp
 private val TilePadding = 8.dp
+private val PinBadgeSize = 20.dp
+private val PinBadgePadding = 3.dp
 
 /**
  * A single app tile in the launcher grid: icon + label, ≥ 64 dp
  * tap target enforced by [FemtoDimens.MinTouchTarget]. [onLongClick] opens the
- * drawer's pin / unpin menu.
+ * drawer's pin / unpin menu; [isPinned] overlays a small pin badge on the icon.
  */
 @Composable
 internal fun AppTile(
@@ -39,6 +48,8 @@ internal fun AppTile(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     onLongClick: (() -> Unit)? = null,
+    iconSize: Dp = DefaultIconSize,
+    isPinned: Boolean = false,
 ) = Column(
     modifier =
         modifier
@@ -48,12 +59,15 @@ internal fun AppTile(
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center,
 ) {
-    Icon(
-        painter = BitmapPainter(entry.icon.asImageBitmap()),
-        contentDescription = entry.label,
-        tint = androidx.compose.ui.graphics.Color.Unspecified,
-        modifier = Modifier.size(IconSize),
-    )
+    Box {
+        Icon(
+            painter = BitmapPainter(entry.icon.asImageBitmap()),
+            contentDescription = entry.label,
+            tint = Color.Unspecified,
+            modifier = Modifier.size(iconSize),
+        )
+        if (isPinned) PinBadge(modifier = Modifier.align(Alignment.TopEnd))
+    }
     Spacer(Modifier.height(IconLabelGap))
     Text(
         text = entry.label,
@@ -64,3 +78,16 @@ internal fun AppTile(
         textAlign = TextAlign.Center,
     )
 }
+
+@Composable
+private fun PinBadge(modifier: Modifier = Modifier) =
+    Icon(
+        imageVector = Lucide.Pin,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+        modifier =
+            modifier
+                .size(PinBadgeSize)
+                .background(MaterialTheme.colorScheme.secondaryContainer, CircleShape)
+                .padding(PinBadgePadding),
+    )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -53,6 +53,7 @@ import com.composables.icons.lucide.RotateCcw
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
+import io.github.seijikohara.femto.data.DrawerIconSize
 import io.github.seijikohara.femto.data.FontSlot
 import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.LocationQualitySetting
@@ -146,6 +147,18 @@ internal fun SettingsScreen(
                 value = uiState.glassTintScale,
                 range = MIN_GLASS_OPACITY..MAX_GLASS_OPACITY,
                 onValueChange = { onAction(SettingsAction.SetGlassTintScale(it)) },
+            )
+            SettingsSubheader(stringResource(R.string.settings_subheader_drawer))
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_drawer_icon_size),
+                options =
+                    listOf(
+                        DrawerIconSize.SMALL to stringResource(R.string.settings_icon_size_small),
+                        DrawerIconSize.MEDIUM to stringResource(R.string.settings_icon_size_medium),
+                        DrawerIconSize.LARGE to stringResource(R.string.settings_icon_size_large),
+                    ),
+                selected = uiState.drawerIconSize,
+                onSelect = { onAction(SettingsAction.SetDrawerIconSize(it)) },
             )
             SettingsSubheader(stringResource(R.string.settings_subheader_fonts))
             FontRow(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -3,6 +3,7 @@ package io.github.seijikohara.femto.ui.settings
 import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.DisplaySettings
+import io.github.seijikohara.femto.data.DrawerIconSize
 import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.LocationQualitySetting
 import io.github.seijikohara.femto.data.LocationSettings
@@ -38,6 +39,7 @@ internal data class SettingsUiState(
     val showCalendar: Boolean,
     val showWeather: Boolean,
     val showMusic: Boolean,
+    val drawerIconSize: DrawerIconSize,
     // The chosen Google Fonts families per slot; null means the system font.
     val latinFont: String?,
     val cjkFont: String?,
@@ -73,6 +75,7 @@ internal data class SettingsUiState(
                 showCalendar = DisplaySettings.Default.showCalendar,
                 showWeather = DisplaySettings.Default.showWeather,
                 showMusic = DisplaySettings.Default.showMusic,
+                drawerIconSize = DrawerIconSize.MEDIUM,
                 latinFont = null,
                 cjkFont = null,
                 locationQuality = LocationSettings.Default.quality,
@@ -174,6 +177,10 @@ internal sealed interface SettingsAction {
 
     data class SetShowMusic(
         val value: Boolean,
+    ) : SettingsAction
+
+    data class SetDrawerIconSize(
+        val value: DrawerIconSize,
     ) : SettingsAction
 
     data class SetLocationQuality(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import io.github.seijikohara.femto.data.DisplayPreferences
 import io.github.seijikohara.femto.data.DisplaySettingsStore
+import io.github.seijikohara.femto.data.DrawerPreferences
+import io.github.seijikohara.femto.data.DrawerSettingsStore
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.LocationPreferences
 import io.github.seijikohara.femto.data.LocationSettingsStore
@@ -20,13 +22,15 @@ internal class SettingsViewModel(
     private val displayPreferences: DisplaySettingsStore,
     private val fontPreferences: FontPreferences,
     private val locationPreferences: LocationSettingsStore,
+    private val drawerPreferences: DrawerSettingsStore,
 ) : ViewModel() {
     val uiState: StateFlow<SettingsUiState> =
         combine(
             displayPreferences.settings,
             fontPreferences.selection,
             locationPreferences.settings,
-        ) { display, font, location ->
+            drawerPreferences.iconSize,
+        ) { display, font, location, drawerIconSize ->
             SettingsUiState(
                 themeMode = display.themeMode,
                 accentColor = display.accentColor,
@@ -51,6 +55,7 @@ internal class SettingsViewModel(
                 showCalendar = display.showCalendar,
                 showWeather = display.showWeather,
                 showMusic = display.showMusic,
+                drawerIconSize = drawerIconSize,
                 latinFont = font.latinFamily,
                 cjkFont = font.cjkFamily,
                 locationQuality = location.quality,
@@ -155,6 +160,10 @@ internal class SettingsViewModel(
                     displayPreferences.setShowMusic(action.value)
                 }
 
+                is SettingsAction.SetDrawerIconSize -> {
+                    drawerPreferences.setIconSize(action.value)
+                }
+
                 is SettingsAction.SetLocationQuality -> {
                     locationPreferences.setQuality(action.value)
                 }
@@ -189,6 +198,7 @@ internal class SettingsViewModelFactory(
             displayPreferences = DisplayPreferences(application),
             fontPreferences = FontPreferences(application),
             locationPreferences = LocationPreferences(application),
+            drawerPreferences = DrawerPreferences(application),
         ) as T
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,8 +82,6 @@
     <string name="drawer_retry">Retry</string>
     <string name="drawer_layout_grid">Grid layout</string>
     <string name="drawer_layout_list">List layout</string>
-    <string name="drawer_section_pinned">Pinned</string>
-    <string name="drawer_section_apps">Apps</string>
     <string name="drawer_pin">Pin</string>
     <string name="drawer_unpin">Unpin</string>
     <string name="drawer_search_hint">Search apps</string>
@@ -120,6 +118,11 @@
     <string name="settings_group_glass_opacity">Glass opacity</string>
     <string name="settings_glass_blur_value">%1$d dp</string>
     <string name="settings_glass_opacity_value">%1$d%%</string>
+    <string name="settings_subheader_drawer">App drawer</string>
+    <string name="settings_group_drawer_icon_size">Icon size</string>
+    <string name="settings_icon_size_small">Small</string>
+    <string name="settings_icon_size_medium">Medium</string>
+    <string name="settings_icon_size_large">Large</string>
     <string name="settings_subheader_fonts">Fonts</string>
     <string name="settings_subheader_map_rendering">Rendering</string>
     <string name="settings_subheader_map_appearance">Appearance</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/DrawerPreferencesTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/DrawerPreferencesTest.kt
@@ -18,23 +18,53 @@ class DrawerPreferencesTest {
     // round-trip steps therefore live in one test method, so the persisted file
     // and the singleton never disagree across tests.
     @Test
-    fun `togglePinned round-trips pin, unpin, and re-pin without touching other pins`() =
+    fun `drawer preferences round-trip pins in order and persist the icon size`() =
         runTest {
             val store = DrawerPreferences(ApplicationProvider.getApplicationContext())
 
+            // Pins keep insertion order, not label/alphabetical order.
             store.togglePinned(OTHER)
             store.togglePinned(COMPONENT)
-            assertEquals(setOf(OTHER, COMPONENT), store.pinned.first())
+            assertEquals(listOf(OTHER, COMPONENT), store.pinned.first())
 
             store.togglePinned(COMPONENT)
-            assertEquals(setOf(OTHER), store.pinned.first())
+            assertEquals(listOf(OTHER), store.pinned.first())
 
+            // Re-pinning appends at the end.
             store.togglePinned(COMPONENT)
-            assertEquals(setOf(OTHER, COMPONENT), store.pinned.first())
+            assertEquals(listOf(OTHER, COMPONENT), store.pinned.first())
+
+            assertEquals(DrawerIconSize.MEDIUM, store.iconSize.first())
+            store.setIconSize(DrawerIconSize.LARGE)
+            assertEquals(DrawerIconSize.LARGE, store.iconSize.first())
         }
 
     private companion object {
         const val COMPONENT = "com.example.music/.MainActivity"
         const val OTHER = "com.example.maps/.MapsActivity"
     }
+}
+
+class ResolvePinnedOrderTest {
+    @Test
+    fun `returns ordered entries from the order string`() =
+        assertEquals(
+            listOf("b/.B", "a/.A"),
+            resolvePinnedOrder(order = "b/.B\na/.A", legacy = setOf("z/.Z")),
+        )
+
+    @Test
+    fun `falls back to the legacy set sorted when no order exists`() =
+        assertEquals(
+            listOf("a/.A", "b/.B"),
+            resolvePinnedOrder(order = null, legacy = setOf("b/.B", "a/.A")),
+        )
+
+    @Test
+    fun `returns empty when neither key exists`() =
+        assertEquals(emptyList(), resolvePinnedOrder(order = null, legacy = null))
+
+    @Test
+    fun `drops empty segments from a blank order string`() =
+        assertEquals(emptyList(), resolvePinnedOrder(order = "", legacy = null))
 }

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDrawerSettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDrawerSettingsStore.kt
@@ -1,0 +1,36 @@
+package io.github.seijikohara.femto.testfixtures
+
+import io.github.seijikohara.femto.data.DrawerIconSize
+import io.github.seijikohara.femto.data.DrawerLayout
+import io.github.seijikohara.femto.data.DrawerSettingsStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * In-memory [DrawerSettingsStore] for view-model tests: every setter mutates a
+ * [MutableStateFlow] synchronously, so a test sees the write with no DataStore IO
+ * and no cross-dispatcher timing.
+ */
+internal class FakeDrawerSettingsStore(
+    initialLayout: DrawerLayout = DrawerLayout.GRID,
+    initialIconSize: DrawerIconSize = DrawerIconSize.MEDIUM,
+    initialPinned: List<String> = emptyList(),
+) : DrawerSettingsStore {
+    private val layoutState = MutableStateFlow(initialLayout)
+    private val iconSizeState = MutableStateFlow(initialIconSize)
+    private val pinnedState = MutableStateFlow(initialPinned)
+
+    override val layout: Flow<DrawerLayout> = layoutState
+    override val iconSize: Flow<DrawerIconSize> = iconSizeState
+    override val pinned: Flow<List<String>> = pinnedState
+
+    override suspend fun setLayout(value: DrawerLayout) = layoutState.update { value }
+
+    override suspend fun setIconSize(value: DrawerIconSize) = iconSizeState.update { value }
+
+    override suspend fun togglePinned(flattenedComponent: String) =
+        pinnedState.update { current ->
+            if (flattenedComponent in current) current - flattenedComponent else current + flattenedComponent
+        }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSearchTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSearchTest.kt
@@ -1,0 +1,45 @@
+package io.github.seijikohara.femto.ui.drawer
+
+import io.github.seijikohara.femto.data.DrawerLayout
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class AppDrawerSearchTest {
+    @Test
+    fun `ranks prefix matches before substring matches`() =
+        assertEquals(
+            listOf("Maps", "Music", "Gmail"),
+            filterAndRank(listOf("Gmail", "Maps", "Music", "Phone"), "m") { it },
+        )
+
+    @Test
+    fun `matches case-insensitively`() =
+        assertEquals(
+            listOf("maps", "MUSIC"),
+            filterAndRank(listOf("maps", "MUSIC", "Phone"), "M") { it },
+        )
+
+    @Test
+    fun `keeps input order within each partition`() =
+        assertEquals(
+            listOf("Mb", "Ma", "xMb", "xMa"),
+            filterAndRank(listOf("xMb", "Mb", "xMa", "Ma"), "m") { it },
+        )
+
+    @Test
+    fun `returns items unchanged for a blank query`() {
+        val items = listOf("Gmail", "Maps")
+        assertEquals(items, filterAndRank(items, "  ") { it })
+    }
+
+    @Test
+    fun `returns empty when nothing matches`() = assertEquals(emptyList(), filterAndRank(listOf("Phone"), "z") { it })
+
+    @Test
+    fun `effectiveLayout forces LIST while a query is active`() {
+        assertEquals(DrawerLayout.LIST, effectiveLayout(DrawerLayout.GRID, "m"))
+        assertEquals(DrawerLayout.GRID, effectiveLayout(DrawerLayout.GRID, ""))
+        assertEquals(DrawerLayout.GRID, effectiveLayout(DrawerLayout.GRID, "   "))
+        assertEquals(DrawerLayout.LIST, effectiveLayout(DrawerLayout.LIST, ""))
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.DisplaySettings
+import io.github.seijikohara.femto.data.DrawerIconSize
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.LocationQualitySetting
@@ -11,6 +12,7 @@ import io.github.seijikohara.femto.data.LocationSettings
 import io.github.seijikohara.femto.data.MapColorScheme
 import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.testfixtures.FakeDisplaySettingsStore
+import io.github.seijikohara.femto.testfixtures.FakeDrawerSettingsStore
 import io.github.seijikohara.femto.testfixtures.FakeLocationSettingsStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -38,6 +40,7 @@ class SettingsViewModelTest {
     private val application: Application = ApplicationProvider.getApplicationContext()
     private val store = FakeDisplaySettingsStore()
     private val locationStore = FakeLocationSettingsStore()
+    private val drawerStore = FakeDrawerSettingsStore()
     private val dispatcher = StandardTestDispatcher()
 
     @Before
@@ -211,5 +214,13 @@ class SettingsViewModelTest {
             assertEquals(60, store.settings.first().glassTintScale)
         }
 
-    private fun viewModel() = SettingsViewModel(store, FontPreferences(application), locationStore)
+    @Test
+    fun `SetDrawerIconSize writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetDrawerIconSize(DrawerIconSize.LARGE))
+            advanceUntilIdle()
+            assertEquals(DrawerIconSize.LARGE, drawerStore.iconSize.first())
+        }
+
+    private fun viewModel() = SettingsViewModel(store, FontPreferences(application), locationStore, drawerStore)
 }

--- a/docs/superpowers/plans/2026-06-10-app-drawer-revamp.md
+++ b/docs/superpowers/plans/2026-06-10-app-drawer-revamp.md
@@ -1,0 +1,116 @@
+# App Drawer Revamp Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pinned dock fixed at the drawer sheet bottom, S/M/L icon size presets in Settings, and search polish (prefix-priority ordering, auto-list layout).
+
+**Architecture:** Persistence changes live in `data/DrawerPreferences.kt` (ordered pins, icon size enum). Pure ranking/layout functions live in a new `ui/drawer/AppDrawerSearch.kt` for JVM testability. `AppDrawerScreen` restructures into a Column with a fixed `PinnedDock` row. Settings wires `DrawerSettingsStore` into the existing ViewModel via a new `ChoiceRow`.
+
+**Tech Stack:** Kotlin, Jetpack Compose (M3), DataStore Preferences, JUnit4 + Robolectric.
+
+Spec: `docs/superpowers/specs/2026-06-10-app-drawer-revamp-design.md`
+
+---
+
+### Task 1: DrawerPreferences — ordered pins + icon size
+
+**Files:**
+- Modify: `app/src/main/java/io/github/seijikohara/femto/data/DrawerPreferences.kt`
+- Test: `app/src/test/java/io/github/seijikohara/femto/data/DrawerPreferencesTest.kt`
+
+- [ ] Add `DrawerIconSize { SMALL, MEDIUM, LARGE }` enum.
+- [ ] Change `DrawerSettingsStore.pinned` to `Flow<List<String>>` (pin order), add `iconSize: Flow<DrawerIconSize>` and `setIconSize`.
+- [ ] Extract migration as a top-level pure function:
+
+```kotlin
+internal fun resolvePinnedOrder(order: String?, legacy: Set<String>?): List<String> =
+    order?.split(PIN_SEPARATOR)?.filter { it.isNotEmpty() }
+        ?: legacy?.sorted()
+        ?: emptyList()
+```
+
+`PIN_SEPARATOR = '\n'` (cannot appear in a flattened `ComponentName`). `togglePinned` reads the resolved list, appends/removes, writes `drawer_pinned_order`, and removes the legacy `drawer_pinned` key.
+
+- [ ] Tests: pure-function tests for `resolvePinnedOrder` (order kept, legacy sorted fallback, empty default); extend the existing single Robolectric round-trip test to assert append order, unpin, icon size round-trip.
+- [ ] Run `./gradlew :app:testDebugUnitTest --tests '*DrawerPreferences*'` → PASS.
+- [ ] Commit.
+
+### Task 2: Search ranking + auto-list pure functions
+
+**Files:**
+- Create: `app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSearch.kt`
+- Test: `app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSearchTest.kt`
+
+- [ ] Implement:
+
+```kotlin
+internal fun <T> filterAndRank(items: List<T>, query: String, labelOf: (T) -> String): List<T>
+// blank query → items unchanged; else startsWith matches (ignoreCase) first,
+// then contains matches; both partitions keep input order.
+
+internal fun effectiveLayout(persisted: DrawerLayout, query: String): DrawerLayout
+// non-blank query → LIST, else persisted.
+```
+
+- [ ] JVM tests (no Robolectric): prefix beats substring, case-insensitive, stable order within partitions, blank query passthrough, auto-list selection.
+- [ ] Run tests → PASS. Commit.
+
+### Task 3: AppTile / AppListRow size parameters + pin badge
+
+**Files:**
+- Modify: `app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppTile.kt`
+- Modify: `app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppListRow.kt`
+
+- [ ] `AppTile(entry, onClick, modifier, onLongClick, iconSize: Dp = 64.dp, isPinned: Boolean = false)` — icon wrapped in a `Box`; when pinned, a small `Lucide.Pin` badge at `Alignment.TopEnd` on a `secondaryContainer` circle.
+- [ ] `AppListRow(..., iconSize: Dp = 40.dp, isPinned: Boolean = false)` — pinned shows a trailing `Lucide.Pin` icon.
+- [ ] Compile check via Task 5 build (callers update there). Commit with Task 5 if interim build breaks; otherwise commit now with default-arg compatibility.
+
+### Task 4: PinnedDock component
+
+**Files:**
+- Create: `app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt`
+
+- [ ] `PinnedDock(apps: List<AppEntry>, onLaunch, onUnpin, modifier)` — `HorizontalDivider` + `Surface(color = surfaceContainerHigh)` + `LazyRow` (stable keys). Tile: 64 dp icon + one-line 18 sp label, width ~96 dp, long-press opens an Unpin `DropdownMenu`. `@PreviewLightDark` preview.
+- [ ] Commit with Task 5.
+
+### Task 5: AppDrawerScreen restructure + AppDrawerSheet wiring
+
+**Files:**
+- Modify: `app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt`
+- Modify: `app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt`
+- Modify: `app/src/main/res/values/strings.xml`
+
+- [ ] `AppDrawerScreen` signature: `pinned: List<String>`, new `iconSize: DrawerIconSize`.
+- [ ] `ContentState`: Column = TopBar / content `Box(weight 1f)` / `PinnedDock` (only when pinned apps resolve non-empty; dock list = pinned order mapped through loaded apps, unaffected by query).
+- [ ] Grid/list show ALL matched apps (no pinned section split, headers removed); per-item `isPinned` flag drives the badge. Remove `drawer_section_pinned` / `drawer_section_apps` strings.
+- [ ] Use `filterAndRank` and `effectiveLayout(layout, query)`.
+- [ ] Tile dimensions from preset (private to AppDrawerScreen.kt):
+
+| Preset | tile min width | grid icon | list icon |
+| --- | --- | --- | --- |
+| SMALL | 96.dp | 48.dp | 32.dp |
+| MEDIUM | 120.dp | 64.dp | 40.dp |
+| LARGE | 160.dp | 88.dp | 56.dp |
+
+- [ ] `AppDrawerSheet`: collect `pinned` as `List`, collect `iconSize`, pass through.
+- [ ] Update previews. Build `assembleDebug` → green. Commit (Tasks 3+4+5 together if split builds red).
+
+### Task 6: Settings integration
+
+**Files:**
+- Modify: `ui/settings/SettingsUiState.kt`, `SettingsViewModel.kt`, `SettingsScreen.kt`
+- Modify: `app/src/main/res/values/strings.xml`
+- Test: `app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt` (+ fake in `testfixtures/` if VM test exists)
+
+- [ ] `SettingsUiState`: add `drawerIconSize: DrawerIconSize` (Initial = `MEDIUM`); add `SettingsAction.SetDrawerIconSize`.
+- [ ] `SettingsViewModel`: inject `DrawerSettingsStore`, add its `iconSize` to the `combine`, handle the action; update `SettingsViewModelFactory`.
+- [ ] `SettingsScreen`: `ChoiceRow` "App drawer icon size" (Small/Medium/Large) in the Display section. New strings.
+- [ ] If `SettingsViewModelTest` exists: add `FakeDrawerSettingsStore` to `testfixtures/` and cover the new action.
+- [ ] Run unit tests → PASS. Commit.
+
+### Task 7: Verify, PR, merge
+
+- [ ] `./gradlew spotlessApply` then verify via the `verify-android-build` skill (`assembleDebug` + `lint`).
+- [ ] `./gradlew test` full pass.
+- [ ] Dispatch `compose-launcher-reviewer` on the diff; address findings.
+- [ ] Push branch, open PR (no Claude attribution), merge per user instruction.

--- a/docs/superpowers/specs/2026-06-10-app-drawer-revamp-design.md
+++ b/docs/superpowers/specs/2026-06-10-app-drawer-revamp-design.md
@@ -1,0 +1,147 @@
+# App Drawer Revamp — Design
+
+Date: 2026-06-10
+Status: Approved scope — pinned dock, icon size presets, search polish
+
+## Goal
+
+Improve the app drawer bottom sheet so that pinned apps are always one
+tap away, icon size adapts to user preference, and search reaches the
+target app with minimal input. Scope decisions follow a competitive
+study of comparable car launchers and general-purpose Android
+launchers (see Research notes below).
+
+## Scope
+
+In scope:
+
+1. Pinned dock fixed at the bottom of the drawer sheet.
+2. Icon size presets (Small / Medium / Large) configurable in
+   Settings.
+3. Search polish: prefix-priority result ordering and automatic
+   list-layout while a query is active.
+
+Out of scope (deferred to future work):
+
+- "Recent apps" section (requires the `PACKAGE_USAGE_STATS` special
+  permission and a grant-flow design).
+- Drag-and-drop reordering of pinned apps.
+- Customisable footer quick-access shortcuts (touches the home screen
+  surface, separate feature).
+
+## Design
+
+### 1. Pinned dock
+
+Restructure `AppDrawerScreen` content as a `Column`:
+
+```
+ModalBottomSheet (height fraction 0.72, unchanged)
+└─ Column
+   ├─ Search field + toolbar (layout toggle)   — unchanged
+   ├─ App grid or list                          — weight(1f), scrolls
+   └─ PinnedDock                                — fixed row
+```
+
+- `PinnedDock` is a `LazyRow`. Each tile shows the app icon plus a
+  one-line label (ellipsised) at `FemtoDimens.MinBodyTextSize`,
+  matching `AppTile` typography. Tile touch target stays at or above
+  `FemtoDimens.MinTouchTarget` (64 dp); tile width is approximately
+  96 dp so the label remains readable.
+- The dock sits on `surfaceContainerHigh` with a `HorizontalDivider`
+  above it to visually separate the fixed region from the scrolling
+  grid.
+- When no apps are pinned, the dock is not composed (no empty fixed
+  row).
+- The current "Pinned" section at the top of the grid/list is
+  removed. The grid/list shows **all** apps, including pinned ones,
+  so every app stays findable in one place; pinned apps carry a small
+  pin badge.
+- Long-press menu on grid/list tiles keeps Pin / Unpin. Dock tiles
+  gain a long-press Unpin action.
+
+### 2. Pin order persistence
+
+- Pinned apps render in the order they were pinned. The existing
+  DataStore value `drawer_pinned: Set<String>` cannot express order,
+  so persistence moves to an ordered representation under a new key
+  (`drawer_pinned_order: String`, flattened component names joined
+  with `\n`, which cannot appear in a flattened `ComponentName`).
+- Migration: on first read, if the new key is absent and the legacy
+  set is present, seed the order from the legacy set sorted by label
+  order (alphabetical as a deterministic fallback), then clear the
+  legacy key.
+
+### 3. Icon size presets
+
+- New enum `DrawerIconSize { SMALL, MEDIUM, LARGE }` persisted in
+  `DrawerPreferences` (key `drawer_icon_size`), default `MEDIUM`
+  (matches current dimensions).
+
+| Preset | Grid tile min width | Grid icon | List icon |
+| --- | --- | --- | --- |
+| SMALL | 96 dp | 48 dp | 32 dp |
+| MEDIUM (current) | 120 dp | 64 dp | 40 dp |
+| LARGE | 160 dp | 88 dp | 56 dp |
+
+- Tile width and list row height never drop below
+  `FemtoDimens.MinTouchTarget` (64 dp) at any preset.
+- Settings gains an "App drawer icon size" row using an M3
+  `SegmentedButton` group (three options, applied immediately).
+- The dock tile size is independent of the preset (fixed) to keep the
+  dock height stable.
+
+### 4. Search polish
+
+- **Prefix-priority ordering**: filter results sort `startsWith`
+  matches (case-insensitive) before `contains` matches; ties keep
+  label order. Typing "M" surfaces Maps / Music first.
+- **Automatic list layout**: while the query is non-blank the drawer
+  renders the list layout regardless of the persisted preference,
+  because labels are the primary signal when searching. Clearing the
+  query restores the persisted layout. The persisted value is never
+  written by this behaviour.
+- Both behaviours live in pure functions so they are unit-testable
+  without Compose.
+
+## Components touched
+
+| File | Change |
+| --- | --- |
+| `data/DrawerPreferences.kt` | `DrawerIconSize` enum, ordered pin persistence + migration |
+| `ui/drawer/AppDrawerScreen.kt` | Column restructure, dock slot, search ordering, auto-list |
+| `ui/drawer/components/PinnedDock.kt` (new) | Fixed dock row |
+| `ui/home/components/AppTile.kt` | Size parameterisation, pin badge |
+| `ui/home/components/AppListRow.kt` | Size parameterisation, pin badge |
+| `ui/settings/...` | Icon size segmented row |
+| `app/src/test/...` | Preferences round-trip + migration, search ordering, auto-list selection |
+
+## Error handling
+
+- Pinned component names that no longer resolve to an installed app
+  are skipped at render time and pruned from the persisted order on
+  the next pin/unpin write (same behaviour as the current set-based
+  implementation).
+- DataStore read failures fall back to defaults (`MEDIUM`, empty pin
+  order), matching the existing `DrawerPreferences` posture.
+
+## Testing
+
+- JVM unit tests: ordered pin persistence (round-trip, append order,
+  unpin removal, legacy-set migration), `DrawerIconSize` round-trip,
+  prefix-priority sort, auto-list layout selection.
+- Compose previews: `@PreviewLightDark` for the dock and for each
+  icon-size preset.
+- Manual verification on the TBox-Mock AVD (800x480 @ 150 dpi) for
+  dock reachability and LARGE-preset label wrapping.
+
+## Research notes
+
+Competitive study (2026-06-10, `similar-app-researcher`): the
+bottom-sheet drawer with pinned-priority access is already the
+strongest pattern for head units versus full-screen drawers
+(context loss over the map) and favourites-only models (poor full-app
+reachability). Differentiators adopted from the study: three-step icon
+size presets (one-tap selection beats continuous sliders for in-car
+touch), prefix-priority search, and automatic list layout during
+search (no comparable launcher ships either search behaviour).


### PR DESCRIPTION
## Summary

Revamps the app drawer bottom sheet around three improvements scoped from a competitive study of car launchers and general-purpose Android launchers (design spec and implementation plan included under `docs/superpowers/`).

### Pinned dock
- Pinned apps move from a top section to a dock **fixed at the bottom of the sheet**: a horizontally scrolling row in pin order, always one tap away regardless of grid scroll position.
- Pin persistence migrates from an unordered `Set<String>` to a newline-joined ordered string (`drawer_pinned_order`) with a sorted fallback from the legacy key; the legacy key is cleared on the first write.
- The grid/list now shows **all** apps (pinned ones carry a pin badge) so every app stays findable in one place. Dock tiles enforce the 64 dp touch-target floor and use the 18 sp body-text floor for labels.

### Icon size presets
- New `DrawerIconSize` (Small / Medium / Large) persisted in `DrawerPreferences`; Medium matches the previous dimensions.
- Settings exposes an "Icon size" choice row in the Display section. Tile widths scale 96/120/160 dp; grid icons 48/64/88 dp; list icons 32/40/56 dp. All presets stay above the 64 dp touch target.

### Search polish
- Prefix matches rank before substring matches (one typed letter surfaces the apps starting with it).
- A non-blank query forces the list layout so labels stay readable while searching; clearing restores the persisted layout without writing it.
- Both behaviours are pure functions (`AppDrawerSearch.kt`) with JVM unit tests.

## Testing
- `./gradlew test` — green (new: ordered-pin round-trip + legacy migration, search ranking, auto-list selection, Settings action)
- `./gradlew assembleDebug lint` — green
- `compileDebugAndroidTestKotlin` — green; added a dock render/launch Compose test