### PR TITLE
fix(home): keep fullscreen while a bottom sheet is open

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import io.github.seijikohara.femto.data.apps.AppsRepository
@@ -48,6 +47,7 @@ import io.github.seijikohara.femto.data.location.hasReadPhoneStatePermission
 import io.github.seijikohara.femto.data.system.SystemPermissionSignals
 import io.github.seijikohara.femto.ui.assistant.AssistantOption
 import io.github.seijikohara.femto.ui.assistant.AssistantSheet
+import io.github.seijikohara.femto.ui.common.hideSystemBarsTransiently
 import io.github.seijikohara.femto.ui.drawer.AppDrawerSheet
 import io.github.seijikohara.femto.ui.fontpicker.FontPickerSheet
 import io.github.seijikohara.femto.ui.home.HomeEvent
@@ -246,15 +246,8 @@ class MainActivity : ComponentActivity() {
     private fun applyFullscreen(setting: FullscreenSetting) {
         val controller = WindowCompat.getInsetsController(window, window.decorView)
         when (setting) {
-            FullscreenSetting.ON -> {
-                controller.systemBarsBehavior =
-                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-                controller.hide(WindowInsetsCompat.Type.systemBars())
-            }
-
-            FullscreenSetting.OFF -> {
-                controller.show(WindowInsetsCompat.Type.systemBars())
-            }
+            FullscreenSetting.ON -> controller.hideSystemBarsTransiently()
+            FullscreenSetting.OFF -> controller.show(WindowInsetsCompat.Type.systemBars())
         }
     }
 

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -183,6 +183,10 @@ class MainActivity : ComponentActivity() {
                         )
                     },
                 )
+                // The modal sheets render in their own windows, which do not inherit
+                // the Activity's immersive flags; pass the fullscreen choice so each
+                // re-applies it to its window (see ImmersiveSheetEffect).
+                val fullscreen = display.fullscreen == FullscreenSetting.ON
                 if (showDrawer) {
                     AppDrawerSheet(
                         onLaunch = { component ->
@@ -190,6 +194,7 @@ class MainActivity : ComponentActivity() {
                             showDrawer = false
                         },
                         onDismiss = { showDrawer = false },
+                        fullscreen = fullscreen,
                     )
                 }
                 if (showAssistant) {
@@ -203,6 +208,7 @@ class MainActivity : ComponentActivity() {
                             showAssistant = false
                         },
                         onDismiss = { showAssistant = false },
+                        fullscreen = fullscreen,
                     )
                 }
                 if (showSettings) {
@@ -211,12 +217,14 @@ class MainActivity : ComponentActivity() {
                         onOpenSystemSettings = ::openSystemSettings,
                         onOpenFontPicker = { fontPickerSlot = it },
                         onDismiss = { showSettings = false },
+                        fullscreen = fullscreen,
                     )
                 }
                 fontPickerSlot?.let { slot ->
                     FontPickerSheet(
                         slot = slot,
                         onDismiss = { fontPickerSlot = null },
+                        fullscreen = fullscreen,
                     )
                 }
             }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/assistant/AssistantSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/assistant/AssistantSheet.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
 /**
@@ -32,6 +33,7 @@ internal fun AssistantSheet(
     onLaunchOption: (AssistantOption) -> Unit,
     onSubmitQuery: (String) -> Unit,
     onDismiss: () -> Unit,
+    fullscreen: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
@@ -39,6 +41,7 @@ internal fun AssistantSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,
     ) {
+        ImmersiveSheetEffect(fullscreen)
         Box(
             modifier =
                 Modifier

--- a/app/src/main/java/io/github/seijikohara/femto/ui/common/ImmersiveSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/common/ImmersiveSheet.kt
@@ -1,0 +1,48 @@
+package io.github.seijikohara.femto.ui.common
+
+import android.view.View
+import android.view.Window
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+
+/**
+ * Hide the system bars on the host [ModalBottomSheet][androidx.compose.material3.ModalBottomSheet]'s
+ * own window while [fullscreen] is on. A modal sheet renders in a separate window
+ * that does not inherit the Activity's immersive flags, so without this the
+ * launcher's fullscreen visibly drops — the status / navigation bars reappear —
+ * for as long as a sheet is open (`MainActivity.applyFullscreen` only governs the
+ * Activity window). Mirrors the Activity's transient-swipe behaviour so a swipe
+ * still reveals the bars and they auto-hide again.
+ *
+ * Call from inside the sheet's content lambda so [LocalView] resolves to the sheet
+ * window. A no-op when [fullscreen] is off, or when no sheet/dialog window is found
+ * (e.g. a preview).
+ */
+@Composable
+internal fun ImmersiveSheetEffect(fullscreen: Boolean) {
+    if (!fullscreen) return
+    val view = LocalView.current
+    LaunchedEffect(view) {
+        val window = view.dialogWindowOrNull() ?: return@LaunchedEffect
+        WindowCompat.getInsetsController(window, view).apply {
+            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            hide(WindowInsetsCompat.Type.systemBars())
+        }
+    }
+}
+
+// Walk up to the modal-sheet / dialog window host, which exposes its Window
+// through DialogWindowProvider.
+private fun View.dialogWindowOrNull(): Window? {
+    var ancestor = parent
+    while (ancestor != null) {
+        if (ancestor is DialogWindowProvider) return ancestor.window
+        ancestor = ancestor.parent
+    }
+    return null
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/common/ImmersiveSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/common/ImmersiveSheet.kt
@@ -27,13 +27,22 @@ import androidx.core.view.WindowInsetsControllerCompat
 internal fun ImmersiveSheetEffect(fullscreen: Boolean) {
     if (!fullscreen) return
     val view = LocalView.current
-    LaunchedEffect(view) {
+    // Key on fullscreen too so a toggle while the sheet is open re-applies.
+    LaunchedEffect(view, fullscreen) {
         val window = view.dialogWindowOrNull() ?: return@LaunchedEffect
-        WindowCompat.getInsetsController(window, view).apply {
-            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-            hide(WindowInsetsCompat.Type.systemBars())
-        }
+        WindowCompat.getInsetsController(window, view).hideSystemBarsTransiently()
     }
+}
+
+/**
+ * Hide the status and navigation bars with the transient-swipe behaviour (a swipe
+ * reveals them briefly, then they auto-hide). The launcher's fullscreen SSOT,
+ * shared between the Activity window ([MainActivity][io.github.seijikohara.femto.MainActivity])
+ * and the modal-sheet windows ([ImmersiveSheetEffect]) so both stay in step.
+ */
+internal fun WindowInsetsControllerCompat.hideSystemBarsTransiently() {
+    systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+    hide(WindowInsetsCompat.Type.systemBars())
 }
 
 // Walk up to the modal-sheet / dialog window host, which exposes its Window

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.seijikohara.femto.data.apps.DrawerIconSize
 import io.github.seijikohara.femto.data.apps.DrawerLayout
 import io.github.seijikohara.femto.data.apps.DrawerPreferences
+import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import kotlinx.coroutines.launch
 
@@ -50,6 +51,7 @@ import kotlinx.coroutines.launch
 internal fun AppDrawerSheet(
     onLaunch: (ComponentName) -> Unit,
     onDismiss: () -> Unit,
+    fullscreen: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -69,6 +71,7 @@ internal fun AppDrawerSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,
     ) {
+        ImmersiveSheetEffect(fullscreen)
         Box(
             modifier =
                 Modifier

--- a/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.data.fonts.FontSlot
+import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
 /**
@@ -25,6 +26,7 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
 internal fun FontPickerSheet(
     slot: FontSlot,
     onDismiss: () -> Unit,
+    fullscreen: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.FontPickerSheetHeightFraction).dp
@@ -33,6 +35,7 @@ internal fun FontPickerSheet(
         modifier = modifier,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
     ) {
+        ImmersiveSheetEffect(fullscreen)
         Box(
             modifier =
                 Modifier

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.data.fonts.FontSlot
+import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
 /**
@@ -32,6 +33,7 @@ internal fun SettingsSheet(
     onOpenSystemSettings: () -> Unit,
     onOpenFontPicker: (FontSlot) -> Unit,
     onDismiss: () -> Unit,
+    fullscreen: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
@@ -39,6 +41,7 @@ internal fun SettingsSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,
     ) {
+        ImmersiveSheetEffect(fullscreen)
         Box(
             modifier =
                 Modifier


### PR DESCRIPTION
## Summary

Opening any bottom sheet (app drawer, assistant, settings, font picker) temporarily dropped the launcher's fullscreen — the system bars reappeared for as long as the sheet was open and re-hid only on dismiss. This was not intentional: a Compose `ModalBottomSheet` renders in **its own window**, which does not inherit the Activity's immersive flags. `MainActivity.applyFullscreen` / `onWindowFocusChanged` only govern the Activity window.

## Fix

- New `ui/common/ImmersiveSheetEffect(fullscreen)`: from inside a sheet's content it finds the sheet window via `DialogWindowProvider` (walking the View parent chain) and re-applies the same hide + transient-swipe behaviour while fullscreen is on. No-op when fullscreen is off or no window is found (e.g. a preview).
- Each of the four sheets takes a `fullscreen` flag, threaded from the persisted `DisplaySettings` in `MainActivity`.
- The hide sequence is shared via `WindowInsetsControllerCompat.hideSystemBarsTransiently()`, used by both the Activity window and the sheet windows so they can never drift.

## Verification

- `./gradlew spotlessCheck` — passed
- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- `./gradlew lint` — no new findings
- `./gradlew test` — passed
- On the head-unit emulator (fullscreen on): confirmed the system bars stay hidden while the settings sheet is open and expanded, where they previously reappeared.
- `compose-launcher-reviewer` run on the diff — no blocking findings; the actionable suggestions (LaunchedEffect key, DRY of the hide sequence) are applied.