### PR TITLE
feat(home): open the default calendar and weather apps from their cards

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.testfixtures.fakeCalendarSnapshot
@@ -19,7 +21,7 @@ class CalendarCardTest {
     fun renders_each_days_events_in_the_agenda_list() {
         rule.setContent {
             FemtoTheme {
-                CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true)
+                CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true, onOpen = {})
             }
         }
         // The agenda lists every day, so events from different days all render
@@ -32,7 +34,7 @@ class CalendarCardTest {
     fun omits_days_without_events_from_the_agenda() {
         rule.setContent {
             FemtoTheme {
-                CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true)
+                CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true, onOpen = {})
             }
         }
         // The fixture's 2026-05-02 is a free day (and not today), so its gutter
@@ -51,6 +53,7 @@ class CalendarCardTest {
                             days = fakeCalendarSnapshot().days.map { it.copy(events = emptyList()) },
                         ),
                     is24Hour = true,
+                    onOpen = {},
                 )
             }
         }
@@ -68,7 +71,7 @@ class CalendarCardTest {
     fun shows_today_number_for_granted_snapshot() {
         rule.setContent {
             FemtoTheme {
-                CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true)
+                CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true, onOpen = {})
             }
         }
         // The hero head renders the day-of-month of the fixture's `today`
@@ -79,10 +82,22 @@ class CalendarCardTest {
     }
 
     @Test
+    fun tapping_the_card_dispatches_open() {
+        var opened = false
+        rule.setContent {
+            FemtoTheme {
+                CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true, onOpen = { opened = true })
+            }
+        }
+        rule.onRoot().performClick()
+        assert(opened) { "expected the card tap to dispatch onOpen" }
+    }
+
+    @Test
     fun shows_permission_denied_message_when_access_is_denied() {
         rule.setContent {
             FemtoTheme {
-                CalendarCard(snapshot = fakeCalendarSnapshot(hasCalendarAccess = false), is24Hour = true)
+                CalendarCard(snapshot = fakeCalendarSnapshot(hasCalendarAccess = false), is24Hour = true, onOpen = {})
             }
         }
         // Resolve the copy from resources so the literal stays the SSOT in
@@ -99,7 +114,7 @@ class CalendarCardTest {
     fun shows_query_failed_message_when_the_provider_query_failed() {
         rule.setContent {
             FemtoTheme {
-                CalendarCard(snapshot = fakeCalendarSnapshot(queryFailed = true), is24Hour = true)
+                CalendarCard(snapshot = fakeCalendarSnapshot(queryFailed = true), is24Hour = true, onOpen = {})
             }
         }
         // Resolve the copy from resources so the literal stays the SSOT in

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/CalendarCardTest.kt
@@ -1,10 +1,10 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import io.github.seijikohara.femto.R
@@ -89,7 +89,7 @@ class CalendarCardTest {
                 CalendarCard(snapshot = fakeCalendarSnapshot(), is24Hour = true, onOpen = { opened = true })
             }
         }
-        rule.onRoot().performClick()
+        rule.onNode(hasClickAction()).performClick()
         assert(opened) { "expected the card tap to dispatch onOpen" }
     }
 

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
 import io.github.seijikohara.femto.data.weather.WeatherCode
 import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
@@ -27,6 +29,7 @@ class WeatherCardTest {
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     is24Hour = true,
+                    onOpen = {},
                 )
             }
         }
@@ -43,6 +46,7 @@ class WeatherCardTest {
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     is24Hour = true,
+                    onOpen = {},
                 )
             }
         }
@@ -60,6 +64,7 @@ class WeatherCardTest {
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     is24Hour = true,
+                    onOpen = {},
                 )
             }
         }
@@ -77,6 +82,7 @@ class WeatherCardTest {
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     is24Hour = true,
+                    onOpen = {},
                 )
             }
         }
@@ -96,6 +102,7 @@ class WeatherCardTest {
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     is24Hour = true,
+                    onOpen = {},
                 )
             }
         }
@@ -113,6 +120,7 @@ class WeatherCardTest {
                     temperatureUnit = TemperatureUnit.CELSIUS,
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
                     is24Hour = false,
+                    onOpen = {},
                 )
             }
         }
@@ -121,5 +129,23 @@ class WeatherCardTest {
         // pattern because the meridiem word is locale-dependent ("PM" / "午後").
         val expected = LocalTime.of(12, 0).format(DateTimeFormatter.ofPattern("h a"))
         rule.onNodeWithText(expected).assertIsDisplayed()
+    }
+
+    @Test
+    fun tapping_the_card_dispatches_open() {
+        var opened = false
+        rule.setContent {
+            FemtoTheme {
+                WeatherCard(
+                    snapshot = fakeWeatherSnapshot(),
+                    temperatureUnit = TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
+                    onOpen = { opened = true },
+                )
+            }
+        }
+        rule.onRoot().performClick()
+        assert(opened) { "expected the card tap to dispatch onOpen" }
     }
 }

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
@@ -1,10 +1,10 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import io.github.seijikohara.femto.data.weather.WeatherCode
 import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
@@ -145,7 +145,7 @@ class WeatherCardTest {
                 )
             }
         }
-        rule.onRoot().performClick()
+        rule.onNode(hasClickAction()).performClick()
         assert(opened) { "expected the card tap to dispatch onOpen" }
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeAction.kt
@@ -30,6 +30,10 @@ internal sealed interface HomeAction {
 
     data object OpenBrowser : HomeAction
 
+    data object OpenCalendar : HomeAction
+
+    data object OpenWeather : HomeAction
+
     data object OpenSettings : HomeAction
 
     data object OpenAssistant : HomeAction

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -171,6 +171,17 @@ internal class HomeViewModel(
                 mutableEvents.tryEmit(HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_BROWSER))
             }
 
+            HomeAction.OpenCalendar -> {
+                mutableEvents.tryEmit(HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_CALENDAR))
+            }
+
+            HomeAction.OpenWeather -> {
+                // CATEGORY_APP_WEATHER ships exactly at the minSdk (API 33).
+                // Devices without a weather app declaring the category no-op
+                // gracefully via the host's tryStartActivity.
+                mutableEvents.tryEmit(HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_WEATHER))
+            }
+
             HomeAction.OpenSettings -> {
                 mutableEvents.tryEmit(HomeEvent.OpenInAppSettings)
             }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -1,7 +1,9 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -56,26 +58,38 @@ import java.time.format.DateTimeFormatter
 internal fun CalendarCard(
     snapshot: CalendarSnapshot?,
     is24Hour: Boolean,
+    onOpen: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier,
     shape = MaterialTheme.shapes.large,
     color = MaterialTheme.colorScheme.surfaceContainer,
 ) {
-    when {
-        // null is the loading frame: render nothing rather than a denial the
-        // user has not earned yet.
-        snapshot == null -> Unit
+    // The whole card opens the default calendar app (CATEGORY_APP_CALENDAR),
+    // in every state: even the denial/failed hints lead somewhere useful.
+    // Inner clickable (not on the Surface modifier) so the ripple stays
+    // inside the rounded shape — the MusicCard pattern.
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .clickable(onClickLabel = stringResource(R.string.calendar_open_app)) { onOpen() },
+    ) {
+        when {
+            // null is the loading frame: render nothing rather than a denial the
+            // user has not earned yet.
+            snapshot == null -> Unit
 
-        // A non-null snapshot with access denied carries no real data, so show the
-        // denial message instead of a hollow agenda.
-        !snapshot.hasCalendarAccess -> CenteredHint(stringResource(R.string.calendar_permission_denied))
+            // A non-null snapshot with access denied carries no real data, so show the
+            // denial message instead of a hollow agenda.
+            !snapshot.hasCalendarAccess -> CenteredHint(stringResource(R.string.calendar_permission_denied))
 
-        // Access is granted but the provider query faulted: the empty agenda is
-        // a read failure, not a free month, so say so rather than fake it.
-        snapshot.queryFailed -> CenteredHint(stringResource(R.string.calendar_query_failed))
+            // Access is granted but the provider query faulted: the empty agenda is
+            // a read failure, not a free month, so say so rather than fake it.
+            snapshot.queryFailed -> CenteredHint(stringResource(R.string.calendar_query_failed))
 
-        else -> CalendarContent(snapshot, is24Hour)
+            else -> CalendarContent(snapshot, is24Hour)
+        }
     }
 }
 
@@ -333,6 +347,7 @@ private fun CalendarCardPreview() {
                     hasCalendarAccess = true,
                 ),
             is24Hour = true,
+            onOpen = {},
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -317,6 +317,7 @@ private fun InfoPane(
                 CalendarCard(
                     snapshot = uiState.calendar,
                     is24Hour = is24Hour,
+                    onOpen = { onAction(HomeAction.OpenCalendar) },
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                 )
             }
@@ -326,6 +327,7 @@ private fun InfoPane(
                     temperatureUnit = temperatureUnit,
                     speedUnit = speedUnit,
                     is24Hour = is24Hour,
+                    onOpen = { onAction(HomeAction.OpenWeather) },
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                 )
             }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -79,9 +80,16 @@ internal fun WeatherCard(
     temperatureUnit: TemperatureUnit,
     speedUnit: SpeedUnit,
     is24Hour: Boolean,
+    onOpen: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
-    modifier = modifier,
+    modifier = modifier
+        // The whole card opens the default weather app (CATEGORY_APP_WEATHER,
+        // available exactly from the minSdk). clip keeps the ripple inside
+        // the rounded shape; the inner Column scrolls, so the clickable
+        // lives on the Surface rather than competing with the scroll.
+        .clip(MaterialTheme.shapes.large)
+        .clickable(onClickLabel = stringResource(R.string.weather_open_app)) { onOpen() },
     shape = MaterialTheme.shapes.large,
     color = MaterialTheme.colorScheme.surfaceContainer,
 ) {
@@ -419,6 +427,7 @@ private fun WeatherCardPreview() {
             temperatureUnit = TemperatureUnit.CELSIUS,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
             is24Hour = true,
+            onOpen = {},
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,10 +21,12 @@
     <!-- Calendar card -->
     <string name="calendar_permission_denied">Calendar access not granted</string>
     <string name="calendar_all_day">All day</string>
+    <string name="calendar_open_app">Open calendar</string>
     <string name="calendar_no_events">No events</string>
 
     <!-- Weather card -->
     <string name="weather_unavailable">Weather unavailable</string>
+    <string name="weather_open_app">Open weather</string>
     <string name="weather_metric_feels">FEELS</string>
     <string name="weather_metric_wind">WIND</string>
     <string name="weather_metric_humidity">HUMID.</string>

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -164,6 +164,24 @@ class HomeViewModelTest {
         }
 
     @Test
+    fun `onAction OpenCalendar emits LaunchAppCategory APP_CALENDAR`() =
+        runTest {
+            stubViewModel().assertEvent(
+                action = HomeAction.OpenCalendar,
+                expected = HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_CALENDAR),
+            )
+        }
+
+    @Test
+    fun `onAction OpenWeather emits LaunchAppCategory APP_WEATHER`() =
+        runTest {
+            stubViewModel().assertEvent(
+                action = HomeAction.OpenWeather,
+                expected = HomeEvent.LaunchAppCategory(Intent.CATEGORY_APP_WEATHER),
+            )
+        }
+
+    @Test
     fun `onAction OpenSettings emits OpenInAppSettings`() =
         runTest {
             stubViewModel().assertEvent(


### PR DESCRIPTION
## Summary

Tapping the calendar / weather info-pane cards now launches the device's default app for that domain:

- **Calendar** → `Intent.CATEGORY_APP_CALENDAR` (API 15+)
- **Weather** → `Intent.CATEGORY_APP_WEATHER` — added in **API 33, exactly this project's minSdk**; verified present in the compileSdk (API 37) jar via javap

Both reuse the existing `HomeEvent.LaunchAppCategory` path (`makeMainSelectorActivity` + `tryStartActivity`), so the launch honours the user's default app across markets with no package lists, and a device with no app declaring the category (weather is commonly undeclared) degrades to a graceful no-op. The whole card is the tap target with an accessibility `onClickLabel`, following the music card's open-the-source pattern; every state is tappable (the calendar's permission-denied hint included — the calendar app is a useful destination from there too).

## Verification

- `spotlessCheck` / `test` (2 new ViewModel event cases) / `compileDebugAndroidTestKotlin` (2 new tap-dispatch cases) / `assembleDebug` / `lint` (no new findings) — green.
- Emulator: tapping the calendar card launches `com.google.android.calendar` (window-focus transition observed); the weather tap no-ops on the emulator (no app declares the category), as designed.