### PR TITLE
feat(map): recolor roads and theme-track buildings for readability

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapScheme.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapScheme.kt
@@ -55,22 +55,56 @@ internal fun mapStyleRefFor(
 /**
  * The Material colours the ACCENT scheme paints onto the map, as "#rrggbb" hex.
  * [background] tints the map background, [water] the water bodies, [land] the
- * landcover / landuse / parks. Derived from the theme so they track light/dark and
- * the user's accent. The same three layers are recoloured in both backends.
+ * landcover / landuse / parks, [roadMajor] / [roadMinor] / [roadCasing] the
+ * transportation lines, and [building] the 2D building fills. Derived from the
+ * theme so they track light/dark and the user's accent. The same layer groups are
+ * recoloured in both backends.
+ *
+ * [building] doubles as the 3D fill-extrusion colour for EVERY scheme (not just
+ * ACCENT): the LIVE backend's injected buildings are theme-tracked so they stay
+ * subdued on any base style (see the features push in WebMapView.kt).
  */
 internal data class AccentMapColors(
     val background: String,
     val water: String,
     val land: String,
+    val roadMajor: String,
+    val roadMinor: String,
+    val roadCasing: String,
+    val building: String,
 )
 
 // The accent palette both backends paint onto the ACCENT scheme, mapped from the
-// Material roles in one place: background = surface, water = primaryContainer,
-// land = surfaceVariant. Derived from the theme, so it tracks light/dark + accent.
+// Material roles in one place. Both modes follow the same readability rule —
+// roads float above the ground — but reach it from opposite directions, so the
+// role mapping is mode-dependent:
+//  - Light: near-white roads on a slightly darker ground (the classic light
+//    car-nav look), with a visible casing edge; background = surfaceContainer
+//    also matches the map card surface (MapPanel), so the pre-first-frame card
+//    and the map read as one plane.
+//  - Dark: the ground drops to the darkest surface tone and roads brighten
+//    above it (ground < buildings < minor < major), so the road network — not
+//    the buildings — is the brightest shape on the panel.
 @Composable
-internal fun accentMapColors(): AccentMapColors =
-    AccentMapColors(
-        background = MaterialTheme.colorScheme.surface.toCssHex(),
-        water = MaterialTheme.colorScheme.primaryContainer.toCssHex(),
-        land = MaterialTheme.colorScheme.surfaceVariant.toCssHex(),
-    )
+internal fun accentMapColors(isDark: Boolean): AccentMapColors =
+    if (isDark) {
+        AccentMapColors(
+            background = MaterialTheme.colorScheme.surface.toCssHex(),
+            water = MaterialTheme.colorScheme.primaryContainer.toCssHex(),
+            land = MaterialTheme.colorScheme.surfaceContainerLow.toCssHex(),
+            roadMajor = MaterialTheme.colorScheme.outlineVariant.toCssHex(),
+            roadMinor = MaterialTheme.colorScheme.surfaceContainerHighest.toCssHex(),
+            roadCasing = MaterialTheme.colorScheme.surfaceContainer.toCssHex(),
+            building = MaterialTheme.colorScheme.surfaceContainerHigh.toCssHex(),
+        )
+    } else {
+        AccentMapColors(
+            background = MaterialTheme.colorScheme.surfaceContainer.toCssHex(),
+            water = MaterialTheme.colorScheme.primaryContainer.toCssHex(),
+            land = MaterialTheme.colorScheme.surfaceContainerHigh.toCssHex(),
+            roadMajor = MaterialTheme.colorScheme.surface.toCssHex(),
+            roadMinor = MaterialTheme.colorScheme.surfaceContainerHighest.toCssHex(),
+            roadCasing = MaterialTheme.colorScheme.outlineVariant.toCssHex(),
+            building = MaterialTheme.colorScheme.surfaceContainerHighest.toCssHex(),
+        )
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapSnapshot.kt
@@ -71,7 +71,6 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.suspendCancellableCoroutine
-import org.json.JSONObject
 import org.maplibre.android.MapLibre
 import org.maplibre.android.camera.CameraPosition
 import org.maplibre.android.camera.CameraUpdateFactory
@@ -107,7 +106,7 @@ internal fun SnapshotMap(
             MapStyleSetting.DARK -> true
         }
     val styleRef = mapStyleRefFor(if (isDark) mapConfig.schemeDark else mapConfig.schemeLight, isDark)
-    val accentColors = accentMapColors()
+    val accentColors = accentMapColors(isDark)
     val widthPx = with(LocalDensity.current) { maxWidth.roundToPx() }
     val heightPx = with(LocalDensity.current) { maxHeight.roundToPx() }
     // Render at a fraction of the panel resolution; the Image upscales it to fill,
@@ -363,39 +362,6 @@ private fun styleBuilderFor(
     }
 
 private fun Context.readAsset(path: String): String = assets.open(path).bufferedReader().use { it.readText() }
-
-// Recolour the background, water, and landcover/landuse/park fills of a style JSON
-// with the accent palette, leaving roads and labels (legible against the base) as
-// they are. The same three layer groups are recoloured in map.html for the live
-// backend; keep the two in sync.
-private fun recolorAccent(
-    styleJson: String,
-    colors: AccentMapColors,
-): String {
-    val root = JSONObject(styleJson)
-    val layers = root.optJSONArray("layers") ?: return styleJson
-    for (i in 0 until layers.length()) {
-        val layer = layers.getJSONObject(i)
-        val paint = layer.optJSONObject("paint") ?: JSONObject().also { layer.put("paint", it) }
-        val sourceLayer = layer.optString("source-layer")
-        when {
-            layer.optString("type") == "background" -> {
-                paint.put("background-color", colors.background)
-            }
-
-            layer.optString("type") == "fill" && sourceLayer == "water" -> {
-                paint.put("fill-color", colors.water)
-            }
-
-            layer.optString("type") == "fill" && sourceLayer in ACCENT_LAND_LAYERS -> {
-                paint.put("fill-color", colors.land)
-            }
-        }
-    }
-    return root.toString()
-}
-
-private val ACCENT_LAND_LAYERS = setOf("landcover", "landuse", "park")
 
 // How often the snapshot loop polls the current fix for movement. A frame is only
 // produced when the fix actually moves (shouldRerender), so this just bounds the

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapStyleRecolor.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapStyleRecolor.kt
@@ -1,0 +1,72 @@
+package io.github.seijikohara.femto.ui.home.components
+
+import org.json.JSONObject
+
+/**
+ * Recolour a bundled base style's JSON with the ACCENT palette: background, water,
+ * landcover / landuse / park fills, transportation lines, and 2D building fills.
+ * Roads keep their zoom-interpolated widths from the base style, so the visual
+ * hierarchy (motorway / major / minor) survives the recolour; labels stay untouched.
+ *
+ * Mirrors `injectFeatures` / `roadClassOrNull` in `webmap/src/style.ts` for the
+ * live backend — keep the layer groups and the road classification in sync.
+ */
+internal fun recolorAccent(
+    styleJson: String,
+    colors: AccentMapColors,
+): String {
+    val root = JSONObject(styleJson)
+    val layers = root.optJSONArray("layers") ?: return styleJson
+    for (i in 0 until layers.length()) {
+        val layer = layers.getJSONObject(i)
+        val sourceLayer = layer.optString("source-layer")
+        val type = layer.optString("type")
+        when {
+            type == "background" -> {
+                layer.paint().put("background-color", colors.background)
+            }
+
+            type == "fill" && sourceLayer == "water" -> {
+                layer.paint().put("fill-color", colors.water)
+            }
+
+            type == "fill" && sourceLayer in AccentLandLayers -> {
+                layer.paint().put("fill-color", colors.land)
+            }
+
+            type == "fill" && sourceLayer == "building" -> {
+                layer.paint().put("fill-color", colors.building)
+            }
+
+            type == "line" && sourceLayer == "transportation" -> {
+                roadColorOrNull(layer.optString("id"), colors)?.let { layer.paint().put("line-color", it) }
+            }
+        }
+    }
+    return root.toString()
+}
+
+// Created only on a recolour match, so untouched layers keep their exact shape
+// (the TS mirror's setPaint behaves the same way).
+private fun JSONObject.paint(): JSONObject = optJSONObject("paint") ?: JSONObject().also { put("paint", it) }
+
+// Road classification by layer id, shared between the bundled light/dark styles.
+// "subtle" (the low-zoom motorway representation) classifies as minor: in the dark
+// base its colour is identical to highway_minor, and as "major" it would render a
+// casing-less dark hairline on the dark background. Railways, piers, oneway arrows,
+// and aeroways fall outside the highway_/tunnel_ prefixes and keep their base
+// colours. Mirrors roadClassOrNull in webmap/src/style.ts — keep in sync.
+private fun roadColorOrNull(
+    id: String,
+    colors: AccentMapColors,
+): String? =
+    when {
+        !id.startsWith("highway_") && !id.startsWith("tunnel_") -> null
+        "casing" in id -> colors.roadCasing
+        RoadMinorKeywords.any { it in id } -> colors.roadMinor
+        else -> colors.roadMajor
+    }
+
+private val AccentLandLayers = setOf("landcover", "landuse", "park")
+
+private val RoadMinorKeywords = listOf("minor", "path", "subtle")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -270,7 +270,7 @@ internal fun WebMapView(
     // the bundled base with these Material colours (in map.html's transformStyle);
     // the others are plain hosted / bundled styles.
     val styleRef = mapStyleRefFor(if (isDark) mapConfig.schemeDark else mapConfig.schemeLight, isDark)
-    val accentColors = accentMapColors()
+    val accentColors = accentMapColors(isDark)
 
     // Each effect keys on [pageReady] (so it fires once the page is ready) and on
     // [webView] (so a rebuilt WebView gets the state re-pushed), then pushes the
@@ -312,16 +312,23 @@ internal fun WebMapView(
         val accent = (styleRef as? MapStyleRef.Accent)?.let { accentColors }
         webView.evaluateJavascript(
             "window.setStyleUrl && setStyleUrl('$url', " +
-                "'${accent?.background ?: ""}', '${accent?.water ?: ""}', '${accent?.land ?: ""}')",
+                "'${accent?.background ?: ""}', '${accent?.water ?: ""}', '${accent?.land ?: ""}', " +
+                "'${accent?.roadMajor ?: ""}', '${accent?.roadMinor ?: ""}', '${accent?.roadCasing ?: ""}', " +
+                "'${accent?.building ?: ""}')",
             null,
         )
     }
-    // LIVE-only feature toggles (3D buildings / terrain). The page merges them into
+    // LIVE-only feature toggles (3D buildings / terrain) plus the theme-tracked
+    // extrusion colour, which applies to EVERY scheme. The page merges them into
     // the style via MapLibre transformStyle, so this re-applies the style.
-    LaunchedEffect(webView, pageReady.value, mapConfig.buildings3d, mapConfig.terrain) {
+    LaunchedEffect(webView, pageReady.value, mapConfig.buildings3d, mapConfig.terrain, accentColors.building) {
         if (!pageReady.value) return@LaunchedEffect
+        // Same debounce as the style push above: the theme cross-fade churns the
+        // building colour once per frame after a theme change.
+        delay(STYLE_PUSH_DEBOUNCE_MS)
         webView.evaluateJavascript(
-            "window.setFeatures && setFeatures(${mapConfig.buildings3d}, ${mapConfig.terrain})",
+            "window.setFeatures && setFeatures(" +
+                "${mapConfig.buildings3d}, ${mapConfig.terrain}, '${accentColors.building}')",
             null,
         )
     }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/components/MapStyleRecolorTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/components/MapStyleRecolorTest.kt
@@ -1,0 +1,105 @@
+package io.github.seijikohara.femto.ui.home.components
+
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+// Mirrors the assertions in webmap/src/style.test.ts (the live backend's recolour
+// tests) so the two backends' layer groups and road classification stay in sync.
+// Robolectric provides the real org.json implementation recolorAccent runs on.
+@RunWith(RobolectricTestRunner::class)
+class MapStyleRecolorTest {
+    private val colors =
+        AccentMapColors(
+            background = "#101010",
+            water = "#202020",
+            land = "#303030",
+            roadMajor = "#404040",
+            roadMinor = "#505050",
+            roadCasing = "#606060",
+            building = "#707070",
+        )
+
+    private fun layer(
+        id: String,
+        type: String,
+        sourceLayer: String? = null,
+    ): String =
+        buildString {
+            append("""{"id":"$id","type":"$type"""")
+            sourceLayer?.let { append(""","source-layer":"$it"""") }
+            append("}")
+        }
+
+    private val styleJson =
+        """
+        {"version":8,"layers":[
+            ${layer("bg", "background")},
+            ${layer("water", "fill", "water")},
+            ${layer("park", "fill", "park")},
+            ${layer("building", "fill", "building")},
+            ${layer("highway_motorway_casing", "line", "transportation")},
+            ${layer("highway_motorway_inner", "line", "transportation")},
+            ${layer("tunnel_motorway_inner", "line", "transportation")},
+            ${layer("highway_major_subtle", "line", "transportation")},
+            ${layer("highway_minor", "line", "transportation")},
+            ${layer("highway_path", "line", "transportation")},
+            ${layer("tunnel_motorway_casing", "line", "transportation")},
+            ${layer("railway_minor", "line", "transportation")},
+            ${layer("road_pier", "line", "transportation")},
+            ${layer("aeroway-runway", "line", "aeroway")},
+            ${layer("labels", "symbol", "place")}
+        ]}
+        """.trimIndent()
+
+    private fun recoloredPaintOrNull(id: String): JSONObject? {
+        val layers = JSONObject(recolorAccent(styleJson, colors)).getJSONArray("layers")
+        return (0 until layers.length())
+            .map { layers.getJSONObject(it) }
+            .first { it.getString("id") == id }
+            .optJSONObject("paint")
+    }
+
+    @Test
+    fun recolors_background_water_land_and_building_fills() {
+        assertEquals(colors.background, recoloredPaintOrNull("bg")?.getString("background-color"))
+        assertEquals(colors.water, recoloredPaintOrNull("water")?.getString("fill-color"))
+        assertEquals(colors.land, recoloredPaintOrNull("park")?.getString("fill-color"))
+        assertEquals(colors.building, recoloredPaintOrNull("building")?.getString("fill-color"))
+    }
+
+    @Test
+    fun recolors_casing_roads_with_the_casing_color() {
+        assertEquals(colors.roadCasing, recoloredPaintOrNull("highway_motorway_casing")?.getString("line-color"))
+        assertEquals(colors.roadCasing, recoloredPaintOrNull("tunnel_motorway_casing")?.getString("line-color"))
+    }
+
+    @Test
+    fun recolors_minor_path_and_subtle_roads_with_the_minor_color() {
+        assertEquals(colors.roadMinor, recoloredPaintOrNull("highway_minor")?.getString("line-color"))
+        assertEquals(colors.roadMinor, recoloredPaintOrNull("highway_path")?.getString("line-color"))
+        assertEquals(colors.roadMinor, recoloredPaintOrNull("highway_major_subtle")?.getString("line-color"))
+    }
+
+    @Test
+    fun recolors_inner_roads_with_the_major_color() {
+        assertEquals(colors.roadMajor, recoloredPaintOrNull("highway_motorway_inner")?.getString("line-color"))
+        assertEquals(colors.roadMajor, recoloredPaintOrNull("tunnel_motorway_inner")?.getString("line-color"))
+    }
+
+    @Test
+    fun leaves_railways_piers_and_aeroways_untouched() {
+        assertNull(recoloredPaintOrNull("railway_minor"))
+        assertNull(recoloredPaintOrNull("road_pier"))
+        assertNull(recoloredPaintOrNull("aeroway-runway"))
+    }
+
+    @Test
+    fun returns_input_unchanged_when_style_has_no_layers() {
+        val noLayers = """{"version":8}"""
+        assertEquals(noLayers, recolorAccent(noLayers, colors))
+    }
+}

--- a/webmap/src/main.ts
+++ b/webmap/src/main.ts
@@ -27,8 +27,21 @@ declare global {
 			markerPos: number,
 			markerColor: string,
 		) => void;
-		setStyleUrl: (url: string, bg: string, water: string, land: string) => void;
-		setFeatures: (buildings: boolean, terrain: boolean) => void;
+		setStyleUrl: (
+			url: string,
+			bg: string,
+			water: string,
+			land: string,
+			roadMajor: string,
+			roadMinor: string,
+			roadCasing: string,
+			building: string,
+		) => void;
+		setFeatures: (
+			buildings: boolean,
+			terrain: boolean,
+			buildingColor: string,
+		) => void;
 		onHostResume: () => void;
 	}
 }
@@ -75,6 +88,8 @@ const state = {
 	accentColors: null as AccentColors | null,
 	buildings: false,
 	terrain: false,
+	// Theme-tracked 3D extrusion colour, set by setFeatures alongside the toggle.
+	buildingColor: "",
 	styleFadeGen: 0,
 	firstCamera: true,
 	lastErrorReportMs: 0,
@@ -91,6 +106,7 @@ function applyStyle(): void {
 					buildings: state.buildings,
 					terrain: state.terrain,
 					accent: state.accentColors,
+					buildingColor: state.buildingColor,
 				}),
 		});
 	}
@@ -282,20 +298,39 @@ try {
 		}
 	};
 	// Android -> JS: switch the base style and (for the ACCENT scheme) its
-	// recolour palette; empty colour args mean a plain, non-accent style.
-	window.setStyleUrl = (url, bg, water, land) => {
+	// recolour palette; an empty bg means a plain, non-accent style.
+	window.setStyleUrl = (
+		url,
+		bg,
+		water,
+		land,
+		roadMajor,
+		roadMinor,
+		roadCasing,
+		building,
+	) => {
 		if (!url) return;
 		state.currentStyleUrl = url;
 		state.accentColors = bg
-			? { background: bg, water: water, land: land }
+			? {
+					background: bg,
+					water: water,
+					land: land,
+					roadMajor: roadMajor,
+					roadMinor: roadMinor,
+					roadCasing: roadCasing,
+					building: building,
+				}
 			: null;
 		applyStyleWithFade();
 	};
-	// Android -> JS: flip the LIVE feature toggles, then re-apply the style so
-	// transformStyle injects (or omits) the matching layers/sources.
-	window.setFeatures = (buildings, terrain) => {
+	// Android -> JS: flip the LIVE feature toggles (plus the theme-tracked
+	// extrusion colour), then re-apply the style so transformStyle injects
+	// (or omits) the matching layers/sources.
+	window.setFeatures = (buildings, terrain, buildingColor) => {
 		state.buildings = !!buildings;
 		state.terrain = !!terrain;
+		state.buildingColor = buildingColor || "";
 		applyStyleWithFade();
 	};
 	// Host (Android) calls this on lifecycle resume so the map re-measures and

--- a/webmap/src/style.test.ts
+++ b/webmap/src/style.test.ts
@@ -1,14 +1,30 @@
-import type { StyleSpecification } from "maplibre-gl";
+import type { LayerSpecification, StyleSpecification } from "maplibre-gl";
 import { describe, expect, it } from "vitest";
 import {
+	BUILDING_EXTRUSION_OPACITY,
 	injectFeatures,
 	MAPTERHORN_DEM_URL,
 	MAX_MARKER_DROP,
 	markerPadTop,
+	roadClassOrNull,
 	vectorSourceId,
 } from "./style";
 
-const OFF = { buildings: false, terrain: false, accent: null };
+const OFF = {
+	buildings: false,
+	terrain: false,
+	accent: null,
+	buildingColor: "",
+};
+
+function roadLine(id: string): LayerSpecification {
+	return {
+		id,
+		type: "line",
+		source: "openmaptiles",
+		"source-layer": "transportation",
+	} as LayerSpecification;
+}
 
 function baseStyle(): StyleSpecification {
 	return {
@@ -32,10 +48,24 @@ function baseStyle(): StyleSpecification {
 				"source-layer": "park",
 			},
 			{
-				id: "road",
+				id: "building",
 				type: "fill",
 				source: "openmaptiles",
-				"source-layer": "transportation",
+				"source-layer": "building",
+			},
+			roadLine("highway_motorway_casing"),
+			roadLine("highway_motorway_inner"),
+			roadLine("highway_major_subtle"),
+			roadLine("highway_minor"),
+			roadLine("highway_path"),
+			roadLine("tunnel_motorway_casing"),
+			roadLine("railway_minor"),
+			roadLine("road_pier"),
+			{
+				id: "aeroway-runway",
+				type: "line",
+				source: "openmaptiles",
+				"source-layer": "aeroway",
 			},
 			{
 				id: "labels",
@@ -60,8 +90,10 @@ describe("vectorSourceId", () => {
 });
 
 describe("injectFeatures: 3D buildings", () => {
+	const BUILDINGS = { ...OFF, buildings: true, buildingColor: "#404040" };
+
 	it("inserts the extrusion layer beneath the first symbol layer", () => {
-		const style = injectFeatures(baseStyle(), { ...OFF, buildings: true });
+		const style = injectFeatures(baseStyle(), BUILDINGS);
 		const ids = style.layers.map((l) => l.id);
 		expect(ids.indexOf("femto-3d-buildings")).toBe(ids.indexOf("labels") - 1);
 	});
@@ -69,27 +101,47 @@ describe("injectFeatures: 3D buildings", () => {
 	it("appends the extrusion layer when the style has no symbol layer", () => {
 		const style = baseStyle();
 		style.layers = style.layers.filter((l) => l.type !== "symbol");
-		const out = injectFeatures(style, { ...OFF, buildings: true });
+		const out = injectFeatures(style, BUILDINGS);
 		expect(out.layers.at(-1)?.id).toBe("femto-3d-buildings");
+	});
+
+	it("paints the extrusion with the pushed theme colour, semi-transparent", () => {
+		const style = injectFeatures(baseStyle(), BUILDINGS);
+		const paint = (
+			style.layers.find((l) => l.id === "femto-3d-buildings") as {
+				paint?: Record<string, unknown>;
+			}
+		).paint;
+		expect(paint?.["fill-extrusion-color"]).toBe(BUILDINGS.buildingColor);
+		expect(paint?.["fill-extrusion-opacity"]).toBe(BUILDING_EXTRUSION_OPACITY);
 	});
 
 	it("does not inject without a vector source", () => {
 		const style = baseStyle();
 		style.sources = {};
-		const out = injectFeatures(style, { ...OFF, buildings: true });
+		const out = injectFeatures(style, BUILDINGS);
+		expect(out.layers.some((l) => l.id === "femto-3d-buildings")).toBe(false);
+	});
+
+	it("does not inject before the theme colour arrives", () => {
+		const out = injectFeatures(baseStyle(), {
+			...OFF,
+			buildings: true,
+			buildingColor: "",
+		});
 		expect(out.layers.some((l) => l.id === "femto-3d-buildings")).toBe(false);
 	});
 
 	it("is idempotent across re-application", () => {
-		const once = injectFeatures(baseStyle(), { ...OFF, buildings: true });
-		const twice = injectFeatures(once, { ...OFF, buildings: true });
+		const once = injectFeatures(baseStyle(), BUILDINGS);
+		const twice = injectFeatures(once, BUILDINGS);
 		expect(
 			twice.layers.filter((l) => l.id === "femto-3d-buildings"),
 		).toHaveLength(1);
 	});
 
 	it("removes a previously injected layer when toggled off", () => {
-		const on = injectFeatures(baseStyle(), { ...OFF, buildings: true });
+		const on = injectFeatures(baseStyle(), BUILDINGS);
 		const off = injectFeatures(on, OFF);
 		expect(off.layers.some((l) => l.id === "femto-3d-buildings")).toBe(false);
 	});
@@ -118,27 +170,59 @@ describe("injectFeatures: terrain", () => {
 });
 
 describe("injectFeatures: accent recolour", () => {
-	const accent = { background: "#101010", water: "#202020", land: "#303030" };
+	const accent = {
+		background: "#101010",
+		water: "#202020",
+		land: "#303030",
+		roadMajor: "#404040",
+		roadMinor: "#505050",
+		roadCasing: "#606060",
+		building: "#707070",
+	};
 
-	it("recolours background, water, and land fills", () => {
+	function paintOf(style: StyleSpecification, id: string) {
+		return (
+			style.layers.find((l) => l.id === id) as {
+				paint?: Record<string, unknown>;
+			}
+		).paint;
+	}
+
+	it("recolours background, water, land, and building fills", () => {
 		const style = injectFeatures(baseStyle(), { ...OFF, accent });
-		const paintOf = (id: string) =>
-			(
-				style.layers.find((l) => l.id === id) as {
-					paint?: Record<string, unknown>;
-				}
-			).paint;
-		expect(paintOf("bg")?.["background-color"]).toBe(accent.background);
-		expect(paintOf("water")?.["fill-color"]).toBe(accent.water);
-		expect(paintOf("park")?.["fill-color"]).toBe(accent.land);
+		expect(paintOf(style, "bg")?.["background-color"]).toBe(accent.background);
+		expect(paintOf(style, "water")?.["fill-color"]).toBe(accent.water);
+		expect(paintOf(style, "park")?.["fill-color"]).toBe(accent.land);
+		expect(paintOf(style, "building")?.["fill-color"]).toBe(accent.building);
 	});
 
-	it("leaves road fills untouched", () => {
+	it("recolours roads by class: casing, minor (incl. path/subtle), major", () => {
 		const style = injectFeatures(baseStyle(), { ...OFF, accent });
-		const road = style.layers.find((l) => l.id === "road") as {
-			paint?: Record<string, unknown>;
-		};
-		expect(road.paint?.["fill-color"]).toBeUndefined();
+		expect(paintOf(style, "highway_motorway_casing")?.["line-color"]).toBe(
+			accent.roadCasing,
+		);
+		expect(paintOf(style, "tunnel_motorway_casing")?.["line-color"]).toBe(
+			accent.roadCasing,
+		);
+		expect(paintOf(style, "highway_minor")?.["line-color"]).toBe(
+			accent.roadMinor,
+		);
+		expect(paintOf(style, "highway_path")?.["line-color"]).toBe(
+			accent.roadMinor,
+		);
+		expect(paintOf(style, "highway_major_subtle")?.["line-color"]).toBe(
+			accent.roadMinor,
+		);
+		expect(paintOf(style, "highway_motorway_inner")?.["line-color"]).toBe(
+			accent.roadMajor,
+		);
+	});
+
+	it("leaves railways, piers, and aeroways untouched", () => {
+		const style = injectFeatures(baseStyle(), { ...OFF, accent });
+		expect(paintOf(style, "railway_minor")?.["line-color"]).toBeUndefined();
+		expect(paintOf(style, "road_pier")?.["line-color"]).toBeUndefined();
+		expect(paintOf(style, "aeroway-runway")?.["line-color"]).toBeUndefined();
 	});
 
 	it("applies no recolour for a plain (non-accent) style", () => {
@@ -147,6 +231,40 @@ describe("injectFeatures: accent recolour", () => {
 			paint?: Record<string, unknown>;
 		};
 		expect(bg.paint).toBeUndefined();
+		expect(paintOf(style, "building")?.["fill-color"]).toBeUndefined();
+	});
+});
+
+describe("roadClassOrNull", () => {
+	it("classifies highway_/tunnel_ transportation lines", () => {
+		expect(roadClassOrNull(roadLine("highway_motorway_casing"))).toBe("casing");
+		expect(roadClassOrNull(roadLine("highway_minor"))).toBe("minor");
+		expect(roadClassOrNull(roadLine("highway_path"))).toBe("minor");
+		expect(roadClassOrNull(roadLine("highway_major_subtle"))).toBe("minor");
+		expect(roadClassOrNull(roadLine("highway_major_inner"))).toBe("major");
+		expect(roadClassOrNull(roadLine("tunnel_motorway_inner"))).toBe("major");
+	});
+
+	it("returns null outside the highway_/tunnel_ prefixes", () => {
+		expect(roadClassOrNull(roadLine("railway_minor"))).toBeNull();
+		expect(roadClassOrNull(roadLine("road_pier"))).toBeNull();
+	});
+
+	it("returns null for non-line or non-transportation layers", () => {
+		expect(
+			roadClassOrNull({
+				id: "highway_minor",
+				type: "fill",
+				"source-layer": "transportation",
+			} as LayerSpecification),
+		).toBeNull();
+		expect(
+			roadClassOrNull({
+				id: "highway_minor",
+				type: "line",
+				"source-layer": "aeroway",
+			} as LayerSpecification),
+		).toBeNull();
 	});
 });
 

--- a/webmap/src/style.ts
+++ b/webmap/src/style.ts
@@ -6,15 +6,26 @@ export interface AccentColors {
 	background: string;
 	water: string;
 	land: string;
+	roadMajor: string;
+	roadMinor: string;
+	roadCasing: string;
+	building: string;
 }
 
 // The feature merge is parameterised on the page state instead of reading it,
 // so a test can exercise every combination without touching globals.
+// [buildingColor] is the theme-tracked 3D extrusion colour, applied for EVERY
+// scheme (not just ACCENT) so the buildings stay subdued on any base style.
 export interface MapFeatures {
 	buildings: boolean;
 	terrain: boolean;
 	accent: AccentColors | null;
+	buildingColor: string;
 }
+
+// Subdued, see-through buildings: the extrusion must never outshout the roads
+// (the car-nav priority), so it renders semi-transparent in its theme colour.
+export const BUILDING_EXTRUSION_OPACITY = 0.5;
 
 // DEM = Mapterhorn (free, no key); the provider's required credit is shown by
 // the host's Compose attribution overlay when terrain is active.
@@ -44,6 +55,25 @@ export function markerPadTop(
 export function vectorSourceId(style: StyleSpecification): string | undefined {
 	const sources = style.sources ?? {};
 	return Object.keys(sources).find((id) => sources[id].type === "vector");
+}
+
+// Road classification by layer id, shared between the bundled light/dark styles.
+// "subtle" (the low-zoom motorway representation) classifies as minor: in the dark
+// base its colour is identical to highway_minor, and as "major" it would render a
+// casing-less dark hairline on the dark background. Railways, piers, oneway
+// arrows, and aeroways fall outside the highway_/tunnel_ prefixes and keep their
+// base colours. Mirrors roadColorOrNull in MapStyleRecolor.kt — keep in sync.
+export function roadClassOrNull(
+	layer: LayerSpecification,
+): "casing" | "minor" | "major" | null {
+	const sourceLayer = (layer as { "source-layer"?: string })["source-layer"];
+	if (layer.type !== "line" || sourceLayer !== "transportation") return null;
+	if (!layer.id.startsWith("highway_") && !layer.id.startsWith("tunnel_"))
+		return null;
+	if (layer.id.includes("casing")) return "casing";
+	if (["minor", "path", "subtle"].some((k) => layer.id.includes(k)))
+		return "minor";
+	return "major";
 }
 
 // Style-spec paint maps are per-layer-type unions; this helper funnels the few
@@ -79,13 +109,16 @@ export function injectFeatures(
 		delete nextStyle.sources.terrainSource;
 		delete nextStyle.terrain;
 	}
-	// ACCENT scheme: recolour background / water / land fills with the accent
-	// palette, leaving roads + labels legible against the base. Mirrors the
-	// Kotlin recolorAccent in MapPanel.kt — keep the layer groups in sync.
+	// ACCENT scheme: recolour background / water / land / building fills and the
+	// transportation lines with the accent palette. Roads keep their base widths,
+	// so the motorway/major/minor hierarchy survives; labels stay untouched.
+	// Mirrors the Kotlin recolorAccent in MapStyleRecolor.kt — keep the layer
+	// groups and the road classification in sync.
 	const accent = features.accent;
 	if (accent) {
 		for (const l of nextStyle.layers) {
 			const sourceLayer = (l as { "source-layer"?: string })["source-layer"];
+			const roadClass = roadClassOrNull(l);
 			if (l.type === "background")
 				setPaint(l, "background-color", accent.background);
 			else if (l.type === "fill" && sourceLayer === "water")
@@ -96,10 +129,20 @@ export function injectFeatures(
 				ACCENT_LAND.includes(sourceLayer)
 			)
 				setPaint(l, "fill-color", accent.land);
+			else if (l.type === "fill" && sourceLayer === "building")
+				setPaint(l, "fill-color", accent.building);
+			else if (roadClass === "casing")
+				setPaint(l, "line-color", accent.roadCasing);
+			else if (roadClass === "minor")
+				setPaint(l, "line-color", accent.roadMinor);
+			else if (roadClass === "major")
+				setPaint(l, "line-color", accent.roadMajor);
 		}
 	}
 	const src = vectorSourceId(nextStyle);
-	if (features.buildings && src) {
+	// An empty colour would fail MapLibre's style validation, so buildings wait
+	// for the first features push (which always carries the theme colour).
+	if (features.buildings && features.buildingColor && src) {
 		// Insert beneath the first label (symbol) layer so labels stay on top.
 		const firstSymbol = nextStyle.layers.find((l) => l.type === "symbol");
 		const buildings = {
@@ -110,7 +153,7 @@ export function injectFeatures(
 			minzoom: 14,
 			filter: ["!=", ["get", "hide_3d"], true],
 			paint: {
-				"fill-extrusion-color": "#c2c8d0",
+				"fill-extrusion-color": features.buildingColor,
 				"fill-extrusion-height": [
 					"interpolate",
 					["linear"],
@@ -129,7 +172,7 @@ export function injectFeatures(
 					16,
 					["get", "render_min_height"],
 				],
-				"fill-extrusion-opacity": 0.85,
+				"fill-extrusion-opacity": BUILDING_EXTRUSION_OPACITY,
 			},
 		} as LayerSpecification;
 		if (firstSymbol)


### PR DESCRIPTION
## Problem

Emulator review of the map's light/dark rendering surfaced two readability problems:

- **Roads were nearly invisible in both modes.** The ACCENT scheme recolors the background to the theme surface tones but left road line colors from the bundled base styles (Positron-derived white roads / Dark Matter dark road beds), collapsing the luminance relationship those palettes assume — white-on-white in light, dark-on-dark in dark.
- **3D buildings dominated dark maps.** The LIVE fill-extrusion used a hardcoded `#c2c8d0` / opacity `0.85`, theme-blind; in dark mode it was the highest-contrast element on screen, inverting the visual hierarchy (buildings over roads) on a car-nav display.

## Changes

- **Road recolor (ACCENT, both backends).** The recolor now paints transportation lines in three classes — major fill, minor fill, casing — classified by layer-id keywords shared between the bundled styles (`casing` → casing; `minor` / `path` / `subtle` → minor; other `highway_` / `tunnel_` lines → major). Railways, piers, and aeroways keep their base colors. Road widths stay untouched, so the base styles' zoom hierarchy survives.
- **Mode-dependent role mapping** (`accentMapColors(isDark)`, all colors from `MaterialTheme.colorScheme`):
  - Light: near-white roads (`surface`) on a slightly darker ground (`surfaceContainer`, matching the map card surface), `outlineVariant` casing.
  - Dark: the ground drops to the darkest tone (`surface`) and roads brighten above it — ground < buildings < minor (`surfaceContainerHighest`) < major (`outlineVariant`) — so the road network, not the buildings, is the brightest shape on the panel.
- **Theme-tracked, semi-transparent 3D buildings (all schemes).** The extrusion color rides the `setFeatures` bridge and renders at `BUILDING_EXTRUSION_OPACITY = 0.5`, replacing the hardcoded paint. The 2D building fill is recolored under ACCENT only.
- **Refactor.** `recolorAccent` moved from `MapSnapshot.kt` to `MapStyleRecolor.kt` (internal, testable); the webmap bridge grew to `setStyleUrl(url, bg, water, land, roadMajor, roadMinor, roadCasing, building)` and `setFeatures(buildings, terrain, buildingColor)`; the features push gained the same debounce as the style push since the theme cross-fade now churns it.

## Tests

- `webmap/src/style.test.ts`: extended fixture with boundary road layers; flipped the stale "roads untouched" assertion; new cases for road classes, exclusions, building color/opacity, and the empty-color guard (21 pass).
- New `MapStyleRecolorTest.kt` (Robolectric): mirrors the vitest assertions against the Kotlin backend (6 pass).

## Verification

- `./gradlew spotlessCheck assembleDebug lint test` — BUILD SUCCESSFUL.
- `pnpm run check` (biome + tsc + vitest) — green.
- Visual check on the TBox-Mock emulator (LIVE map, 3D buildings, terrain) in both `uimode` settings: roads legible in both modes, buildings subdued below roads in emphasis; non-recolored elements (railways, labels) intact.