### PR TITLE
feat(home): events-only calendar agenda and width-driven forecast chips

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
@@ -29,16 +29,39 @@ class CalendarCardTest {
     }
 
     @Test
-    fun shows_a_placeholder_for_days_without_events() {
+    fun omits_days_without_events_from_the_agenda() {
         rule.setContent {
             FemtoTheme {
                 CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true)
             }
         }
-        // The fixture has free days (e.g. 2026-05-02), each shown with the em-dash
-        // placeholder, so at least one renders.
-        val placeholders = rule.onAllNodesWithText("—").fetchSemanticsNodes()
-        assert(placeholders.isNotEmpty()) { "expected at least one free-day placeholder" }
+        // The fixture's 2026-05-02 is a free day (and not today), so its gutter
+        // day number must not render — free days no longer occupy agenda rows.
+        val freeDayGutters = rule.onAllNodesWithText("2").fetchSemanticsNodes()
+        assert(freeDayGutters.isEmpty()) { "expected the free day '2' to be omitted from the agenda" }
+    }
+
+    @Test
+    fun shows_no_events_line_when_today_is_free() {
+        rule.setContent {
+            FemtoTheme {
+                CalendarCard(
+                    snapshot =
+                        fakeCalendarSnapshot(
+                            days = fakeCalendarSnapshot().days.map { it.copy(events = emptyList()) },
+                        ),
+                    is24Hour = true,
+                )
+            }
+        }
+        // Today stays in the agenda even with no events, carrying an explicit
+        // no-events line instead of silently vanishing.
+        val noEvents =
+            InstrumentationRegistry
+                .getInstrumentation()
+                .targetContext
+                .getString(R.string.calendar_no_events)
+        rule.onNodeWithText(noEvents).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -7,19 +7,17 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -27,9 +25,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
-import com.composables.icons.lucide.Clock
-import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.Sun
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.CalendarSnapshot
 import io.github.seijikohara.femto.data.DayCell
@@ -49,8 +44,9 @@ import java.time.format.DateTimeFormatter
  *
  *  1. Head — big day number (primary tint) + weekday + month label, always today.
  *  2. Days — a scrollable vertical list of the coming days (today first), each row
- *     showing that day's full set of events. Days with no events are shown too,
- *     with a muted placeholder, so the list reads as a continuous agenda.
+ *     showing that day's full set of events. Days with no events are omitted so
+ *     the short card spends every row on real entries; only today stays when
+ *     free, carrying an explicit no-events line.
  *
  * Typography and spacing originated in the retired dashboard-v2 design mockup;
  * the dashboard's 18sp body-size floor is intentionally relaxed here so the
@@ -97,11 +93,19 @@ private fun CalendarContent(
     verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGapCompact),
 ) {
     Head(snapshot)
+    // Free days are dropped rather than rendered as placeholder rows: the
+    // glance question is "what is coming up", and on the short head-unit card
+    // a six-row continuous agenda clipped before reaching the real entries.
+    // Today is the one exception — it stays visible even when free.
+    val visibleDays =
+        remember(snapshot) {
+            snapshot.days.filter { it.hasEvent || it.date == snapshot.today }
+        }
     LazyColumn(
         modifier = Modifier.fillMaxWidth().weight(1f),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        items(items = snapshot.days, key = { it.date.toString() }) { day ->
+        items(items = visibleDays, key = { it.date.toString() }) { day ->
             DayRow(day = day, isToday = day.date == snapshot.today, is24Hour = is24Hour)
         }
     }
@@ -202,8 +206,10 @@ private fun DayRow(
         verticalArrangement = Arrangement.spacedBy(3.dp),
     ) {
         if (day.events.isEmpty()) {
+            // Only today can reach here (free days are filtered out upstream);
+            // an explicit line beats a bare dash for the one row that stays.
             Text(
-                text = NO_EVENTS_PLACEHOLDER,
+                text = stringResource(R.string.calendar_no_events),
                 style = MaterialTheme.typography.bodyMedium.copy(fontSize = 13.sp, lineHeight = 18.sp),
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                 maxLines = 1,
@@ -211,11 +217,9 @@ private fun DayRow(
         } else {
             day.events.forEach { event ->
                 EventRow(
-                    // A timed event leads with a clock; an all-day event (null time)
-                    // leads with a sun so it reads as "all day" at a glance.
-                    icon = if (event.time != null) Lucide.Clock else Lucide.Sun,
                     // Event times honour the user's 12/24-hour clock setting, matching
-                    // the dashboard clock rather than always printing 24-hour.
+                    // the dashboard clock rather than always printing 24-hour; "All
+                    // day" in the same slot marks the untimed events.
                     time =
                         event.time?.format(eventTimeFormatter(is24Hour))
                             ?: stringResource(R.string.calendar_all_day),
@@ -226,9 +230,11 @@ private fun DayRow(
     }
 }
 
+// No leading glyph: the time slot ("14:00" / "All day") already states the
+// event kind, and on the ~165 dp head-unit card every glyph-width goes to the
+// title instead.
 @Composable
 private fun EventRow(
-    icon: ImageVector,
     time: String,
     title: String,
 ) = Row(
@@ -236,12 +242,6 @@ private fun EventRow(
     horizontalArrangement = Arrangement.spacedBy(6.dp),
     verticalAlignment = Alignment.Top,
 ) {
-    Icon(
-        imageVector = icon,
-        contentDescription = null,
-        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(top = 3.dp).size(12.dp),
-    )
     Text(
         text = time,
         style =
@@ -279,8 +279,6 @@ private fun CenteredHint(text: String) =
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
-
-private const val NO_EVENTS_PLACEHOLDER = "—"
 
 // 24-hour "14:30" or compact 12-hour "2:30 PM"; the latter stays short enough to
 // keep the narrow agenda row from clipping the event title.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -64,7 +65,8 @@ import kotlin.math.roundToInt
  *
  *  1. Head — big temperature + a hero per-condition glyph.
  *  2. Metrics — Feels / Wind / Humid row.
- *  3. Forecast — three hourly chips.
+ *  3. Forecast — hourly chips on a horizontal timeline (three on the
+ *     head-unit card, more when the card is wide enough).
  *
  * Typography and spacing originated in the `.weather-card` rules of the
  * retired dashboard-v2 design mockup — the same intentional relaxation of
@@ -219,14 +221,19 @@ private fun Forecast(
     temperatureUnit: TemperatureUnit,
     is24Hour: Boolean,
 ) {
-    val next = hourly.take(3)
-    if (next.isEmpty()) return
-    Column(verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGapCompact)) {
+    if (hourly.isEmpty()) return
+    // Hours read left-to-right as a timeline (deliberately not a vertical list
+    // like the calendar agenda — the forecast answers "how does it trend", and
+    // the horizontal axis carries that). The chip count derives from the card
+    // width: never fewer than the three the head-unit card was designed
+    // around, gaining hours on wider panels instead of stretching three chips.
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val chipCount = (maxWidth / FemtoDimens.ForecastChipMinWidth).toInt().coerceIn(3, 6)
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            next.forEach { hour ->
+            hourly.take(chipCount).forEach { hour ->
                 ForecastChip(hour, sunrise, sunset, temperatureUnit, is24Hour, modifier = Modifier.weight(1f))
             }
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -92,6 +92,13 @@ object FemtoDimens {
     /** Weather glyph inside the 3-hour forecast chips. */
     val WeatherGlyphSmall = 18.dp
 
+    /**
+     * Minimum width per hourly-forecast chip. The chip count derives from the
+     * card width at this floor (never fewer than three chips), so wider
+     * panels gain forecast hours instead of stretching three chips.
+     */
+    val ForecastChipMinWidth = 52.dp
+
     /** Large numeric anchor (big-day, big-temp) display size. */
     val BigNumberFontSize = 56.sp
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <!-- Calendar card -->
     <string name="calendar_permission_denied">Calendar access not granted</string>
     <string name="calendar_all_day">All day</string>
+    <string name="calendar_no_events">No events</string>
 
     <!-- Weather card -->
     <string name="weather_unavailable">Weather unavailable</string>


### PR DESCRIPTION
## Summary

Layout refinement of the two info-pane cards, per the maintainer's design decision (events-only agenda chosen over collapse-runs / week-dots alternatives; horizontal forecast timeline deliberately kept over a vertical list).

### CalendarCard
- The agenda **omits days without events** — the six-day continuous list spent rows on em-dash placeholders, which clipped real entries on the short head-unit card (~165×207 dp) and on phone portrait. Today is the one exception: it stays visible with an explicit **"No events"** line when free.
- The per-event clock/sun glyph is removed; the time slot ("14:00" / "All day") already states the event kind, and the freed width goes to the title.

### WeatherCard
- The forecast stays a **horizontal timeline** (hours read left→right). The chip count now derives from the card width (`FemtoDimens.ForecastChipMinWidth`, min 3 / max 6), so wide cards gain forecast hours (the repository already supplies a 5-hour slice) instead of stretching three chips.
- Removed the vestigial single-child `Column` wrapper around the chip row.

## Verification
- `./gradlew spotlessCheck assembleDebug test compileDebugAndroidTestKotlin` — green.
- `CalendarCardTest` updated: free days omitted; today-free shows the no-events line (string resolved from resources).
- Visually verified on the TBox-Mock emulator at both the 853×512 dp head-unit geometry and the 412×915 dp phone-portrait geometry.
- `compose-launcher-reviewer` pass: no blocking findings.