### PR TITLE
docs: add mounted smartphones as a third target device class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
 # Femto Car Launcher
 
-Android home launcher for car head units (aftermarket CarPlay /
-Android Auto AI boxes and built-in Android units). MVP targets
-Android 13 (API 33).
+Android home launcher for in-car displays across three device
+classes: aftermarket CarPlay / Android Auto AI boxes, built-in
+Android head units, and smartphones mounted as a car-navigation
+display. MVP targets Android 13 (API 33).
 
 The launcher is designed for **multi-region distribution**. No
 single market is privileged in design, code, or documentation;
@@ -29,7 +30,8 @@ when markets diverge.
 - Web map page (`webmap/`): TypeScript + Vite + `maplibre-gl`, managed
   with pnpm (pinned via `packageManager`). Vite's `build.target` is
   `chrome109` — the Android 13 factory WebView; aftermarket AI boxes
-  may never update it, so never raise it without revisiting that floor.
+  may never update it, so never raise it without revisiting that floor
+  (phone WebViews stay current, but the strictest device class governs).
 
 ## Source layout
 
@@ -154,8 +156,13 @@ family per slot, downloaded on demand and cached on disk.
 - `MainActivity` is registered with categories `HOME`, `DEFAULT`,
   and `LAUNCHER`, `launchMode="singleTask"`,
   `stateNotNeeded="true"`.
-- Orientation is **not** locked — both portrait and landscape head
-  units must work.
+- Orientation is **not** locked — portrait and landscape must both
+  work (landscape head units, portrait phone mounts, and everything
+  between).
+- On a smartphone the launcher also runs as a **regular app** via the
+  `LAUNCHER` category; becoming the default HOME screen is optional
+  there. Never assume the app owns the device — a phone is a shared,
+  daily-use device that happens to spend time in a car mount.
 - Aftermarket AI boxes lock the default-launcher slot; the app
   launches via a host-side "boot-up app" hook with a ~30 s delay. That
   is outside our control, but cold start inside the process is a key

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Femto Car Launcher
 
-**A glanceable Android home launcher for car head units.**
+**A glanceable Android home launcher for in-car displays.**
 
 [![CI](https://github.com/seijikohara/femto-car-launcher/actions/workflows/ci.yml/badge.svg)](https://github.com/seijikohara/femto-car-launcher/actions/workflows/ci.yml)
 [![Download nightly APK](https://img.shields.io/badge/download-nightly_APK-3BE0AE?logo=android&logoColor=white)](https://github.com/seijikohara/femto-car-launcher/releases/tag/nightly)
@@ -15,11 +15,13 @@
 </div>
 
 Femto Car Launcher is an Android home-screen replacement (launcher) for
-in-car head units. It targets two hardware classes: aftermarket CarPlay /
-Android Auto AI boxes that inject Android into a factory display, and
-built-in Android head units. The launcher replaces the stock home screen
-with a single glanceable dashboard tuned for automotive viewing distances
-and touch accuracy.
+in-car displays. It targets three hardware classes: aftermarket CarPlay /
+Android Auto AI boxes that inject Android into a factory display,
+built-in Android head units, and smartphones mounted as a car-navigation
+display. The launcher replaces the stock home screen with a single
+glanceable dashboard tuned for automotive viewing distances and touch
+accuracy. On a phone it also runs as a regular app — becoming the
+default home screen is optional.
 
 The minimum supported platform is Android 13 (Application Programming
 Interface (API) level 33). The launcher is built for multi-region
@@ -166,7 +168,8 @@ The debug Android Package (APK) is written to
 `app/build/outputs/apk/debug/app-debug.apk`. Install it with
 `adb install -r <apk>` or run the app from Android Studio. To smoke-test on
 an emulator, create an AVD that approximates a head-unit display (a wide
-landscape profile) and launch the app as the home activity.
+landscape profile) and launch the app as the home activity, or use a
+regular phone AVD in portrait — the dashboard adapts to both.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Per the maintainer's decision (2026-06-10), smartphones mounted as a car-navigation display are now a first-class target alongside aftermarket AI boxes and built-in Android head units.

- **README.md** — tagline and intro now state three hardware classes; on a phone the launcher also runs as a regular app (default-HOME optional). Emulator smoke-test note covers phone-portrait AVDs.
- **CLAUDE.md** — intro states the three device classes. `#launcher-behavior` adds the phone posture (regular-app usage via `LAUNCHER`, never assume the app owns the device) and broadens the orientation rule to portrait phone mounts. The `chrome109` webmap floor explicitly stays (phone WebViews are current; the strictest device class governs).

Out of scope (tracked separately): phone-portrait layout / insets / cutout verification.

## Verification
- `./gradlew spotlessCheck` — passed.