### PR TITLE
feat(drawer): scale the pinned dock with the icon preset, drag to reorder pins

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreenTest.kt
@@ -37,6 +37,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = {},
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = {},
                 )
             }
@@ -59,6 +60,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = {},
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = {},
                 )
             }
@@ -82,6 +84,7 @@ class AppDrawerScreenTest {
                     onTogglePin = { pinned = it },
                     onToggleLayout = {},
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = {},
                 )
             }
@@ -106,6 +109,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = { toggled = true },
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = {},
                 )
             }
@@ -128,6 +132,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = {},
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = {},
                 )
             }
@@ -150,6 +155,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = {},
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = {},
                 )
             }
@@ -173,6 +179,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = {},
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = {},
                 )
             }
@@ -197,6 +204,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = {},
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = {},
                 )
             }
@@ -221,6 +229,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = {},
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = { retried = true },
                 )
             }
@@ -246,6 +255,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = {},
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = {},
                     compact = true,
                     onExpand = { expanded = true },
@@ -274,6 +284,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = {},
                     onSelectIconSize = {},
+                    onReorderPins = {},
                     onRetry = {},
                     compact = true,
                     onExpand = { expanded = true },
@@ -299,6 +310,7 @@ class AppDrawerScreenTest {
                     onTogglePin = {},
                     onToggleLayout = {},
                     onSelectIconSize = { selected = it },
+                    onReorderPins = {},
                     onRetry = {},
                 )
             }

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDockTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDockTest.kt
@@ -1,0 +1,99 @@
+package io.github.seijikohara.femto.ui.drawer.components
+
+import android.content.ComponentName
+import android.graphics.Bitmap
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.data.apps.AppEntry
+import io.github.seijikohara.femto.data.apps.DrawerIconSize
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class PinnedDockTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val icon: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+    private val maps = AppEntry(ComponentName("com.maps", ".Main"), "Maps", icon)
+    private val music = AppEntry(ComponentName("com.music", ".Main"), "Music", icon)
+    private val phone = AppEntry(ComponentName("com.phone", ".Main"), "Phone", icon)
+
+    private fun setDock(onReorder: (List<String>) -> Unit) {
+        rule.setContent {
+            FemtoTheme {
+                PinnedDock(
+                    apps = listOf(maps, music, phone),
+                    iconSize = DrawerIconSize.MEDIUM,
+                    onLaunch = {},
+                    onUnpin = {},
+                    onReorder = onReorder,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun move_right_commits_the_swapped_order() {
+        var committed: List<String>? = null
+        setDock(onReorder = { committed = it })
+        // A still long-press opens the tile menu (the drag detector's no-travel
+        // fallback), where Move right swaps with the next tile and commits.
+        rule.onNodeWithContentDescription("Maps").performTouchInput { longClick() }
+        rule.onNodeWithText("Move right").performClick()
+        assertEquals(
+            listOf("com.music/.Main", "com.maps/.Main", "com.phone/.Main"),
+            committed,
+        )
+    }
+
+    @Test
+    fun move_left_commits_the_swapped_order() {
+        var committed: List<String>? = null
+        setDock(onReorder = { committed = it })
+        rule.onNodeWithContentDescription("Phone").performTouchInput { longClick() }
+        rule.onNodeWithText("Move left").performClick()
+        assertEquals(
+            listOf("com.maps/.Main", "com.phone/.Main", "com.music/.Main"),
+            committed,
+        )
+    }
+
+    @Test
+    fun long_press_drag_right_commits_the_swapped_order() {
+        var committed: List<String>? = null
+        setDock(onReorder = { committed = it })
+        // Synthesize the reorder gesture deterministically: press, hold past
+        // the long-press timeout, travel right by more than half a slot
+        // (96 dp tile + gutter), lift. The dock must commit the swap.
+        rule.onNodeWithContentDescription("Maps").performTouchInput {
+            down(center)
+            advanceEventTime(viewConfiguration.longPressTimeoutMillis + 100)
+            repeat(10) {
+                moveBy(Offset(with(rule.density) { 14.dp.toPx() }, 0f))
+                advanceEventTime(16)
+            }
+            up()
+        }
+        rule.waitForIdle()
+        assertEquals(
+            listOf("com.music/.Main", "com.maps/.Main", "com.phone/.Main"),
+            committed,
+        )
+    }
+
+    @Test
+    fun the_first_tile_offers_no_move_left() {
+        setDock(onReorder = {})
+        rule.onNodeWithContentDescription("Maps").performTouchInput { longClick() }
+        rule.onNodeWithText("Move right").assertExists()
+        rule.onNodeWithText("Move left").assertDoesNotExist()
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/data/apps/DrawerPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/apps/DrawerPreferences.kt
@@ -35,6 +35,13 @@ internal interface DrawerSettingsStore {
 
     /** Append the component if absent, remove it if present. */
     suspend fun togglePinned(flattenedComponent: String)
+
+    /**
+     * Replace the pin order wholesale (drag-reorder commit). Entries not
+     * currently pinned are persisted as-is — the caller derives [value] from
+     * the rendered dock, which is itself resolved from the persisted order.
+     */
+    suspend fun setPinnedOrder(value: List<String>)
 }
 
 // A flattened ComponentName ("package/class") can never contain a newline, so it
@@ -99,6 +106,13 @@ internal class DrawerPreferences(
                 if (flattenedComponent in current) current - flattenedComponent else current + flattenedComponent
             prefs[PINNED_ORDER_KEY] = updated.joinToString(PIN_SEPARATOR)
             // The ordered key is authoritative from the first write on.
+            prefs.remove(LEGACY_PINNED_KEY)
+        }
+    }
+
+    override suspend fun setPinnedOrder(value: List<String>) {
+        context.drawerDataStore.editOrLog(TAG) { prefs ->
+            prefs[PINNED_ORDER_KEY] = value.joinToString(PIN_SEPARATOR)
             prefs.remove(LEGACY_PINNED_KEY)
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -100,6 +100,7 @@ internal fun AppDrawerScreen(
     onTogglePin: (ComponentName) -> Unit,
     onToggleLayout: () -> Unit,
     onSelectIconSize: (DrawerIconSize) -> Unit,
+    onReorderPins: (List<String>) -> Unit,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
     compact: Boolean = false,
@@ -114,9 +115,11 @@ internal fun AppDrawerScreen(
         compact -> {
             CompactContent(
                 uiState = uiState,
+                iconSize = iconSize,
                 pinned = pinned,
                 onLaunch = onLaunch,
                 onTogglePin = onTogglePin,
+                onReorderPins = onReorderPins,
                 onExpand = onExpand,
             )
         }
@@ -131,6 +134,7 @@ internal fun AppDrawerScreen(
                 onTogglePin = onTogglePin,
                 onToggleLayout = onToggleLayout,
                 onSelectIconSize = onSelectIconSize,
+                onReorderPins = onReorderPins,
             )
         }
 
@@ -152,9 +156,11 @@ internal fun AppDrawerScreen(
 @Composable
 private fun CompactContent(
     uiState: AppDrawerUiState,
+    iconSize: DrawerIconSize,
     pinned: List<String>,
     onLaunch: (ComponentName) -> Unit,
     onTogglePin: (ComponentName) -> Unit,
+    onReorderPins: (List<String>) -> Unit,
     onExpand: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(modifier = modifier.fillMaxWidth()) {
@@ -167,8 +173,10 @@ private fun CompactContent(
             LaunchedEffect(dockApps.isEmpty()) { if (dockApps.isEmpty()) currentOnExpand() }
             PinnedDock(
                 apps = dockApps,
+                iconSize = iconSize,
                 onLaunch = onLaunch,
                 onUnpin = onTogglePin,
+                onReorder = onReorderPins,
             )
         }
 
@@ -252,6 +260,7 @@ private fun ContentState(
     onTogglePin: (ComponentName) -> Unit,
     onToggleLayout: () -> Unit,
     onSelectIconSize: (DrawerIconSize) -> Unit,
+    onReorderPins: (List<String>) -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(modifier = modifier.fillMaxSize()) {
     var query by remember { mutableStateOf("") }
@@ -288,8 +297,10 @@ private fun ContentState(
     if (dockApps.isNotEmpty()) {
         PinnedDock(
             apps = dockApps,
+            iconSize = iconSize,
             onLaunch = onLaunch,
             onUnpin = onTogglePin,
+            onReorder = onReorderPins,
         )
     }
 }
@@ -557,6 +568,7 @@ private fun AppDrawerContentPreview() {
             onTogglePin = {},
             onToggleLayout = {},
             onSelectIconSize = {},
+            onReorderPins = {},
             onRetry = {},
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
@@ -111,6 +111,9 @@ internal fun AppDrawerSheet(
                     onSelectIconSize = { size ->
                         scope.launch { drawerPreferences.setIconSize(size) }
                     },
+                    onReorderPins = { order ->
+                        scope.launch { drawerPreferences.setPinnedOrder(order) }
+                    },
                     onRetry = { viewModel.onAction(AppDrawerAction.Refresh) },
                     compact = compact,
                     onExpand = { expanded = true },

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
@@ -82,11 +82,13 @@ private fun DrawerIconSize.dockDimensions(): DockDimensions =
  * scrolling row of icon + label tiles in pin order, visually separated from the
  * scrolling app grid by a divider on a raised container colour. Tap launches.
  *
- * Long-press starts a horizontal drag-reorder: the held tile follows the
- * finger and swaps places as it crosses its neighbours; lifting commits the
- * new order through [onReorder]. A long-press WITHOUT movement falls back to
- * the tile menu (Unpin, plus Move left / Move right — the precision-free
- * reorder path for a bumpy cabin or accessibility services).
+ * Long-press then drag reorders: the held tile follows the finger and swaps
+ * places as it crosses its neighbours; lifting commits the new order through
+ * [onReorder]. A long-press lifted WITHOUT travel opens the tile menu
+ * (Unpin, plus Move left / Move right — the precision-free reorder path for
+ * a bumpy cabin or accessibility services). The menu deliberately opens on
+ * lift, not at the long-press timeout: a focusable popup appearing mid-press
+ * cancels the pointer stream and would kill the drag.
  *
  * Callers skip composing the dock when [apps] is empty.
  */
@@ -171,14 +173,26 @@ internal fun PinnedDock(
                                         if (dragTravelled) {
                                             onReorder(order.map { it.componentName.flattenToString() })
                                         } else {
-                                            // A long-press that never moved is the
-                                            // menu gesture, exactly as before.
                                             menuKey = key
                                         }
                                         draggingKey = null
                                         dragDelta = 0f
                                     },
                                     onDragCancel = {
+                                        if (dragTravelled) {
+                                            // Revert the optimistic swaps: nothing
+                                            // was committed, so the dock falls back
+                                            // to the persisted order.
+                                            order.clear()
+                                            order.addAll(apps)
+                                        } else {
+                                            // A no-travel lift lands HERE, not in
+                                            // onDragEnd: the child clickable
+                                            // consumes the up (its tap), which the
+                                            // detector reports as a cancel. It is
+                                            // the menu gesture.
+                                            menuKey = key
+                                        }
                                         draggingKey = null
                                         dragDelta = 0f
                                     },
@@ -238,8 +252,11 @@ private fun DockTile(
             Modifier
                 .width(dimensions.tileWidth)
                 .defaultMinSize(minHeight = FemtoDimens.MinTouchTarget)
-                // Plain clickable: the long-press path belongs to the dock's
-                // drag detector (which falls back to the menu on a still press).
+                // Plain clickable launches on tap. The menu must NOT open at
+                // the long-press timeout: a focusable popup appearing mid-press
+                // cancels the original pointer stream and would make the
+                // reorder drag impossible — so the dock's drag detector opens
+                // it on lift instead.
                 .clickable(onClick = { onLaunch(entry.componentName) }),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
@@ -2,7 +2,8 @@ package io.github.seijikohara.femto.ui.drawer.components
 
 import android.content.ComponentName
 import android.graphics.Bitmap
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,7 +12,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
@@ -26,48 +26,89 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.ArrowRight
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.PinOff
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.apps.AppEntry
+import io.github.seijikohara.femto.data.apps.DrawerIconSize
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.tileLabel
+import kotlin.math.abs
 
-// Wide enough for a readable one-line 18 sp label while keeping several pins
-// visible at once on the 853 dp-wide reference head unit.
-private val DockTileWidth = 96.dp
-private val DockIconSize = 64.dp
 private val DockIconLabelGap = 4.dp
 private val DockVerticalPadding = 8.dp
+
+// Per-preset dock tile dimensions, scaled in step with the drawer grid's
+// presets (the dock previously hardcoded the MEDIUM values and ignored the
+// user's icon-size choice). Tile widths keep a readable one-line label and
+// stay above the touch-target floor via the tile's min height.
+private data class DockDimensions(
+    val tileWidth: Dp,
+    val iconSize: Dp,
+)
+
+private fun DrawerIconSize.dockDimensions(): DockDimensions =
+    when (this) {
+        DrawerIconSize.SMALL -> DockDimensions(tileWidth = 80.dp, iconSize = 48.dp)
+        DrawerIconSize.MEDIUM -> DockDimensions(tileWidth = 96.dp, iconSize = 64.dp)
+        DrawerIconSize.LARGE -> DockDimensions(tileWidth = 128.dp, iconSize = 88.dp)
+    }
 
 /**
  * Pinned-apps dock fixed at the bottom of the drawer sheet: a horizontally
  * scrolling row of icon + label tiles in pin order, visually separated from the
- * scrolling app grid by a divider on a raised container colour. Tap launches;
- * long-press offers Unpin. Callers skip composing the dock when [apps] is empty.
+ * scrolling app grid by a divider on a raised container colour. Tap launches.
+ *
+ * Long-press starts a horizontal drag-reorder: the held tile follows the
+ * finger and swaps places as it crosses its neighbours; lifting commits the
+ * new order through [onReorder]. A long-press WITHOUT movement falls back to
+ * the tile menu (Unpin, plus Move left / Move right — the precision-free
+ * reorder path for a bumpy cabin or accessibility services).
+ *
+ * Callers skip composing the dock when [apps] is empty.
  */
 @Composable
 internal fun PinnedDock(
     apps: List<AppEntry>,
+    iconSize: DrawerIconSize,
     onLaunch: (ComponentName) -> Unit,
     onUnpin: (ComponentName) -> Unit,
+    onReorder: (List<String>) -> Unit,
     modifier: Modifier = Modifier,
 ) = Column(modifier = modifier.fillMaxWidth()) {
     HorizontalDivider()
+    val dimensions = iconSize.dockDimensions()
+    // Local working order: drag swaps mutate this list optimistically per
+    // frame; the persisted order arrives back through [apps] and re-seeds it.
+    val order = remember(apps) { apps.toMutableStateList() }
+    var draggingKey by remember { mutableStateOf<String?>(null) }
+    var dragDelta by remember { mutableFloatStateOf(0f) }
+    var dragTravelled by remember { mutableStateOf(false) }
+    var menuKey by remember { mutableStateOf<String?>(null) }
+    val stepPx = with(LocalDensity.current) { (dimensions.tileWidth + FemtoDimens.GridGutter).toPx() }
     Surface(color = MaterialTheme.colorScheme.surfaceContainerHigh) {
         LazyRow(
             modifier = Modifier.fillMaxWidth(),
@@ -75,64 +116,185 @@ internal fun PinnedDock(
                 PaddingValues(horizontal = FemtoDimens.ScreenPadding, vertical = DockVerticalPadding),
             horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
         ) {
-            items(items = apps, key = { it.componentName.flattenToString() }) { entry ->
-                DockTile(entry = entry, onLaunch = onLaunch, onUnpin = onUnpin)
+            items(items = order, key = { it.componentName.flattenToString() }) { entry ->
+                val key = entry.componentName.flattenToString()
+                val dragging = draggingKey == key
+                DockTile(
+                    entry = entry,
+                    dimensions = dimensions,
+                    menuOpen = menuKey == key,
+                    canMoveLeft = order.indexOf(entry) > 0,
+                    canMoveRight = order.indexOf(entry) < order.lastIndex,
+                    onLaunch = onLaunch,
+                    onUnpin = onUnpin,
+                    onDismissMenu = { menuKey = null },
+                    onMove = { offset ->
+                        val index = order.indexOf(entry)
+                        val target = (index + offset).coerceIn(0, order.lastIndex)
+                        if (target != index) {
+                            order.add(target, order.removeAt(index))
+                            onReorder(order.map { it.componentName.flattenToString() })
+                        }
+                    },
+                    modifier =
+                        Modifier
+                            // The held tile rides above its neighbours and tracks
+                            // the finger; everyone else stays put (the swap
+                            // animation is the position change itself).
+                            .zIndex(if (dragging) 1f else 0f)
+                            .graphicsLayer { translationX = if (dragging) dragDelta else 0f }
+                            .pointerInput(key, stepPx) {
+                                detectDragGesturesAfterLongPress(
+                                    onDragStart = {
+                                        draggingKey = key
+                                        dragDelta = 0f
+                                        dragTravelled = false
+                                    },
+                                    onDrag = { change, amount ->
+                                        change.consume()
+                                        dragDelta += amount.x
+                                        if (abs(dragDelta) > viewConfiguration.touchSlop) dragTravelled = true
+                                        val index = order.indexOfFirst { it.componentName.flattenToString() == key }
+                                        val (reordered, residual) = reorderByDrag(
+                                            order.toList(),
+                                            index,
+                                            dragDelta,
+                                            stepPx,
+                                        )
+                                        if (reordered.size == order.size && reordered != order.toList()) {
+                                            order.clear()
+                                            order.addAll(reordered)
+                                        }
+                                        dragDelta = residual
+                                    },
+                                    onDragEnd = {
+                                        if (dragTravelled) {
+                                            onReorder(order.map { it.componentName.flattenToString() })
+                                        } else {
+                                            // A long-press that never moved is the
+                                            // menu gesture, exactly as before.
+                                            menuKey = key
+                                        }
+                                        draggingKey = null
+                                        dragDelta = 0f
+                                    },
+                                    onDragCancel = {
+                                        draggingKey = null
+                                        dragDelta = 0f
+                                    },
+                                )
+                            },
+                )
             }
         }
     }
 }
 
+/**
+ * Advance a horizontal drag-reorder by one gesture frame: while the
+ * accumulated [dragDelta] has crossed more than half a slot ([stepPx]) the
+ * dragged item at [fromIndex] swaps one position in that direction and the
+ * delta is rebased on the new slot. Returns the (possibly) reordered list and
+ * the residual delta. Pure, so the swap math is JVM-unit-testable.
+ */
+internal fun <T> reorderByDrag(
+    items: List<T>,
+    fromIndex: Int,
+    dragDelta: Float,
+    stepPx: Float,
+): Pair<List<T>, Float> {
+    if (fromIndex !in items.indices || stepPx <= 0f) return items to dragDelta
+    val reordered = items.toMutableList()
+    var index = fromIndex
+    var delta = dragDelta
+    while (delta > stepPx / 2 && index < reordered.lastIndex) {
+        reordered.add(index + 1, reordered.removeAt(index))
+        index++
+        delta -= stepPx
+    }
+    while (delta < -stepPx / 2 && index > 0) {
+        reordered.add(index - 1, reordered.removeAt(index))
+        index--
+        delta += stepPx
+    }
+    return reordered to delta
+}
+
 @Composable
 private fun DockTile(
     entry: AppEntry,
+    dimensions: DockDimensions,
+    menuOpen: Boolean,
+    canMoveLeft: Boolean,
+    canMoveRight: Boolean,
     onLaunch: (ComponentName) -> Unit,
     onUnpin: (ComponentName) -> Unit,
+    onDismissMenu: () -> Unit,
+    onMove: (Int) -> Unit,
     modifier: Modifier = Modifier,
-) {
-    var menuOpen by remember { mutableStateOf(false) }
-    Box(modifier = modifier) {
-        Column(
-            modifier =
-                Modifier
-                    .width(DockTileWidth)
-                    .defaultMinSize(minHeight = FemtoDimens.MinTouchTarget)
-                    .combinedClickable(
-                        onClick = { onLaunch(entry.componentName) },
-                        onLongClick = { menuOpen = true },
-                    ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Icon(
-                painter = BitmapPainter(entry.icon.asImageBitmap()),
-                contentDescription = entry.label,
-                tint = Color.Unspecified,
-                modifier = Modifier.size(DockIconSize),
-            )
-            Spacer(Modifier.height(DockIconLabelGap))
-            // Same deterministic line box as the grid tiles (see tileLabel), so
-            // dock tiles measure identically across scripts and fallbacks.
-            Text(
-                text = entry.label,
-                style = MaterialTheme.typography.tileLabel(),
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+) = Box(modifier = modifier) {
+    Column(
+        modifier =
+            Modifier
+                .width(dimensions.tileWidth)
+                .defaultMinSize(minHeight = FemtoDimens.MinTouchTarget)
+                // Plain clickable: the long-press path belongs to the dock's
+                // drag detector (which falls back to the menu on a still press).
+                .clickable(onClick = { onLaunch(entry.componentName) }),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            painter = BitmapPainter(entry.icon.asImageBitmap()),
+            contentDescription = entry.label,
+            tint = Color.Unspecified,
+            modifier = Modifier.size(dimensions.iconSize),
+        )
+        Spacer(Modifier.height(DockIconLabelGap))
+        // Same deterministic line box as the grid tiles (see tileLabel), so
+        // dock tiles measure identically across scripts and fallbacks.
+        Text(
+            text = entry.label,
+            style = MaterialTheme.typography.tileLabel(),
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+    DropdownMenu(expanded = menuOpen, onDismissRequest = onDismissMenu) {
+        if (canMoveLeft) {
             DropdownMenuItem(
-                text = { Text(stringResource(R.string.drawer_unpin)) },
+                text = { Text(stringResource(R.string.drawer_move_left)) },
                 // M3's default menu-item height (48 dp) sits below the automotive floor.
                 modifier = Modifier.sizeIn(minHeight = FemtoDimens.MinTouchTarget),
-                leadingIcon = { Icon(imageVector = Lucide.PinOff, contentDescription = null) },
+                leadingIcon = { Icon(imageVector = Lucide.ArrowLeft, contentDescription = null) },
                 onClick = {
-                    onUnpin(entry.componentName)
-                    menuOpen = false
+                    onMove(-1)
+                    onDismissMenu()
                 },
             )
         }
+        if (canMoveRight) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.drawer_move_right)) },
+                modifier = Modifier.sizeIn(minHeight = FemtoDimens.MinTouchTarget),
+                leadingIcon = { Icon(imageVector = Lucide.ArrowRight, contentDescription = null) },
+                onClick = {
+                    onMove(1)
+                    onDismissMenu()
+                },
+            )
+        }
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.drawer_unpin)) },
+            modifier = Modifier.sizeIn(minHeight = FemtoDimens.MinTouchTarget),
+            leadingIcon = { Icon(imageVector = Lucide.PinOff, contentDescription = null) },
+            onClick = {
+                onUnpin(entry.componentName)
+                onDismissMenu()
+            },
+        )
     }
 }
 
@@ -148,8 +310,10 @@ private fun PinnedDockPreview() {
                     AppEntry(ComponentName("com.music", ".Main"), "Music", icon),
                     AppEntry(ComponentName("com.phone", ".Main"), "Phone", icon),
                 ),
+            iconSize = DrawerIconSize.MEDIUM,
             onLaunch = {},
             onUnpin = {},
+            onReorder = {},
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,8 @@
     <string name="drawer_layout_list">List layout</string>
     <string name="drawer_pin">Pin</string>
     <string name="drawer_unpin">Unpin</string>
+    <string name="drawer_move_left">Move left</string>
+    <string name="drawer_move_right">Move right</string>
     <string name="drawer_search_hint">Search apps</string>
     <string name="drawer_search_clear">Clear search</string>
     <string name="drawer_no_matches">No apps match your search</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/apps/DrawerPreferencesTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/apps/DrawerPreferencesTest.kt
@@ -27,6 +27,12 @@ class DrawerPreferencesTest {
             store.togglePinned(COMPONENT)
             assertEquals(listOf(OTHER, COMPONENT), store.pinned.first())
 
+            // A wholesale reorder (drag commit) replaces the order verbatim.
+            store.setPinnedOrder(listOf(COMPONENT, OTHER))
+            assertEquals(listOf(COMPONENT, OTHER), store.pinned.first())
+            store.setPinnedOrder(listOf(OTHER, COMPONENT))
+            assertEquals(listOf(OTHER, COMPONENT), store.pinned.first())
+
             store.togglePinned(COMPONENT)
             assertEquals(listOf(OTHER), store.pinned.first())
 

--- a/app/src/test/java/io/github/seijikohara/femto/ui/drawer/components/ReorderByDragTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/drawer/components/ReorderByDragTest.kt
@@ -1,0 +1,68 @@
+package io.github.seijikohara.femto.ui.drawer.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private const val STEP = 100f
+
+class ReorderByDragTest {
+    private val items = listOf("a", "b", "c", "d")
+
+    @Test
+    fun `a small delta moves nothing and keeps the residual`() {
+        val (reordered, residual) = reorderByDrag(items, fromIndex = 1, dragDelta = 40f, stepPx = STEP)
+        assertEquals(items, reordered)
+        assertEquals(40f, residual)
+    }
+
+    @Test
+    fun `crossing half a slot to the right swaps one position and rebases the delta`() {
+        val (reordered, residual) = reorderByDrag(items, fromIndex = 1, dragDelta = 60f, stepPx = STEP)
+        assertEquals(listOf("a", "c", "b", "d"), reordered)
+        assertEquals(-40f, residual)
+    }
+
+    @Test
+    fun `crossing half a slot to the left swaps one position`() {
+        val (reordered, residual) = reorderByDrag(items, fromIndex = 2, dragDelta = -60f, stepPx = STEP)
+        assertEquals(listOf("a", "c", "b", "d"), reordered)
+        assertEquals(40f, residual)
+    }
+
+    @Test
+    fun `a fast fling crosses multiple slots in one frame`() {
+        // 260 px crosses the half-slot boundaries at 50/150/250 px: three swaps,
+        // leaving the item rebased 40 px short of its new slot centre.
+        val (reordered, residual) = reorderByDrag(items, fromIndex = 0, dragDelta = 260f, stepPx = STEP)
+        assertEquals(listOf("b", "c", "d", "a"), reordered)
+        assertEquals(-40f, residual)
+    }
+
+    @Test
+    fun `the first item cannot move further left`() {
+        val (reordered, residual) = reorderByDrag(items, fromIndex = 0, dragDelta = -500f, stepPx = STEP)
+        assertEquals(items, reordered)
+        assertEquals(-500f, residual)
+    }
+
+    @Test
+    fun `the last item cannot move further right`() {
+        val (reordered, residual) = reorderByDrag(items, fromIndex = 3, dragDelta = 500f, stepPx = STEP)
+        assertEquals(items, reordered)
+        assertEquals(500f, residual)
+    }
+
+    @Test
+    fun `an out-of-range index is a no-op`() {
+        val (reordered, residual) = reorderByDrag(items, fromIndex = 9, dragDelta = 500f, stepPx = STEP)
+        assertEquals(items, reordered)
+        assertEquals(500f, residual)
+    }
+
+    @Test
+    fun `a non-positive step is a no-op`() {
+        val (reordered, residual) = reorderByDrag(items, fromIndex = 1, dragDelta = 500f, stepPx = 0f)
+        assertEquals(items, reordered)
+        assertEquals(500f, residual)
+    }
+}


### PR DESCRIPTION
## Summary (field report driven)

1. **Bug — pinned icons ignored the icon-size preset**: `PinnedDock` hardcoded the MEDIUM tile dimensions. It now derives per-preset dock dimensions (S 48 / M 64 / L 88 dp icons) in step with the drawer grid.
2. **Feature — drag to reorder pins**: long-press a dock tile and drag horizontally; the held tile follows the finger (zIndex + translation) and swaps as it crosses half a neighbour's slot. The swap math is a pure `reorderByDrag` function (8 JVM tests incl. multi-slot flings and edge clamps); lifting commits via the new `DrawerPreferences.setPinnedOrder` (the pin list was already order-persisted).
3. **Accessibility / bumpy-cabin path**: a long-press *without* movement still opens the tile menu, which now carries **Move left / Move right** beside Unpin — reorder without precision dragging.

## Verification

- `spotlessCheck` / `test` (reorder math + DrawerPreferences round-trip incl. `setPinnedOrder`) / `compileDebugAndroidTestKotlin` / `assembleDebug` / `lint` (no new finding classes) — green.
- Emulator (TBox-Mock): pinned two apps; long-press-drag swapped their order on screen; the order **survived closing and reopening the sheet** (persistence); switching the preset to Large visibly scaled the dock tiles. Screenshots in the session log.