### PR TITLE
docs: fix stale facts found by CLAUDE.md / .claude audit

### DIFF
--- a/.claude/agents/similar-app-researcher.md
+++ b/.claude/agents/similar-app-researcher.md
@@ -12,7 +12,10 @@ tools:
 ---
 
 You are a research analyst for **femto-car-launcher**, an Android home
-launcher targeting OTTOCAST / Carlinkit AI boxes (Android 13 baseline).
+launcher for in-car displays across three device classes — aftermarket
+CarPlay / Android Auto AI boxes (e.g. OTTOCAST, Carlinkit), built-in
+Android head units, and smartphones mounted as a car-navigation
+display (Android 13 baseline).
 The caller will give you a feature, capability, or design question
 plus (optionally) a target set of apps. Your job is to deliver an
 evidence-grounded brief that informs the project's implementation

--- a/.claude/skills/add-viewmodel/references/viewmodel-template.md
+++ b/.claude/skills/add-viewmodel/references/viewmodel-template.md
@@ -15,8 +15,9 @@ import androidx.compose.runtime.Immutable
 
 @Immutable
 data class <Area>UiState(
-    // Add stable fields. Use kotlinx.collections.immutable.ImmutableList
-    // for lists where stability matters for skippability.
+    // Add stable fields. Keep collections read-only (List<T>) per
+    // CLAUDE.md#kotlin-style; @Immutable above declares the class
+    // stable to the Compose compiler despite the List fields.
     val isLoading: Boolean = false,
     val items: List<String> = emptyList(),
 ) {

--- a/.claude/skills/verify-android-build/SKILL.md
+++ b/.claude/skills/verify-android-build/SKILL.md
@@ -87,4 +87,4 @@ task. Default is `assembleDebug`.
 | `Unresolved reference: libs.<x>` | Forgot to add the alias in `libs.versions.toml` | Add to `[libraries]` (and `[plugins]` for plugins), then re-sync. See `CLAUDE.md#dependencies`. |
 | `Theme.Material3.DayNight.NoActionBar` not found | `com.google.android.material:material` removed | Re-add it in `libs.versions.toml` and `app/build.gradle.kts` |
 | `:app:buildWebMap` fails | TypeScript / Vite error under `webmap/` | Fix the webmap source; Gradle provisions Node and pnpm itself. Keep Vite's `build.target` at `chrome109` (CLAUDE.md, Tech stack) |
-| Compose Compiler version mismatch | Kotlin updated but `kotlin-compose` plugin pinned | Bump `kotlin` and `compose-compiler` plugin in lock-step (see `CLAUDE.md#dependencies`) |
+| Compose Compiler version mismatch | `kotlin-compose` plugin pinned to its own version instead of `version.ref = "kotlin"` | Point the plugin back at the shared `kotlin` version ref — the lock-step is automatic when both share it (see `CLAUDE.md#dependencies`) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,10 @@ when markets diverge.
   supported-device floor stays Android 13 / API 33).
 - AndroidX: `core-ktx`, `core-splashscreen`, `activity-compose`,
   `lifecycle-runtime-compose`, `lifecycle-viewmodel-compose`,
-  `datastore-preferences`.
+  `datastore-preferences`, `webkit`.
+- Key third-party libraries: MapLibre Android SDK (SNAPSHOT map
+  rendering), OkHttp (HTTP clients), MaterialKolor (preset-accent
+  scheme generation), Lucide icons, Haze (blur effects).
 - Web map page (`webmap/`): TypeScript + Vite + `maplibre-gl`, managed
   with pnpm (pinned via `packageManager`). Vite's `build.target` is
   `chrome109` — the Android 13 factory WebView; aftermarket AI boxes
@@ -61,7 +64,7 @@ app/src/
 │   │       │   ├── <Area>ViewModel.kt# StateFlow<UiState>; handles Action
 │   │       │   └── components/       # Area-private widgets
 │   │       └── theme/                # FemtoTheme + tokens + PreviewLightDark
-│   └── res/                          # themes (values{,-night}/), strings (per-locale), icon drawables, xml/
+│   └── res/                          # themes (values{,-night}/), strings, icon drawables, xml/
 ├── test/...                          # JVM unit tests (runTest + TestDispatcher)
 └── androidTest/...                   # Compose UI tests (createComposeRule)
 ```


### PR DESCRIPTION
## Summary

Audit of `CLAUDE.md` and `.claude/**` against the current codebase. All anchor citations, the permission audit table, version claims (AGP / Gradle / BOM / SDK levels / JDK), skills and agents tables, and webmap claims verified accurate. Four stale or inaccurate statements found and fixed:

- **CLAUDE.md tech stack** — add `androidx-webkit` to the AndroidX list and name the key third-party libraries (MapLibre Android SDK, OkHttp, MaterialKolor, Lucide, Haze) the catalog already declares.
- **CLAUDE.md source layout** — `res/` has no per-locale strings directories yet (only `values/` and `values-night/`); drop the claim.
- **similar-app-researcher agent** — replace the single-device-class intro (AI boxes only) with the three-device-class framing CLAUDE.md has used since #131.
- **verify-android-build skill** — the catalog has no separate `compose-compiler` entry; the `kotlin-compose` plugin shares `version.ref = "kotlin"`, so describe the pinned-plugin failure mode instead of a manual lock-step bump.
- **add-viewmodel template** — stop recommending `kotlinx.collections.immutable`, which is not a project dependency.

## Out of scope (reported, not changed)

- Leftover worktree `.claude/worktrees/assistant-direct-launch` (branch `fix-sheet-fullscreen`, merged as #139, clean) can be removed.
- Local `main` checkout is behind `origin/main` (#136–#139).

## Verification

- `./gradlew spotlessCheck` — passed.