### PR TITLE
fix(home): stop orientation flapping after choosing forced portrait

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -118,8 +118,20 @@ class MainActivity : ComponentActivity() {
             LaunchedEffect(display.keepScreenOn) {
                 applyKeepScreenOn(display.keepScreenOn)
             }
-            LaunchedEffect(display.orientation) {
-                applyOrientation(display.orientation)
+            // A forced-portrait choice rotates the (naturally landscape)
+            // panel, which recreates the Activity; the first composition
+            // after that recreation would briefly apply the AUTO default,
+            // request a rotation back, then rotate again when the persisted
+            // choice arrives — relaunching the Activity every ~1 s forever
+            // (reproduced on the 800x480 head-unit emulator). A null initial
+            // value skips the apply until the persisted choice lands; in the
+            // meantime the recreated Activity keeps the requestedOrientation
+            // its previous instance set, so the orientation never flaps.
+            val orientation by remember {
+                displayPreferences.settings.map { it.orientation }.distinctUntilChanged()
+            }.collectAsStateWithLifecycle(initialValue = null)
+            LaunchedEffect(orientation) {
+                orientation?.let { applyOrientation(it) }
             }
             FemtoTheme(fontFamily = fontFamily, accent = display.accentColor, darkTheme = darkTheme) {
                 // The dashboard stays composed; the app drawer, assistant, and


### PR DESCRIPTION
## Summary

Choosing **Portrait** in Settings made the launcher oscillate Portrait ↔ Landscape indefinitely (Activity relaunch every ~1 s), leaving it unusable on the 800x480 head unit.

### Root cause

1. `PORTRAIT` rotates the naturally-landscape panel, which recreates `MainActivity` (no `configChanges` is declared, intentionally).
2. The first composition after recreation collects `DisplaySettings` with `initialValue = DisplaySettings.Default`, so `LaunchedEffect(display.orientation)` briefly applies the **AUTO** default — resetting `requestedOrientation` to `UNSPECIFIED` and requesting a rotation back toward landscape.
3. The persisted `PORTRAIT` then arrives and rotates again; every rotation recreates the Activity, returning to step 2 forever.

`LANDSCAPE` never hit this because AUTO and `SENSOR_LANDSCAPE` resolve to the same axis on a landscape panel, so no rotation (and no recreation) occurs.

### Fix

Collect the orientation separately with a **null initial value** and skip `applyOrientation` until the persisted choice lands. The recreated Activity keeps the `requestedOrientation` its previous instance set in the meantime, so the orientation never flaps. The neighbouring fullscreen/keep-screen-on effects keep the shared `display` state: their initial-value flash cannot trigger recreation and is a visual no-op.

## Testing

- Reproduced the loop on the TBox-Mock emulator (800x480) with the previous build: logcat showed continuous `finishDrawing of relaunch` for `MainActivity` every ~1.2 s after selecting Portrait.
- With this fix: the same Landscape → Portrait switch rotates exactly once (relaunch count 1 in logcat) and stays stable for 30 s; cold start with PORTRAIT persisted starts directly in portrait with no oscillation.
- `./gradlew spotlessCheck assembleDebug lint test` — BUILD SUCCESSFUL.
- `compose-launcher-reviewer` pass: no blocking findings.