### PR TITLE
fix(geocoder): pace reverse-geocode lookups and bound the stale fallback

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/ReverseGeocoderRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/ReverseGeocoderRepository.kt
@@ -4,7 +4,6 @@ import android.location.Location
 import android.util.Log
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
@@ -46,13 +45,13 @@ internal class ReverseGeocoderRepository(
         object : LinkedHashMap<String, CacheEntry>(MAX_ENTRIES, LOAD_FACTOR, true) {
             override fun removeEldestEntry(eldest: Map.Entry<String, CacheEntry>): Boolean = size > MAX_ENTRIES
         }
-    private var lastResult: ShortAddress? = null
-    private var lastRequestAtMs = 0L
+    private var lastResult: ResolvedFallback? = null
+    private var lastRequestAtMs: Long? = null
 
     // Serialises resolve: the flow runs on the IO pool where overlapping
-    // collections are possible, and the throttle's read-then-update pair must
-    // be atomic or two callers can both pass the spacing check and violate
-    // Nominatim's 1 request/second policy. The lock also covers the LRU map,
+    // collections are possible, and the pacing gate's read-then-update pair
+    // must be atomic or two callers can both pass the spacing check and
+    // violate Nominatim's usage policy. The lock also covers the LRU map,
     // which is not safe under concurrent mutation.
     private val mutex = Mutex()
 
@@ -67,11 +66,24 @@ internal class ReverseGeocoderRepository(
             val key = bucketKey(location.latitude, location.longitude)
             cachedAddress(key)?.let { return it }
 
-            // Nominatim's usage policy caps callers at 1 request per second; the
-            // 100 m bucket already collapses most calls, and this spacing guards
-            // the remaining boundary crossings. Holding the lock across the delay
-            // and the request keeps the spacing global, not per-caller.
-            throttle()
+            // Pace network lookups: Nominatim's usage policy sets 1 request per
+            // second as an absolute ceiling, but sustained 1 Hz traffic from a
+            // moving vehicle still reads as bulk use, so unresolved buckets only
+            // reach the network once per pacing window. A bucket inside the
+            // window reuses the last resolved address instead of waiting —
+            // adjacent 100 m buckets share their locality-level address, and
+            // skipping (rather than delaying) keeps the flow from queueing
+            // stale fixes behind a timer. A null lastRequestAtMs means no
+            // lookup has been issued yet, so the first fix resolves
+            // immediately.
+            val sinceLastRequestMs = lastRequestAtMs?.let { nowMs() - it }
+            if (sinceLastRequestMs != null && sinceLastRequestMs < NETWORK_PACING_MS) {
+                return fallbackFor(location)
+            }
+            // Stamped before the call on purpose: a failed request still spent
+            // the server's goodwill (and a dead network gains nothing from a
+            // tight retry loop), so failures consume the pacing window too.
+            lastRequestAtMs = nowMs()
 
             runCatching {
                 api.reverse(location.latitude, location.longitude)?.address?.let {
@@ -86,10 +98,20 @@ internal class ReverseGeocoderRepository(
             }.getOrNull()
                 ?.also {
                     cache[key] = CacheEntry(it, nowMs())
-                    lastResult = it
+                    lastResult = ResolvedFallback(it, location)
                 }
-                ?: lastResult
+                ?: fallbackFor(location)
         }
+
+    // Serve the last resolved address only while the new fix is still near
+    // where that address was true. Beyond the bound (e.g. a long network
+    // outage while driving) a stale address is worse than none, so the row
+    // degrades to its placeholder instead. The entry is kept — not cleared —
+    // so driving back into range restores it.
+    private fun fallbackFor(location: Location): ShortAddress? =
+        lastResult
+            ?.takeIf { it.resolvedAt.distanceTo(location) <= FALLBACK_MAX_DISTANCE_M }
+            ?.address
 
     // Return the cached address only while it is within the TTL window. A
     // stale entry is dropped so the next visit re-queries and can recover from
@@ -103,12 +125,6 @@ internal class ReverseGeocoderRepository(
                 null
             }
         }
-
-    private suspend fun throttle() {
-        val elapsed = nowMs() - lastRequestAtMs
-        if (elapsed < MIN_REQUEST_SPACING_MS) delay(MIN_REQUEST_SPACING_MS - elapsed)
-        lastRequestAtMs = nowMs()
-    }
 
     private fun bucketKey(
         lat: Double,
@@ -128,9 +144,31 @@ internal class ReverseGeocoderRepository(
         val resolvedAtMs: Long,
     )
 
-    private companion object {
+    // The last successfully resolved address paired with the fix it was
+    // resolved for, so the fallback can refuse to serve it once the vehicle
+    // has moved far from where the address was true.
+    private data class ResolvedFallback(
+        val address: ShortAddress,
+        val resolvedAt: Location,
+    )
+
+    // Internal (not private) so tests reference these bounds directly instead
+    // of mirroring the values (CLAUDE.md#ssot-dry).
+    internal companion object {
         const val BUCKET_M = 100f
-        const val MIN_REQUEST_SPACING_MS = 1_000L
+
+        // Minimum spacing between network lookups. Far above Nominatim's
+        // 1 req/s ceiling on purpose: the policy treats sustained high-rate
+        // traffic as bulk use, and at motorway speed a 15 s window still
+        // refreshes the address every few hundred metres — finer than the
+        // locality-level line the overlay renders.
+        const val NETWORK_PACING_MS = 15_000L
+
+        // Drop the failure fallback once the fix is this far from where the
+        // last address was resolved. Inside the bound a slightly stale
+        // neighbouring address is still truthful at the displayed
+        // granularity; beyond it the row shows its placeholder instead.
+        const val FALLBACK_MAX_DISTANCE_M = 5_000f
 
         // Cap the per-bucket cache so a long drive cannot grow it without
         // bound; ~256 buckets covers a large daily travel envelope while

--- a/app/src/test/java/io/github/seijikohara/femto/data/ReverseGeocoderRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/ReverseGeocoderRepositoryTest.kt
@@ -4,6 +4,9 @@ package io.github.seijikohara.femto.data
 
 import android.location.Location
 import app.cash.turbine.test
+import io.github.seijikohara.femto.data.ReverseGeocoderRepository.Companion.MAX_ENTRIES
+import io.github.seijikohara.femto.data.ReverseGeocoderRepository.Companion.NETWORK_PACING_MS
+import io.github.seijikohara.femto.data.ReverseGeocoderRepository.Companion.TTL_MS
 import io.github.seijikohara.femto.testfixtures.fakeLocation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -80,8 +83,10 @@ class ReverseGeocoderRepositoryTest {
             val near = fakeLocation()
             val far = fakeLocation(latitude = 35.7000)
             // Drain all three fixes (near, far, near) so the cached revisit is
-            // exercised before the request count is asserted.
-            newRepo(flowOf(near, far, near)).addressFlow().test {
+            // exercised before the request count is asserted. The clock
+            // advances one pacing window per issued request so the far bucket
+            // clears the pacing gate.
+            newRepo(flowOf(near, far, near), nowMs = pacedClock()).addressFlow().test {
                 assertEquals("新宿区", awaitItem()?.locality)
                 awaitItem()
                 assertEquals("新宿区", awaitItem()?.locality)
@@ -99,12 +104,51 @@ class ReverseGeocoderRepositoryTest {
             server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
             server.enqueue(MockResponse().setResponseCode(429))
 
+            // The far fix sits ~4.7 km from the resolved address — inside the
+            // fallback distance bound, so the rate-limited lookup still serves
+            // the last value.
             val flow = flowOf(fakeLocation(), fakeLocation(latitude = 35.7000))
-            newRepo(flow).addressFlow().test {
+            newRepo(flow, nowMs = pacedClock()).addressFlow().test {
                 assertEquals("新宿区", awaitItem()?.locality)
                 // The throttled second bucket returns the cached value, not null.
                 assertEquals("新宿区", awaitItem()?.locality)
                 cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `skips the network lookup for a new bucket inside the pacing window`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+
+            // The clock never advances, so the far bucket arrives inside the
+            // pacing window and must reuse the last address with no request.
+            val flow = flowOf(fakeLocation(), fakeLocation(latitude = 35.7000))
+            newRepo(flow, nowMs = { 0L }).addressFlow().test {
+                assertEquals("新宿区", awaitItem()?.locality)
+                assertEquals("新宿区", awaitItem()?.locality)
+                awaitComplete()
+            }
+
+            assertEquals(1, server.requestCount)
+        }
+
+    @Test
+    fun `drops the stale fallback once the fix moves beyond the distance bound`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(SHINJUKU_BODY))
+            server.enqueue(MockResponse().setResponseCode(429))
+
+            // Advance the clock one pacing window per issued request so the
+            // failing far lookup is actually sent; the far fix is ~115 km from
+            // the last resolved address, far past the fallback distance bound.
+            val flow = flowOf(fakeLocation(), fakeLocation(latitude = 36.7000))
+            newRepo(flow, nowMs = pacedClock()).addressFlow().test {
+                assertEquals("新宿区", awaitItem()?.locality)
+                // A stale address from 115 km away is worse than no address.
+                assertNull(awaitItem())
+                awaitComplete()
             }
         }
 
@@ -149,7 +193,7 @@ class ReverseGeocoderRepositoryTest {
                 }
             val fixes = listOf(eldest) + newer + eldest
 
-            newRepo(fixes.asFlow()).addressFlow().test {
+            newRepo(fixes.asFlow(), nowMs = pacedClock()).addressFlow().test {
                 repeat(fixes.size) { assertEquals("新宿区", awaitItem()?.locality) }
                 awaitComplete()
             }
@@ -173,7 +217,17 @@ class ReverseGeocoderRepositoryTest {
             // request count makes the TTL crossing deterministic regardless of
             // when the eager flow drains, where a variable mutated between
             // awaitItem() calls would race the buffered emissions.
-            val nowMs = { if (server.requestCount >= 2) TTL_MS + 1 else 0L }
+            // Before the TTL crossing the clock advances one pacing window per
+            // request so the far bucket clears the pacing gate; the crossing
+            // adds that pacing offset because the near entry was stamped at
+            // one window past zero.
+            val nowMs = {
+                if (server.requestCount >= 2) {
+                    TTL_MS + NETWORK_PACING_MS + 1
+                } else {
+                    server.requestCount * NETWORK_PACING_MS
+                }
+            }
             // near -> far -> near: the far fix between the two near visits keeps
             // distinctUntilChangedByBucket from collapsing them, so the second
             // near visit actually reaches resolve().
@@ -196,6 +250,11 @@ class ReverseGeocoderRepositoryTest {
             assertEquals(3, server.requestCount)
         }
 
+    // Advance the clock one pacing window per issued request so multi-bucket
+    // scenarios clear the pacing gate deterministically, mirroring the
+    // request-count-tied clock the TTL test uses.
+    private fun pacedClock(): () -> Long = { server.requestCount * NETWORK_PACING_MS }
+
     private fun TestScope.newRepo(
         locationFlow: Flow<Location?>,
         nowMs: () -> Long = { testScheduler.currentTime },
@@ -211,18 +270,14 @@ class ReverseGeocoderRepositoryTest {
                     ioDispatcher = dispatcher,
                 ),
             ioDispatcher = dispatcher,
-            // Tie the throttle clock to the scheduler so delay() advances it.
+            // The injected clock keeps the pacing gate and the cache TTL
+            // deterministic under the test scheduler.
             nowMs = nowMs,
         )
     }
 
     private companion object {
         const val USER_AGENT = "femto-car-launcher/1.0 (test)"
-
-        // Mirrors ReverseGeocoderRepository.MAX_ENTRIES / TTL_MS, which are
-        // private; keep these in sync if the production bounds change.
-        const val MAX_ENTRIES = 256
-        const val TTL_MS = 24L * 60L * 60L * 1_000L
 
         // A starting latitude and a step large enough that each fix lands in a
         // distinct 100 m bucket (~0.001 deg ~= 111 m).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,16 +9,19 @@ spotless {
     val ktlintVersion = libs.versions.ktlint.get()
     kotlinGradle {
         target("**/*.gradle.kts")
-        targetExclude("**/build/**", ".gradle/**")
+        // **/.gradle/** also covers app/.gradle, where the node-gradle plugin
+        // unpacks pnpm (which ships its own Markdown and script files).
+        targetExclude("**/build/**", "**/.gradle/**")
         ktlint(ktlintVersion)
     }
     format("markdown") {
         target("**/*.md")
         targetExclude(
             "**/build/**",
-            ".gradle/**",
+            "**/.gradle/**",
             ".idea/**",
             ".kotlin/**",
+            "**/node_modules/**",
         )
         endWithNewline()
     }


### PR DESCRIPTION
## Summary

Implements the two release-blocking findings from the reverse-geocoding logic review.

### Request pacing (usage-policy risk)

Sustained driving crossed a new 100 m bucket every few seconds (~3 s at motorway speed), so the launcher issued reverse-geocode requests at a rate Nominatim's usage policy treats as bulk traffic, even though each request respected the 1 req/s ceiling.

- Replaces the 1 s delay-based throttle with a 15 s pacing gate.
- A bucket inside the window skips the network entirely and reuses the last resolved address — adjacent 100 m buckets share their locality-level address, and skipping (rather than delaying) keeps the flow from queueing stale fixes behind a timer.
- Failed requests also consume the window, so a rate-limited or offline endpoint never sees a tight retry loop.

### Distance-bounded failure fallback (correctness risk)

The failure fallback previously served the last successful address indefinitely; after a long network outage while driving it could show an address tens of kilometres behind the vehicle.

- The last resolved address is now paired with the fix it was resolved for and dropped beyond 5 km; the overlay row degrades to its placeholder instead.
- The entry is kept rather than cleared, so driving back into range restores it.

### Incidental

- Spotless: `.gradle/**` excludes only matched the repository root; `app/.gradle` (where the node-gradle plugin unpacks pnpm) failed `spotlessMarkdownCheck` on pnpm's bundled README. Now `**/.gradle/**` plus `**/node_modules/**`.
- The repository companion is `internal` so tests reference the production bounds directly instead of mirroring them (SSOT).

## Out of scope

- A `zoom` query parameter was considered and deliberately not added: the overlay line includes the house number (banchi), which lower zoom levels drop.
- The East-Asian address-composition concerns for KR (road-name addresses, Latin-script joining) need response samples from those regions first.

## Testing

- TDD: two new unit tests (pacing skip, distance-bounded fallback) written first and watched fail; multi-bucket tests drive the pacing gate with a request-count-tied clock.
- `./gradlew spotlessCheck assembleDebug lint test` — BUILD SUCCESSFUL.
- TBox-Mock emulator (800x480): address row renders the reverse-geocoded address through the new pacing gate; no `NominatimApi` / `ReverseGeocoder` warnings in logcat.