### PR TITLE
feat(diagnostics): in-app per-feature diagnostics sheet

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -48,6 +48,7 @@ import io.github.seijikohara.femto.data.system.SystemPermissionSignals
 import io.github.seijikohara.femto.ui.assistant.AssistantOption
 import io.github.seijikohara.femto.ui.assistant.AssistantSheet
 import io.github.seijikohara.femto.ui.common.hideSystemBarsTransiently
+import io.github.seijikohara.femto.ui.diagnostics.DiagnosticsSheet
 import io.github.seijikohara.femto.ui.drawer.AppDrawerSheet
 import io.github.seijikohara.femto.ui.fontpicker.FontPickerSheet
 import io.github.seijikohara.femto.ui.home.HomeEvent
@@ -143,6 +144,8 @@ class MainActivity : ComponentActivity() {
                 var showSettings by rememberSaveable { mutableStateOf(false) }
                 // The font picker opens over settings for one slot at a time; null = closed.
                 var fontPickerSlot by rememberSaveable { mutableStateOf<FontSlot?>(null) }
+                // Diagnostics opens over settings, like the font picker.
+                var showDiagnostics by rememberSaveable { mutableStateOf(false) }
                 HomeRoute(
                     is24Hour = resolveIs24Hour(display.clock),
                     showClockSeconds = display.showClockSeconds,
@@ -216,6 +219,7 @@ class MainActivity : ComponentActivity() {
                         onOpenNotificationAccess = ::openNotificationListenerSettings,
                         onOpenSystemSettings = ::openSystemSettings,
                         onOpenFontPicker = { fontPickerSlot = it },
+                        onOpenDiagnostics = { showDiagnostics = true },
                         onDismiss = { showSettings = false },
                         fullscreen = fullscreen,
                     )
@@ -224,6 +228,12 @@ class MainActivity : ComponentActivity() {
                     FontPickerSheet(
                         slot = slot,
                         onDismiss = { fontPickerSlot = null },
+                        fullscreen = fullscreen,
+                    )
+                }
+                if (showDiagnostics) {
+                    DiagnosticsSheet(
+                        onDismiss = { showDiagnostics = false },
                         fullscreen = fullscreen,
                     )
                 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/music/AudioSpectrumRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/music/AudioSpectrumRepository.kt
@@ -11,13 +11,20 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.withTimeoutOrNull
 
 private const val TAG = "AudioSpectrumRepo"
+
+// Probe window: at the typical 20 Hz capture rate this sees ~40 frames —
+// plenty to tell sustained silence from intermittent signal.
+private const val DIAGNOSIS_WINDOW_MS = 2_000L
 
 /**
  * Streams per-band spectrum levels of whatever audio the device is playing,
@@ -44,6 +51,26 @@ internal class AudioSpectrumRepository(
         activeFlow
             .distinctUntilChanged()
             .flatMapLatest { active -> if (active) captureFlow() else flowOf(null) }
+
+    /**
+     * Probe the capture path for a short window and classify what came back
+     * (see [SpectrumDiagnosis]). Runs its own short-lived Visualizer; safe
+     * to call while the rendering capture is active — multiple handles on
+     * the output mix coexist. Stops early on the first decisive emission
+     * (an engine failure or a clear signal).
+     */
+    suspend fun diagnose(): SpectrumDiagnosis {
+        if (!context.hasRecordAudioPermission()) return SpectrumDiagnosis.NO_PERMISSION
+        val emissions = mutableListOf<FloatArray?>()
+        withTimeoutOrNull(DIAGNOSIS_WINDOW_MS) {
+            captureFlow()
+                .takeWhile { bands ->
+                    emissions += bands
+                    bands != null && bands.none { it > DIAGNOSIS_SIGNAL_LEVEL }
+                }.collect()
+        }
+        return classifySpectrumProbe(emissions)
+    }
 
     private fun captureFlow(): Flow<FloatArray?> =
         callbackFlow {

--- a/app/src/main/java/io/github/seijikohara/femto/data/music/SpectrumDiagnosis.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/music/SpectrumDiagnosis.kt
@@ -1,0 +1,31 @@
+package io.github.seijikohara.femto.data.music
+
+/**
+ * Outcome of a short spectrum-capture probe, surfaced as the Music spectrum
+ * setting's live status line. The visualization fails silently by design
+ * (a flat strip), so without this readout a head-unit user cannot tell a
+ * missing grant from an unsupported audio HAL from a player whose stream
+ * bypasses the mixer — and neither can we without adb access.
+ */
+internal enum class SpectrumDiagnosis { NO_PERMISSION, ENGINE_UNAVAILABLE, SILENT, ACTIVE }
+
+// A band level above this counts as real signal; well above the dB floor's
+// quantization noise yet far below any audible content's normalized level.
+internal const val DIAGNOSIS_SIGNAL_LEVEL = 0.02f
+
+/**
+ * Classify a probe window's capture emissions. `null` emissions mark an
+ * engine that refused to start (permission is pre-checked by the caller);
+ * an empty window — no capture callbacks at all — reads as [SpectrumDiagnosis.SILENT]
+ * because the engine constructed but produced nothing to render.
+ */
+internal fun classifySpectrumProbe(emissions: List<FloatArray?>): SpectrumDiagnosis =
+    when {
+        emissions.any { it == null } -> SpectrumDiagnosis.ENGINE_UNAVAILABLE
+
+        emissions.any { bands ->
+            bands != null && bands.any { it > DIAGNOSIS_SIGNAL_LEVEL }
+        } -> SpectrumDiagnosis.ACTIVE
+
+        else -> SpectrumDiagnosis.SILENT
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/data/system/DiagnosticsRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/system/DiagnosticsRepository.kt
@@ -103,7 +103,17 @@ internal class DiagnosticsRepository(
                 .start()
                 .inputStream
                 .bufferedReader()
-                .useLines { lines -> lines.toList().takeLast(MAX_LOG_LINES) }
+                // Stream into a bounded tail: the dump can run to megabytes
+                // on a chatty device, and only the newest lines matter.
+                .useLines { lines ->
+                    lines
+                        .fold(ArrayDeque<String>(MAX_LOG_LINES)) { tail, line ->
+                            tail.also {
+                                if (it.size == MAX_LOG_LINES) it.removeFirst()
+                                it.addLast(line)
+                            }
+                        }.toList()
+                }
         }.onFailure { Log.w(TAG, "self logcat read failed; diagnostics omit the log tail", it) }
             .getOrDefault(emptyList())
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/system/DiagnosticsRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/system/DiagnosticsRepository.kt
@@ -1,0 +1,109 @@
+package io.github.seijikohara.femto.data.system
+
+import android.Manifest
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.getSystemService
+import io.github.seijikohara.femto.BuildConfig
+import io.github.seijikohara.femto.data.location.hasBluetoothConnectPermission
+import io.github.seijikohara.femto.data.location.hasCoarseLocationPermission
+import io.github.seijikohara.femto.data.location.hasFineLocationPermission
+import io.github.seijikohara.femto.data.location.hasReadCalendarPermission
+import io.github.seijikohara.femto.data.location.hasReadPhoneStatePermission
+import io.github.seijikohara.femto.data.location.hasRecordAudioPermission
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val TAG = "DiagnosticsRepo"
+
+// Enough tail to cover the warnings of a feature being exercised right now
+// without turning the report into a novel.
+private const val MAX_LOG_LINES = 80
+
+/** One runtime grant's state, keyed by the full permission constant. */
+internal data class DiagnosticPermission(
+    val permission: String,
+    val granted: Boolean,
+)
+
+/** A point-in-time health capture of everything the dashboard depends on. */
+internal data class DiagnosticsSnapshot(
+    val appVersion: String,
+    val deviceModel: String,
+    val androidRelease: String,
+    val sdkInt: Int,
+    val permissions: List<DiagnosticPermission>,
+    val notificationListenerEnabled: Boolean,
+    val networkOnline: Boolean,
+    val networkTransports: List<String>,
+    val recentWarningLogs: List<String>,
+)
+
+/**
+ * Collects the diagnostics snapshot for the in-app Diagnostics screen.
+ *
+ * Exists because the deployed head units are rarely adb-reachable: every
+ * launcher feature degrades silently by design (missing grant, disabled
+ * listener, unsupported HAL, rate-limited API), and without this surface
+ * neither the user nor a remote debugging session can tell which gate is
+ * closed. The recent-warnings tail relies on `logcat -d` returning the
+ * calling app's own lines without `READ_LOGS` (uid-filtered since
+ * Android 4.1); on builds that restrict even that, the section degrades to
+ * empty with one WARN.
+ */
+internal class DiagnosticsRepository(
+    private val context: Context,
+) {
+    suspend fun snapshot(): DiagnosticsSnapshot =
+        withContext(Dispatchers.IO) {
+            DiagnosticsSnapshot(
+                appVersion = "${BuildConfig.VERSION_NAME} (${if (BuildConfig.DEBUG) "debug" else "release"})",
+                deviceModel = "${Build.MANUFACTURER} ${Build.MODEL}",
+                androidRelease = Build.VERSION.RELEASE,
+                sdkInt = Build.VERSION.SDK_INT,
+                permissions = permissionStates(),
+                notificationListenerEnabled =
+                    context.packageName in NotificationManagerCompat.getEnabledListenerPackages(context),
+                networkOnline =
+                    networkCapabilities()?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) == true,
+                networkTransports = networkCapabilities()?.transportLabels().orEmpty(),
+                recentWarningLogs = recentWarningLogsOrEmpty(),
+            )
+        }
+
+    private fun permissionStates(): List<DiagnosticPermission> =
+        listOf(
+            DiagnosticPermission(Manifest.permission.ACCESS_FINE_LOCATION, context.hasFineLocationPermission()),
+            DiagnosticPermission(Manifest.permission.ACCESS_COARSE_LOCATION, context.hasCoarseLocationPermission()),
+            DiagnosticPermission(Manifest.permission.READ_CALENDAR, context.hasReadCalendarPermission()),
+            DiagnosticPermission(Manifest.permission.READ_PHONE_STATE, context.hasReadPhoneStatePermission()),
+            DiagnosticPermission(Manifest.permission.BLUETOOTH_CONNECT, context.hasBluetoothConnectPermission()),
+            DiagnosticPermission(Manifest.permission.RECORD_AUDIO, context.hasRecordAudioPermission()),
+        )
+
+    private fun networkCapabilities(): NetworkCapabilities? =
+        context.getSystemService<ConnectivityManager>()?.let { it.getNetworkCapabilities(it.activeNetwork) }
+
+    private fun NetworkCapabilities.transportLabels(): List<String> =
+        listOfNotNull(
+            "Wi-Fi".takeIf { hasTransport(NetworkCapabilities.TRANSPORT_WIFI) },
+            "Cellular".takeIf { hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) },
+            "Ethernet".takeIf { hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) },
+            "Bluetooth".takeIf { hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH) },
+        )
+
+    private fun recentWarningLogsOrEmpty(): List<String> =
+        runCatching {
+            ProcessBuilder("logcat", "-d", "-v", "time", "*:W")
+                .redirectErrorStream(true)
+                .start()
+                .inputStream
+                .bufferedReader()
+                .useLines { lines -> lines.toList().takeLast(MAX_LOG_LINES) }
+        }.onFailure { Log.w(TAG, "self logcat read failed; diagnostics omit the log tail", it) }
+            .getOrDefault(emptyList())
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReport.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReport.kt
@@ -1,0 +1,60 @@
+package io.github.seijikohara.femto.ui.diagnostics
+
+import io.github.seijikohara.femto.data.music.MusicCardState
+
+/**
+ * Render the diagnostics state as a plain-text report for the clipboard.
+ *
+ * Deliberately English and unlocalized: the report is a debug artifact meant
+ * to be pasted into an issue or a remote debugging session, where stable
+ * machine-greppable wording beats locale fidelity. Pure, so the exact shape
+ * is pinned by JVM tests.
+ */
+internal fun diagnosticsReport(uiState: DiagnosticsUiState): String =
+    buildString {
+        appendLine("== Femto Car Launcher diagnostics ==")
+        uiState.snapshot?.let { snapshot ->
+            appendLine("App: ${snapshot.appVersion}")
+            appendLine("Device: ${snapshot.deviceModel} / Android ${snapshot.androidRelease} (API ${snapshot.sdkInt})")
+            appendLine("-- Permissions --")
+            snapshot.permissions.forEach { state ->
+                appendLine("${state.permission.substringAfterLast('.')}: ${if (state.granted) "granted" else "DENIED"}")
+            }
+            appendLine("Notification listener: ${if (snapshot.notificationListenerEnabled) "enabled" else "DISABLED"}")
+            appendLine("-- Network --")
+            appendLine(
+                if (snapshot.networkOnline) {
+                    "Online (${snapshot.networkTransports.joinToString().ifEmpty { "unknown transport" }})"
+                } else {
+                    "OFFLINE"
+                },
+            )
+        } ?: appendLine("Snapshot UNAVAILABLE (collection failed; see app logs)")
+        appendLine("-- Music --")
+        appendLine("Session: ${uiState.musicState.described()}")
+        appendLine("Spectrum capture: ${uiState.spectrum?.name ?: "not probed"}")
+        uiState.snapshot?.recentWarningLogs?.let { logs ->
+            appendLine("-- Recent warnings (${logs.size}) --")
+            logs.forEach(::appendLine)
+        }
+    }
+
+/** One-line session description shared by the report and the screen row. */
+internal fun MusicCardState?.described(): String =
+    when (this) {
+        is MusicCardState.Playing -> {
+            "${nowPlaying.packageName} (${if (nowPlaying.isPlaying) "playing" else "paused"})"
+        }
+
+        MusicCardState.NoActiveSession -> {
+            "no active session"
+        }
+
+        MusicCardState.NeedsPermission -> {
+            "notification listener NOT granted"
+        }
+
+        null -> {
+            "unknown"
+        }
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsRoute.kt
@@ -1,0 +1,36 @@
+package io.github.seijikohara.femto.ui.diagnostics
+
+import android.content.ClipData
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.launch
+
+@Composable
+internal fun DiagnosticsRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val viewModel: DiagnosticsViewModel = viewModel(factory = DiagnosticsViewModelFactory)
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    DiagnosticsScreen(
+        uiState = uiState,
+        onAction = viewModel::onAction,
+        onBack = onBack,
+        onCopyReport = {
+            scope.launch {
+                clipboard.setClipEntry(
+                    ClipEntry(ClipData.newPlainText("Femto diagnostics", diagnosticsReport(uiState))),
+                )
+            }
+        },
+        modifier = modifier,
+    )
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
@@ -59,20 +59,27 @@ internal fun DiagnosticsScreen(
         onAction = onAction,
         onCopyReport = onCopyReport,
     )
+    // The music rows render outside the snapshot gate: the probes degrade
+    // independently in the ViewModel, and a broken snapshot collector must
+    // not hide the spectrum verdict — the broken device is exactly where
+    // this screen earns its keep.
     uiState.snapshot?.let { snapshot ->
         BuildSection(snapshot)
         PermissionsSection(snapshot)
         MusicSection(uiState)
         NetworkSection(snapshot)
         LogsSection(snapshot.recentWarningLogs)
-    } ?: Text(
-        text =
-            stringResource(
-                if (uiState.isLoading) R.string.diagnostics_loading else R.string.diagnostics_unavailable,
-            ),
-        style = MaterialTheme.typography.bodyLarge,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
+    } ?: run {
+        Text(
+            text =
+                stringResource(
+                    if (uiState.isLoading) R.string.diagnostics_loading else R.string.diagnostics_unavailable,
+                ),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        MusicSection(uiState)
+    }
 }
 
 @Composable

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
@@ -1,0 +1,281 @@
+package io.github.seijikohara.femto.ui.diagnostics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.Lucide
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.music.SpectrumDiagnosis
+import io.github.seijikohara.femto.data.system.DiagnosticsSnapshot
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+
+/**
+ * Per-feature health readout: which gate (grant, listener, capture engine,
+ * network) is blocking which dashboard feature, plus the app's own recent
+ * warning logs. The launcher degrades silently by design, and deployed head
+ * units are rarely adb-reachable — this screen plus the copyable report is
+ * the remote-debugging surface.
+ */
+@Composable
+internal fun DiagnosticsScreen(
+    uiState: DiagnosticsUiState,
+    onAction: (DiagnosticsAction) -> Unit,
+    onBack: () -> Unit,
+    onCopyReport: () -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier =
+        modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 12.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+) {
+    Header(onBack = onBack)
+    ActionButtons(
+        isLoading = uiState.isLoading,
+        onAction = onAction,
+        onCopyReport = onCopyReport,
+    )
+    uiState.snapshot?.let { snapshot ->
+        BuildSection(snapshot)
+        PermissionsSection(snapshot)
+        MusicSection(uiState)
+        NetworkSection(snapshot)
+        LogsSection(snapshot.recentWarningLogs)
+    } ?: Text(
+        text =
+            stringResource(
+                if (uiState.isLoading) R.string.diagnostics_loading else R.string.diagnostics_unavailable,
+            ),
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun Header(onBack: () -> Unit) =
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        IconButton(onClick = onBack, modifier = Modifier.size(FemtoDimens.MinTouchTarget)) {
+            Icon(
+                imageVector = Lucide.ArrowLeft,
+                contentDescription = stringResource(R.string.settings_back),
+                tint = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.size(28.dp),
+            )
+        }
+        Text(
+            text = stringResource(R.string.diagnostics_title),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+    }
+
+@Composable
+private fun ActionButtons(
+    isLoading: Boolean,
+    onAction: (DiagnosticsAction) -> Unit,
+    onCopyReport: () -> Unit,
+) = Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+) {
+    Button(
+        onClick = { onAction(DiagnosticsAction.Refresh) },
+        enabled = !isLoading,
+        modifier = Modifier.weight(1f).heightIn(min = FemtoDimens.MinTouchTarget),
+    ) {
+        Text(
+            text =
+                stringResource(
+                    if (isLoading) R.string.diagnostics_loading else R.string.diagnostics_refresh,
+                ),
+        )
+    }
+    OutlinedButton(
+        onClick = onCopyReport,
+        modifier = Modifier.weight(1f).heightIn(min = FemtoDimens.MinTouchTarget),
+    ) {
+        Text(text = stringResource(R.string.diagnostics_copy))
+    }
+}
+
+@Composable
+private fun BuildSection(snapshot: DiagnosticsSnapshot) =
+    Section(title = stringResource(R.string.diagnostics_section_build)) {
+        ValueRow(label = snapshot.appVersion)
+        ValueRow(label = "${snapshot.deviceModel} / Android ${snapshot.androidRelease} (API ${snapshot.sdkInt})")
+    }
+
+@Composable
+private fun PermissionsSection(snapshot: DiagnosticsSnapshot) =
+    Section(title = stringResource(R.string.diagnostics_section_permissions)) {
+        snapshot.permissions.forEach { state ->
+            StatusRow(
+                label = state.permission.substringAfterLast('.'),
+                value =
+                    stringResource(
+                        if (state.granted) R.string.diagnostics_granted else R.string.diagnostics_denied,
+                    ),
+                healthy = state.granted,
+            )
+        }
+        StatusRow(
+            label = stringResource(R.string.diagnostics_listener),
+            value =
+                stringResource(
+                    if (snapshot.notificationListenerEnabled) {
+                        R.string.diagnostics_enabled
+                    } else {
+                        R.string.diagnostics_disabled
+                    },
+                ),
+            healthy = snapshot.notificationListenerEnabled,
+        )
+    }
+
+@Composable
+private fun MusicSection(uiState: DiagnosticsUiState) =
+    Section(title = stringResource(R.string.diagnostics_section_music)) {
+        ValueRow(label = stringResource(R.string.diagnostics_music_session, uiState.musicState.described()))
+        StatusRow(
+            label = stringResource(R.string.diagnostics_spectrum),
+            value = spectrumLabel(uiState.spectrum),
+            healthy = uiState.spectrum == SpectrumDiagnosis.ACTIVE,
+        )
+        Text(
+            text = stringResource(R.string.diagnostics_spectrum_hint),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+@Composable
+private fun NetworkSection(snapshot: DiagnosticsSnapshot) =
+    Section(title = stringResource(R.string.diagnostics_section_network)) {
+        StatusRow(
+            label = stringResource(R.string.diagnostics_network),
+            value =
+                if (snapshot.networkOnline) {
+                    stringResource(R.string.diagnostics_online, snapshot.networkTransports.joinToString())
+                } else {
+                    stringResource(R.string.diagnostics_offline)
+                },
+            healthy = snapshot.networkOnline,
+        )
+    }
+
+@Composable
+private fun LogsSection(logs: List<String>) =
+    Section(title = stringResource(R.string.diagnostics_section_logs, logs.size)) {
+        if (logs.isEmpty()) {
+            Text(
+                text = stringResource(R.string.diagnostics_logs_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            logs.forEach { line ->
+                // Log lines are glance metadata, not dashboard body text, so
+                // they take the sanctioned GlanceTextSize relaxation.
+                Text(
+                    text = line,
+                    style =
+                        MaterialTheme.typography.bodySmall.copy(
+                            fontSize = FemtoDimens.GlanceTextSize,
+                            fontFamily = FontFamily.Monospace,
+                        ),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+
+@Composable
+private fun Section(
+    title: String,
+    content: @Composable () -> Unit,
+) = Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+    Text(
+        text = title,
+        // Same section-title voice as the settings sections this sheet
+        // opens from.
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+    )
+    content()
+}
+
+@Composable
+private fun ValueRow(label: String) =
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+
+@Composable
+private fun StatusRow(
+    label: String,
+    value: String,
+    healthy: Boolean,
+) = Row(modifier = Modifier.fillMaxWidth()) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.weight(1f),
+    )
+    Text(
+        text = value,
+        style = MaterialTheme.typography.bodyLarge,
+        color = if (healthy) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+    )
+}
+
+@Composable
+private fun spectrumLabel(diagnosis: SpectrumDiagnosis?): String =
+    stringResource(
+        when (diagnosis) {
+            SpectrumDiagnosis.ACTIVE -> R.string.diagnostics_spectrum_active
+            SpectrumDiagnosis.SILENT -> R.string.diagnostics_spectrum_silent
+            SpectrumDiagnosis.ENGINE_UNAVAILABLE -> R.string.diagnostics_spectrum_engine
+            SpectrumDiagnosis.NO_PERMISSION -> R.string.diagnostics_spectrum_no_permission
+            null -> R.string.diagnostics_spectrum_not_probed
+        },
+    )
+
+@PreviewLightDark
+@Composable
+private fun DiagnosticsScreenPreview() {
+    FemtoTheme {
+        DiagnosticsScreen(
+            uiState = DiagnosticsUiState.Initial,
+            onAction = {},
+            onBack = {},
+            onCopyReport = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsSheet.kt
@@ -1,0 +1,44 @@
+package io.github.seijikohara.femto.ui.diagnostics
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+
+/**
+ * The Diagnostics screen as a Material 3 [ModalBottomSheet] over settings,
+ * mirroring the font-picker hosting. Starts expanded — the point is reading
+ * a report, not peeking at one.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DiagnosticsSheet(
+    onDismiss: () -> Unit,
+    fullscreen: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        ImmersiveSheetEffect(fullscreen)
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(sheetHeight),
+        ) {
+            DiagnosticsRoute(onBack = onDismiss)
+        }
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsUiState.kt
@@ -1,0 +1,24 @@
+package io.github.seijikohara.femto.ui.diagnostics
+
+import io.github.seijikohara.femto.data.music.MusicCardState
+import io.github.seijikohara.femto.data.music.SpectrumDiagnosis
+import io.github.seijikohara.femto.data.system.DiagnosticsSnapshot
+
+internal data class DiagnosticsUiState(
+    val isLoading: Boolean = true,
+    // null until the first collection lands (or when it failed — the screen
+    // shows the unavailable row and the report says so explicitly).
+    val snapshot: DiagnosticsSnapshot? = null,
+    // null until the first probe completes; the probe is only meaningful
+    // while music is playing, which the screen calls out.
+    val spectrum: SpectrumDiagnosis? = null,
+    val musicState: MusicCardState? = null,
+) {
+    companion object {
+        val Initial: DiagnosticsUiState = DiagnosticsUiState()
+    }
+}
+
+internal sealed interface DiagnosticsAction {
+    data object Refresh : DiagnosticsAction
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsViewModel.kt
@@ -1,0 +1,98 @@
+package io.github.seijikohara.femto.ui.diagnostics
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.seijikohara.femto.data.common.WhileUiSubscribed
+import io.github.seijikohara.femto.data.music.AudioSpectrumRepository
+import io.github.seijikohara.femto.data.music.MusicCardState
+import io.github.seijikohara.femto.data.music.MusicSessionRepository
+import io.github.seijikohara.femto.data.music.SpectrumDiagnosis
+import io.github.seijikohara.femto.data.system.DiagnosticsRepository
+import io.github.seijikohara.femto.data.system.DiagnosticsSnapshot
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+private const val TAG = "DiagnosticsViewModel"
+
+/**
+ * Owns the Diagnostics screen state: an on-demand snapshot + spectrum probe
+ * (action-driven) merged with the live music-session state (flow-derived).
+ * Dependencies are plain seams so JVM tests drive every transition without
+ * Android types.
+ */
+internal class DiagnosticsViewModel(
+    private val collectSnapshot: suspend () -> DiagnosticsSnapshot,
+    private val probeSpectrum: suspend () -> SpectrumDiagnosis,
+    musicStateFlow: Flow<MusicCardState>,
+) : ViewModel() {
+    private val probes = MutableStateFlow(DiagnosticsUiState.Initial)
+
+    val uiState: StateFlow<DiagnosticsUiState> =
+        combine(
+            probes,
+            musicStateFlow.catch { e ->
+                if (e is CancellationException) throw e
+                // Degrade the row, keep the rest of the report usable.
+                Log.e(TAG, "music state flow failed", e)
+                emit(MusicCardState.NoActiveSession)
+            },
+        ) { probed, music -> probed.copy(musicState = music) }
+            .stateIn(viewModelScope, WhileUiSubscribed, DiagnosticsUiState.Initial)
+
+    init {
+        refresh()
+    }
+
+    fun onAction(action: DiagnosticsAction) =
+        when (action) {
+            DiagnosticsAction.Refresh -> refresh()
+        }
+
+    private fun refresh() {
+        probes.update { it.copy(isLoading = true) }
+        viewModelScope.launch {
+            // Each probe degrades to null independently so a broken collector
+            // never hides the other one's findings — this screen exists to
+            // surface failure, not to add its own silent variety.
+            val snapshot = runCatchingOrNull("snapshot") { collectSnapshot() }
+            val spectrum = runCatchingOrNull("spectrum probe") { probeSpectrum() }
+            probes.update { it.copy(isLoading = false, snapshot = snapshot, spectrum = spectrum) }
+        }
+    }
+
+    private inline fun <T> runCatchingOrNull(
+        label: String,
+        block: () -> T,
+    ): T? =
+        runCatching(block)
+            .onFailure {
+                // runCatching also traps cancellation; rethrow to keep
+                // structured concurrency intact (AppDrawerViewModel precedent).
+                if (it is CancellationException) throw it
+                Log.e(TAG, "$label failed", it)
+            }.getOrNull()
+}
+
+/** Wires the production repositories without an UNCHECKED_CAST factory. */
+internal val DiagnosticsViewModelFactory: ViewModelProvider.Factory =
+    viewModelFactory {
+        initializer {
+            val application = checkNotNull(this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
+            DiagnosticsViewModel(
+                collectSnapshot = DiagnosticsRepository(application)::snapshot,
+                probeSpectrum = AudioSpectrumRepository(application)::diagnose,
+                musicStateFlow = MusicSessionRepository(application).stateFlow(),
+            )
+        }
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsRoute.kt
@@ -26,6 +26,7 @@ internal fun SettingsRoute(
     onOpenNotificationAccess: () -> Unit,
     onOpenSystemSettings: () -> Unit,
     onOpenFontPicker: (FontSlot) -> Unit,
+    onOpenDiagnostics: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -61,6 +62,7 @@ internal fun SettingsRoute(
         onOpenNotificationAccess = onOpenNotificationAccess,
         onOpenSystemSettings = onOpenSystemSettings,
         onOpenFontPicker = onOpenFontPicker,
+        onOpenDiagnostics = onOpenDiagnostics,
         modifier = modifier,
     )
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -91,6 +91,7 @@ internal fun SettingsScreen(
     onOpenNotificationAccess: () -> Unit,
     onOpenSystemSettings: () -> Unit,
     onOpenFontPicker: (FontSlot) -> Unit,
+    onOpenDiagnostics: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier.fillMaxSize(),
@@ -417,6 +418,10 @@ internal fun SettingsScreen(
             ActionRow(
                 title = stringResource(R.string.settings_open_system_settings),
                 onClick = onOpenSystemSettings,
+            )
+            ActionRow(
+                title = stringResource(R.string.settings_open_diagnostics),
+                onClick = onOpenDiagnostics,
             )
             ResetRow(onConfirm = { onAction(SettingsAction.ResetToDefaults) })
         }
@@ -905,6 +910,7 @@ private fun SettingsScreenPreview() {
             onOpenNotificationAccess = {},
             onOpenSystemSettings = {},
             onOpenFontPicker = {},
+            onOpenDiagnostics = {},
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
@@ -32,6 +32,7 @@ internal fun SettingsSheet(
     onOpenNotificationAccess: () -> Unit,
     onOpenSystemSettings: () -> Unit,
     onOpenFontPicker: (FontSlot) -> Unit,
+    onOpenDiagnostics: () -> Unit,
     onDismiss: () -> Unit,
     fullscreen: Boolean,
     modifier: Modifier = Modifier,
@@ -53,6 +54,7 @@ internal fun SettingsSheet(
                 onOpenNotificationAccess = onOpenNotificationAccess,
                 onOpenSystemSettings = onOpenSystemSettings,
                 onOpenFontPicker = onOpenFontPicker,
+                onOpenDiagnostics = onOpenDiagnostics,
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,36 @@
     <string name="settings_panel_music_spectrum_desc">Show a spectrum of the playing audio behind the playback controls; uses the audio-capture (microphone) permission.</string>
     <string name="settings_open_notification_access">Notification access</string>
     <string name="settings_open_system_settings">System settings</string>
+    <string name="settings_open_diagnostics">Diagnostics</string>
+
+    <!-- Diagnostics sheet -->
+    <string name="diagnostics_title">Diagnostics</string>
+    <string name="diagnostics_refresh">Refresh</string>
+    <string name="diagnostics_loading">Collecting…</string>
+    <string name="diagnostics_copy">Copy report</string>
+    <string name="diagnostics_unavailable">Diagnostics collection failed; see the app logs.</string>
+    <string name="diagnostics_section_build">Build</string>
+    <string name="diagnostics_section_permissions">Permissions</string>
+    <string name="diagnostics_section_music">Music</string>
+    <string name="diagnostics_section_network">Network</string>
+    <string name="diagnostics_section_logs">Recent warnings (%1$d)</string>
+    <string name="diagnostics_granted">Granted</string>
+    <string name="diagnostics_denied">Denied</string>
+    <string name="diagnostics_enabled">Enabled</string>
+    <string name="diagnostics_disabled">Disabled</string>
+    <string name="diagnostics_listener">Notification listener</string>
+    <string name="diagnostics_music_session">Session: %1$s</string>
+    <string name="diagnostics_spectrum">Spectrum capture</string>
+    <string name="diagnostics_spectrum_active">Signal detected</string>
+    <string name="diagnostics_spectrum_silent">Running, stream silent</string>
+    <string name="diagnostics_spectrum_engine">Engine unavailable</string>
+    <string name="diagnostics_spectrum_no_permission">No mic permission</string>
+    <string name="diagnostics_spectrum_not_probed">Not probed</string>
+    <string name="diagnostics_spectrum_hint">Probe the spectrum while music is playing: silence here with an active session means the player bypasses the audio mixer.</string>
+    <string name="diagnostics_network">Connectivity</string>
+    <string name="diagnostics_online">Online (%1$s)</string>
+    <string name="diagnostics_offline">Offline</string>
+    <string name="diagnostics_logs_empty">No recent warnings, or log access is restricted on this device.</string>
     <string name="settings_reset_to_defaults">Reset to defaults</string>
     <string name="settings_reset_confirm_title">Reset all settings?</string>
     <string name="settings_reset_confirm_message">This restores every display, unit, map, location, panel and font setting to its default value.</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/music/SpectrumDiagnosisTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/music/SpectrumDiagnosisTest.kt
@@ -1,0 +1,51 @@
+package io.github.seijikohara.femto.data.music
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SpectrumDiagnosisTest {
+    @Test
+    fun `a null emission classifies as engine unavailable`() {
+        assertEquals(
+            SpectrumDiagnosis.ENGINE_UNAVAILABLE,
+            classifySpectrumProbe(listOf(null)),
+        )
+    }
+
+    @Test
+    fun `a null emission wins over later signal`() {
+        assertEquals(
+            SpectrumDiagnosis.ENGINE_UNAVAILABLE,
+            classifySpectrumProbe(listOf(null, floatArrayOf(0.5f))),
+        )
+    }
+
+    @Test
+    fun `any band above the signal level classifies as active`() {
+        assertEquals(
+            SpectrumDiagnosis.ACTIVE,
+            classifySpectrumProbe(listOf(FloatArray(20), floatArrayOf(0f, DIAGNOSIS_SIGNAL_LEVEL + 0.01f))),
+        )
+    }
+
+    @Test
+    fun `all-zero frames classify as silent`() {
+        assertEquals(
+            SpectrumDiagnosis.SILENT,
+            classifySpectrumProbe(listOf(FloatArray(20), FloatArray(20))),
+        )
+    }
+
+    @Test
+    fun `levels at or below the threshold stay silent`() {
+        assertEquals(
+            SpectrumDiagnosis.SILENT,
+            classifySpectrumProbe(listOf(floatArrayOf(DIAGNOSIS_SIGNAL_LEVEL))),
+        )
+    }
+
+    @Test
+    fun `an empty window classifies as silent`() {
+        assertEquals(SpectrumDiagnosis.SILENT, classifySpectrumProbe(emptyList()))
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDiagnosticsSnapshot.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDiagnosticsSnapshot.kt
@@ -1,0 +1,28 @@
+package io.github.seijikohara.femto.testfixtures
+
+import android.Manifest
+import io.github.seijikohara.femto.data.system.DiagnosticPermission
+import io.github.seijikohara.femto.data.system.DiagnosticsSnapshot
+
+internal fun fakeDiagnosticsSnapshot(
+    permissions: List<DiagnosticPermission> =
+        listOf(
+            DiagnosticPermission(Manifest.permission.ACCESS_FINE_LOCATION, granted = true),
+            DiagnosticPermission(Manifest.permission.RECORD_AUDIO, granted = false),
+        ),
+    notificationListenerEnabled: Boolean = true,
+    networkOnline: Boolean = true,
+    networkTransports: List<String> = listOf("Wi-Fi"),
+    recentWarningLogs: List<String> = listOf("06-12 12:00:00.000 W/AudioSpectrumRepo: sample warning"),
+): DiagnosticsSnapshot =
+    DiagnosticsSnapshot(
+        appVersion = "1.0 (debug)",
+        deviceModel = "Acme TBox",
+        androidRelease = "13",
+        sdkInt = 33,
+        permissions = permissions,
+        notificationListenerEnabled = notificationListenerEnabled,
+        networkOnline = networkOnline,
+        networkTransports = networkTransports,
+        recentWarningLogs = recentWarningLogs,
+    )

--- a/app/src/test/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReportTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReportTest.kt
@@ -1,0 +1,56 @@
+package io.github.seijikohara.femto.ui.diagnostics
+
+import io.github.seijikohara.femto.data.music.MusicCardState
+import io.github.seijikohara.femto.data.music.SpectrumDiagnosis
+import io.github.seijikohara.femto.testfixtures.fakeDiagnosticsSnapshot
+import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class DiagnosticsReportTest {
+    @Test
+    fun `report carries permission states with denied flagged loudly`() {
+        val report =
+            diagnosticsReport(
+                DiagnosticsUiState(isLoading = false, snapshot = fakeDiagnosticsSnapshot()),
+            )
+        assertTrue(report.contains("ACCESS_FINE_LOCATION: granted"))
+        assertTrue(report.contains("RECORD_AUDIO: DENIED"))
+    }
+
+    @Test
+    fun `report names the playing session and the probe verdict`() {
+        val report =
+            diagnosticsReport(
+                DiagnosticsUiState(
+                    isLoading = false,
+                    snapshot = fakeDiagnosticsSnapshot(),
+                    spectrum = SpectrumDiagnosis.SILENT,
+                    musicState = MusicCardState.Playing(fakeNowPlaying()),
+                ),
+            )
+        assertTrue(report.contains("com.spotify.music (playing)"))
+        assertTrue(report.contains("Spectrum capture: SILENT"))
+    }
+
+    @Test
+    fun `report includes the log tail with its count`() {
+        val report =
+            diagnosticsReport(
+                DiagnosticsUiState(isLoading = false, snapshot = fakeDiagnosticsSnapshot()),
+            )
+        assertTrue(report.contains("Recent warnings (1)"))
+        assertTrue(report.contains("sample warning"))
+    }
+
+    @Test
+    fun `a missing snapshot is reported explicitly`() {
+        val report = diagnosticsReport(DiagnosticsUiState(isLoading = false, snapshot = null))
+        assertTrue(report.contains("Snapshot UNAVAILABLE"))
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsViewModelTest.kt
@@ -1,0 +1,95 @@
+package io.github.seijikohara.femto.ui.diagnostics
+
+import app.cash.turbine.test
+import io.github.seijikohara.femto.data.music.MusicCardState
+import io.github.seijikohara.femto.data.music.SpectrumDiagnosis
+import io.github.seijikohara.femto.testfixtures.fakeDiagnosticsSnapshot
+import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class DiagnosticsViewModelTest {
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `refresh lands the snapshot and the spectrum probe in uiState`() =
+        runTest {
+            val snapshot = fakeDiagnosticsSnapshot()
+            val viewModel =
+                DiagnosticsViewModel(
+                    collectSnapshot = { snapshot },
+                    probeSpectrum = { SpectrumDiagnosis.SILENT },
+                    musicStateFlow = flowOf(MusicCardState.Playing(fakeNowPlaying())),
+                )
+            viewModel.uiState.test {
+                val state = awaitItem()
+                assertFalse(state.isLoading)
+                assertEquals(snapshot, state.snapshot)
+                assertEquals(SpectrumDiagnosis.SILENT, state.spectrum)
+                assertEquals(MusicCardState.Playing(fakeNowPlaying()), state.musicState)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `a failing snapshot degrades to null without hiding the probe`() =
+        runTest {
+            val viewModel =
+                DiagnosticsViewModel(
+                    collectSnapshot = { error("collector broke") },
+                    probeSpectrum = { SpectrumDiagnosis.ENGINE_UNAVAILABLE },
+                    musicStateFlow = flowOf(MusicCardState.NoActiveSession),
+                )
+            viewModel.uiState.test {
+                val state = awaitItem()
+                assertEquals(null, state.snapshot)
+                assertEquals(SpectrumDiagnosis.ENGINE_UNAVAILABLE, state.spectrum)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Refresh action re-runs the probes`() =
+        runTest {
+            var probes = 0
+            val viewModel =
+                DiagnosticsViewModel(
+                    collectSnapshot = { fakeDiagnosticsSnapshot() },
+                    probeSpectrum = {
+                        probes++
+                        SpectrumDiagnosis.ACTIVE
+                    },
+                    musicStateFlow = flowOf(MusicCardState.NoActiveSession),
+                )
+            viewModel.uiState.test {
+                awaitItem()
+                viewModel.onAction(DiagnosticsAction.Refresh)
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertEquals(2, probes)
+        }
+}


### PR DESCRIPTION
## Summary

Adds a Diagnostics sheet (Settings → System → Diagnostics) that reports which gate is blocking which dashboard feature, plus a copy-to-clipboard plain-text report. Motivated by a live field issue: the spectrum visualization (#145) renders nothing on the real head unit, the unit is not adb-reachable, and every launcher feature degrades silently by design — so there was no way to tell a missing grant from an unsupported audio HAL from a mixer-bypassing player.

- **Build/device**: app version + build type, model, Android release/API.
- **Permissions**: every runtime grant (location ×2, calendar, phone state, Bluetooth, record audio) and the notification-listener state.
- **Music**: live session row (source package, playing/paused) from `MusicSessionRepository`.
- **Spectrum probe**: `AudioSpectrumRepository.diagnose()` runs a 2 s capture window and classifies it — `NO_PERMISSION` / `ENGINE_UNAVAILABLE` / `SILENT` (engine ok, stream silent → the player bypasses the mixer) / `ACTIVE`. The pure classifier (`classifySpectrumProbe`) is JVM-tested.
- **Network**: validated connectivity + transports (Wi-Fi/Cellular/Ethernet/Bluetooth — Ethernet matters on head units).
- **Recent warnings**: the app's own logcat tail (uid-filtered `logcat -d`, no `READ_LOGS` needed; degrades to empty where restricted). All the repositories' degrade-with-one-WARN lines become visible on-device.
- **Copy report**: exports everything as stable English plain text (`diagnosticsReport`, JVM-tested) for pasting into an issue or a remote-debugging session.

UDF 4-file shape under `ui/diagnostics/` with the `viewModelFactory` DSL (no `UNCHECKED_CAST`), hosted as a `ModalBottomSheet` over settings like the font picker.

## Verification

- `spotlessCheck` / `assembleDebug` / `lint` (no new finding classes) / `test` — green.
- Emulator (TBox-Mock): full sheet verified — permissions all granted, session `com.android.chrome (playing)`, **spectrum probe correctly reports "Engine unavailable"** (the emulator audio HAL cannot init Visualizer), connectivity online, 80 recent warning lines rendered.