### PR TITLE
fix(diagnostics): probe the spectrum before capturing the log tail

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsViewModel.kt
@@ -64,9 +64,12 @@ internal class DiagnosticsViewModel(
         viewModelScope.launch {
             // Each probe degrades to null independently so a broken collector
             // never hides the other one's findings — this screen exists to
-            // surface failure, not to add its own silent variety.
-            val snapshot = runCatchingOrNull("snapshot") { collectSnapshot() }
+            // surface failure, not to add its own silent variety. The spectrum
+            // probe runs FIRST: its failure detail lands in logcat, and the
+            // snapshot's log tail must be captured after it so the report
+            // carries the exact Visualizer error rather than predating it.
             val spectrum = runCatchingOrNull("spectrum probe") { probeSpectrum() }
+            val snapshot = runCatchingOrNull("snapshot") { collectSnapshot() }
             probes.update { it.copy(isLoading = false, snapshot = snapshot, spectrum = spectrum) }
         }
     }


### PR DESCRIPTION
The refresh sequence ran the snapshot (which reads the app's logcat tail) before the spectrum probe, so the report's Recent warnings always predated the probe of the same refresh — the Visualizer failure detail (e.g. `initCheck failed -3` vs a SecurityException) never made it into the copyable report. Observed in the first field report from the Bengal head unit (#146 follow-up): `Spectrum capture: ENGINE_UNAVAILABLE` with no AudioSpectrumRepo line in the tail. Reordering puts the exact engine error in the next nightly's report.

Verified: spotlessCheck / test / compileDebugKotlin green; existing DiagnosticsViewModelTest covers both probes landing regardless of order.