### PR TITLE
feat(home): ripple the live-position chevron and grey it out when the fix goes stale

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/location/LocationFreshness.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/LocationFreshness.kt
@@ -1,0 +1,19 @@
+package io.github.seijikohara.femto.data.location
+
+import android.location.Location
+
+// How long after the last fix the position counts as lost (e.g. a tunnel). The
+// location flow forwards fixes verbatim and never emits null once seeded, so a
+// lost signal surfaces as a fix that stops ageing-out rather than a null — hence
+// an age threshold rather than a presence check. Mirrored in webmap (main.ts,
+// LOCATION_STALE_THRESHOLD_MS) for the LIVE chevron.
+internal const val LOCATION_STALE_THRESHOLD_MS = 10_000L
+
+/**
+ * Return whether this fix is still fresh at [nowElapsedRealtimeNanos] (pass
+ * [android.os.SystemClock.elapsedRealtimeNanos]). Uses the monotonic
+ * elapsed-realtime clock, not wall time, so a system clock change never makes a
+ * fix look stale.
+ */
+internal fun Location.isFresh(nowElapsedRealtimeNanos: Long): Boolean =
+    nowElapsedRealtimeNanos - elapsedRealtimeNanos <= LOCATION_STALE_THRESHOLD_MS * 1_000_000L

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -7,11 +7,16 @@ import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.PixelFormat
 import android.location.Location
+import android.os.SystemClock
 import android.util.Log
 import android.view.SurfaceView
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
@@ -37,6 +42,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
@@ -67,6 +73,8 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.MapColorScheme
 import io.github.seijikohara.femto.data.display.MapRenderMode
 import io.github.seijikohara.femto.data.display.MapStyleSetting
+import io.github.seijikohara.femto.data.location.LOCATION_STALE_THRESHOLD_MS
+import io.github.seijikohara.femto.data.location.isFresh
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -189,27 +197,59 @@ internal fun Attribution(
     )
 }
 
+/**
+ * Re-evaluate [location] freshness on a 1 s tick so the marker can grey out when
+ * fixes stop arriving (a tunnel): the location flow forwards each fix verbatim
+ * and never emits null on signal loss, so a stale fix would otherwise read as
+ * live forever. A new fix restarts the tick (the key changes) and re-greens the
+ * marker. Once stale, the loop stops — nothing changes until the next fix.
+ */
+@Composable
+internal fun rememberLocationFresh(location: Location): Boolean =
+    produceState(initialValue = true, location) {
+        while (true) {
+            value = location.isFresh(SystemClock.elapsedRealtimeNanos())
+            if (!value) break
+            delay(1_000L)
+        }
+    }.value
+
 // Current-location puck: a heading-up navigation chevron at a fixed on-screen spot
 // (the camera look-ahead keeps the location there, so the chevron stays still while
 // the map slides beneath it). The map is heading-up, so the chevron always points
 // toward the top of the frame (forward); rotationX lays it onto the oblique ground
 // plane so it matches the map's tilt and reads as a nav arrow resting on the road
 // rather than a flat sticker.
+//
+// While [fresh] the chevron is the Material primary and emits a restrained ripple
+// (a live-position cue); once the fix is stale it greys out and the ripple stops,
+// matching the LIVE chevron's `.stale` state in webmap (main.ts).
 @Composable
 internal fun LocationMarker(
     xPx: Float,
     yPx: Float,
     tiltDeg: Int,
+    fresh: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val half = with(LocalDensity.current) { MARKER_ARROW_SIZE.toPx() } / 2f
-    val fill = MaterialTheme.colorScheme.primary
+    // The box is larger than the chevron so the ripple has room to expand beyond
+    // the arrow; the chevron is drawn centred at its own size inside it.
+    val half = with(LocalDensity.current) { MARKER_BOX_SIZE.toPx() } / 2f
+    val fill = if (fresh) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+    val rippleColor = MaterialTheme.colorScheme.primary
     val outlinePx = with(LocalDensity.current) { 1.5.dp.toPx() }
+    val ripple = rememberInfiniteTransition(label = "marker-ripple")
+    val rippleProgress by ripple.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(tween(MARKER_RIPPLE_PERIOD_MS, easing = LinearEasing)),
+        label = "marker-ripple-progress",
+    )
     Box(
         modifier =
             modifier
                 .offset { IntOffset((xPx - half).roundToInt(), (yPx - half).roundToInt()) }
-                .size(MARKER_ARROW_SIZE)
+                .size(MARKER_BOX_SIZE)
                 .graphicsLayer {
                     // Lay the chevron back onto the tilted ground plane so it sits in
                     // the same perspective as the map. transformOrigin centres the
@@ -220,16 +260,37 @@ internal fun LocationMarker(
                 },
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {
-            val w = size.width
-            val h = size.height
+            // An expanding disc that fades as it grows — drawn first so the chevron
+            // sits on top. Only while fresh; a stale fix shows no ripple. A faint
+            // ring on its leading edge sharpens the pulse so it reads clearly.
+            if (fresh) {
+                val maxRadius = size.minDimension / 2f
+                val radius = maxRadius * rippleProgress
+                val fade = 1f - rippleProgress
+                drawCircle(
+                    color = rippleColor.copy(alpha = MARKER_RIPPLE_MAX_ALPHA * fade),
+                    radius = radius,
+                    center = center,
+                )
+                drawCircle(
+                    color = rippleColor.copy(alpha = MARKER_RIPPLE_EDGE_ALPHA * fade),
+                    radius = radius,
+                    center = center,
+                    style = Stroke(width = outlinePx),
+                )
+            }
             // An upward arrowhead with a concave tail notch (the classic nav chevron):
             // tip at top-centre, the two base corners, and a notch rising from the base.
+            // Centred at MARKER_ARROW_SIZE within the larger ripple box.
+            val arrow = MARKER_ARROW_SIZE.toPx()
+            val left = (size.width - arrow) / 2f
+            val top = (size.height - arrow) / 2f
             val chevron =
                 Path().apply {
-                    moveTo(w / 2f, 0f)
-                    lineTo(w, h)
-                    lineTo(w / 2f, h * 0.72f)
-                    lineTo(0f, h)
+                    moveTo(left + arrow / 2f, top)
+                    lineTo(left + arrow, top + arrow)
+                    lineTo(left + arrow / 2f, top + arrow * 0.72f)
+                    lineTo(left, top + arrow)
                     close()
                 }
             drawPath(chevron, color = fill)
@@ -265,10 +326,19 @@ internal fun Fallback(modifier: Modifier = Modifier) =
         )
     }
 
-// Heading-up nav chevron size and the graphicsLayer camera distance (multiplied by
+// Heading-up nav chevron size, the larger box that gives the ripple room to
+// expand past the arrow, and the graphicsLayer camera distance (multiplied by
 // density) that softens the perspective when the chevron is laid onto the tilt.
 private val MARKER_ARROW_SIZE = 30.dp
+private val MARKER_BOX_SIZE = 64.dp
 private const val MARKER_CAMERA_DISTANCE = 12f
+
+// Live-position ripple: one disc per period expanding to the box edge, with a
+// faint ring on its leading edge so the pulse stays legible. Peak opacity is
+// kept moderate — a clear pulse, not a beacon. Mirrored in webmap (main.ts).
+private const val MARKER_RIPPLE_PERIOD_MS = 2_800
+private const val MARKER_RIPPLE_MAX_ALPHA = 0.38f
+private const val MARKER_RIPPLE_EDGE_ALPHA = 0.55f
 
 // Small attribution type: legal credit only, deliberately tiny so the centred
 // speed overlay does not bury it on a narrow map pane.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -73,7 +73,6 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.MapColorScheme
 import io.github.seijikohara.femto.data.display.MapRenderMode
 import io.github.seijikohara.femto.data.display.MapStyleSetting
-import io.github.seijikohara.femto.data.location.LOCATION_STALE_THRESHOLD_MS
 import io.github.seijikohara.femto.data.location.isFresh
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import kotlinx.coroutines.delay
@@ -236,15 +235,7 @@ internal fun LocationMarker(
     // the arrow; the chevron is drawn centred at its own size inside it.
     val half = with(LocalDensity.current) { MARKER_BOX_SIZE.toPx() } / 2f
     val fill = if (fresh) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-    val rippleColor = MaterialTheme.colorScheme.primary
     val outlinePx = with(LocalDensity.current) { 1.5.dp.toPx() }
-    val ripple = rememberInfiniteTransition(label = "marker-ripple")
-    val rippleProgress by ripple.animateFloat(
-        initialValue = 0f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(tween(MARKER_RIPPLE_PERIOD_MS, easing = LinearEasing)),
-        label = "marker-ripple-progress",
-    )
     Box(
         modifier =
             modifier
@@ -259,26 +250,13 @@ internal fun LocationMarker(
                     transformOrigin = TransformOrigin(0.5f, 0.5f)
                 },
     ) {
+        // Composed only while fresh, so the infinite animation (and the
+        // recompositions it drives) stops entirely once the fix goes stale. Drawn
+        // before the chevron, so it sits behind the arrow.
+        if (fresh) {
+            MarkerRipple(color = MaterialTheme.colorScheme.primary, strokeWidthPx = outlinePx)
+        }
         Canvas(modifier = Modifier.fillMaxSize()) {
-            // An expanding disc that fades as it grows — drawn first so the chevron
-            // sits on top. Only while fresh; a stale fix shows no ripple. A faint
-            // ring on its leading edge sharpens the pulse so it reads clearly.
-            if (fresh) {
-                val maxRadius = size.minDimension / 2f
-                val radius = maxRadius * rippleProgress
-                val fade = 1f - rippleProgress
-                drawCircle(
-                    color = rippleColor.copy(alpha = MARKER_RIPPLE_MAX_ALPHA * fade),
-                    radius = radius,
-                    center = center,
-                )
-                drawCircle(
-                    color = rippleColor.copy(alpha = MARKER_RIPPLE_EDGE_ALPHA * fade),
-                    radius = radius,
-                    center = center,
-                    style = Stroke(width = outlinePx),
-                )
-            }
             // An upward arrowhead with a concave tail notch (the classic nav chevron):
             // tip at top-centre, the two base corners, and a notch rising from the base.
             // Centred at MARKER_ARROW_SIZE within the larger ripple box.
@@ -296,6 +274,36 @@ internal fun LocationMarker(
             drawPath(chevron, color = fill)
             drawPath(chevron, color = Color.White, style = Stroke(width = outlinePx))
         }
+    }
+}
+
+// One fading pulse per period: an expanding disc with a ring on its leading edge
+// so it reads clearly. A separate composable so the host only places it while the
+// fix is fresh — keeping the infinite animation out of the tree when it would
+// draw nothing.
+@Composable
+private fun MarkerRipple(
+    color: Color,
+    strokeWidthPx: Float,
+    modifier: Modifier = Modifier,
+) {
+    val ripple = rememberInfiniteTransition(label = "marker-ripple")
+    val progress by ripple.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(tween(MARKER_RIPPLE_PERIOD_MS, easing = LinearEasing)),
+        label = "marker-ripple-progress",
+    )
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val radius = (size.minDimension / 2f) * progress
+        val fade = 1f - progress
+        drawCircle(color = color.copy(alpha = MARKER_RIPPLE_MAX_ALPHA * fade), radius = radius, center = center)
+        drawCircle(
+            color = color.copy(alpha = MARKER_RIPPLE_EDGE_ALPHA * fade),
+            radius = radius,
+            center = center,
+            style = Stroke(width = strokeWidthPx),
+        )
     }
 }
 
@@ -330,6 +338,9 @@ internal fun Fallback(modifier: Modifier = Modifier) =
 // expand past the arrow, and the graphicsLayer camera distance (multiplied by
 // density) that softens the perspective when the chevron is laid onto the tilt.
 private val MARKER_ARROW_SIZE = 30.dp
+
+// Ripple headroom around the arrow; its 64 dp equality with
+// FemtoDimens.MinTouchTarget is coincidental — this is not a tap target.
 private val MARKER_BOX_SIZE = 64.dp
 private const val MARKER_CAMERA_DISTANCE = 12f
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapSnapshot.kt
@@ -239,7 +239,12 @@ internal fun SnapshotMap(
                         .graphicsLayer { alpha = fadeIn.value }
                         .clickable { onTap() },
             )
-            LocationMarker(xPx = markerXPx, yPx = markerYPx, tiltDeg = mapConfig.tiltDeg)
+            LocationMarker(
+                xPx = markerXPx,
+                yPx = markerYPx,
+                tiltDeg = mapConfig.tiltDeg,
+                fresh = rememberLocationFresh(location),
+            )
         }
 
         failed -> {

--- a/app/src/test/java/io/github/seijikohara/femto/data/location/LocationFreshnessTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/location/LocationFreshnessTest.kt
@@ -1,0 +1,33 @@
+package io.github.seijikohara.femto.data.location
+
+import io.github.seijikohara.femto.testfixtures.fakeLocation
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class LocationFreshnessTest {
+    private val thresholdNanos = LOCATION_STALE_THRESHOLD_MS * 1_000_000L
+
+    @Test
+    fun `fix is fresh right at the threshold`() {
+        val fix = fakeLocation(elapsedRealtimeNanos = 0L)
+        assertTrue(fix.isFresh(nowElapsedRealtimeNanos = thresholdNanos))
+    }
+
+    @Test
+    fun `fix is stale just past the threshold`() {
+        val fix = fakeLocation(elapsedRealtimeNanos = 0L)
+        assertFalse(fix.isFresh(nowElapsedRealtimeNanos = thresholdNanos + 1L))
+    }
+
+    @Test
+    fun `a fix from the same instant is fresh`() {
+        val fix = fakeLocation(elapsedRealtimeNanos = 5_000_000_000L)
+        assertTrue(fix.isFresh(nowElapsedRealtimeNanos = 5_000_000_000L))
+    }
+}

--- a/webmap/map.html
+++ b/webmap/map.html
@@ -18,6 +18,30 @@
         transform: translate(-50%, -50%);
         pointer-events: none; display: none; will-change: top, transform;
       }
+      /* Live-position ripple: a fading disc per period expanding past the chevron,
+         with a ring edge so the pulse reads clearly. Coloured by --marker-color
+         (Material primary, set per fix from main.ts). Mirrors the SNAPSHOT
+         chevron's ripple (MapPanel.kt). */
+      /* Keep the chevron above the ripple (a positioned sibling would otherwise
+         paint over it). */
+      #self-marker svg { position: relative; z-index: 1; }
+      #self-marker .ripple {
+        position: absolute; left: 50%; top: 50%;
+        width: 64px; height: 64px; margin: -32px 0 0 -32px;
+        border-radius: 50%;
+        background: var(--marker-color, #3367D6);
+        border: 1.5px solid var(--marker-color, #3367D6);
+        box-sizing: border-box;
+        animation: marker-ripple 2.8s linear infinite;
+      }
+      @keyframes marker-ripple {
+        0%   { transform: scale(0); opacity: 0.38; }
+        100% { transform: scale(1); opacity: 0; }
+      }
+      /* Position lost (a tunnel): grey the chevron whatever its colour and stop
+         the ripple. main.ts toggles .stale from the staleness timer. */
+      #self-marker.stale svg { filter: grayscale(1); }
+      #self-marker.stale .ripple { display: none; }
       /* Style-swap cross-fade: a frozen capture of the outgoing style pinned over
          the map, faded out once the incoming style has rendered. */
       #style-fade {
@@ -32,6 +56,7 @@
     <div id="style-fade"><img alt="" /></div>
     <div id="self-marker">
       <!-- Decorative self-location chevron; the host UI owns the accessible name. -->
+      <span class="ripple"></span>
       <svg width="34" height="34" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <path d="M15 0 L30 30 L15 21.6 L0 30 Z" fill="#3367D6" stroke="#FFFFFF" stroke-width="1.5" stroke-linejoin="round"/>
       </svg>

--- a/webmap/src/main.ts
+++ b/webmap/src/main.ts
@@ -58,6 +58,13 @@ function report(kind: "fatal" | "error", detail: unknown): void {
 	}
 }
 
+// How long after the last camera push (i.e. the last GPS fix) the chevron greys
+// out and stops rippling, marking the position lost (a tunnel). The host pushes
+// a fix per update and stops on signal loss, so the page ages the last push
+// rather than waiting for a null. Mirrors LOCATION_STALE_THRESHOLD_MS in the
+// Kotlin data layer (LocationFreshness.kt) and the SNAPSHOT chevron.
+const LOCATION_STALE_THRESHOLD_MS = 10000;
+
 // Mutable page state in one const holder (let/var are banned — see biome.json
 // and no-let.grit). Camera pushes, style swaps, and error throttling all read
 // and write through here.
@@ -71,6 +78,9 @@ const state = {
 	styleFadeGen: 0,
 	firstCamera: true,
 	lastErrorReportMs: 0,
+	// Wall-clock ms of the last camera push; 0 until the first fix. The stale
+	// timer ages this to decide when the chevron greys out.
+	lastFixMs: 0,
 };
 
 function applyStyle(): void {
@@ -211,6 +221,17 @@ try {
 	const markerEl = document.getElementById("self-marker") as HTMLElement;
 	const markerPath = markerEl.querySelector("path");
 
+	// Grey the chevron and stop its ripple once fixes stop arriving (signal lost
+	// in a tunnel): the host pushes a fix per update and goes quiet on loss, so
+	// the page itself ages the last push. The .stale CSS class greyscales the
+	// chevron and hides the ripple; updateCamera clears it on the next fix.
+	setInterval(() => {
+		const stale =
+			state.lastFixMs > 0 &&
+			Date.now() - state.lastFixMs > LOCATION_STALE_THRESHOLD_MS;
+		markerEl.classList.toggle("stale", stale);
+	}, 1000);
+
 	// Android -> JS: smooth heading-up camera follow (easeTo interpolates between
 	// sparse GPS fixes). The first fix jumps (no fly-in from [0,0]); the rest ease.
 	// The chevron is pinned on screen (not geo-anchored), so only the camera moves
@@ -231,7 +252,12 @@ try {
 	) => {
 		if (!state.map) return;
 		const heading = bearing || 0;
+		// A fresh fix: re-colour the chevron, feed the ripple the same colour, and
+		// clear any stale greyout from a prior signal gap.
 		if (markerColor && markerPath) markerPath.setAttribute("fill", markerColor);
+		if (markerColor) markerEl.style.setProperty("--marker-color", markerColor);
+		state.lastFixMs = Date.now();
+		markerEl.classList.remove("stale");
 		const pos = Math.max(0, Math.min(100, markerPos || 0));
 		markerEl.style.top = `${50 + (pos / 100) * MAX_MARKER_DROP * 100}%`;
 		markerEl.style.transform = `translate(-50%, -50%) perspective(600px) rotateX(${tilt || 0}deg)`;

--- a/webmap/src/main.ts
+++ b/webmap/src/main.ts
@@ -63,7 +63,7 @@ function report(kind: "fatal" | "error", detail: unknown): void {
 // a fix per update and stops on signal loss, so the page ages the last push
 // rather than waiting for a null. Mirrors LOCATION_STALE_THRESHOLD_MS in the
 // Kotlin data layer (LocationFreshness.kt) and the SNAPSHOT chevron.
-const LOCATION_STALE_THRESHOLD_MS = 10000;
+const LOCATION_STALE_THRESHOLD_MS = 10_000;
 
 // Mutable page state in one const holder (let/var are banned — see biome.json
 // and no-let.grit). Camera pushes, style swaps, and error throttling all read


### PR DESCRIPTION
## Summary

Add a slow, restrained ripple behind the map's current-location chevron as a live-position cue, and grey the chevron (ripple stopped) once the fix goes stale — e.g. a tunnel — so a frozen position no longer reads as live. Behaviour is identical across both render backends (LIVE WebView + SNAPSHOT Compose).

- **Fresh fix** → chevron in Material primary + a pulsing ripple.
- **Stale fix** (no new fix for 10 s) → chevron greyed out, ripple stopped.
- **New fix** → chevron re-colours.

## How staleness is derived

The location flow forwards each fix verbatim and never emits null on signal loss, so staleness is an **age threshold**, not a presence check. `LocationFreshness.isFresh` compares the fix's elapsed-realtime clock against `LOCATION_STALE_THRESHOLD_MS` (10 s).

- **SNAPSHOT** (Compose): `rememberLocationFresh` self-times the threshold on a 1 s tick (the flow won't re-emit on loss); `LocationMarker` takes `fresh: Boolean`.
- **LIVE** (webmap): `main.ts` stamps `lastFixMs` per camera push and a 1 s interval toggles a `.stale` class (greyscale + ripple hidden). The 10 s constant is mirrored from Kotlin with a comment citing the SSOT.

## Ripple

One fading disc per **2.8 s** with a ring edge for definition, drawn in a box larger than the arrow so it can expand past it. Mirrored constants keep the two renderers in step. The ripple is a separate composable placed in the tree only while fresh, so the infinite animation stops entirely when greyed out.

## Verification

- `./gradlew spotlessCheck` — passed
- `./gradlew assembleDebug` — BUILD SUCCESSFUL (includes the webmap Vite build)
- `./gradlew lint` — no new findings
- `./gradlew test` — passed (new `LocationFreshnessTest`)
- webmap `biome` + `vitest` — passed
- On the head-unit emulator (LIVE): confirmed fresh = coloured chevron, stale (>10 s) = greyscale, and re-colour on a new fix.
- `compose-launcher-reviewer` run on the diff — the one blocking finding (infinite animation running while stale) is fixed; minor suggestions applied.