### PR TITLE
fix(map): readable roads and labels on the ACCENT dark scheme

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapScheme.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapScheme.kt
@@ -101,11 +101,11 @@ internal fun accentMapColors(isDark: Boolean): AccentMapColors =
             background = MaterialTheme.colorScheme.surface.toCssHex(),
             water = MaterialTheme.colorScheme.primaryContainer.toCssHex(),
             land = MaterialTheme.colorScheme.surfaceContainerLow.toCssHex(),
-            roadMajor = MaterialTheme.colorScheme.outline.toCssHex(),
-            roadMinor = MaterialTheme.colorScheme.outlineVariant.toCssHex(),
+            roadMajor = MaterialTheme.colorScheme.onSurfaceVariant.toCssHex(),
+            roadMinor = MaterialTheme.colorScheme.outline.toCssHex(),
             roadCasing = MaterialTheme.colorScheme.surfaceContainer.toCssHex(),
             building = MaterialTheme.colorScheme.surfaceContainerHigh.toCssHex(),
-            label = MaterialTheme.colorScheme.onSurfaceVariant.toCssHex(),
+            label = MaterialTheme.colorScheme.onSurface.toCssHex(),
         )
     } else {
         AccentMapColors(
@@ -114,8 +114,8 @@ internal fun accentMapColors(isDark: Boolean): AccentMapColors =
             land = MaterialTheme.colorScheme.surfaceContainerHigh.toCssHex(),
             roadMajor = MaterialTheme.colorScheme.surface.toCssHex(),
             roadMinor = MaterialTheme.colorScheme.surfaceContainerHighest.toCssHex(),
-            roadCasing = MaterialTheme.colorScheme.outlineVariant.toCssHex(),
+            roadCasing = MaterialTheme.colorScheme.outline.toCssHex(),
             building = MaterialTheme.colorScheme.surfaceContainerHighest.toCssHex(),
-            label = MaterialTheme.colorScheme.onSurfaceVariant.toCssHex(),
+            label = MaterialTheme.colorScheme.onSurface.toCssHex(),
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapScheme.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapScheme.kt
@@ -72,6 +72,12 @@ internal data class AccentMapColors(
     val roadMinor: String,
     val roadCasing: String,
     val building: String,
+    // Label text colour ([label]); the halo reuses [background], so labels stay
+    // separated from whatever they overlap. The bundled bases' label colours
+    // are tuned to their own backgrounds and go illegible on the Material
+    // surface (verified on TBox-Mock: dark-base grey-101 text on the near-black
+    // dark surface), so ACCENT recolours them like every other layer group.
+    val label: String,
 )
 
 // The accent palette both backends paint onto the ACCENT scheme, mapped from the
@@ -84,7 +90,10 @@ internal data class AccentMapColors(
 //    and the map read as one plane.
 //  - Dark: the ground drops to the darkest surface tone and roads brighten
 //    above it (ground < buildings < minor < major), so the road network — not
-//    the buildings — is the brightest shape on the panel.
+//    the buildings — is the brightest shape on the panel. The road roles sit
+//    deliberately high (outline / outlineVariant): the surfaceContainer* tones
+//    used before measured ~2:1 against the surface ground on the head-unit
+//    panel and the network disappeared (user report, 2026-06-12).
 @Composable
 internal fun accentMapColors(isDark: Boolean): AccentMapColors =
     if (isDark) {
@@ -92,10 +101,11 @@ internal fun accentMapColors(isDark: Boolean): AccentMapColors =
             background = MaterialTheme.colorScheme.surface.toCssHex(),
             water = MaterialTheme.colorScheme.primaryContainer.toCssHex(),
             land = MaterialTheme.colorScheme.surfaceContainerLow.toCssHex(),
-            roadMajor = MaterialTheme.colorScheme.outlineVariant.toCssHex(),
-            roadMinor = MaterialTheme.colorScheme.surfaceContainerHighest.toCssHex(),
+            roadMajor = MaterialTheme.colorScheme.outline.toCssHex(),
+            roadMinor = MaterialTheme.colorScheme.outlineVariant.toCssHex(),
             roadCasing = MaterialTheme.colorScheme.surfaceContainer.toCssHex(),
             building = MaterialTheme.colorScheme.surfaceContainerHigh.toCssHex(),
+            label = MaterialTheme.colorScheme.onSurfaceVariant.toCssHex(),
         )
     } else {
         AccentMapColors(
@@ -106,5 +116,6 @@ internal fun accentMapColors(isDark: Boolean): AccentMapColors =
             roadMinor = MaterialTheme.colorScheme.surfaceContainerHighest.toCssHex(),
             roadCasing = MaterialTheme.colorScheme.outlineVariant.toCssHex(),
             building = MaterialTheme.colorScheme.surfaceContainerHighest.toCssHex(),
+            label = MaterialTheme.colorScheme.onSurfaceVariant.toCssHex(),
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapStyleRecolor.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapStyleRecolor.kt
@@ -4,9 +4,11 @@ import org.json.JSONObject
 
 /**
  * Recolour a bundled base style's JSON with the ACCENT palette: background, water,
- * landcover / landuse / park fills, transportation lines, and 2D building fills.
- * Roads keep their zoom-interpolated widths from the base style, so the visual
- * hierarchy (motorway / major / minor) survives the recolour; labels stay untouched.
+ * landcover / landuse / park fills, transportation lines, 2D building fills, and
+ * label text (theme-tracked colour with a background-coloured halo — the bases'
+ * own label colours are tuned to their own backgrounds and go illegible on the
+ * Material surface). Roads keep their zoom-interpolated widths from the base
+ * style, so the visual hierarchy (motorway / major / minor) survives the recolour.
  *
  * Mirrors `injectFeatures` / `roadClassOrNull` in `webmap/src/style.ts` for the
  * live backend — keep the layer groups and the road classification in sync.
@@ -40,6 +42,17 @@ internal fun recolorAccent(
 
             type == "line" && sourceLayer == "transportation" -> {
                 roadColorOrNull(layer.optString("id"), colors)?.let { layer.paint().put("line-color", it) }
+            }
+
+            // Text-less symbol layers (oneway arrows) ignore the text-* keys.
+            // The halo width is only seeded where the base omits it (e.g. the
+            // motorway names); existing widths are the base's tuning, kept as-is.
+            type == "symbol" -> {
+                layer.paint().apply {
+                    put("text-color", colors.label)
+                    put("text-halo-color", colors.background)
+                    if (!has("text-halo-width")) put("text-halo-width", 1)
+                }
             }
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -338,7 +338,7 @@ internal fun WebMapView(
             "window.setStyleUrl && setStyleUrl('$url', " +
                 "'${accent?.background ?: ""}', '${accent?.water ?: ""}', '${accent?.land ?: ""}', " +
                 "'${accent?.roadMajor ?: ""}', '${accent?.roadMinor ?: ""}', '${accent?.roadCasing ?: ""}', " +
-                "'${accent?.building ?: ""}')",
+                "'${accent?.building ?: ""}', '${accent?.label ?: ""}')",
             null,
         )
     }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/components/MapStyleRecolorTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/components/MapStyleRecolorTest.kt
@@ -21,6 +21,7 @@ class MapStyleRecolorTest {
             roadMinor = "#505050",
             roadCasing = "#606060",
             building = "#707070",
+            label = "#808080",
         )
 
     private fun layer(
@@ -51,7 +52,8 @@ class MapStyleRecolorTest {
             ${layer("railway_minor", "line", "transportation")},
             ${layer("road_pier", "line", "transportation")},
             ${layer("aeroway-runway", "line", "aeroway")},
-            ${layer("labels", "symbol", "place")}
+            ${layer("labels", "symbol", "place")},
+            {"id":"labels_haloed","type":"symbol","source-layer":"place","paint":{"text-halo-width":1.4}}
         ]}
         """.trimIndent()
 
@@ -88,6 +90,19 @@ class MapStyleRecolorTest {
     fun recolors_inner_roads_with_the_major_color() {
         assertEquals(colors.roadMajor, recoloredPaintOrNull("highway_motorway_inner")?.getString("line-color"))
         assertEquals(colors.roadMajor, recoloredPaintOrNull("tunnel_motorway_inner")?.getString("line-color"))
+    }
+
+    @Test
+    fun recolors_labels_with_a_background_halo_and_seeds_a_missing_halo_width() {
+        val paint = recoloredPaintOrNull("labels")
+        assertEquals(colors.label, paint?.getString("text-color"))
+        assertEquals(colors.background, paint?.getString("text-halo-color"))
+        assertEquals(1, paint?.getInt("text-halo-width"))
+    }
+
+    @Test
+    fun keeps_an_existing_halo_width() {
+        assertEquals(1.4, recoloredPaintOrNull("labels_haloed")?.getDouble("text-halo-width"))
     }
 
     @Test

--- a/webmap/src/main.ts
+++ b/webmap/src/main.ts
@@ -44,6 +44,7 @@ declare global {
 			roadMinor: string,
 			roadCasing: string,
 			building: string,
+			label: string,
 		) => void;
 		setFeatures: (
 			buildings: boolean,
@@ -543,6 +544,7 @@ try {
 		roadMinor,
 		roadCasing,
 		building,
+		label,
 	) => {
 		if (!url) return;
 		state.currentStyleUrl = url;
@@ -555,6 +557,7 @@ try {
 					roadMinor: roadMinor,
 					roadCasing: roadCasing,
 					building: building,
+					label: label,
 				}
 			: null;
 		applyStyleWithFade();

--- a/webmap/src/style.test.ts
+++ b/webmap/src/style.test.ts
@@ -73,6 +73,13 @@ function baseStyle(): StyleSpecification {
 				source: "openmaptiles",
 				"source-layer": "place",
 			},
+			{
+				id: "labels_haloed",
+				type: "symbol",
+				source: "openmaptiles",
+				"source-layer": "place",
+				paint: { "text-halo-width": 1.4 },
+			},
 		],
 	} as StyleSpecification;
 }
@@ -178,6 +185,7 @@ describe("injectFeatures: accent recolour", () => {
 		roadMinor: "#505050",
 		roadCasing: "#606060",
 		building: "#707070",
+		label: "#808080",
 	};
 
 	function paintOf(style: StyleSpecification, id: string) {
@@ -216,6 +224,19 @@ describe("injectFeatures: accent recolour", () => {
 		expect(paintOf(style, "highway_motorway_inner")?.["line-color"]).toBe(
 			accent.roadMajor,
 		);
+	});
+
+	it("recolours labels with a background halo, seeding a missing halo width", () => {
+		const style = injectFeatures(baseStyle(), { ...OFF, accent });
+		const paint = paintOf(style, "labels");
+		expect(paint?.["text-color"]).toBe(accent.label);
+		expect(paint?.["text-halo-color"]).toBe(accent.background);
+		expect(paint?.["text-halo-width"]).toBe(1);
+	});
+
+	it("keeps an existing halo width", () => {
+		const style = injectFeatures(baseStyle(), { ...OFF, accent });
+		expect(paintOf(style, "labels_haloed")?.["text-halo-width"]).toBe(1.4);
 	});
 
 	it("leaves railways, piers, and aeroways untouched", () => {

--- a/webmap/src/style.ts
+++ b/webmap/src/style.ts
@@ -10,6 +10,10 @@ export interface AccentColors {
 	roadMinor: string;
 	roadCasing: string;
 	building: string;
+	// Label text colour; the halo reuses background. The bundled bases' label
+	// colours are tuned to their own backgrounds and go illegible on the
+	// Material surface, so ACCENT recolours them like every other layer group.
+	label: string;
 }
 
 // The feature merge is parameterised on the page state instead of reading it,
@@ -109,9 +113,9 @@ export function injectFeatures(
 		delete nextStyle.sources.terrainSource;
 		delete nextStyle.terrain;
 	}
-	// ACCENT scheme: recolour background / water / land / building fills and the
-	// transportation lines with the accent palette. Roads keep their base widths,
-	// so the motorway/major/minor hierarchy survives; labels stay untouched.
+	// ACCENT scheme: recolour background / water / land / building fills, the
+	// transportation lines, and label text with the accent palette. Roads keep
+	// their base widths, so the motorway/major/minor hierarchy survives.
 	// Mirrors the Kotlin recolorAccent in MapStyleRecolor.kt — keep the layer
 	// groups and the road classification in sync.
 	const accent = features.accent;
@@ -137,6 +141,16 @@ export function injectFeatures(
 				setPaint(l, "line-color", accent.roadMinor);
 			else if (roadClass === "major")
 				setPaint(l, "line-color", accent.roadMajor);
+			else if (l.type === "symbol") {
+				// Text-less symbol layers (oneway arrows) ignore the text-* keys.
+				// The halo width is only seeded where the base omits it; existing
+				// widths are the base's tuning, kept as-is.
+				setPaint(l, "text-color", accent.label);
+				setPaint(l, "text-halo-color", accent.background);
+				const paint = (l as { paint?: Record<string, unknown> }).paint;
+				if (paint?.["text-halo-width"] === undefined)
+					setPaint(l, "text-halo-width", 1);
+			}
 		}
 	}
 	const src = vectorSourceId(nextStyle);


### PR DESCRIPTION
## Summary

User report: on the ACCENT dark map, roads and label text blend into the background. Verified on the TBox-Mock emulator — two root causes:

1. **Roads**: the dark palette painted the network in `surfaceContainer*` tones measuring ~2:1 contrast against the `surface` ground; the network effectively disappeared.
2. **Labels**: ACCENT recoloring left symbol layers untouched, so the bundled dark base's label colors applied — grey `rgb(101,101,101)` text and 70%-black water names, tuned for that base's own near-black background, not the Material surface.

## Changes

- **Dark road roles move up the ladder**: `roadMajor` `outlineVariant` → `outline`, `roadMinor` `surfaceContainerHighest` → `outlineVariant`. The ground < building < minor < major brightness hierarchy is preserved; the road network is again the brightest shape on the panel.
- **ACCENT now recolours labels** (both backends, both modes): `text-color` = `onSurfaceVariant`, `text-halo-color` = the map background, and a 1 px halo width seeded only where the base omits it (existing widths are the base's tuning, kept as-is). New `label` palette field flows through `AccentMapColors` / `AccentColors` and `setStyleUrl` (9th argument).
- Kotlin `recolorAccent` and webmap `injectFeatures` stay mirrored per their KDoc contract; tests extended on both sides (`MapStyleRecolorTest`, `style.test.ts`).

## Testing

- `pnpm run check` — Biome + tsc + vitest 37/37 (new label-recolour and halo-width-preservation cases on both sides)
- `./gradlew spotlessCheck test assembleDebug` — green
- TBox-Mock visual verification: dark ACCENT before/after at the same location — road names (中央通り etc.) went from illegible to clearly readable, road network distinct from the ground; light mode re-checked with no regression