### PR TITLE
fix(data): retry floor for stale weather cache, live zone/locale, calendar scan dedup

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
@@ -76,16 +76,21 @@ internal class CalendarRepository(
                 .map { Triple(it.date, hasPermission(), zoneProvider()) }
                 .distinctUntilChanged(),
             calendarChangeFlow().onStart { emit(Unit) },
-        ) { (date, _, _), _ ->
-            buildSnapshot(date)
+        ) { (date, granted, zone), _ ->
+            // The build consumes the key's own values (not fresh provider
+            // reads) so the snapshot always matches the key that produced it.
+            buildSnapshot(date, granted, zone)
         }.distinctUntilChanged().flowOn(Dispatchers.IO)
 
-    private fun buildSnapshot(today: LocalDate): CalendarSnapshot {
-        val granted = hasPermission()
+    private fun buildSnapshot(
+        today: LocalDate,
+        granted: Boolean,
+        zone: ZoneId,
+    ): CalendarSnapshot {
         val locale = localeProvider()
         // null marks a provider fault (see readWindow); the days still build
         // from the clock alone so the strip never disappears.
-        val eventsByDay = if (granted) readWindow(today) else emptyMap()
+        val eventsByDay = if (granted) readWindow(today, zone) else emptyMap()
         val days = (0 until WINDOW_DAYS).map { offset ->
             val date = today.plusDays(offset.toLong())
             DayCell(
@@ -163,11 +168,11 @@ internal class CalendarRepository(
      * "granted but nothing scheduled".
      */
     @SuppressLint("MissingPermission") // Caller checks READ_CALENDAR before subscribing.
-    private fun readWindow(today: LocalDate): Map<LocalDate, List<EventItem>>? =
+    private fun readWindow(
+        today: LocalDate,
+        zone: ZoneId,
+    ): Map<LocalDate, List<EventItem>>? =
         runCatching {
-            // One zone for the whole scan: begin/end bounds and per-row day
-            // bucketing must agree even if the device zone changes mid-build.
-            val zone = zoneProvider()
             val byDay = linkedMapOf<LocalDate, MutableList<EventItem>>()
             context.contentResolver
                 .query(

--- a/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/CalendarRepository.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import java.time.Instant
 import java.time.LocalDate
@@ -56,19 +57,32 @@ private const val TAG = "CalendarRepository"
 internal class CalendarRepository(
     private val context: Context,
     private val clockFlow: Flow<ClockTick>,
-    private val zone: ZoneId = ZoneId.systemDefault(),
-    private val locale: Locale = Locale.getDefault(),
+    // Read per rebuild rather than captured at construction: the repository
+    // outlives timezone and locale changes (a phone mounted as car nav crosses
+    // borders), and captured values would pin the agenda to the old zone /
+    // labels until the process dies.
+    private val zoneProvider: () -> ZoneId = ZoneId::systemDefault,
+    private val localeProvider: () -> Locale = Locale::getDefault,
 ) {
     fun snapshotFlow(): Flow<CalendarSnapshot?> =
         combine(
-            clockFlow,
+            // The snapshot depends on the calendar date, the permission state,
+            // and the zone — not on the tick's minute. Keying the clock side on
+            // that triple drops the old once-a-minute full 30-day Instances
+            // scan (recurrence expansion included) while keeping the ≤1-minute
+            // pickup of a runtime grant or a timezone change that the per-tick
+            // rebuild provided.
+            clockFlow
+                .map { Triple(it.date, hasPermission(), zoneProvider()) }
+                .distinctUntilChanged(),
             calendarChangeFlow().onStart { emit(Unit) },
-        ) { tick, _ ->
-            buildSnapshot(tick.date)
-        }.distinctUntilChanged().flowOn(Dispatchers.Default)
+        ) { (date, _, _), _ ->
+            buildSnapshot(date)
+        }.distinctUntilChanged().flowOn(Dispatchers.IO)
 
     private fun buildSnapshot(today: LocalDate): CalendarSnapshot {
         val granted = hasPermission()
+        val locale = localeProvider()
         // null marks a provider fault (see readWindow); the days still build
         // from the clock alone so the strip never disappears.
         val eventsByDay = if (granted) readWindow(today) else emptyMap()
@@ -83,7 +97,7 @@ internal class CalendarRepository(
         return CalendarSnapshot(
             today = today,
             weekday = today.dayOfWeek.getDisplayName(TextStyle.FULL, locale),
-            monthLabel = monthLabelOf(today),
+            monthLabel = monthLabelOf(today, locale),
             days = days,
             hasCalendarAccess = granted,
             queryFailed = eventsByDay == null,
@@ -97,7 +111,10 @@ internal class CalendarRepository(
      * (2026年3月). A hand-joined "Month Year" string would force English
      * ordering on every locale.
      */
-    private fun monthLabelOf(today: LocalDate): String =
+    private fun monthLabelOf(
+        today: LocalDate,
+        locale: Locale,
+    ): String =
         today.format(
             DateTimeFormatter.ofPattern(
                 DateFormat.getBestDateTimePattern(locale, "yMMMM"),
@@ -114,21 +131,23 @@ internal class CalendarRepository(
      * window. `Instances` requires the begin / end millis embedded as path ids
      * rather than passed as a selection.
      */
-    private fun windowUri(today: LocalDate) =
-        CalendarContract.Instances.CONTENT_URI
-            .buildUpon()
-            .let {
-                ContentUris.appendId(it, today.atStartOfDay(zone).toInstant().toEpochMilli())
-            }.let {
-                ContentUris.appendId(
-                    it,
-                    today
-                        .plusDays(WINDOW_DAYS.toLong())
-                        .atStartOfDay(zone)
-                        .toInstant()
-                        .toEpochMilli(),
-                )
-            }.build()
+    private fun windowUri(
+        today: LocalDate,
+        zone: ZoneId,
+    ) = CalendarContract.Instances.CONTENT_URI
+        .buildUpon()
+        .let {
+            ContentUris.appendId(it, today.atStartOfDay(zone).toInstant().toEpochMilli())
+        }.let {
+            ContentUris.appendId(
+                it,
+                today
+                    .plusDays(WINDOW_DAYS.toLong())
+                    .atStartOfDay(zone)
+                    .toInstant()
+                    .toEpochMilli(),
+            )
+        }.build()
 
     /**
      * Scan the window once and group every event by its local day. The card lists
@@ -146,10 +165,13 @@ internal class CalendarRepository(
     @SuppressLint("MissingPermission") // Caller checks READ_CALENDAR before subscribing.
     private fun readWindow(today: LocalDate): Map<LocalDate, List<EventItem>>? =
         runCatching {
+            // One zone for the whole scan: begin/end bounds and per-row day
+            // bucketing must agree even if the device zone changes mid-build.
+            val zone = zoneProvider()
             val byDay = linkedMapOf<LocalDate, MutableList<EventItem>>()
             context.contentResolver
                 .query(
-                    windowUri(today),
+                    windowUri(today, zone),
                     arrayOf(
                         CalendarContract.Instances.BEGIN,
                         CalendarContract.Instances.TITLE,
@@ -165,7 +187,7 @@ internal class CalendarRepository(
                         // must not contribute to its day's list either.
                         val title = cursor.getString(1) ?: continue
                         val allDay = cursor.getInt(2) != 0
-                        byDay.getOrPut(localDateOf(startMs, allDay)) { mutableListOf() } +=
+                        byDay.getOrPut(localDateOf(startMs, allDay, zone)) { mutableListOf() } +=
                             EventItem(
                                 // All-day rows carry no clock time; surface null
                                 // so the card renders an "all day" label instead
@@ -197,6 +219,7 @@ internal class CalendarRepository(
     private fun localDateOf(
         startMs: Long,
         allDay: Boolean,
+        zone: ZoneId,
     ): LocalDate =
         Instant
             .ofEpochMilli(startMs)
@@ -214,9 +237,10 @@ internal class CalendarRepository(
      * user grants the calendar, so a denied (or racing-revoked) grant skips
      * registration rather than throwing. The card already renders the denial
      * fallback from the clock alone (see [snapshotFlow]), and a grant that
-     * arrives later is picked up on the next clock tick, which re-runs
-     * [buildSnapshot] and its permission check. This mirrors [readWindow], whose
-     * `runCatching` already guards the query side against the same fault.
+     * arrives later is picked up within a minute: each tick re-evaluates the
+     * permission state inside the rebuild key, so the grant flips the key and
+     * re-runs [buildSnapshot]. This mirrors [readWindow], whose `runCatching`
+     * already guards the query side against the same fault.
      */
     private fun calendarChangeFlow(): Flow<Unit> =
         callbackFlow {

--- a/app/src/main/java/io/github/seijikohara/femto/data/ClockRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/ClockRepository.kt
@@ -25,7 +25,10 @@ internal class ClockRepository(
     // process dies.
     private val zoneProvider: () -> ZoneId = ZoneId::systemDefault,
     // Owns the single shared receiver subscription (mirrors LocationRepository);
-    // tests inject their own scope to drive shareIn deterministically.
+    // tests inject their own scope to drive shareIn deterministically. The
+    // default scope is process-lifetime by design — it is never cancelled;
+    // WhileSubscribed parks the upstream (and unregisters the receiver) when
+    // no collector is live.
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
     // One receiver serves every collector: tickFlow() feeds the ViewModel, the

--- a/app/src/main/java/io/github/seijikohara/femto/data/ClockRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/ClockRepository.kt
@@ -5,19 +5,33 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.shareIn
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
 internal class ClockRepository(
     private val context: Context,
-    private val zone: ZoneId = ZoneId.systemDefault(),
+    // Read per tick rather than captured at construction: the repository
+    // outlives timezone changes (a phone mounted as car nav crosses borders),
+    // and a captured ZoneId would pin the clock to the old zone until the
+    // process dies.
+    private val zoneProvider: () -> ZoneId = ZoneId::systemDefault,
+    // Owns the single shared receiver subscription (mirrors LocationRepository);
+    // tests inject their own scope to drive shareIn deterministically.
+    scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
-    fun tickFlow(): Flow<ClockTick> =
+    // One receiver serves every collector: tickFlow() feeds the ViewModel, the
+    // weather repository, and the calendar repository, and a cold flow would
+    // register three receivers for the same system broadcast.
+    private val shared: Flow<ClockTick> =
         callbackFlow {
             val emit: () -> Unit = { trySend(currentTick()) }
             val receiver =
@@ -31,14 +45,23 @@ internal class ClockRepository(
             ContextCompat.registerReceiver(
                 context,
                 receiver,
-                IntentFilter(Intent.ACTION_TIME_TICK),
+                IntentFilter(Intent.ACTION_TIME_TICK).apply {
+                    // TIME_TICK alone leaves a manual time set or a timezone
+                    // change wrong for up to a minute; both broadcasts re-tick
+                    // immediately so the dashboard follows without a restart.
+                    addAction(Intent.ACTION_TIME_CHANGED)
+                    addAction(Intent.ACTION_TIMEZONE_CHANGED)
+                },
                 ContextCompat.RECEIVER_NOT_EXPORTED,
             )
             awaitClose { context.unregisterReceiver(receiver) }
         }.flowOn(Dispatchers.Main.immediate)
+            .shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 1)
+
+    fun tickFlow(): Flow<ClockTick> = shared
 
     private fun currentTick(): ClockTick =
         ZonedDateTime
-            .now(zone)
+            .now(zoneProvider())
             .let { ClockTick(time = it.toLocalTime().withSecond(0).withNano(0), date = it.toLocalDate()) }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/WeatherRepository.kt
@@ -32,9 +32,10 @@ internal class WeatherRepository(
     private var cached: WeatherSnapshot? = null
     private var lastFetchLocation: Location? = null
 
-    // Tracks the most recent refresh attempt regardless of outcome so a sustained
-    // outage (cached == null) cannot retry faster than MIN_RETRY_INTERVAL against
-    // the public Open-Meteo endpoint, which would risk a ban.
+    // Tracks the most recent refresh attempt regardless of outcome so an outage
+    // (with or without an older cached snapshot) cannot retry faster than
+    // MIN_RETRY_INTERVAL against the public Open-Meteo endpoint, which would
+    // risk a ban.
     private var lastAttemptAt: Instant? = null
 
     // Last-seen fix, updated by the location path and re-read on every clock tick.
@@ -93,12 +94,16 @@ internal class WeatherRepository(
     }
 
     private fun shouldRefetch(location: Location): Boolean {
-        val snapshot =
-            cached ?: return lastAttemptAt?.let { attempt ->
-                // No successful cache yet: throttle outage retries so a sustained
-                // failure does not fire once per GPS tick.
-                Duration.between(attempt, clock.instant()).abs() >= MIN_RETRY_INTERVAL
-            } ?: true
+        // Attempt floor first, regardless of cache state. When it only guarded
+        // the no-cache path, a STALE cache during an outage passed the age check
+        // on every GPS tick (~1 Hz while moving) and hammered the public
+        // endpoint — the same storm the floor exists to prevent.
+        val throttled =
+            lastAttemptAt?.let { attempt ->
+                Duration.between(attempt, clock.instant()).abs() < MIN_RETRY_INTERVAL
+            } == true
+        if (throttled) return false
+        val snapshot = cached ?: return true
         val anchor = lastFetchLocation ?: return true
         val ageOk = Duration.between(snapshot.fetchedAt, clock.instant()).abs() < REFRESH_INTERVAL
         val nearOk = anchor.distanceTo(location) < REFRESH_DISTANCE_M
@@ -142,7 +147,8 @@ internal class WeatherRepository(
     private companion object {
         val REFRESH_INTERVAL: Duration = Duration.ofMinutes(30)
 
-        // Floor between outage retries when no successful snapshot exists yet.
+        // Floor between refresh attempts — success or failure, with or without
+        // a cached snapshot.
         val MIN_RETRY_INTERVAL: Duration = Duration.ofMinutes(1)
         const val REFRESH_DISTANCE_M = 5_000f
         const val HOURLY_SLICE_LENGTH = 5

--- a/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/CalendarRepositoryTest.kt
@@ -133,7 +133,7 @@ class CalendarRepositoryTest {
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, AllDayCalendarProvider.TODAY)),
-                    zone = newYork,
+                    zoneProvider = { newYork },
                 )
 
             val snapshot = repository.snapshotFlow().first()
@@ -178,7 +178,7 @@ class CalendarRepositoryTest {
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, MultiDayCalendarProvider.TODAY)),
-                    zone = ZoneOffset.UTC,
+                    zoneProvider = { ZoneOffset.UTC },
                 )
 
             val snapshot = repository.snapshotFlow().first()
@@ -199,6 +199,37 @@ class CalendarRepositoryTest {
         }
 
     @Test
+    fun `scans the events window once for ticks sharing the same date`() =
+        runTest {
+            shadowOf(application).grantPermissions(Manifest.permission.READ_CALENDAR)
+            CountingCalendarProvider.queryCount = 0
+            Robolectric
+                .buildContentProvider(CountingCalendarProvider::class.java)
+                .create(CalendarContract.AUTHORITY)
+
+            val date = LocalDate.of(2026, 6, 3)
+            val repository =
+                CalendarRepository(
+                    application,
+                    // Three ticks a minute apart on the same calendar date — the
+                    // production cadence between midnights.
+                    clockFlow =
+                        flowOf(
+                            ClockTick(LocalTime.of(12, 0), date),
+                            ClockTick(LocalTime.of(12, 1), date),
+                            ClockTick(LocalTime.of(12, 2), date),
+                        ),
+                )
+
+            val snapshot = repository.snapshotFlow().first()
+
+            assertNotNull(snapshot)
+            // Same-date ticks collapse to one rebuild key, so the 30-day
+            // Instances window is scanned once — not once per minute.
+            assertEquals(1, CountingCalendarProvider.queryCount)
+        }
+
+    @Test
     fun `month label follows the locale field order`() =
         runTest {
             // The label is produced from getBestDateTimePattern(locale, "yMMMM").
@@ -212,7 +243,7 @@ class CalendarRepositoryTest {
                     CalendarRepository(
                         application,
                         clockFlow = flowOf(ClockTick(LocalTime.NOON, today)),
-                        locale = locale,
+                        localeProvider = { locale },
                     )
 
                 val snapshot = repository.snapshotFlow().first()
@@ -235,13 +266,13 @@ class CalendarRepositoryTest {
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, today)),
-                    locale = Locale.ENGLISH,
+                    localeProvider = { Locale.ENGLISH },
                 ).snapshotFlow().first()!!.monthLabel
             val jaLabel =
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, today)),
-                    locale = Locale.JAPANESE,
+                    localeProvider = { Locale.JAPANESE },
                 ).snapshotFlow().first()!!.monthLabel
             assertTrue(enLabel != jaLabel)
         }
@@ -382,6 +413,50 @@ class CalendarRepositoryTest {
                     at(TODAY, 12) to "D",
                     at(TODAY.plusDays(2), 14) to "E",
                 )
+        }
+    }
+
+    /**
+     * Stand-in calendar provider that counts [query] invocations and returns an
+     * empty cursor. [queryCount] is reset explicitly by each test because
+     * Robolectric can share the companion across test methods.
+     */
+    class CountingCalendarProvider : ContentProvider() {
+        override fun onCreate(): Boolean = true
+
+        override fun query(
+            uri: Uri,
+            projection: Array<out String>?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+            sortOrder: String?,
+        ): Cursor {
+            queryCount += 1
+            return MatrixCursor(projection ?: arrayOf(CalendarContract.Instances.BEGIN))
+        }
+
+        override fun getType(uri: Uri): String? = null
+
+        override fun insert(
+            uri: Uri,
+            values: ContentValues?,
+        ): Uri? = null
+
+        override fun delete(
+            uri: Uri,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        override fun update(
+            uri: Uri,
+            values: ContentValues?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        companion object {
+            var queryCount: Int = 0
         }
     }
 

--- a/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
@@ -167,7 +167,12 @@ class WeatherRepositoryTest {
             // second emit is seen as +10s (inside MIN_RETRY_INTERVAL) only once the
             // first attempt has actually hit the server — immune to the flowOn(IO) /
             // merge scheduling that made a manually-advanced clock flaky on CI.
-            val clock = RequestCountClock(Instant.parse("2026-05-01T05:32:00Z"), server, Duration.ofSeconds(10))
+            val clock =
+                RequestCountClock(
+                    Instant.parse("2026-05-01T05:32:00Z"),
+                    server,
+                    listOf(Duration.ZERO, Duration.ofSeconds(10)),
+                )
             val repo =
                 WeatherRepository(
                     api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
@@ -200,7 +205,12 @@ class WeatherRepositoryTest {
             // +61s once the first attempt has landed (just past MIN_RETRY_INTERVAL), so
             // the second emit triggers a real retry. Driven off the request count, not
             // wall time, to stay deterministic under flowOn(IO) / merge.
-            val clock = RequestCountClock(Instant.parse("2026-05-01T05:32:00Z"), server, Duration.ofSeconds(61))
+            val clock =
+                RequestCountClock(
+                    Instant.parse("2026-05-01T05:32:00Z"),
+                    server,
+                    listOf(Duration.ZERO, Duration.ofSeconds(61)),
+                )
             val repo =
                 WeatherRepository(
                     api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
@@ -219,6 +229,51 @@ class WeatherRepositoryTest {
                 cancelAndIgnoreRemainingEvents()
             }
 
+            assertEquals(2, server.requestCount)
+        }
+
+    @Test
+    fun `applies the retry floor after a failed refresh of a stale cache`() =
+        runTest {
+            // First call succeeds and seeds the cache; the outage starts after.
+            server.enqueue(MockResponse().setBody(FORECAST_BODY))
+            server.enqueue(MockResponse().setResponseCode(500))
+            server.enqueue(MockResponse().setResponseCode(500))
+
+            // Staleness is driven by DISTANCE (each fix ~10 km from the last, far
+            // past REFRESH_DISTANCE_M) so the cache ages play no role. The clock
+            // is keyed off the request count: the failed second attempt happens
+            // at +2min, and the third emission arrives 10s after that failure —
+            // inside MIN_RETRY_INTERVAL, so it must not reach the network even
+            // though the fix has moved far enough to warrant a refresh.
+            val clock =
+                RequestCountClock(
+                    Instant.parse("2026-05-01T05:32:00Z"),
+                    server,
+                    listOf(Duration.ZERO, Duration.ofMinutes(2), Duration.ofMinutes(2).plusSeconds(10)),
+                )
+            val repo =
+                WeatherRepository(
+                    api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
+                    locationFlow =
+                        flow {
+                            emit(fakeLocation())
+                            emit(fakeLocation(latitude = 35.7480))
+                            emit(fakeLocation(latitude = 35.8380))
+                        },
+                    clockFlow = emptyFlow(),
+                    clock = clock,
+                )
+
+            repo.snapshotFlow().test {
+                assertNotNull(awaitItem()) // fetched and cached
+                assertNotNull(awaitItem()) // failed refresh keeps the cache
+                assertNotNull(awaitItem()) // floored: cache again, no request
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            // The success plus ONE failed stale retry; before the global floor the
+            // third emission fired a request too (once per GPS tick in production).
             assertEquals(2, server.requestCount)
         }
 
@@ -250,21 +305,22 @@ class WeatherRepositoryTest {
         }
 
     // Clock that advances off the MockWebServer request count rather than wall time:
-    // it returns [base] until the first request has landed, then base + [offsetAfterFirst].
+    // it returns base + offsets[requestCount] (the last entry holds beyond the list).
     // Driving the clock off observable progress (not emission timing) makes the
     // outage-retry throttle tests immune to the flowOn(IO) / merge scheduling race that
     // a manually-advanced clock suffered on slow CI runners.
     private class RequestCountClock(
         private val base: Instant,
         private val server: MockWebServer,
-        private val offsetAfterFirst: Duration,
+        private val offsetsByRequestCount: List<Duration>,
         private val zone: ZoneId = ZoneOffset.UTC,
     ) : Clock() {
         override fun getZone(): ZoneId = zone
 
-        override fun withZone(zone: ZoneId): Clock = RequestCountClock(base, server, offsetAfterFirst, zone)
+        override fun withZone(zone: ZoneId): Clock = RequestCountClock(base, server, offsetsByRequestCount, zone)
 
-        override fun instant(): Instant = if (server.requestCount >= 1) base.plus(offsetAfterFirst) else base
+        override fun instant(): Instant =
+            base.plus(offsetsByRequestCount[server.requestCount.coerceAtMost(offsetsByRequestCount.size - 1)])
     }
 
     private companion object {

--- a/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/WeatherRepositoryTest.kt
@@ -278,6 +278,43 @@ class WeatherRepositoryTest {
         }
 
     @Test
+    fun `keeps the floor after a successful fetch even when the fix moves far`() =
+        runTest {
+            server.enqueue(MockResponse().setBody(FORECAST_BODY))
+            server.enqueue(MockResponse().setResponseCode(500))
+
+            // The second fix arrives 30s after the successful fetch, 10 km away —
+            // beyond REFRESH_DISTANCE_M but inside MIN_RETRY_INTERVAL. The floor
+            // wins: a real vehicle cannot cover 5 km inside the one-minute floor,
+            // so the distance trigger never needs to bypass it.
+            val clock =
+                RequestCountClock(
+                    Instant.parse("2026-05-01T05:32:00Z"),
+                    server,
+                    listOf(Duration.ZERO, Duration.ofSeconds(30)),
+                )
+            val repo =
+                WeatherRepository(
+                    api = OpenMeteoApi(client = client, baseUrl = server.url("/").toString()),
+                    locationFlow =
+                        flow {
+                            emit(fakeLocation())
+                            emit(fakeLocation(latitude = 35.7480))
+                        },
+                    clockFlow = emptyFlow(),
+                    clock = clock,
+                )
+
+            repo.snapshotFlow().test {
+                assertNotNull(awaitItem())
+                assertNotNull(awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            assertEquals(1, server.requestCount)
+        }
+
+    @Test
     fun `yields a snapshot from temperature and code when secondary current fields are missing`() =
         runTest {
             // A current block lacking apparent_temperature, windspeed_10m, and is_day


### PR DESCRIPTION
## Summary

Fixes items 1–3 plus the minor findings from the update-logic review (item 4 — staleness affordance — deliberately skipped per the maintainer: weather rarely changes abruptly).

### 1. Weather retry storm (major)
`MIN_RETRY_INTERVAL` only guarded the no-cache path; a **stale cache during an outage** passed the age check and fired an HTTP attempt on every GPS tick (~1 Hz) against the public Open-Meteo endpoint. The floor now applies to every attempt regardless of cache state. Two new regression tests pin the behaviour (failed-stale-retry floor; success-then-10 km-jump stays one request).

### 2. Timezone / locale pinned at construction (major)
`ClockRepository` / `CalendarRepository` captured `ZoneId.systemDefault()` / `Locale.getDefault()` once and only listened to `TIME_TICK` — crossing a border pinned the clock and agenda to the old zone until process death. Zone/locale are now providers read per tick / per rebuild, and the receiver adds `TIME_CHANGED` + `TIMEZONE_CHANGED`. **Verified live on the emulator**: switching the device to America/New_York re-dated the calendar and re-bucketed event times immediately, and back. The visual clock corrects at its own ≤1-minute self-tick by design (its timer is deliberately decoupled from the shared minute flow).

### 3. Calendar scanned the provider every minute (moderate)
The per-minute tick re-ran a full 30-day `Instances` scan (recurrence expansion included). The clock side of the combine is now keyed on `(date, permission, zone)` — the scan runs on date/permission/zone changes and provider notifications, keeping the ≤1-minute pickup of a runtime grant. The build consumes the key's own values, closing the key/build TOCTOU window. New test asserts same-date ticks scan once.

### Minor
- `tickFlow()` shared via `shareIn` (one TIME_TICK receiver instead of three; scope documented as process-lifetime by design, mirroring `LocationRepository`).
- Calendar query moved `Dispatchers.Default` → `IO`.
- Sunrise/sunset day-boundary glyph drift intentionally left (≈1 min/day, no cheap accurate fix).

## Verification
- `./gradlew spotlessCheck assembleDebug test compileDebugAndroidTestKotlin` — green (3 new regression tests included).
- Run on the TBox-Mock emulator: dashboard healthy at head-unit geometry; live timezone-change round-trip verified as above.
- `compose-launcher-reviewer` pass: no blocking findings; all three suggestions applied (boundary test, key-derived build inputs, scope documentation).