### PR TITLE
feat(assistant): launch the system assistant overlay from the dock mic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -125,6 +125,14 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent>
+        <!--
+            Resolve the device's default assistant so the dock mic can hand
+            off to its overlay directly (and fall back to the in-launcher
+            voice sheet when nothing resolves).
+        -->
+        <intent>
+            <action android:name="android.intent.action.ASSIST" />
+        </intent>
     </queries>
 
     <application

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.SearchManager
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -31,6 +32,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import io.github.seijikohara.femto.data.apps.AppsRepository
+import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.ClockSetting
 import io.github.seijikohara.femto.data.display.DisplayPreferences
 import io.github.seijikohara.femto.data.display.DisplaySettings
@@ -174,6 +176,7 @@ class MainActivity : ComponentActivity() {
                     onEvent = { event ->
                         handleHomeEvent(
                             event = event,
+                            assistantLaunch = display.assistantLaunch,
                             setShowDrawer = { showDrawer = it },
                             setShowAssistant = { showAssistant = it },
                             setShowSettings = { showSettings = it },
@@ -270,6 +273,7 @@ class MainActivity : ComponentActivity() {
 
     private fun handleHomeEvent(
         event: HomeEvent,
+        assistantLaunch: AssistantLaunchSetting,
         setShowDrawer: (Boolean) -> Unit,
         setShowAssistant: (Boolean) -> Unit,
         setShowSettings: (Boolean) -> Unit,
@@ -302,26 +306,47 @@ class MainActivity : ComponentActivity() {
                 setShowSettings(true)
             }
 
-            HomeEvent.OpenAssistantSheet -> {
+            HomeEvent.OpenAssistant -> {
                 // Close the drawer overlay so the two bottom sheets never stack.
                 setShowDrawer(false)
-                setShowAssistant(true)
+                // SYSTEM hands off to the default assistant's overlay; the sheet
+                // is the fallback when none resolves (e.g. no assistant installed).
+                if (assistantLaunch != AssistantLaunchSetting.SYSTEM || !launchSystemAssistant()) {
+                    setShowAssistant(true)
+                }
             }
         }
     }
+
+    /**
+     * Launch the device's default assistant (`ACTION_ASSIST`). Assistants such
+     * as the stock voice assistant render as an overlay above the dashboard, so
+     * the launcher stays visible underneath and needs no in-app UI. Returns
+     * false when no assistant resolves (e.g. a head unit without one) so the
+     * caller falls back to the in-launcher voice sheet.
+     */
+    private fun launchSystemAssistant(): Boolean =
+        assistantIntent(AssistantOption.ASSISTANT).let { intent ->
+            packageManager.resolveActivity(intent, PackageManager.ResolveInfoFlags.of(0)) != null &&
+                tryStartActivity(intent)
+        }
 
     // Fire the intent matching the user's elected assistant option. No package is
     // hard-coded, so each action defers to whichever app the user has elected and
     // works across markets and OEM assistants. A missing handler is a silent
     // no-op (tryStartActivity swallows ActivityNotFoundException).
     private fun launchAssistantOption(option: AssistantOption) {
+        tryStartActivity(assistantIntent(option))
+    }
+
+    private fun assistantIntent(option: AssistantOption): Intent {
         val action =
             when (option) {
                 AssistantOption.ASSISTANT -> Intent.ACTION_ASSIST
                 AssistantOption.VOICE_COMMAND -> Intent.ACTION_VOICE_COMMAND
                 AssistantOption.VOICE_SEARCH -> Intent.ACTION_WEB_SEARCH
             }
-        tryStartActivity(Intent(action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        return Intent(action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
 
     // Dispatch a phrase the user spoke into the in-launcher voice surface. The

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
@@ -54,6 +54,8 @@ internal interface DisplaySettingsStore {
 
     suspend fun setKeepScreenOn(value: Boolean)
 
+    suspend fun setAssistantLaunch(value: AssistantLaunchSetting)
+
     suspend fun setMapStyle(value: MapStyleSetting)
 
     suspend fun setMapSchemeLight(value: MapColorScheme)
@@ -113,6 +115,7 @@ internal class DisplayPreferences(
                     dockPosition = prefs[DOCK_POSITION_KEY].toEnumOr(DockPosition.BOTTOM),
                     orientation = prefs[ORIENTATION_KEY].toEnumOr(OrientationSetting.AUTO),
                     keepScreenOn = prefs[KEEP_SCREEN_ON_KEY] ?: true,
+                    assistantLaunch = prefs[ASSISTANT_LAUNCH_KEY].toEnumOr(AssistantLaunchSetting.SYSTEM),
                     mapStyle = prefs[MAP_STYLE_KEY].toEnumOr(MapStyleSetting.AUTO),
                     mapSchemeLight = prefs[MAP_SCHEME_LIGHT_KEY].toEnumOr(MapColorScheme.ACCENT),
                     mapSchemeDark = prefs[MAP_SCHEME_DARK_KEY].toEnumOr(MapColorScheme.ACCENT),
@@ -169,6 +172,10 @@ internal class DisplayPreferences(
 
     override suspend fun setKeepScreenOn(value: Boolean) {
         context.displayDataStore.editOrLog(TAG) { it[KEEP_SCREEN_ON_KEY] = value }
+    }
+
+    override suspend fun setAssistantLaunch(value: AssistantLaunchSetting) {
+        context.displayDataStore.editOrLog(TAG) { it[ASSISTANT_LAUNCH_KEY] = value.name }
     }
 
     override suspend fun setMapStyle(value: MapStyleSetting) {
@@ -249,6 +256,7 @@ internal class DisplayPreferences(
         val DOCK_POSITION_KEY = stringPreferencesKey("dock_position")
         val ORIENTATION_KEY = stringPreferencesKey("orientation")
         val KEEP_SCREEN_ON_KEY = booleanPreferencesKey("keep_screen_on")
+        val ASSISTANT_LAUNCH_KEY = stringPreferencesKey("assistant_launch")
         val MAP_STYLE_KEY = stringPreferencesKey("map_style")
         val MAP_SCHEME_LIGHT_KEY = stringPreferencesKey("map_scheme_light")
         val MAP_SCHEME_DARK_KEY = stringPreferencesKey("map_scheme_dark")

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplaySettings.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplaySettings.kt
@@ -27,6 +27,15 @@ enum class AccentColor { DYNAMIC, BLUE, TEAL, GREEN, AMBER, ORANGE, RED, VIOLET,
 internal enum class FullscreenSetting { OFF, ON }
 
 /**
+ * Assistant entry: [SYSTEM] hands the dock mic to the device's default
+ * assistant, which draws its own overlay above the dashboard (the launcher
+ * stays visible underneath); [IN_APP] opens the in-launcher voice sheet.
+ * [SYSTEM] is the default — the host falls back to the sheet when no
+ * assistant resolves (e.g. a head unit without one installed).
+ */
+internal enum class AssistantLaunchSetting { SYSTEM, IN_APP }
+
+/**
  * Which screen edge hosts the dashboard dock. [BOTTOM] and [TOP] render the
  * horizontal bar; [LEFT] and [RIGHT] render it as a vertical rail.
  */
@@ -113,6 +122,9 @@ internal data class DisplaySettings(
     // Whether to keep the screen awake while the launcher is foreground. Defaults
     // to true: the head unit runs on vehicle power, so the dashboard should stay lit.
     val keepScreenOn: Boolean,
+    // Whether the dock mic launches the system assistant overlay or the
+    // in-launcher voice sheet.
+    val assistantLaunch: AssistantLaunchSetting,
     val mapStyle: MapStyleSetting,
     // Independent colour schemes for the light and dark map contexts (which one
     // applies follows [mapStyle] / the system theme). Both default to ACCENT.
@@ -156,6 +168,7 @@ internal data class DisplaySettings(
                 dockPosition = DockPosition.BOTTOM,
                 orientation = OrientationSetting.AUTO,
                 keepScreenOn = true,
+                assistantLaunch = AssistantLaunchSetting.SYSTEM,
                 mapStyle = MapStyleSetting.AUTO,
                 mapSchemeLight = MapColorScheme.ACCENT,
                 mapSchemeDark = MapColorScheme.ACCENT,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeEvent.kt
@@ -45,6 +45,9 @@ internal sealed interface HomeEvent {
     /** Open the in-app settings screen (units, theme, font, system links). */
     data object OpenInAppSettings : HomeEvent
 
-    /** Open the voice-assistant bottom sheet so the user picks which assistant intent to fire. */
-    data object OpenAssistantSheet : HomeEvent
+    /**
+     * Open the assistant. The host resolves the user's assistant-launch setting:
+     * the system assistant overlay, or the in-launcher voice sheet.
+     */
+    data object OpenAssistant : HomeEvent
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -154,7 +154,7 @@ internal class HomeViewModel(
             }
 
             HomeAction.OpenAssistant -> {
-                mutableEvents.tryEmit(HomeEvent.OpenAssistantSheet)
+                mutableEvents.tryEmit(HomeEvent.OpenAssistant)
             }
 
             HomeAction.ResetTrip -> {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -53,6 +53,7 @@ import com.composables.icons.lucide.RotateCcw
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.apps.DrawerIconSize
 import io.github.seijikohara.femto.data.display.AccentColor
+import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.ClockSetting
 import io.github.seijikohara.femto.data.display.DockPosition
 import io.github.seijikohara.femto.data.display.FullscreenSetting
@@ -157,6 +158,16 @@ internal fun SettingsScreen(
                     ),
                 selected = uiState.dockPosition,
                 onSelect = { onAction(SettingsAction.SetDockPosition(it)) },
+            )
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_assistant),
+                options =
+                    listOf(
+                        AssistantLaunchSetting.SYSTEM to stringResource(R.string.settings_assistant_system),
+                        AssistantLaunchSetting.IN_APP to stringResource(R.string.settings_assistant_in_app),
+                    ),
+                selected = uiState.assistantLaunch,
+                onSelect = { onAction(SettingsAction.SetAssistantLaunch(it)) },
             )
             SettingsSubheader(stringResource(R.string.settings_subheader_glass))
             SliderRow(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.ui.settings
 
 import io.github.seijikohara.femto.data.apps.DrawerIconSize
 import io.github.seijikohara.femto.data.display.AccentColor
+import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.ClockSetting
 import io.github.seijikohara.femto.data.display.DisplaySettings
 import io.github.seijikohara.femto.data.display.DockPosition
@@ -28,6 +29,7 @@ internal data class SettingsUiState(
     val dockPosition: DockPosition,
     val orientation: OrientationSetting,
     val keepScreenOn: Boolean,
+    val assistantLaunch: AssistantLaunchSetting,
     val mapStyle: MapStyleSetting,
     val mapSchemeLight: MapColorScheme,
     val mapSchemeDark: MapColorScheme,
@@ -66,6 +68,7 @@ internal data class SettingsUiState(
                 dockPosition = DisplaySettings.Default.dockPosition,
                 orientation = DisplaySettings.Default.orientation,
                 keepScreenOn = DisplaySettings.Default.keepScreenOn,
+                assistantLaunch = DisplaySettings.Default.assistantLaunch,
                 mapStyle = DisplaySettings.Default.mapStyle,
                 mapSchemeLight = DisplaySettings.Default.mapSchemeLight,
                 mapSchemeDark = DisplaySettings.Default.mapSchemeDark,
@@ -131,6 +134,10 @@ internal sealed interface SettingsAction {
 
     data class SetKeepScreenOn(
         val value: Boolean,
+    ) : SettingsAction
+
+    data class SetAssistantLaunch(
+        val value: AssistantLaunchSetting,
     ) : SettingsAction
 
     data class SetMapStyle(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -43,6 +43,7 @@ internal class SettingsViewModel(
                 dockPosition = display.dockPosition,
                 orientation = display.orientation,
                 keepScreenOn = display.keepScreenOn,
+                assistantLaunch = display.assistantLaunch,
                 mapStyle = display.mapStyle,
                 mapSchemeLight = display.mapSchemeLight,
                 mapSchemeDark = display.mapSchemeDark,
@@ -109,6 +110,10 @@ internal class SettingsViewModel(
 
                 is SettingsAction.SetKeepScreenOn -> {
                     displayPreferences.setKeepScreenOn(action.value)
+                }
+
+                is SettingsAction.SetAssistantLaunch -> {
+                    displayPreferences.setAssistantLaunch(action.value)
                 }
 
                 is SettingsAction.SetMapStyle -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,9 @@
     <string name="settings_group_clock_seconds">Show seconds</string>
     <string name="settings_group_fullscreen">Fullscreen</string>
     <string name="settings_keep_screen_on">Keep screen on</string>
+    <string name="settings_group_assistant">Assistant</string>
+    <string name="settings_assistant_system">System</string>
+    <string name="settings_assistant_in_app">Built-in</string>
     <string name="settings_group_map_rendering">Map rendering</string>
     <string name="settings_map_mode_live">Live</string>
     <string name="settings_map_mode_snapshot">Snapshot</string>

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -1,6 +1,7 @@
 package io.github.seijikohara.femto.testfixtures
 
 import io.github.seijikohara.femto.data.display.AccentColor
+import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.ClockSetting
 import io.github.seijikohara.femto.data.display.DisplaySettings
 import io.github.seijikohara.femto.data.display.DisplaySettingsStore
@@ -50,6 +51,11 @@ internal class FakeDisplaySettingsStore(
     override suspend fun setOrientation(value: OrientationSetting) = state.update { it.copy(orientation = value) }
 
     override suspend fun setKeepScreenOn(value: Boolean) = state.update { it.copy(keepScreenOn = value) }
+
+    override suspend fun setAssistantLaunch(value: AssistantLaunchSetting) =
+        state.update {
+            it.copy(assistantLaunch = value)
+        }
 
     override suspend fun setMapStyle(value: MapStyleSetting) = state.update { it.copy(mapStyle = value) }
 

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -171,11 +171,11 @@ class HomeViewModelTest {
         }
 
     @Test
-    fun `onAction OpenAssistant emits OpenAssistantSheet`() =
+    fun `onAction OpenAssistant emits OpenAssistant`() =
         runTest {
             stubViewModel().assertEvent(
                 action = HomeAction.OpenAssistant,
-                expected = HomeEvent.OpenAssistantSheet,
+                expected = HomeEvent.OpenAssistant,
             )
         }
 

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import io.github.seijikohara.femto.data.apps.DrawerIconSize
 import io.github.seijikohara.femto.data.display.AccentColor
+import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.DisplaySettings
 import io.github.seijikohara.femto.data.display.DockPosition
 import io.github.seijikohara.femto.data.display.FullscreenSetting
@@ -69,6 +70,14 @@ class SettingsViewModelTest {
             viewModel().onAction(SettingsAction.SetKeepScreenOn(false))
             advanceUntilIdle()
             assertEquals(false, store.settings.first().keepScreenOn)
+        }
+
+    @Test
+    fun `SetAssistantLaunch writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetAssistantLaunch(AssistantLaunchSetting.IN_APP))
+            advanceUntilIdle()
+            assertEquals(AssistantLaunchSetting.IN_APP, store.settings.first().assistantLaunch)
         }
 
     @Test


### PR DESCRIPTION
## Summary

The dock mic previously always opened the in-launcher voice sheet, where the system assistant sat behind a second tap on a delegation row. Comparable car launchers hand the mic button straight to the device's default assistant, which renders its own overlay above the dashboard while the launcher stays visible underneath. This PR adopts that one-tap flow.

- Add `AssistantLaunchSetting` (`SYSTEM` / `IN_APP`, default `SYSTEM`) to `DisplaySettings` with a DataStore key and a Settings choice row (System / Built-in).
- `SYSTEM` fires `ACTION_ASSIST` directly when an assistant resolves; it falls back to the in-launcher voice sheet when none does (e.g. a head unit with no assistant installed). `IN_APP` keeps the previous sheet-first flow.
- Declare a `<queries>` intent for `ACTION_ASSIST` so the package-visibility filter lets the launcher resolve the default assistant before firing it. No new permission is requested.
- Rename `HomeEvent.OpenAssistantSheet` to `OpenAssistant` since the host now decides between the overlay hand-off and the sheet.
- Share the assist-intent construction between the dock-mic path and the sheet's delegation rows (`assistantIntent(option)`).

## Verification

- `./gradlew spotlessCheck` — passed
- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- `./gradlew lint` — no new findings
- `./gradlew test` — passed (new `SetAssistantLaunch` ViewModel test; renamed `OpenAssistant` event test)
- `compose-launcher-reviewer` run on the diff — no blocking findings; the intent-construction DRY suggestion is applied