### PR TITLE
feat(home): dockable nav bar, orientation setting, charging-caption removal

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardDockTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardDockTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import io.github.seijikohara.femto.data.DockPosition
 import io.github.seijikohara.femto.testfixtures.fakeSystemStatus
 import io.github.seijikohara.femto.ui.home.HomeAction
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -14,7 +15,7 @@ import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
 
-class DashboardFooterTest {
+class DashboardDockTest {
     @get:Rule
     val rule = createComposeRule()
 
@@ -22,7 +23,7 @@ class DashboardFooterTest {
     fun renders_apps_and_settings_nav_buttons() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(),
                     onAction = {},
                 )
@@ -38,7 +39,7 @@ class DashboardFooterTest {
         var lastAction: HomeAction? = null
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(),
                     onAction = { lastAction = it },
                 )
@@ -53,7 +54,7 @@ class DashboardFooterTest {
         var lastAction: HomeAction? = null
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(),
                     onAction = { lastAction = it },
                 )
@@ -67,7 +68,7 @@ class DashboardFooterTest {
     fun shows_wifi_connected_description_when_wifi_connected() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(wifiConnected = true),
                     onAction = {},
                 )
@@ -80,7 +81,7 @@ class DashboardFooterTest {
     fun shows_bluetooth_on_description_when_enabled_but_not_connected() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(bluetoothEnabled = true, bluetoothConnected = false),
                     onAction = {},
                 )
@@ -93,7 +94,7 @@ class DashboardFooterTest {
     fun shows_bluetooth_off_description_when_adapter_disabled() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(bluetoothEnabled = false, bluetoothConnected = false),
                     onAction = {},
                 )
@@ -106,7 +107,7 @@ class DashboardFooterTest {
     fun shows_cellular_connected_description_when_connected() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(cellularConnected = true),
                     onAction = {},
                 )
@@ -119,7 +120,7 @@ class DashboardFooterTest {
     fun shows_graduated_cellular_icon_when_level_is_known() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(cellularConnected = true, cellularSignalLevel = 3),
                     onAction = {},
                 )
@@ -134,7 +135,7 @@ class DashboardFooterTest {
     fun degrades_cellular_to_binary_icon_when_level_is_null() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     // Connected but level unknown (READ_PHONE_STATE withheld): the
                     // indicator still renders, falling back to the binary glyph.
                     systemStatus = fakeSystemStatus(cellularConnected = true, cellularSignalLevel = null),
@@ -149,7 +150,7 @@ class DashboardFooterTest {
     fun shows_cellular_disconnected_when_signal_level_is_zero() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     // A known level drives the lit state off signal presence, not the
                     // validated-route flag: zero bars reads as disconnected even while
                     // the cellular network momentarily holds NET_CAPABILITY_VALIDATED.
@@ -165,7 +166,7 @@ class DashboardFooterTest {
     fun shows_graduated_wifi_icon_when_connected_with_a_level() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(wifiConnected = true, wifiSignalLevel = 1),
                     onAction = {},
                 )
@@ -178,7 +179,7 @@ class DashboardFooterTest {
     fun hides_cellular_icon_on_telephony_less_unit() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(cellularConnected = null),
                     onAction = {},
                 )
@@ -192,7 +193,7 @@ class DashboardFooterTest {
     fun shows_gps_fixed_description_when_gps_is_fixed() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(gpsFixed = true),
                     onAction = {},
                 )
@@ -205,7 +206,7 @@ class DashboardFooterTest {
     fun shows_gps_searching_description_when_gps_is_not_fixed() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(gpsFixed = false),
                     onAction = {},
                 )
@@ -218,7 +219,7 @@ class DashboardFooterTest {
     fun renders_gps_satellite_count_text() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(gpsFixed = true, gpsSatelliteCount = 9),
                     onAction = {},
                 )
@@ -231,7 +232,7 @@ class DashboardFooterTest {
     fun renders_battery_percent_text() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(batteryPercent = 78),
                     onAction = {},
                 )
@@ -241,15 +242,32 @@ class DashboardFooterTest {
     }
 
     @Test
-    fun shows_charging_caption_when_charging() {
+    fun does_not_render_a_charging_caption() {
         rule.setContent {
             FemtoTheme {
-                DashboardFooter(
+                DashboardDock(
                     systemStatus = fakeSystemStatus(charging = true),
                     onAction = {},
                 )
             }
         }
-        rule.onNodeWithText("Charging").assertIsDisplayed()
+        // Charging reads from the bolt glyph and tint alone; no text caption.
+        rule.onNodeWithText("Charging").assertDoesNotExist()
+    }
+
+    @Test
+    fun vertical_rail_renders_all_nav_buttons() {
+        rule.setContent {
+            FemtoTheme {
+                DashboardDock(
+                    systemStatus = fakeSystemStatus(),
+                    onAction = {},
+                    position = DockPosition.LEFT,
+                )
+            }
+        }
+        rule.onNodeWithContentDescription("Apps").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Settings").assertIsDisplayed()
+        rule.onNodeWithContentDescription("Phone").assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffoldTest.kt
@@ -28,7 +28,7 @@ class DashboardScaffoldTest {
         // exercises the scaffold layout without standing up a MapLibre GL surface.
         // The clock overlay self-times from the wall clock, so the dashboard has
         // no deterministic time string to assert; the map fallback, weather,
-        // music, and footer panels carry the stable assertions instead.
+        // music, and dock panels carry the stable assertions instead.
         val uiState =
             HomeUiState.Initial.copy(
                 clock = ClockTick(LocalTime.of(14, 32), LocalDate.of(2026, 5, 1)),
@@ -60,7 +60,7 @@ class DashboardScaffoldTest {
     @Test
     fun hides_info_panels_disabled_by_visibility_flags() {
         // Disabling every info-pane panel drops the whole info pane, so none of
-        // their content renders while the map and footer stay put.
+        // their content renders while the map and dock stay put.
         val uiState =
             HomeUiState.Initial.copy(
                 location = null,

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.SearchManager
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -36,6 +37,7 @@ import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.FontRepository
 import io.github.seijikohara.femto.data.FontSlot
 import io.github.seijikohara.femto.data.FullscreenSetting
+import io.github.seijikohara.femto.data.OrientationSetting
 import io.github.seijikohara.femto.data.SystemPermissionSignals
 import io.github.seijikohara.femto.data.ThemeMode
 import io.github.seijikohara.femto.data.hasBluetoothConnectPermission
@@ -115,6 +117,9 @@ class MainActivity : ComponentActivity() {
             }
             LaunchedEffect(display.keepScreenOn) {
                 applyKeepScreenOn(display.keepScreenOn)
+            }
+            LaunchedEffect(display.orientation) {
+                applyOrientation(display.orientation)
             }
             FemtoTheme(fontFamily = fontFamily, accent = display.accentColor, darkTheme = darkTheme) {
                 // The dashboard stays composed; the app drawer, assistant, and
@@ -238,6 +243,17 @@ class MainActivity : ComponentActivity() {
         } else {
             window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
+    }
+
+    // SENSOR_* variants (not the plain LANDSCAPE/PORTRAIT) so a forced axis still
+    // follows 180-degree flips — some head units are mounted inverted.
+    private fun applyOrientation(setting: OrientationSetting) {
+        requestedOrientation =
+            when (setting) {
+                OrientationSetting.AUTO -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+                OrientationSetting.LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                OrientationSetting.PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+            }
     }
 
     private fun handleHomeEvent(

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -71,7 +71,7 @@ class MainActivity : ComponentActivity() {
     private var fullscreenSetting = FullscreenSetting.OFF
 
     // Emit on the process-wide refresh signal so permission-gated flows (e.g.
-    // the Bluetooth footer indicator) re-read after a late runtime grant.
+    // the Bluetooth dock indicator) re-read after a late runtime grant.
     private val permissionsLauncher =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
             SystemPermissionSignals.refreshes.tryEmit(Unit)
@@ -127,6 +127,7 @@ class MainActivity : ComponentActivity() {
                 HomeRoute(
                     is24Hour = resolveIs24Hour(display.clock),
                     showClockSeconds = display.showClockSeconds,
+                    dockPosition = display.dockPosition,
                     speedUnit = display.speedUnit.resolved(),
                     temperatureUnit = display.temperatureUnit.resolved(),
                     mapConfig =

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -52,6 +52,13 @@ internal enum class FullscreenSetting { OFF, ON }
  */
 internal enum class DockPosition { BOTTOM, TOP, LEFT, RIGHT }
 
+/**
+ * Screen orientation: follow the head unit ([AUTO], the default — portrait and
+ * landscape units must both work, per CLAUDE.md#launcher-behavior), or force
+ * landscape / portrait for units that misreport their natural orientation.
+ */
+internal enum class OrientationSetting { AUTO, LANDSCAPE, PORTRAIT }
+
 /** Map light/dark style: follow the system theme, or force light / dark. */
 internal enum class MapStyleSetting { AUTO, LIGHT, DARK }
 
@@ -121,6 +128,8 @@ internal data class DisplaySettings(
     val fullscreen: FullscreenSetting,
     // Which screen edge hosts the dashboard dock; BOTTOM is the classic dock.
     val dockPosition: DockPosition,
+    // Screen orientation; AUTO follows the head unit's natural orientation.
+    val orientation: OrientationSetting,
     // Whether to keep the screen awake while the launcher is foreground. Defaults
     // to true: the head unit runs on vehicle power, so the dashboard should stay lit.
     val keepScreenOn: Boolean,
@@ -165,6 +174,7 @@ internal data class DisplaySettings(
                 showClockSeconds = false,
                 fullscreen = FullscreenSetting.ON,
                 dockPosition = DockPosition.BOTTOM,
+                orientation = OrientationSetting.AUTO,
                 keepScreenOn = true,
                 mapStyle = MapStyleSetting.AUTO,
                 mapSchemeLight = MapColorScheme.ACCENT,
@@ -210,6 +220,8 @@ internal interface DisplaySettingsStore {
     suspend fun setFullscreen(value: FullscreenSetting)
 
     suspend fun setDockPosition(value: DockPosition)
+
+    suspend fun setOrientation(value: OrientationSetting)
 
     suspend fun setKeepScreenOn(value: Boolean)
 
@@ -270,6 +282,7 @@ internal class DisplayPreferences(
                     showClockSeconds = prefs[SHOW_CLOCK_SECONDS_KEY] ?: false,
                     fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.ON),
                     dockPosition = prefs[DOCK_POSITION_KEY].toEnumOr(DockPosition.BOTTOM),
+                    orientation = prefs[ORIENTATION_KEY].toEnumOr(OrientationSetting.AUTO),
                     keepScreenOn = prefs[KEEP_SCREEN_ON_KEY] ?: true,
                     mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
                     mapSchemeLight = prefs[MAP_SCHEME_LIGHT_KEY].toEnumOr(MapColorScheme.ACCENT),
@@ -319,6 +332,10 @@ internal class DisplayPreferences(
 
     override suspend fun setDockPosition(value: DockPosition) {
         context.displayDataStore.editOrLog(TAG) { it[DOCK_POSITION_KEY] = value.name }
+    }
+
+    override suspend fun setOrientation(value: OrientationSetting) {
+        context.displayDataStore.editOrLog(TAG) { it[ORIENTATION_KEY] = value.name }
     }
 
     override suspend fun setKeepScreenOn(value: Boolean) {
@@ -401,6 +418,7 @@ internal class DisplayPreferences(
         val SHOW_CLOCK_SECONDS_KEY = booleanPreferencesKey("show_clock_seconds")
         val FULLSCREEN_KEY = stringPreferencesKey("fullscreen")
         val DOCK_POSITION_KEY = stringPreferencesKey("dock_position")
+        val ORIENTATION_KEY = stringPreferencesKey("orientation")
         val KEEP_SCREEN_ON_KEY = booleanPreferencesKey("keep_screen_on")
         val MAP_STYLE_KEY = stringPreferencesKey("map_style")
         val MAP_SCHEME_LIGHT_KEY = stringPreferencesKey("map_scheme_light")

--- a/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/DisplayPreferences.kt
@@ -46,6 +46,12 @@ enum class AccentColor { DYNAMIC, BLUE, TEAL, GREEN, AMBER, ORANGE, RED, VIOLET,
 /** Fullscreen: keep the system bars, or hide both status and navigation bars. */
 internal enum class FullscreenSetting { OFF, ON }
 
+/**
+ * Which screen edge hosts the dashboard dock. [BOTTOM] and [TOP] render the
+ * horizontal bar; [LEFT] and [RIGHT] render it as a vertical rail.
+ */
+internal enum class DockPosition { BOTTOM, TOP, LEFT, RIGHT }
+
 /** Map light/dark style: follow the system theme, or force light / dark. */
 internal enum class MapStyleSetting { AUTO, LIGHT, DARK }
 
@@ -113,6 +119,8 @@ internal data class DisplaySettings(
     // per-minute instead of per-second.
     val showClockSeconds: Boolean,
     val fullscreen: FullscreenSetting,
+    // Which screen edge hosts the dashboard dock; BOTTOM is the classic dock.
+    val dockPosition: DockPosition,
     // Whether to keep the screen awake while the launcher is foreground. Defaults
     // to true: the head unit runs on vehicle power, so the dashboard should stay lit.
     val keepScreenOn: Boolean,
@@ -156,6 +164,7 @@ internal data class DisplaySettings(
                 clock = ClockSetting.AUTO,
                 showClockSeconds = false,
                 fullscreen = FullscreenSetting.ON,
+                dockPosition = DockPosition.BOTTOM,
                 keepScreenOn = true,
                 mapStyle = MapStyleSetting.AUTO,
                 mapSchemeLight = MapColorScheme.ACCENT,
@@ -199,6 +208,8 @@ internal interface DisplaySettingsStore {
     suspend fun setShowClockSeconds(value: Boolean)
 
     suspend fun setFullscreen(value: FullscreenSetting)
+
+    suspend fun setDockPosition(value: DockPosition)
 
     suspend fun setKeepScreenOn(value: Boolean)
 
@@ -258,6 +269,7 @@ internal class DisplayPreferences(
                     clock = prefs[CLOCK_KEY].toEnumOr(ClockSetting.AUTO),
                     showClockSeconds = prefs[SHOW_CLOCK_SECONDS_KEY] ?: false,
                     fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.ON),
+                    dockPosition = prefs[DOCK_POSITION_KEY].toEnumOr(DockPosition.BOTTOM),
                     keepScreenOn = prefs[KEEP_SCREEN_ON_KEY] ?: true,
                     mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
                     mapSchemeLight = prefs[MAP_SCHEME_LIGHT_KEY].toEnumOr(MapColorScheme.ACCENT),
@@ -303,6 +315,10 @@ internal class DisplayPreferences(
 
     override suspend fun setFullscreen(value: FullscreenSetting) {
         context.displayDataStore.editOrLog(TAG) { it[FULLSCREEN_KEY] = value.name }
+    }
+
+    override suspend fun setDockPosition(value: DockPosition) {
+        context.displayDataStore.editOrLog(TAG) { it[DOCK_POSITION_KEY] = value.name }
     }
 
     override suspend fun setKeepScreenOn(value: Boolean) {
@@ -384,6 +400,7 @@ internal class DisplayPreferences(
         val CLOCK_KEY = stringPreferencesKey("clock")
         val SHOW_CLOCK_SECONDS_KEY = booleanPreferencesKey("show_clock_seconds")
         val FULLSCREEN_KEY = stringPreferencesKey("fullscreen")
+        val DOCK_POSITION_KEY = stringPreferencesKey("dock_position")
         val KEEP_SCREEN_ON_KEY = booleanPreferencesKey("keep_screen_on")
         val MAP_STYLE_KEY = stringPreferencesKey("map_style")
         val MAP_SCHEME_LIGHT_KEY = stringPreferencesKey("map_scheme_light")

--- a/app/src/main/java/io/github/seijikohara/femto/data/LocationPermissions.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/LocationPermissions.kt
@@ -40,7 +40,7 @@ internal fun Context.hasReadCalendarPermission(): Boolean =
 
 /**
  * `READ_PHONE_STATE` gates the cellular `SignalStrength` read. It is a runtime
- * grant on every supported API level; without it the footer's cellular
+ * grant on every supported API level; without it the dock's cellular
  * indicator degrades to the binary connected/disconnected icon.
  */
 internal fun Context.hasReadPhoneStatePermission(): Boolean =

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatus.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatus.kt
@@ -3,7 +3,7 @@ package io.github.seijikohara.femto.data
 import androidx.compose.runtime.Immutable
 
 /**
- * Read-only system connectivity / power surface for the footer status cluster.
+ * Read-only system connectivity / power surface for the dock status cluster.
  *
  * All fields default to the "off / unknown" state in [Initial] so a fresh
  * subscriber renders a neutral cluster while the repository's first emit
@@ -12,18 +12,18 @@ import androidx.compose.runtime.Immutable
 @Immutable
 data class SystemStatus(
     // Null on a device with no telephony feature (e.g. a Wi-Fi-only AI box), so
-    // the footer hides the cellular indicator entirely rather than showing a
+    // the dock hides the cellular indicator entirely rather than showing a
     // permanently-disconnected one; true/false once telephony is present.
     val cellularConnected: Boolean?,
     // 0..4 graduated cellular signal level, or null when telephony is absent, the
     // READ_PHONE_STATE grant is withheld, or no reading has arrived. When null but
-    // cellularConnected is non-null, the footer degrades to the binary icon.
+    // cellularConnected is non-null, the dock degrades to the binary icon.
     val cellularSignalLevel: Int?,
     val wifiConnected: Boolean,
     // 0..4 graduated Wi-Fi signal level. Defaults to 0 (no bars) until the first
-    // capability reading arrives; the footer uses this for the graduated icon.
+    // capability reading arrives; the dock uses this for the graduated icon.
     val wifiSignalLevel: Int,
-    // Whether the Bluetooth adapter is powered on. The footer lights the BT icon
+    // Whether the Bluetooth adapter is powered on. The dock lights the BT icon
     // on this (an enabled adapter should not read as off), separate from whether a
     // device is actually connected.
     val bluetoothEnabled: Boolean,
@@ -32,16 +32,16 @@ data class SystemStatus(
     // falls back to the enabled state.
     val bluetoothConnected: Boolean,
     // Null until the first battery reading arrives, or on battery-less units —
-    // distinguishes "unknown" from a genuine 0% so the footer never reads as a
+    // distinguishes "unknown" from a genuine 0% so the dock never reads as a
     // dead battery during cold start.
     val batteryPercent: Int?,
     val charging: Boolean,
     // True while a recent GPS_PROVIDER fix is fresh; flips back to false once the
-    // last fix ages past the freshness window so the footer reads "searching"
+    // last fix ages past the freshness window so the dock reads "searching"
     // when GPS reception drops (e.g. a tunnel or a parked cold start).
     val gpsFixed: Boolean,
     // Satellites currently used in the GPS fix (0 while searching / no GNSS read).
-    // Shown under the footer's GPS icon as a coarse reception quality readout.
+    // Shown under the dock's GPS icon as a coarse reception quality readout.
     val gpsSatelliteCount: Int,
 ) {
     companion object {

--- a/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/SystemStatusRepository.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.transformLatest
 
 /**
- * Footer status cluster — Wi-Fi connectivity / signal strength, cellular
+ * Dock status cluster — Wi-Fi connectivity / signal strength, cellular
  * connectivity / signal strength, Bluetooth connectivity, battery percent
  * and charging state.
  *
@@ -58,7 +58,7 @@ import kotlinx.coroutines.flow.transformLatest
  * (the connected-device APIs throw without the grant), so a paired head unit
  * still reads as BT-on rather than a misleading "disconnected". Cellular
  * signal strength requires `READ_PHONE_STATE`; when
- * denied the level flow emits null and the footer degrades to the binary
+ * denied the level flow emits null and the dock degrades to the binary
  * connected/disconnected icon.
  *
  * GPS reception is derived from the shared [locationFlow]: a fresh GPS_PROVIDER
@@ -162,7 +162,7 @@ internal class SystemStatusRepository(
     /**
      * Mobile-data connectivity, connectivity-only (no SIM / signal-strength
      * read, so no READ_PHONE_STATE). Emits null on a device with no telephony
-     * feature so the footer hides the indicator rather than showing a
+     * feature so the dock hides the indicator rather than showing a
      * permanently-disconnected one. Mirrors [wifiFlow] for the validated check.
      */
     private fun cellularFlow(): Flow<Boolean?> {
@@ -247,7 +247,7 @@ internal class SystemStatusRepository(
             awaitClose { tm.unregisterTelephonyCallback(callback) }
         }
 
-    // Combine the reception flag with the satellite count so the footer renders
+    // Combine the reception flag with the satellite count so the dock renders
     // both from one [SystemStatus] slot. combine emits once both sources have
     // seeded (gpsFixedFlow via onStart, gnssSatelliteFlow via its leading 0).
     private fun gpsFlow(): Flow<GpsReading> =
@@ -258,7 +258,7 @@ internal class SystemStatusRepository(
     /**
      * GPS reception flag. Emits true on each fresh GPS_PROVIDER fix, then false
      * once that fix ages past [GPS_FIX_FRESHNESS_MS] with no follow-up — so the
-     * footer reads "searching" when reception drops (tunnel, parked cold start).
+     * dock reads "searching" when reception drops (tunnel, parked cold start).
      *
      * The provider predicate mirrors [TripRepository]'s GPS-only gate; NETWORK
      * fixes (cell-tower / Wi-Fi) centre the map but do not represent a GPS lock,
@@ -279,7 +279,7 @@ internal class SystemStatusRepository(
 
     /**
      * Count of satellites used in the current GPS fix, via [GnssStatus]. Emits 0
-     * to start and whenever GNSS reports none used (searching), so the footer's
+     * to start and whenever GNSS reports none used (searching), so the dock's
      * satellite readout reflects the no-fix case. Needs ACCESS_FINE_LOCATION; the
      * map already gates on that grant, and without it this stays 0.
      */
@@ -413,7 +413,7 @@ internal class SystemStatusRepository(
         val level: Int,
     )
 
-    // [enabled] = adapter powered on (lights the footer icon); [connected] = a
+    // [enabled] = adapter powered on (lights the dock icon); [connected] = a
     // device is actively connected (selects the connected glyph). They diverge when
     // BT is on with nothing paired/connected.
     private data class BluetoothReading(
@@ -429,7 +429,7 @@ internal class SystemStatusRepository(
     )
 
     // Pairs the GPS freshness flag (from locationFlow) with the GnssStatus
-    // satellite count so the footer renders both from one combined slot.
+    // satellite count so the dock renders both from one combined slot.
     private data class GpsReading(
         val fixed: Boolean,
         val satellites: Int,
@@ -438,7 +438,7 @@ internal class SystemStatusRepository(
     internal companion object {
         // Top index of the shared 0..4 graduated signal range used by both the
         // Wi-Fi level and the cellular SignalStrength.level (which already reports
-        // 0 (NONE) .. 4 (GREAT)). The DashboardFooter icon ramp keys off the same
+        // 0 (NONE) .. 4 (GREAT)). The DashboardDock icon ramp keys off the same
         // range.
         private const val MAX_SIGNAL_LEVEL = 4
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import io.github.seijikohara.femto.data.DockPosition
 import io.github.seijikohara.femto.data.hasFineLocationPermission
 import io.github.seijikohara.femto.ui.home.components.GlassConfig
 import io.github.seijikohara.femto.ui.home.components.MapConfig
@@ -30,6 +31,7 @@ internal fun HomeRoute(
     glassConfig: GlassConfig,
     onEvent: (HomeEvent) -> Unit,
     modifier: Modifier = Modifier,
+    dockPosition: DockPosition = DockPosition.BOTTOM,
 ) {
     val context = LocalContext.current
     val viewModel: HomeViewModel =
@@ -51,6 +53,7 @@ internal fun HomeRoute(
         glassConfig = glassConfig,
         onAction = viewModel::onAction,
         modifier = modifier,
+        dockPosition = dockPosition,
     )
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import io.github.seijikohara.femto.data.DockPosition
 import io.github.seijikohara.femto.ui.home.components.DashboardScaffold
 import io.github.seijikohara.femto.ui.home.components.GlassConfig
 import io.github.seijikohara.femto.ui.home.components.MapConfig
@@ -26,6 +27,7 @@ internal fun HomeScreen(
     glassConfig: GlassConfig,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
+    dockPosition: DockPosition = DockPosition.BOTTOM,
 ) = Surface(
     modifier = modifier.fillMaxSize(),
     color = MaterialTheme.colorScheme.background,
@@ -41,6 +43,7 @@ internal fun HomeScreen(
         glassConfig = glassConfig,
         onAction = onAction,
         modifier = Modifier.fillMaxSize(),
+        dockPosition = dockPosition,
     )
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppsBarShortcut.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/AppsBarShortcut.kt
@@ -6,14 +6,14 @@ package io.github.seijikohara.femto.ui.home.components
  * `intentCategory` matches the value the launcher dispatches via
  * `HomeEvent.LaunchAppCategory`, deferring the actual app pick to whichever
  * app the user has elected as the default for that category. The production
- * footer renders bespoke navigation buttons in [DashboardFooter] rather than
+ * dock renders bespoke navigation buttons in [DashboardDock] rather than
  * the generic tile.
  */
 internal enum class AppsBarShortcut(
     val intentCategory: String,
 ) {
     // TODO: Phone maps to APP_CONTACTS, not a dialer. A proper dialer entry
-    //  needs ACTION_DIAL plumbing; align the category and footer label then.
+    //  needs ACTION_DIAL plumbing; align the category and dock label then.
     Phone("android.intent.category.APP_CONTACTS"),
     Music("android.intent.category.APP_MUSIC"),
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
@@ -442,11 +442,20 @@ private fun StatusIcon(
     )
 }
 
+// The 13sp metric readout under the GPS / battery icons. It sits below the
+// dashboard's 18sp body floor under the dock glance-metadata allowance
+// (CLAUDE.md#automotive-overrides); tabular figures keep the digits steady.
+@Composable
+private fun statusMetricStyle() =
+    MaterialTheme.typography.labelLarge.copy(
+        fontSize = 13.sp,
+        fontWeight = FontWeight.SemiBold,
+        fontFeatureSettings = TabularFigures,
+    )
+
 // Satellite icon stacked over the count of satellites used in the current fix,
 // mirroring BatteryIndicator. The icon and count dim together while searching
 // (no fresh GPS fix) so a parked / tunnelled cold start reads as "0 locked".
-// The 13sp count uses the same dock glance-metadata allowance as the battery
-// percent (CLAUDE.md#automotive-overrides).
 @Composable
 private fun GpsIndicator(
     fixed: Boolean,
@@ -469,21 +478,14 @@ private fun GpsIndicator(
     )
     Text(
         text = stringResource(R.string.status_gps_satellites, satelliteCount),
-        style =
-            MaterialTheme.typography.labelLarge.copy(
-                fontSize = 13.sp,
-                fontWeight = FontWeight.SemiBold,
-                fontFeatureSettings = TabularFigures,
-            ),
+        style = statusMetricStyle(),
         color = tint,
         maxLines = 1,
     )
 }
 
 // Battery icon stacked over its percent. Charging is conveyed by the bolt glyph
-// and the accent tint alone — no caption. The 13sp percent sits below the
-// dashboard's 18sp body floor under the same dock glance-metadata allowance
-// the cluster already uses (CLAUDE.md#automotive-overrides).
+// and the accent tint alone — no caption.
 @Composable
 private fun BatteryIndicator(
     percent: Int?,
@@ -504,12 +506,7 @@ private fun BatteryIndicator(
         // Render an em-dash while the percent is unknown (cold start / battery-less
         // unit) so the cluster never reads as a dead 0% battery.
         text = if (percent == null) "—" else stringResource(R.string.battery_percent, percent),
-        style =
-            MaterialTheme.typography.labelLarge.copy(
-                fontSize = 13.sp,
-                fontWeight = FontWeight.SemiBold,
-                fontFeatureSettings = TabularFigures,
-            ),
+        style = statusMetricStyle(),
         color = MaterialTheme.colorScheme.onSurface,
         maxLines = 1,
     )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
@@ -6,12 +6,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -58,6 +60,7 @@ import com.composables.icons.lucide.WifiHigh
 import com.composables.icons.lucide.WifiLow
 import com.composables.icons.lucide.WifiZero
 import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.DockPosition
 import io.github.seijikohara.femto.data.SystemStatus
 import io.github.seijikohara.femto.ui.home.HomeAction
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
@@ -65,59 +68,125 @@ import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.TabularFigures
 
-// Below this footer width the read-only status cluster is dropped so the seven
-// nav buttons keep room to render at >= FemtoDimens.MinTouchTarget without
+// Below this dock extent (width for the horizontal bar, height for the
+// vertical rail) the read-only status cluster is dropped so the seven nav
+// buttons keep room to render at >= FemtoDimens.MinTouchTarget without
 // clipping on portrait / narrow head units. Derived from the layout, not tuned
 // to a device: 7 buttons * 64 dp floor (448 dp) + the status cluster (~140 dp)
-// + dividers and horizontal padding (~70 dp) ~= 660 dp, rounded up for headroom.
+// + dividers and padding (~70 dp) ~= 660 dp, rounded up for headroom.
 // Adding an eighth button raises the button term by one MinTouchTarget.
-private val CompactFooterWidth: Dp = 700.dp
+private val CompactDockExtent: Dp = 700.dp
+
+// The seven dock destinations in display order. This app IS the launcher, so no
+// Home button. Shared by the horizontal bar and the vertical rail so the set
+// and order stay identical.
+private data class NavSpec(
+    val icon: ImageVector,
+    val labelRes: Int,
+    val action: HomeAction,
+)
+
+private val NavSpecs =
+    listOf(
+        NavSpec(Lucide.Phone, R.string.nav_phone, HomeAction.Shortcut(AppsBarShortcut.Phone)),
+        NavSpec(Lucide.LayoutGrid, R.string.nav_apps, HomeAction.OpenAppDrawer),
+        NavSpec(Lucide.Music, R.string.nav_music, HomeAction.Shortcut(AppsBarShortcut.Music)),
+        NavSpec(Lucide.Navigation, R.string.nav_navigation, HomeAction.OpenMaps),
+        NavSpec(Lucide.Globe, R.string.nav_browser, HomeAction.OpenBrowser),
+        NavSpec(Lucide.Mic, R.string.nav_assistant, HomeAction.OpenAssistant),
+        NavSpec(Lucide.Settings, R.string.nav_settings, HomeAction.OpenSettings),
+    )
 
 /**
- * Bottom dock. Originally derived from `docs/design/dashboard-v2-mockup.html`
+ * Dashboard dock. Originally derived from `docs/design/dashboard-v2-mockup.html`
  * `.footer`, since evolved from on-device feedback (shorter height, no Home
- * button, added cellular indicator and charging caption); this composable, not
- * the mockup, is now the authoritative footer spec.
+ * button, added cellular indicator); this composable, not the mockup, is now the
+ * authoritative dock spec.
  *
- *  - [FemtoDimens.FooterHeight] surface with a 1 dp top divider (`outlineVariant`).
+ * [position] picks the hosting edge: [DockPosition.BOTTOM] / [DockPosition.TOP]
+ * render the classic horizontal bar (the 1 dp `outlineVariant` divider sits on
+ * the edge facing the dashboard), [DockPosition.LEFT] / [DockPosition.RIGHT]
+ * render the same content as a vertical rail of [FemtoDimens.DockThickness] width.
+ *
  *  - Seven equal-weight nav buttons (Phone / Apps / Music / Navigation /
- *    Browser / Assistant / Settings). This app IS the launcher, so no Home button.
- *  - A 1 dp vertical divider separates the actionable nav from a read-only
- *    status cluster: cellular (hidden on telephony-less units), Wi-Fi,
- *    Bluetooth, GPS reception, and a battery indicator (icon over percent, with
- *    a "Charging" caption while plugged in).
+ *    Browser / Assistant / Settings).
+ *  - A 1 dp divider separates the actionable nav from a read-only status
+ *    cluster: cellular (hidden on telephony-less units), Wi-Fi, Bluetooth, GPS
+ *    reception, and a battery indicator (icon over percent; charging reads from
+ *    the bolt glyph and accent tint).
  *
  * Iconography is Lucide stroke-1.75 for parity with the design SSOT.
  */
 @Composable
-internal fun DashboardFooter(
+internal fun DashboardDock(
     systemStatus: SystemStatus,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
+    position: DockPosition = DockPosition.BOTTOM,
+) = when (position) {
+    DockPosition.BOTTOM, DockPosition.TOP -> {
+        HorizontalDock(
+            systemStatus = systemStatus,
+            onAction = onAction,
+            dividerAtBottom = position == DockPosition.TOP,
+            modifier = modifier,
+        )
+    }
+
+    DockPosition.LEFT, DockPosition.RIGHT -> {
+        VerticalDock(
+            systemStatus = systemStatus,
+            onAction = onAction,
+            dividerAtStart = position == DockPosition.RIGHT,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun HorizontalDock(
+    systemStatus: SystemStatus,
+    onAction: (HomeAction) -> Unit,
+    dividerAtBottom: Boolean,
+    modifier: Modifier = Modifier,
 ) = Surface(
-    modifier = modifier.height(FemtoDimens.FooterHeight),
+    modifier = modifier.height(FemtoDimens.DockThickness),
     color = MaterialTheme.colorScheme.surface,
 ) {
     Column {
-        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        if (!dividerAtBottom) HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
         BoxWithConstraints(
             modifier =
                 Modifier
-                    .fillMaxSize()
+                    .weight(1f)
+                    .fillMaxWidth()
                     .padding(horizontal = 24.dp),
         ) {
             // The seven nav buttons plus the cluster cannot both fit on a narrow
             // portrait head unit; below the threshold the read-only status
             // cluster yields so the actionable nav stays uncut.
-            val showStatusCluster = maxWidth >= CompactFooterWidth
+            val showStatusCluster = maxWidth >= CompactDockExtent
             Row(
                 modifier = Modifier.fillMaxSize(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                NavRow(
-                    onAction = onAction,
+                Row(
                     modifier = Modifier.weight(1f),
-                )
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    // Each button takes an equal weight so the seven buttons share the
+                    // width and shrink toward FemtoDimens.MinTouchTarget instead of
+                    // clipping when the row is narrow.
+                    NavSpecs.forEach { spec ->
+                        NavButton(
+                            icon = spec.icon,
+                            description = stringResource(spec.labelRes),
+                            onClick = { onAction(spec.action) },
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
                 if (showStatusCluster) {
                     VerticalDivider(
                         modifier =
@@ -128,68 +197,76 @@ internal fun DashboardFooter(
                     )
                     StatusCluster(
                         status = systemStatus,
+                        vertical = false,
                         modifier = Modifier.padding(start = 20.dp),
                     )
                 }
             }
         }
+        if (dividerAtBottom) HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
     }
 }
 
+// The same dock content turned 90 degrees: nav buttons share the height, the
+// status cluster stacks beneath them, and the divider faces the dashboard.
 @Composable
-private fun NavRow(
+private fun VerticalDock(
+    systemStatus: SystemStatus,
     onAction: (HomeAction) -> Unit,
+    dividerAtStart: Boolean,
     modifier: Modifier = Modifier,
-) = Row(
-    modifier = modifier,
-    horizontalArrangement = Arrangement.SpaceBetween,
-    verticalAlignment = Alignment.CenterVertically,
+) = Surface(
+    modifier = modifier.width(FemtoDimens.DockThickness),
+    color = MaterialTheme.colorScheme.surface,
 ) {
-    // Each button takes an equal weight so the seven buttons share the width and
-    // shrink toward FemtoDimens.MinTouchTarget instead of clipping when the row
-    // is narrow. The widthIn floor in NavButton keeps every tap target legal.
-    NavButton(
-        icon = Lucide.Phone,
-        description = stringResource(R.string.nav_phone),
-        onClick = { onAction(HomeAction.Shortcut(AppsBarShortcut.Phone)) },
-        modifier = Modifier.weight(1f),
-    )
-    NavButton(
-        icon = Lucide.LayoutGrid,
-        description = stringResource(R.string.nav_apps),
-        onClick = { onAction(HomeAction.OpenAppDrawer) },
-        modifier = Modifier.weight(1f),
-    )
-    NavButton(
-        icon = Lucide.Music,
-        description = stringResource(R.string.nav_music),
-        onClick = { onAction(HomeAction.Shortcut(AppsBarShortcut.Music)) },
-        modifier = Modifier.weight(1f),
-    )
-    NavButton(
-        icon = Lucide.Navigation,
-        description = stringResource(R.string.nav_navigation),
-        onClick = { onAction(HomeAction.OpenMaps) },
-        modifier = Modifier.weight(1f),
-    )
-    NavButton(
-        icon = Lucide.Globe,
-        description = stringResource(R.string.nav_browser),
-        onClick = { onAction(HomeAction.OpenBrowser) },
-        modifier = Modifier.weight(1f),
-    )
-    NavButton(
-        icon = Lucide.Mic,
-        description = stringResource(R.string.nav_assistant),
-        onClick = { onAction(HomeAction.OpenAssistant) },
-        modifier = Modifier.weight(1f),
-    )
-    NavButton(
-        icon = Lucide.Settings,
-        description = stringResource(R.string.nav_settings),
-        onClick = { onAction(HomeAction.OpenSettings) },
-        modifier = Modifier.weight(1f),
-    )
+    Row {
+        if (dividerAtStart) VerticalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        BoxWithConstraints(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .padding(vertical = 24.dp),
+        ) {
+            val showStatusCluster = maxHeight >= CompactDockExtent
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.SpaceBetween,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    // The same equal-weight sharing as the horizontal bar, on the
+                    // height instead of the width.
+                    NavSpecs.forEach { spec ->
+                        NavButton(
+                            icon = spec.icon,
+                            description = stringResource(spec.labelRes),
+                            onClick = { onAction(spec.action) },
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+                if (showStatusCluster) {
+                    HorizontalDivider(
+                        modifier =
+                            Modifier
+                                .padding(top = 4.dp)
+                                .width(48.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                    )
+                    StatusCluster(
+                        status = systemStatus,
+                        vertical = true,
+                        modifier = Modifier.padding(top = 20.dp),
+                    )
+                }
+            }
+        }
+        if (!dividerAtStart) VerticalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+    }
 }
 
 @Composable
@@ -199,10 +276,11 @@ private fun NavButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Box(
+    // The minimum floor keeps every tap target legal in both orientations; the
+    // hosting bar / rail stretches the free axis through the weight.
     modifier =
         modifier
-            .height(FemtoDimens.MinTouchTarget)
-            .widthIn(min = FemtoDimens.MinTouchTarget)
+            .defaultMinSize(minWidth = FemtoDimens.MinTouchTarget, minHeight = FemtoDimens.MinTouchTarget)
             .clip(RoundedCornerShape(14.dp))
             .clickable(onClick = onClick)
             .semantics { contentDescription = description },
@@ -219,61 +297,79 @@ private fun NavButton(
 @Composable
 private fun StatusCluster(
     status: SystemStatus,
+    vertical: Boolean,
     modifier: Modifier = Modifier,
-) = Row(
-    modifier = modifier.fillMaxHeight(),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(18.dp),
 ) {
-    // Cellular is hidden entirely on telephony-less units (null), rather than
-    // shown permanently disconnected.
-    status.cellularConnected?.let { connected ->
-        val level = status.cellularSignalLevel
-        // Drive the lit state off signal presence when the level is known: on a
-        // Wi-Fi-primary head unit the cellular network repeatedly drops in and out
-        // of NET_CAPABILITY_VALIDATED (Wi-Fi owns the default route), which flickered
-        // the icon. A known SignalStrength.level tracks the radio directly and is
-        // stable; fall back to the validated-connectivity flag only when the level is
-        // unknown (READ_PHONE_STATE withheld).
-        val active = level?.let { it > 0 } ?: connected
+    // One content slot rendered into either axis container, so the indicator set
+    // and order stay identical between the horizontal bar and the vertical rail.
+    val indicators: @Composable () -> Unit = {
+        // Cellular is hidden entirely on telephony-less units (null), rather than
+        // shown permanently disconnected.
+        status.cellularConnected?.let { connected ->
+            val level = status.cellularSignalLevel
+            // Drive the lit state off signal presence when the level is known: on a
+            // Wi-Fi-primary head unit the cellular network repeatedly drops in and out
+            // of NET_CAPABILITY_VALIDATED (Wi-Fi owns the default route), which flickered
+            // the icon. A known SignalStrength.level tracks the radio directly and is
+            // stable; fall back to the validated-connectivity flag only when the level is
+            // unknown (READ_PHONE_STATE withheld).
+            val active = level?.let { it > 0 } ?: connected
+            StatusIcon(
+                // A known level picks the graduated bars; a null level (READ_PHONE_STATE
+                // withheld / no reading yet) degrades to the binary connected icon.
+                icon = level?.let { cellularIconForLevel(it) } ?: Lucide.Signal,
+                active = active,
+                description =
+                    stringResource(
+                        if (active) R.string.status_cellular_connected else R.string.status_cellular_disconnected,
+                    ),
+            )
+        }
         StatusIcon(
-            // A known level picks the graduated bars; a null level (READ_PHONE_STATE
-            // withheld / no reading yet) degrades to the binary connected icon.
-            icon = level?.let { cellularIconForLevel(it) } ?: Lucide.Signal,
-            active = active,
+            // The Wi-Fi level is always known once connected; degrade to the binary
+            // icon only when disconnected so a dimmed flat icon reads as "off".
+            icon = if (status.wifiConnected) wifiIconForLevel(status.wifiSignalLevel) else Lucide.Wifi,
+            active = status.wifiConnected,
             description =
                 stringResource(
-                    if (active) R.string.status_cellular_connected else R.string.status_cellular_disconnected,
+                    if (status.wifiConnected) R.string.status_wifi_connected else R.string.status_wifi_disconnected,
                 ),
         )
+        StatusIcon(
+            // Off / on / connected each get a distinct glyph: a crossed icon when the
+            // adapter is powered off, the plain glyph when on but unpaired, the linked
+            // glyph when a device is connected.
+            icon = bluetoothIconFor(enabled = status.bluetoothEnabled, connected = status.bluetoothConnected),
+            active = status.bluetoothEnabled,
+            description =
+                stringResource(
+                    when {
+                        status.bluetoothConnected -> R.string.status_bluetooth_connected
+                        status.bluetoothEnabled -> R.string.status_bluetooth_on
+                        else -> R.string.status_bluetooth_off
+                    },
+                ),
+        )
+        GpsIndicator(fixed = status.gpsFixed, satelliteCount = status.gpsSatelliteCount)
+        BatteryIndicator(percent = status.batteryPercent, charging = status.charging)
     }
-    StatusIcon(
-        // The Wi-Fi level is always known once connected; degrade to the binary
-        // icon only when disconnected so a dimmed flat icon reads as "off".
-        icon = if (status.wifiConnected) wifiIconForLevel(status.wifiSignalLevel) else Lucide.Wifi,
-        active = status.wifiConnected,
-        description =
-            stringResource(
-                if (status.wifiConnected) R.string.status_wifi_connected else R.string.status_wifi_disconnected,
-            ),
-    )
-    StatusIcon(
-        // Off / on / connected each get a distinct glyph: a crossed icon when the
-        // adapter is powered off, the plain glyph when on but unpaired, the linked
-        // glyph when a device is connected.
-        icon = bluetoothIconFor(enabled = status.bluetoothEnabled, connected = status.bluetoothConnected),
-        active = status.bluetoothEnabled,
-        description =
-            stringResource(
-                when {
-                    status.bluetoothConnected -> R.string.status_bluetooth_connected
-                    status.bluetoothEnabled -> R.string.status_bluetooth_on
-                    else -> R.string.status_bluetooth_off
-                },
-            ),
-    )
-    GpsIndicator(fixed = status.gpsFixed, satelliteCount = status.gpsSatelliteCount)
-    BatteryIndicator(percent = status.batteryPercent, charging = status.charging)
+    if (vertical) {
+        Column(
+            modifier = modifier,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(18.dp),
+        ) {
+            indicators()
+        }
+    } else {
+        Row(
+            modifier = modifier.fillMaxHeight(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(18.dp),
+        ) {
+            indicators()
+        }
+    }
 }
 
 // Graduated Wi-Fi glyph for a 0..4 level. Lucide ships four distinct Wi-Fi
@@ -349,7 +445,7 @@ private fun StatusIcon(
 // Satellite icon stacked over the count of satellites used in the current fix,
 // mirroring BatteryIndicator. The icon and count dim together while searching
 // (no fresh GPS fix) so a parked / tunnelled cold start reads as "0 locked".
-// The 13sp count uses the same footer glance-metadata allowance as the battery
+// The 13sp count uses the same dock glance-metadata allowance as the battery
 // percent (CLAUDE.md#automotive-overrides).
 @Composable
 private fun GpsIndicator(
@@ -384,10 +480,10 @@ private fun GpsIndicator(
     )
 }
 
-// Battery icon stacked over its percent, with a "Charging" caption beneath while
-// plugged in. The 13sp percent and 10sp caption sit below the dashboard's 18sp
-// body floor under the same footer glance-metadata allowance the cluster already
-// uses (CLAUDE.md#automotive-overrides).
+// Battery icon stacked over its percent. Charging is conveyed by the bolt glyph
+// and the accent tint alone — no caption. The 13sp percent sits below the
+// dashboard's 18sp body floor under the same dock glance-metadata allowance
+// the cluster already uses (CLAUDE.md#automotive-overrides).
 @Composable
 private fun BatteryIndicator(
     percent: Int?,
@@ -417,22 +513,14 @@ private fun BatteryIndicator(
         color = MaterialTheme.colorScheme.onSurface,
         maxLines = 1,
     )
-    if (charging) {
-        Text(
-            text = stringResource(R.string.status_charging),
-            style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
-            color = MaterialTheme.colorScheme.primary,
-            maxLines = 1,
-        )
-    }
 }
 
 @PreviewLightDark
-@Preview(name = "Dashboard footer", widthDp = 1280, heightDp = 64)
+@Preview(name = "Dashboard dock", widthDp = 1280, heightDp = 64)
 @Composable
-private fun DashboardFooterPreview() {
+private fun DashboardDockPreview() {
     FemtoTheme {
-        DashboardFooter(
+        DashboardDock(
             systemStatus =
                 SystemStatus(
                     cellularConnected = true,
@@ -454,11 +542,11 @@ private fun DashboardFooterPreview() {
 // Narrow portrait head unit: the status cluster drops and the nav buttons share
 // the width down toward FemtoDimens.MinTouchTarget rather than clipping.
 @PreviewLightDark
-@Preview(name = "Dashboard footer (narrow)", widthDp = 520, heightDp = 64)
+@Preview(name = "Dashboard dock (narrow)", widthDp = 520, heightDp = 64)
 @Composable
-private fun DashboardFooterNarrowPreview() {
+private fun DashboardDockNarrowPreview() {
     FemtoTheme {
-        DashboardFooter(
+        DashboardDock(
             systemStatus =
                 SystemStatus(
                     cellularConnected = null,
@@ -473,6 +561,33 @@ private fun DashboardFooterNarrowPreview() {
                     gpsSatelliteCount = 0,
                 ),
             onAction = {},
+        )
+    }
+}
+
+// Vertical rail on a tall edge: the nav buttons share the height and the status
+// cluster stacks beneath them.
+@PreviewLightDark
+@Preview(name = "Dashboard dock (left rail)", widthDp = 64, heightDp = 800)
+@Composable
+private fun DashboardDockRailPreview() {
+    FemtoTheme {
+        DashboardDock(
+            systemStatus =
+                SystemStatus(
+                    cellularConnected = true,
+                    cellularSignalLevel = 3,
+                    wifiConnected = true,
+                    wifiSignalLevel = 4,
+                    bluetoothEnabled = true,
+                    bluetoothConnected = true,
+                    batteryPercent = 78,
+                    charging = true,
+                    gpsFixed = true,
+                    gpsSatelliteCount = 9,
+                ),
+            onAction = {},
+            position = DockPosition.LEFT,
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
+import io.github.seijikohara.femto.data.DockPosition
 import io.github.seijikohara.femto.ui.home.HomeAction
 import io.github.seijikohara.femto.ui.home.HomeUiState
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
@@ -42,8 +43,11 @@ internal data class PanelVisibility(
 }
 
 /**
- * Top-level dashboard layout. Two panes plus a fixed footer, arranged
- * responsively from the available viewport rather than a fixed canvas:
+ * Top-level dashboard layout. Two panes plus a fixed dock, arranged
+ * responsively from the available viewport rather than a fixed canvas.
+ * [dockPosition] picks the dock's hosting edge: bottom/top as a horizontal
+ * bar, left/right as a vertical rail; the panes reflow into the remaining space
+ * because their portrait/landscape split reads its own constraints:
  *
  * ```
  * Landscape (wide)                    Portrait (tall)
@@ -53,9 +57,9 @@ internal data class PanelVisibility(
  * |  + SpeedOverlay   |  + Weather|    +-----------------------+
  * |                   |  MusicCard|    | InfoPane (1)          |
  * +-------------------+-----------+    |  Calendar + Weather   |
- * | DashboardFooter               |    |  MusicCard            |
+ * | DashboardDock                 |    |  MusicCard            |
  * +-------------------------------+    +-----------------------+
- *                                      | DashboardFooter       |
+ *                                      | DashboardDock         |
  *                                      +-----------------------+
  * ```
  *
@@ -69,7 +73,7 @@ internal data class PanelVisibility(
  *
  * `enableEdgeToEdge()` lets the activity paint under the system bars; the
  * scaffold reserves them back with [windowInsetsPadding] so nothing tap-able
- * (the footer especially) hides behind the navigation bar.
+ * (the dock especially) hides behind the navigation bar.
  *
  * The scaffold owns no state of its own; everything reads from [uiState] and
  * reports back through [onAction].
@@ -86,91 +90,148 @@ internal fun DashboardScaffold(
     glassConfig: GlassConfig,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
-) = Column(
-    modifier =
+    dockPosition: DockPosition = DockPosition.BOTTOM,
+) {
+    val rootModifier =
         modifier
             .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.systemBars),
-) {
-    BoxWithConstraints(
-        modifier =
-            Modifier
-                .weight(1f)
-                .fillMaxWidth(),
-    ) {
-        val compact = maxHeight < CompactHeightBreakpoint || maxWidth < CompactWidthBreakpoint
-        val portrait = maxHeight > maxWidth
-        val screenPadding = if (compact) CompactScreenPadding else FemtoDimens.ScreenPadding
-        val paneGap = if (compact) CompactPaneGap else FemtoDimens.PaneGap
-        if (portrait) {
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(screenPadding),
-                verticalArrangement = Arrangement.spacedBy(paneGap),
-            ) {
-                MapPane(
-                    uiState = uiState,
-                    is24Hour = is24Hour,
-                    showClockSeconds = showClockSeconds,
-                    speedUnit = speedUnit,
-                    mapConfig = mapConfig,
-                    glassConfig = glassConfig,
-                    onAction = onAction,
-                    modifier = Modifier.weight(MAP_PANE_PORTRAIT_WEIGHT).fillMaxWidth(),
-                )
-                if (panels.anyInfoPanel) {
-                    InfoPane(
-                        uiState = uiState,
-                        temperatureUnit = temperatureUnit,
-                        speedUnit = speedUnit,
-                        panels = panels,
-                        paneGap = paneGap,
-                        is24Hour = is24Hour,
-                        onAction = onAction,
-                        modifier = Modifier.weight(1f).fillMaxWidth(),
-                    )
-                }
+            .windowInsetsPadding(WindowInsets.systemBars)
+    val panes: @Composable (Modifier) -> Unit = { panesModifier ->
+        DashboardPanes(
+            uiState = uiState,
+            is24Hour = is24Hour,
+            showClockSeconds = showClockSeconds,
+            speedUnit = speedUnit,
+            temperatureUnit = temperatureUnit,
+            mapConfig = mapConfig,
+            panels = panels,
+            glassConfig = glassConfig,
+            onAction = onAction,
+            modifier = panesModifier,
+        )
+    }
+    val dock: @Composable (Modifier) -> Unit = { dockModifier ->
+        DashboardDock(
+            systemStatus = uiState.systemStatus,
+            onAction = onAction,
+            position = dockPosition,
+            modifier = dockModifier,
+        )
+    }
+    when (dockPosition) {
+        DockPosition.BOTTOM -> {
+            Column(rootModifier) {
+                panes(Modifier.weight(1f).fillMaxWidth())
+                dock(Modifier.fillMaxWidth())
             }
-        } else {
-            Row(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(screenPadding),
-                horizontalArrangement = Arrangement.spacedBy(paneGap),
-            ) {
-                MapPane(
-                    uiState = uiState,
-                    is24Hour = is24Hour,
-                    showClockSeconds = showClockSeconds,
-                    speedUnit = speedUnit,
-                    mapConfig = mapConfig,
-                    glassConfig = glassConfig,
-                    onAction = onAction,
-                    modifier = Modifier.weight(MAP_PANE_LANDSCAPE_WEIGHT).fillMaxHeight(),
-                )
-                if (panels.anyInfoPanel) {
-                    InfoPane(
-                        uiState = uiState,
-                        temperatureUnit = temperatureUnit,
-                        speedUnit = speedUnit,
-                        panels = panels,
-                        paneGap = paneGap,
-                        is24Hour = is24Hour,
-                        onAction = onAction,
-                        modifier = Modifier.weight(1f).fillMaxHeight(),
-                    )
-                }
+        }
+
+        DockPosition.TOP -> {
+            Column(rootModifier) {
+                dock(Modifier.fillMaxWidth())
+                panes(Modifier.weight(1f).fillMaxWidth())
+            }
+        }
+
+        DockPosition.LEFT -> {
+            Row(rootModifier) {
+                dock(Modifier.fillMaxHeight())
+                panes(Modifier.weight(1f).fillMaxHeight())
+            }
+        }
+
+        DockPosition.RIGHT -> {
+            Row(rootModifier) {
+                panes(Modifier.weight(1f).fillMaxHeight())
+                dock(Modifier.fillMaxHeight())
             }
         }
     }
-    DashboardFooter(
-        systemStatus = uiState.systemStatus,
-        onAction = onAction,
-        modifier = Modifier.fillMaxWidth(),
-    )
+}
+
+// The responsive two-pane dashboard body: everything except the dock. Reads
+// the available viewport itself so the portrait/landscape split keys off the
+// space the dock placement leaves, not the raw screen.
+@Composable
+private fun DashboardPanes(
+    uiState: HomeUiState,
+    is24Hour: Boolean,
+    showClockSeconds: Boolean,
+    speedUnit: SpeedUnit,
+    temperatureUnit: TemperatureUnit,
+    mapConfig: MapConfig,
+    panels: PanelVisibility,
+    glassConfig: GlassConfig,
+    onAction: (HomeAction) -> Unit,
+    modifier: Modifier = Modifier,
+) = BoxWithConstraints(modifier = modifier) {
+    val compact = maxHeight < CompactHeightBreakpoint || maxWidth < CompactWidthBreakpoint
+    val portrait = maxHeight > maxWidth
+    val screenPadding = if (compact) CompactScreenPadding else FemtoDimens.ScreenPadding
+    val paneGap = if (compact) CompactPaneGap else FemtoDimens.PaneGap
+    if (portrait) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(screenPadding),
+            verticalArrangement = Arrangement.spacedBy(paneGap),
+        ) {
+            MapPane(
+                uiState = uiState,
+                is24Hour = is24Hour,
+                showClockSeconds = showClockSeconds,
+                speedUnit = speedUnit,
+                mapConfig = mapConfig,
+                glassConfig = glassConfig,
+                onAction = onAction,
+                modifier = Modifier.weight(MAP_PANE_PORTRAIT_WEIGHT).fillMaxWidth(),
+            )
+            if (panels.anyInfoPanel) {
+                InfoPane(
+                    uiState = uiState,
+                    temperatureUnit = temperatureUnit,
+                    speedUnit = speedUnit,
+                    panels = panels,
+                    paneGap = paneGap,
+                    is24Hour = is24Hour,
+                    onAction = onAction,
+                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                )
+            }
+        }
+    } else {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(screenPadding),
+            horizontalArrangement = Arrangement.spacedBy(paneGap),
+        ) {
+            MapPane(
+                uiState = uiState,
+                is24Hour = is24Hour,
+                showClockSeconds = showClockSeconds,
+                speedUnit = speedUnit,
+                mapConfig = mapConfig,
+                glassConfig = glassConfig,
+                onAction = onAction,
+                modifier = Modifier.weight(MAP_PANE_LANDSCAPE_WEIGHT).fillMaxHeight(),
+            )
+            if (panels.anyInfoPanel) {
+                InfoPane(
+                    uiState = uiState,
+                    temperatureUnit = temperatureUnit,
+                    speedUnit = speedUnit,
+                    panels = panels,
+                    paneGap = paneGap,
+                    is24Hour = is24Hour,
+                    onAction = onAction,
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                )
+            }
+        }
+    }
 }
 
 @Composable
@@ -375,6 +436,28 @@ private fun DashboardScaffoldPortraitPreview() {
             panels = PanelVisibility(),
             glassConfig = GlassConfig(),
             onAction = {},
+        )
+    }
+}
+
+// Dock as a left rail on the 5:3 head unit: the panes reflow into the
+// remaining width and the nav buttons share the rail height.
+@PreviewLightDark
+@Preview(name = "Dashboard - left rail dock", widthDp = 853, heightDp = 512)
+@Composable
+private fun DashboardScaffoldLeftRailPreview() {
+    FemtoTheme {
+        DashboardScaffold(
+            uiState = HomeUiState.Initial,
+            is24Hour = true,
+            showClockSeconds = true,
+            speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            temperatureUnit = TemperatureUnit.CELSIUS,
+            mapConfig = MapConfig(),
+            panels = PanelVisibility(),
+            glassConfig = GlassConfig(),
+            onAction = {},
+            dockPosition = DockPosition.LEFT,
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -53,6 +53,7 @@ import com.composables.icons.lucide.RotateCcw
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
+import io.github.seijikohara.femto.data.DockPosition
 import io.github.seijikohara.femto.data.DrawerIconSize
 import io.github.seijikohara.femto.data.FontSlot
 import io.github.seijikohara.femto.data.FullscreenSetting
@@ -132,6 +133,18 @@ internal fun SettingsScreen(
                 title = stringResource(R.string.settings_keep_screen_on),
                 checked = uiState.keepScreenOn,
                 onCheckedChange = { onAction(SettingsAction.SetKeepScreenOn(it)) },
+            )
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_dock_position),
+                options =
+                    listOf(
+                        DockPosition.BOTTOM to stringResource(R.string.settings_dock_bottom),
+                        DockPosition.TOP to stringResource(R.string.settings_dock_top),
+                        DockPosition.LEFT to stringResource(R.string.settings_dock_left),
+                        DockPosition.RIGHT to stringResource(R.string.settings_dock_right),
+                    ),
+                selected = uiState.dockPosition,
+                onSelect = { onAction(SettingsAction.SetDockPosition(it)) },
             )
             SettingsSubheader(stringResource(R.string.settings_subheader_glass))
             SliderRow(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -61,6 +61,7 @@ import io.github.seijikohara.femto.data.LocationQualitySetting
 import io.github.seijikohara.femto.data.MapColorScheme
 import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.data.MapStyleSetting
+import io.github.seijikohara.femto.data.OrientationSetting
 import io.github.seijikohara.femto.data.SpeedUnitSetting
 import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.ThemeMode
@@ -124,6 +125,17 @@ internal fun SettingsScreen(
                 onSelect = { onAction(SettingsAction.SetAccentColor(it)) },
             )
             SettingsSubheader(stringResource(R.string.settings_subheader_screen))
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_orientation),
+                options =
+                    listOf(
+                        OrientationSetting.AUTO to stringResource(R.string.settings_option_auto),
+                        OrientationSetting.LANDSCAPE to stringResource(R.string.settings_orientation_landscape),
+                        OrientationSetting.PORTRAIT to stringResource(R.string.settings_orientation_portrait),
+                    ),
+                selected = uiState.orientation,
+                onSelect = { onAction(SettingsAction.SetOrientation(it)) },
+            )
             SwitchRow(
                 title = stringResource(R.string.settings_group_fullscreen),
                 checked = uiState.fullscreen == FullscreenSetting.ON,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -11,6 +11,7 @@ import io.github.seijikohara.femto.data.LocationSettings
 import io.github.seijikohara.femto.data.MapColorScheme
 import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.data.MapStyleSetting
+import io.github.seijikohara.femto.data.OrientationSetting
 import io.github.seijikohara.femto.data.SpeedUnitSetting
 import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.ThemeMode
@@ -25,6 +26,7 @@ internal data class SettingsUiState(
     val showClockSeconds: Boolean,
     val fullscreen: FullscreenSetting,
     val dockPosition: DockPosition,
+    val orientation: OrientationSetting,
     val keepScreenOn: Boolean,
     val mapStyle: MapStyleSetting,
     val mapSchemeLight: MapColorScheme,
@@ -62,6 +64,7 @@ internal data class SettingsUiState(
                 showClockSeconds = DisplaySettings.Default.showClockSeconds,
                 fullscreen = DisplaySettings.Default.fullscreen,
                 dockPosition = DisplaySettings.Default.dockPosition,
+                orientation = DisplaySettings.Default.orientation,
                 keepScreenOn = DisplaySettings.Default.keepScreenOn,
                 mapStyle = DisplaySettings.Default.mapStyle,
                 mapSchemeLight = DisplaySettings.Default.mapSchemeLight,
@@ -120,6 +123,10 @@ internal sealed interface SettingsAction {
 
     data class SetDockPosition(
         val value: DockPosition,
+    ) : SettingsAction
+
+    data class SetOrientation(
+        val value: OrientationSetting,
     ) : SettingsAction
 
     data class SetKeepScreenOn(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -3,6 +3,7 @@ package io.github.seijikohara.femto.ui.settings
 import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.DisplaySettings
+import io.github.seijikohara.femto.data.DockPosition
 import io.github.seijikohara.femto.data.DrawerIconSize
 import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.LocationQualitySetting
@@ -23,6 +24,7 @@ internal data class SettingsUiState(
     val clock: ClockSetting,
     val showClockSeconds: Boolean,
     val fullscreen: FullscreenSetting,
+    val dockPosition: DockPosition,
     val keepScreenOn: Boolean,
     val mapStyle: MapStyleSetting,
     val mapSchemeLight: MapColorScheme,
@@ -59,6 +61,7 @@ internal data class SettingsUiState(
                 clock = DisplaySettings.Default.clock,
                 showClockSeconds = DisplaySettings.Default.showClockSeconds,
                 fullscreen = DisplaySettings.Default.fullscreen,
+                dockPosition = DisplaySettings.Default.dockPosition,
                 keepScreenOn = DisplaySettings.Default.keepScreenOn,
                 mapStyle = DisplaySettings.Default.mapStyle,
                 mapSchemeLight = DisplaySettings.Default.mapSchemeLight,
@@ -113,6 +116,10 @@ internal sealed interface SettingsAction {
 
     data class SetFullscreen(
         val value: FullscreenSetting,
+    ) : SettingsAction
+
+    data class SetDockPosition(
+        val value: DockPosition,
     ) : SettingsAction
 
     data class SetKeepScreenOn(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -39,6 +39,7 @@ internal class SettingsViewModel(
                 clock = display.clock,
                 showClockSeconds = display.showClockSeconds,
                 fullscreen = display.fullscreen,
+                dockPosition = display.dockPosition,
                 keepScreenOn = display.keepScreenOn,
                 mapStyle = display.mapStyle,
                 mapSchemeLight = display.mapSchemeLight,
@@ -94,6 +95,10 @@ internal class SettingsViewModel(
 
                 is SettingsAction.SetFullscreen -> {
                     displayPreferences.setFullscreen(action.value)
+                }
+
+                is SettingsAction.SetDockPosition -> {
+                    displayPreferences.setDockPosition(action.value)
                 }
 
                 is SettingsAction.SetKeepScreenOn -> {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -40,6 +40,7 @@ internal class SettingsViewModel(
                 showClockSeconds = display.showClockSeconds,
                 fullscreen = display.fullscreen,
                 dockPosition = display.dockPosition,
+                orientation = display.orientation,
                 keepScreenOn = display.keepScreenOn,
                 mapStyle = display.mapStyle,
                 mapSchemeLight = display.mapSchemeLight,
@@ -99,6 +100,10 @@ internal class SettingsViewModel(
 
                 is SettingsAction.SetDockPosition -> {
                     displayPreferences.setDockPosition(action.value)
+                }
+
+                is SettingsAction.SetOrientation -> {
+                    displayPreferences.setOrientation(action.value)
                 }
 
                 is SettingsAction.SetKeepScreenOn -> {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -31,11 +31,12 @@ object FemtoDimens {
     val AlbumArtSize = 72.dp
 
     /**
-     * Footer dock height. Set to exactly [MinTouchTarget] (64.dp): the dock
-     * holds full-height nav buttons, so it cannot go lower without breaching the
-     * tap-target floor (CLAUDE.md#automotive-overrides).
+     * Dock thickness: its height as a horizontal bar, its width as a vertical
+     * rail. Set to exactly [MinTouchTarget] (64.dp): the dock holds full-size
+     * nav buttons, so it cannot go lower without breaching the tap-target floor
+     * (CLAUDE.md#automotive-overrides).
      */
-    val FooterHeight = 64.dp
+    val DockThickness = 64.dp
 
     /** Album art size inside the music card's vertical playing layout. */
     val MusicArtSize = 140.dp

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,9 @@
     <string name="settings_group_glass_opacity">Glass opacity</string>
     <string name="settings_glass_blur_value">%1$d dp</string>
     <string name="settings_glass_opacity_value">%1$d%%</string>
+    <string name="settings_group_orientation">Orientation</string>
+    <string name="settings_orientation_landscape">Landscape</string>
+    <string name="settings_orientation_portrait">Portrait</string>
     <string name="settings_group_dock_position">Dock position</string>
     <string name="settings_dock_bottom">Bottom</string>
     <string name="settings_dock_top">Top</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,11 @@
     <string name="settings_group_glass_opacity">Glass opacity</string>
     <string name="settings_glass_blur_value">%1$d dp</string>
     <string name="settings_glass_opacity_value">%1$d%%</string>
+    <string name="settings_group_dock_position">Dock position</string>
+    <string name="settings_dock_bottom">Bottom</string>
+    <string name="settings_dock_top">Top</string>
+    <string name="settings_dock_left">Left</string>
+    <string name="settings_dock_right">Right</string>
     <string name="settings_subheader_drawer">App drawer</string>
     <string name="settings_group_drawer_icon_size">Icon size</string>
     <string name="settings_icon_size_small">Small</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/SystemStatusRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/SystemStatusRepositoryTest.kt
@@ -74,7 +74,7 @@ class SystemStatusRepositoryTest {
     fun `bluetoothEnabled tracks the adapter power state`() =
         runTest {
             // isEnabled() needs no permission, so the enabled flag is readable even
-            // without BLUETOOTH_CONNECT; the footer lights the icon on it.
+            // without BLUETOOTH_CONNECT; the dock lights the icon on it.
             setBluetoothEnabled(true)
 
             val status = firstStatusMatching(SystemStatusRepository(application)) { it.bluetoothEnabled }
@@ -112,7 +112,7 @@ class SystemStatusRepositoryTest {
     fun `batteryPercent is null when the sticky reports an unknown level`() =
         runTest {
             // level = -1 / scale = -1 is the framework's "unknown" sentinel; the
-            // flow maps it to null so the footer never reads it as a dead 0%. The
+            // flow maps it to null so the dock never reads it as a dead 0%. The
             // seeded default is also null, so collecting the first emission is
             // sufficient and there is no later non-null reading to wait for.
             application.sendStickyBroadcast(batteryIntent(level = -1, scale = -1))
@@ -194,7 +194,7 @@ class SystemStatusRepositoryTest {
         runTest {
             // Telephony is present, but Robolectric grants no runtime permissions on
             // sdk 33, so telephonySignalFlow cannot register the callback and emits
-            // null — the footer degrades to the binary cellular icon.
+            // null — the dock degrades to the binary cellular icon.
             shadowOf(application.packageManager).setSystemFeature(PackageManager.FEATURE_TELEPHONY, true)
 
             val status = SystemStatusRepository(application).statusFlow().first()

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -4,6 +4,7 @@ import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.ClockSetting
 import io.github.seijikohara.femto.data.DisplaySettings
 import io.github.seijikohara.femto.data.DisplaySettingsStore
+import io.github.seijikohara.femto.data.DockPosition
 import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.MapColorScheme
 import io.github.seijikohara.femto.data.MapRenderMode
@@ -42,6 +43,8 @@ internal class FakeDisplaySettingsStore(
     override suspend fun setShowClockSeconds(value: Boolean) = state.update { it.copy(showClockSeconds = value) }
 
     override suspend fun setFullscreen(value: FullscreenSetting) = state.update { it.copy(fullscreen = value) }
+
+    override suspend fun setDockPosition(value: DockPosition) = state.update { it.copy(dockPosition = value) }
 
     override suspend fun setKeepScreenOn(value: Boolean) = state.update { it.copy(keepScreenOn = value) }
 

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -9,6 +9,7 @@ import io.github.seijikohara.femto.data.FullscreenSetting
 import io.github.seijikohara.femto.data.MapColorScheme
 import io.github.seijikohara.femto.data.MapRenderMode
 import io.github.seijikohara.femto.data.MapStyleSetting
+import io.github.seijikohara.femto.data.OrientationSetting
 import io.github.seijikohara.femto.data.SpeedUnitSetting
 import io.github.seijikohara.femto.data.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.ThemeMode
@@ -45,6 +46,8 @@ internal class FakeDisplaySettingsStore(
     override suspend fun setFullscreen(value: FullscreenSetting) = state.update { it.copy(fullscreen = value) }
 
     override suspend fun setDockPosition(value: DockPosition) = state.update { it.copy(dockPosition = value) }
+
+    override suspend fun setOrientation(value: OrientationSetting) = state.update { it.copy(orientation = value) }
 
     override suspend fun setKeepScreenOn(value: Boolean) = state.update { it.copy(keepScreenOn = value) }
 

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/components/DashboardDockIconsTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/components/DashboardDockIconsTest.kt
@@ -20,11 +20,11 @@ import com.composables.icons.lucide.WifiZero
 import org.junit.Test
 import kotlin.test.assertEquals
 
-// Pure icon-mapping tests for the footer status cluster. Each indicator that
+// Pure icon-mapping tests for the dock status cluster. Each indicator that
 // exposes an intensity (cellular / Wi-Fi level, battery percent) or a multi-state
 // axis (bluetooth) maps to a distinct Lucide glyph; these lock the ramps so a
 // future glyph rename or off-by-one threshold is caught.
-class DashboardFooterIconsTest {
+class DashboardDockIconsTest {
     @Test
     fun `cellular steps across the signal levels`() {
         assertEquals(Lucide.SignalLow, cellularIconForLevel(0))

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -12,6 +12,7 @@ import io.github.seijikohara.femto.data.LocationQualitySetting
 import io.github.seijikohara.femto.data.LocationSettings
 import io.github.seijikohara.femto.data.MapColorScheme
 import io.github.seijikohara.femto.data.MapRenderMode
+import io.github.seijikohara.femto.data.OrientationSetting
 import io.github.seijikohara.femto.testfixtures.FakeDisplaySettingsStore
 import io.github.seijikohara.femto.testfixtures.FakeDrawerSettingsStore
 import io.github.seijikohara.femto.testfixtures.FakeLocationSettingsStore
@@ -221,6 +222,14 @@ class SettingsViewModelTest {
             viewModel().onAction(SettingsAction.SetDockPosition(DockPosition.LEFT))
             advanceUntilIdle()
             assertEquals(DockPosition.LEFT, store.settings.first().dockPosition)
+        }
+
+    @Test
+    fun `SetOrientation writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetOrientation(OrientationSetting.LANDSCAPE))
+            advanceUntilIdle()
+            assertEquals(OrientationSetting.LANDSCAPE, store.settings.first().orientation)
         }
 
     @Test

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import io.github.seijikohara.femto.data.AccentColor
 import io.github.seijikohara.femto.data.DisplaySettings
+import io.github.seijikohara.femto.data.DockPosition
 import io.github.seijikohara.femto.data.DrawerIconSize
 import io.github.seijikohara.femto.data.FontPreferences
 import io.github.seijikohara.femto.data.FullscreenSetting
@@ -212,6 +213,14 @@ class SettingsViewModelTest {
             advanceUntilIdle()
             assertEquals(12, store.settings.first().glassBlurRadius)
             assertEquals(60, store.settings.first().glassTintScale)
+        }
+
+    @Test
+    fun `SetDockPosition writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetDockPosition(DockPosition.LEFT))
+            advanceUntilIdle()
+            assertEquals(DockPosition.LEFT, store.settings.first().dockPosition)
         }
 
     @Test


### PR DESCRIPTION
## Summary

Three dashboard-shell improvements from on-device feedback:

### Dockable nav bar (`DockPosition`)
- The dashboard dock (nav buttons + status cluster) can now be hosted on any screen edge — Bottom (default) / Top / Left / Right — via a new Settings choice row. `LEFT`/`RIGHT` render it as a vertical rail of the same 64 dp thickness; the 1 dp divider always faces the dashboard.
- The pane layout responds to the space the dock leaves because `DashboardPanes` reads its own constraints (`BoxWithConstraints`); the existing compact-spacing and portrait/landscape breakpoints keep working unchanged.
- Below 700 dp of dock extent (bar width or rail height) the read-only status cluster yields so the seven nav buttons never drop under the 64 dp touch-target floor.

### Rename: Footer → Dock
`DashboardFooter` → `DashboardDock`, `FemtoDimens.FooterHeight` → `DockThickness`, comments and test files follow. The surface is no longer tied to the bottom edge, so the footer name no longer described it.

### Screen orientation setting (`OrientationSetting`)
- Auto (default) / Landscape / Portrait, applied via `requestedOrientation` with `SENSOR_*` variants so forced axes still follow 180° flips on inverted mounts.
- Auto stays the default per CLAUDE.md#launcher-behavior (portrait and landscape head units must both work); the forced options serve units that misreport their natural orientation.

### Charging caption removal
The battery indicator's "Charging" text is gone — the bolt glyph and accent tint already convey the state, matching the caption-less Wi-Fi / BT / cellular indicators.

## Testing
- `./gradlew test assembleDebug lint` — green
- `compileDebugAndroidTestKotlin` — green; `DashboardDockTest` now asserts the caption is absent and the vertical rail renders all seven nav buttons
- New `SettingsViewModelTest` cases for `SetDockPosition` / `SetOrientation`
- New previews: vertical rail dock, left-rail dashboard on the 5:3 head-unit geometry