### PR TITLE
fix(home): two-line calendar event rows and clock-notation forecast hours

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
@@ -11,6 +11,8 @@ import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Rule
 import org.junit.Test
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
 class WeatherCardTest {
     @get:Rule
@@ -97,7 +99,27 @@ class WeatherCardTest {
                 )
             }
         }
-        // The fixture's first hourly entry is 12:00, rendered via "%02dh".
-        rule.onNodeWithText("12h").assertIsDisplayed()
+        // The fixture's first hourly entry is 12:00, rendered in the 24-hour
+        // clock notation so the 12/24-hour setting is visibly honoured.
+        rule.onNodeWithText("12:00").assertIsDisplayed()
+    }
+
+    @Test
+    fun renders_forecast_hours_in_12_hour_notation_when_configured() {
+        rule.setContent {
+            FemtoTheme {
+                WeatherCard(
+                    snapshot = fakeWeatherSnapshot(),
+                    temperatureUnit = TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = false,
+                )
+            }
+        }
+        // The same 12:00 entry switches to the meridiem notation when the
+        // clock setting is 12-hour. The expected text is built with the same
+        // pattern because the meridiem word is locale-dependent ("PM" / "午後").
+        val expected = LocalTime.of(12, 0).format(DateTimeFormatter.ofPattern("h a"))
+        rule.onNodeWithText(expected).assertIsDisplayed()
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -237,10 +237,12 @@ private fun DayRow(
 private fun EventRow(
     time: String,
     title: String,
-) = Row(
+) = Column(
+    // Time above, title below: the side-by-side row made a wrapping title
+    // hang after the time at an unnatural break, while the two-line stack
+    // wraps from the card's left edge.
     modifier = Modifier.fillMaxWidth(),
-    horizontalArrangement = Arrangement.spacedBy(6.dp),
-    verticalAlignment = Alignment.Top,
+    verticalArrangement = Arrangement.spacedBy(1.dp),
 ) {
     Text(
         text = time,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -56,6 +56,7 @@ import io.github.seijikohara.femto.ui.theme.sectionLabel
 import io.github.seijikohara.femto.ui.theme.weatherGlyphs
 import java.time.Instant
 import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 import kotlin.math.roundToInt
 
 /**
@@ -305,20 +306,17 @@ private fun EmptyState() =
         )
     }
 
-// Forecast hour label honouring the user's clock setting: compact 24-hour "09h"
-// or 12-hour "9a" / "2p" so the tiny chip never widens. Midnight reads "12a",
-// noon "12p".
+// Forecast hour label in the same notation family as the clock and the
+// calendar ("12:00" / "12 PM" via the locale's meridiem word), so the
+// 12/24-hour setting is visibly honoured. The earlier compact "12h" / "12p"
+// forms read as setting-agnostic shorthand.
+private val ForecastHourFormatter24: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+private val ForecastHourFormatter12: DateTimeFormatter = DateTimeFormatter.ofPattern("h a")
+
 private fun forecastHourLabel(
     time: LocalTime,
     is24Hour: Boolean,
-): String =
-    if (is24Hour) {
-        "%02dh".format(time.hour)
-    } else {
-        val hour12 = ((time.hour + 11) % 12) + 1
-        val meridiem = if (time.hour < 12) "a" else "p"
-        "$hour12$meridiem"
-    }
+): String = time.format(if (is24Hour) ForecastHourFormatter24 else ForecastHourFormatter12)
 
 // Day/night drives the sun-vs-moon glyph for CLEAR. Use the snapshot's real
 // sunrise/sunset when present; fall back to a fixed 6..18 window only when either


### PR DESCRIPTION
## Summary

Two maintainer-requested refinements to the info-pane cards.

### CalendarCard
- **Event rows are now two lines** — time above, title below. The previous side-by-side row made a wrapping title break at an unnatural position (the second line hung after the time column); the stack wraps from the card's left edge.

### WeatherCard
- **Forecast hour labels follow the 12/24-hour clock setting visibly.** The `is24Hour` plumbing already reached the chips, but the compact custom forms (`06h` / `6a`) read as setting-agnostic shorthand. Chips now use the same notation family as the clock and calendar: `06:00` (24h) / `6 AM` (12h, locale meridiem word via `DateTimeFormatter`).

## Verification
- `./gradlew spotlessCheck assembleDebug test compileDebugAndroidTestKotlin` — green.
- `WeatherCardTest`: 24h assertion updated to `12:00`; new 12-hour-notation case computes the locale-dependent expected string with the same pattern (multi-region safe).
- Visually verified on the TBox-Mock emulator at head-unit geometry: chips render `06:00 / 07:00 / 08:00`; calendar rows stack time over title; a free today shows the `No events` line.
- `compose-launcher-reviewer` pass: no blocking findings.