### PR TITLE
feat(diagnostics): performance section and a Markdown report

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/system/PerformanceProbe.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/system/PerformanceProbe.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
 
 /**
@@ -126,26 +127,32 @@ internal class PerformanceProbe(
     private suspend fun sampleFrameStats(): FrameStats? =
         withContext(Dispatchers.Main) {
             val intervals = mutableListOf<Long>()
-            suspendCancellableCoroutine { continuation ->
-                val choreographer = Choreographer.getInstance()
-                val callback =
-                    object : Choreographer.FrameCallback {
-                        var previousNanos = 0L
+            // The Choreographer goes quiet when the display sleeps or the host
+            // is backgrounded; without a ceiling the whole snapshot() — and the
+            // Refresh button — would hang on it. On timeout the partial sample
+            // still reduces to stats (an empty one to null).
+            withTimeoutOrNull(FRAME_SAMPLE_TIMEOUT_MS) {
+                suspendCancellableCoroutine { continuation ->
+                    val choreographer = Choreographer.getInstance()
+                    val callback =
+                        object : Choreographer.FrameCallback {
+                            var previousNanos = 0L
 
-                        override fun doFrame(frameTimeNanos: Long) {
-                            if (previousNanos != 0L) {
-                                intervals += (frameTimeNanos - previousNanos) / NANOS_PER_MS
-                            }
-                            previousNanos = frameTimeNanos
-                            if (intervals.size < FRAME_SAMPLE_COUNT) {
-                                choreographer.postFrameCallback(this)
-                            } else {
-                                continuation.resume(Unit)
+                            override fun doFrame(frameTimeNanos: Long) {
+                                if (previousNanos != 0L) {
+                                    intervals += (frameTimeNanos - previousNanos) / NANOS_PER_MS
+                                }
+                                previousNanos = frameTimeNanos
+                                if (intervals.size < FRAME_SAMPLE_COUNT) {
+                                    choreographer.postFrameCallback(this)
+                                } else {
+                                    continuation.resume(Unit)
+                                }
                             }
                         }
-                    }
-                choreographer.postFrameCallback(callback)
-                continuation.invokeOnCancellation { choreographer.removeFrameCallback(callback) }
+                    choreographer.postFrameCallback(callback)
+                    continuation.invokeOnCancellation { choreographer.removeFrameCallback(callback) }
+                }
             }
             computeFrameStats(intervals)
         }
@@ -197,8 +204,11 @@ internal fun computeFrameStats(intervalsMs: List<Long>): FrameStats? {
 }
 
 // ~2 s of vsync callbacks at 60 Hz; long enough to catch periodic stalls,
-// short enough that Refresh stays snappy.
+// short enough that Refresh stays snappy. The timeout bounds a stalled or
+// silent Choreographer while leaving generous room for a janky device to
+// finish the full sample.
 private const val FRAME_SAMPLE_COUNT = 120
+private const val FRAME_SAMPLE_TIMEOUT_MS = 10_000L
 
 // One missed 60 Hz vsync (>2 frame periods) marks the interval as delayed.
 private const val DELAYED_FRAME_MS = 32L

--- a/app/src/main/java/io/github/seijikohara/femto/data/system/PerformanceProbe.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/system/PerformanceProbe.kt
@@ -1,0 +1,211 @@
+package io.github.seijikohara.femto.data.system
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Debug
+import android.os.PowerManager
+import android.os.Process
+import android.os.SystemClock
+import android.view.Choreographer
+import android.webkit.WebView
+import androidx.core.content.getSystemService
+import io.github.seijikohara.femto.data.display.DisplayPreferences
+import io.github.seijikohara.femto.data.location.LocationPreferences
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+
+/**
+ * How a thermal level reads on the diagnostics surface. Mirrors
+ * [PowerManager]'s `THERMAL_STATUS_*` ladder; [UNKNOWN] covers a missing
+ * service. [isThrottling] marks the levels where the platform is already
+ * slowing the device — the first suspect when "everything got sluggish".
+ */
+internal enum class ThermalLevel(
+    val isThrottling: Boolean,
+) {
+    NONE(false),
+    LIGHT(false),
+    MODERATE(true),
+    SEVERE(true),
+    CRITICAL(true),
+    EMERGENCY(true),
+    SHUTDOWN(true),
+    UNKNOWN(false),
+}
+
+/** UI-thread frame-delivery stats from a short [Choreographer] sample. */
+internal data class FrameStats(
+    val sampledFrames: Int,
+    val medianMs: Long,
+    val worstMs: Long,
+    val delayedPercent: Int,
+)
+
+/** One labelled value for the report's settings snapshot. */
+internal data class DiagnosticEntry(
+    val label: String,
+    val value: String,
+)
+
+/** Point-in-time performance capture for the Diagnostics screen. */
+internal data class PerformanceSnapshot(
+    val thermal: ThermalLevel,
+    // 0..1 fraction of the throttling threshold (1.0 = throttling now);
+    // null when the platform cannot forecast (rate-limited or unsupported).
+    val thermalHeadroom: Float?,
+    val powerSaveMode: Boolean,
+    val availMemMb: Int,
+    val totalMemMb: Int,
+    val lowMemory: Boolean,
+    val appPssMb: Int,
+    val javaHeapUsedMb: Int,
+    val javaHeapMaxMb: Int,
+    val nativeHeapMb: Int,
+    val processUptimeMinutes: Long,
+    val deviceUptimeMinutes: Long,
+    val frameStats: FrameStats?,
+    val webViewVersion: String?,
+    val mapSettings: List<DiagnosticEntry>,
+)
+
+/**
+ * Collects the performance snapshot: thermal state, memory pressure, process /
+ * device uptime, a short UI-thread frame sample, the WebView provider version,
+ * and the active map/location settings. Exists for the same reason as
+ * [DiagnosticsRepository]: deployed head units are rarely adb-reachable, and
+ * "the launcher feels sluggish" needs numbers — is the device throttling, out
+ * of memory, long-uptime, or configured into a heavy map — before any code
+ * path is worth suspecting.
+ */
+internal class PerformanceProbe(
+    private val context: Context,
+) {
+    suspend fun snapshot(): PerformanceSnapshot {
+        // The frame sample must run where the Choreographer of the UI thread
+        // lives; everything else is plain reads moved off the main thread.
+        val frameStats = sampleFrameStats()
+        return withContext(Dispatchers.IO) {
+            val power = context.getSystemService<PowerManager>()
+            val memory =
+                ActivityManager.MemoryInfo().also {
+                    context.getSystemService<ActivityManager>()?.getMemoryInfo(it)
+                }
+            val runtime = Runtime.getRuntime()
+            PerformanceSnapshot(
+                thermal = power?.currentThermalStatus.toThermalLevel(),
+                thermalHeadroom =
+                    power
+                        ?.getThermalHeadroom(HEADROOM_FORECAST_SECONDS)
+                        ?.takeIf { it.isFinite() },
+                powerSaveMode = power?.isPowerSaveMode == true,
+                availMemMb = (memory.availMem / BYTES_PER_MB).toInt(),
+                totalMemMb = (memory.totalMem / BYTES_PER_MB).toInt(),
+                lowMemory = memory.lowMemory,
+                appPssMb = (Debug.getPss() / KB_PER_MB).toInt(),
+                javaHeapUsedMb = ((runtime.totalMemory() - runtime.freeMemory()) / BYTES_PER_MB).toInt(),
+                javaHeapMaxMb = (runtime.maxMemory() / BYTES_PER_MB).toInt(),
+                nativeHeapMb = (Debug.getNativeHeapAllocatedSize() / BYTES_PER_MB).toInt(),
+                processUptimeMinutes =
+                    (SystemClock.elapsedRealtime() - Process.getStartElapsedRealtime()) / MS_PER_MINUTE,
+                deviceUptimeMinutes = SystemClock.elapsedRealtime() / MS_PER_MINUTE,
+                frameStats = frameStats,
+                webViewVersion =
+                    WebView.getCurrentWebViewPackage()?.let { "${it.packageName} ${it.versionName}" },
+                mapSettings = mapSettingEntries(),
+            )
+        }
+    }
+
+    // Capture vsync-callback intervals on the main thread for a short window.
+    // postFrameCallback re-arms every vsync whether or not content changed, so
+    // a stretched interval means the MAIN THREAD was busy past its deadline —
+    // the direct cause of "taps feel laggy" — independent of GPU load.
+    private suspend fun sampleFrameStats(): FrameStats? =
+        withContext(Dispatchers.Main) {
+            val intervals = mutableListOf<Long>()
+            runCatching {
+                suspendCancellableCoroutine { continuation ->
+                    val choreographer = Choreographer.getInstance()
+                    val callback =
+                        object : Choreographer.FrameCallback {
+                            var previousNanos = 0L
+
+                            override fun doFrame(frameTimeNanos: Long) {
+                                if (previousNanos != 0L) {
+                                    intervals += (frameTimeNanos - previousNanos) / NANOS_PER_MS
+                                }
+                                previousNanos = frameTimeNanos
+                                if (intervals.size < FRAME_SAMPLE_COUNT) {
+                                    choreographer.postFrameCallback(this)
+                                } else {
+                                    continuation.resume(Unit)
+                                }
+                            }
+                        }
+                    choreographer.postFrameCallback(callback)
+                    continuation.invokeOnCancellation { choreographer.removeFrameCallback(callback) }
+                }
+            }
+            computeFrameStats(intervals)
+        }
+
+    private suspend fun mapSettingEntries(): List<DiagnosticEntry> {
+        val display = DisplayPreferences(context).settings.first()
+        val location = LocationPreferences(context).settings.first()
+        return listOf(
+            DiagnosticEntry("Map render mode", display.mapRenderMode.name),
+            DiagnosticEntry("3D buildings / terrain", "${display.map3dBuildings} / ${display.mapTerrain}"),
+            DiagnosticEntry("Map zoom / tilt", "z${display.mapZoom} / ${display.mapTiltDeg}°"),
+            DiagnosticEntry("Snapshot render percent", "${display.mapRenderPercent}%"),
+            DiagnosticEntry("Location quality", location.quality.name),
+            DiagnosticEntry("Location interval", "${location.intervalMillis} ms"),
+            DiagnosticEntry("Location min distance", "${location.minUpdateDistanceMeters} m"),
+        )
+    }
+}
+
+private fun Int?.toThermalLevel(): ThermalLevel =
+    when (this) {
+        PowerManager.THERMAL_STATUS_NONE -> ThermalLevel.NONE
+        PowerManager.THERMAL_STATUS_LIGHT -> ThermalLevel.LIGHT
+        PowerManager.THERMAL_STATUS_MODERATE -> ThermalLevel.MODERATE
+        PowerManager.THERMAL_STATUS_SEVERE -> ThermalLevel.SEVERE
+        PowerManager.THERMAL_STATUS_CRITICAL -> ThermalLevel.CRITICAL
+        PowerManager.THERMAL_STATUS_EMERGENCY -> ThermalLevel.EMERGENCY
+        PowerManager.THERMAL_STATUS_SHUTDOWN -> ThermalLevel.SHUTDOWN
+        else -> ThermalLevel.UNKNOWN
+    }
+
+/**
+ * Reduce sampled vsync intervals to [FrameStats]; null when the sample is
+ * empty (the Choreographer never delivered — e.g. the probe ran while the
+ * host was backgrounded). Pure, so the maths is pinned by JVM tests.
+ */
+internal fun computeFrameStats(intervalsMs: List<Long>): FrameStats? {
+    if (intervalsMs.isEmpty()) return null
+    val sorted = intervalsMs.sorted()
+    return FrameStats(
+        sampledFrames = intervalsMs.size,
+        medianMs = sorted[sorted.size / 2],
+        worstMs = sorted.last(),
+        delayedPercent = intervalsMs.count { it > DELAYED_FRAME_MS } * 100 / intervalsMs.size,
+    )
+}
+
+// ~2 s of vsync callbacks at 60 Hz; long enough to catch periodic stalls,
+// short enough that Refresh stays snappy.
+private const val FRAME_SAMPLE_COUNT = 120
+
+// One missed 60 Hz vsync (>2 frame periods) marks the interval as delayed.
+private const val DELAYED_FRAME_MS = 32L
+
+// getThermalHeadroom forecast window; 10 s is the documented typical use.
+private const val HEADROOM_FORECAST_SECONDS = 10
+
+private const val BYTES_PER_MB = 1024L * 1024L
+private const val KB_PER_MB = 1024L
+private const val MS_PER_MINUTE = 60_000L
+private const val NANOS_PER_MS = 1_000_000L

--- a/app/src/main/java/io/github/seijikohara/femto/data/system/PerformanceProbe.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/system/PerformanceProbe.kt
@@ -126,32 +126,33 @@ internal class PerformanceProbe(
     private suspend fun sampleFrameStats(): FrameStats? =
         withContext(Dispatchers.Main) {
             val intervals = mutableListOf<Long>()
-            runCatching {
-                suspendCancellableCoroutine { continuation ->
-                    val choreographer = Choreographer.getInstance()
-                    val callback =
-                        object : Choreographer.FrameCallback {
-                            var previousNanos = 0L
+            suspendCancellableCoroutine { continuation ->
+                val choreographer = Choreographer.getInstance()
+                val callback =
+                    object : Choreographer.FrameCallback {
+                        var previousNanos = 0L
 
-                            override fun doFrame(frameTimeNanos: Long) {
-                                if (previousNanos != 0L) {
-                                    intervals += (frameTimeNanos - previousNanos) / NANOS_PER_MS
-                                }
-                                previousNanos = frameTimeNanos
-                                if (intervals.size < FRAME_SAMPLE_COUNT) {
-                                    choreographer.postFrameCallback(this)
-                                } else {
-                                    continuation.resume(Unit)
-                                }
+                        override fun doFrame(frameTimeNanos: Long) {
+                            if (previousNanos != 0L) {
+                                intervals += (frameTimeNanos - previousNanos) / NANOS_PER_MS
+                            }
+                            previousNanos = frameTimeNanos
+                            if (intervals.size < FRAME_SAMPLE_COUNT) {
+                                choreographer.postFrameCallback(this)
+                            } else {
+                                continuation.resume(Unit)
                             }
                         }
-                    choreographer.postFrameCallback(callback)
-                    continuation.invokeOnCancellation { choreographer.removeFrameCallback(callback) }
-                }
+                    }
+                choreographer.postFrameCallback(callback)
+                continuation.invokeOnCancellation { choreographer.removeFrameCallback(callback) }
             }
             computeFrameStats(intervals)
         }
 
+    // Labels stay English on the SCREEN as well as in the report: the entry
+    // list is a debug artifact shared verbatim with the unlocalized Markdown
+    // report, where stable machine-greppable wording is the contract.
     private suspend fun mapSettingEntries(): List<DiagnosticEntry> {
         val display = DisplayPreferences(context).settings.first()
         val location = LocationPreferences(context).settings.first()

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReport.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReport.kt
@@ -1,43 +1,117 @@
 package io.github.seijikohara.femto.ui.diagnostics
 
 import io.github.seijikohara.femto.data.music.MusicCardState
+import io.github.seijikohara.femto.data.system.PerformanceSnapshot
 
 /**
- * Render the diagnostics state as a plain-text report for the clipboard.
+ * Render the diagnostics state as a Markdown report for the clipboard.
  *
- * Deliberately English and unlocalized: the report is a debug artifact meant
- * to be pasted into an issue or a remote debugging session, where stable
- * machine-greppable wording beats locale fidelity. Pure, so the exact shape
- * is pinned by JVM tests.
+ * Markdown because the report's destination is an issue tracker or a chat —
+ * headings, the permissions table, and the fenced log block survive the paste
+ * with their structure intact, and the fenced block keeps log lines grep-able
+ * as plain text. Deliberately English and unlocalized: stable
+ * machine-greppable wording beats locale fidelity in a debug artifact. Pure,
+ * so the exact shape is pinned by JVM tests.
  */
 internal fun diagnosticsReport(uiState: DiagnosticsUiState): String =
     buildString {
-        appendLine("== Femto Car Launcher diagnostics ==")
+        appendLine("# Femto Car Launcher diagnostics")
+        appendLine()
         uiState.snapshot?.let { snapshot ->
-            appendLine("App: ${snapshot.appVersion}")
-            appendLine("Device: ${snapshot.deviceModel} / Android ${snapshot.androidRelease} (API ${snapshot.sdkInt})")
-            appendLine("-- Permissions --")
+            appendLine("- App: ${snapshot.appVersion}")
+            appendLine(
+                "- Device: ${snapshot.deviceModel} / Android ${snapshot.androidRelease} (API ${snapshot.sdkInt})",
+            )
+            appendLine()
+            appendLine("## Permissions")
+            appendLine()
+            appendLine("| Permission | State |")
+            appendLine("| --- | --- |")
             snapshot.permissions.forEach { state ->
-                appendLine("${state.permission.substringAfterLast('.')}: ${if (state.granted) "granted" else "DENIED"}")
+                appendLine(
+                    "| ${state.permission.substringAfterLast('.')} | ${if (state.granted) "granted" else "DENIED"} |",
+                )
             }
-            appendLine("Notification listener: ${if (snapshot.notificationListenerEnabled) "enabled" else "DISABLED"}")
-            appendLine("-- Network --")
+            appendLine(
+                "| Notification listener | ${if (snapshot.notificationListenerEnabled) "enabled" else "DISABLED"} |",
+            )
+            appendLine()
+            appendLine("## Network")
+            appendLine()
             appendLine(
                 if (snapshot.networkOnline) {
-                    "Online (${snapshot.networkTransports.joinToString().ifEmpty { "unknown transport" }})"
+                    "- Online (${snapshot.networkTransports.joinToString().ifEmpty { "unknown transport" }})"
                 } else {
-                    "OFFLINE"
+                    "- OFFLINE"
                 },
             )
         } ?: appendLine("Snapshot UNAVAILABLE (collection failed; see app logs)")
-        appendLine("-- Music --")
-        appendLine("Session: ${uiState.musicState.described()}")
-        appendLine("Spectrum capture: ${uiState.spectrum?.name ?: "not probed"}")
+        appendLine()
+        appendLine("## Music")
+        appendLine()
+        appendLine("- Session: ${uiState.musicState.described()}")
+        appendLine("- Spectrum capture: ${uiState.spectrum?.name ?: "not probed"}")
+        uiState.performance?.let { appendPerformance(it) }
         uiState.snapshot?.recentWarningLogs?.let { logs ->
-            appendLine("-- Recent warnings (${logs.size}) --")
+            appendLine()
+            appendLine("## Recent warnings (${logs.size})")
+            appendLine()
+            appendLine("```text")
             logs.forEach(::appendLine)
+            appendLine("```")
         }
     }
+
+private fun StringBuilder.appendPerformance(performance: PerformanceSnapshot) {
+    appendLine()
+    appendLine("## Performance")
+    appendLine()
+    val headroom = performance.thermalHeadroom?.let { " (headroom %.2f)".format(it) }.orEmpty()
+    appendLine("- Thermal: ${performance.thermal.name}$headroom")
+    appendLine("- Power save: ${if (performance.powerSaveMode) "ON" else "off"}")
+    appendLine(
+        "- Device memory: ${performance.availMemMb} / ${performance.totalMemMb} MB free" +
+            if (performance.lowMemory) " (LOW MEMORY)" else "",
+    )
+    appendLine(
+        "- App memory: PSS ${performance.appPssMb} MB, " +
+            "Java heap ${performance.javaHeapUsedMb}/${performance.javaHeapMaxMb} MB, " +
+            "native ${performance.nativeHeapMb} MB",
+    )
+    appendLine(
+        "- Uptime: process ${performance.processUptimeMinutes.asUptime()}, " +
+            "device ${performance.deviceUptimeMinutes.asUptime()}",
+    )
+    appendLine(
+        performance.frameStats?.let { frames ->
+            "- UI frames (${frames.sampledFrames} sampled): median ${frames.medianMs} ms, " +
+                "worst ${frames.worstMs} ms, delayed ${frames.delayedPercent}%"
+        } ?: "- UI frames: sample unavailable",
+    )
+    appendLine("- WebView: ${performance.webViewVersion ?: "unknown"}")
+    appendLine()
+    appendLine("## Map settings")
+    appendLine()
+    performance.mapSettings.forEach { entry ->
+        appendLine("- ${entry.label}: ${entry.value}")
+    }
+}
+
+// "3d 7h" / "5h 4m" / "12m" — coarse on purpose; uptime is a suspect ranking
+// signal, not a stopwatch.
+private fun Long.asUptime(): String {
+    val days = this / MINUTES_PER_DAY
+    val hours = this % MINUTES_PER_DAY / MINUTES_PER_HOUR
+    val minutes = this % MINUTES_PER_HOUR
+    return when {
+        days > 0 -> "${days}d ${hours}h"
+        hours > 0 -> "${hours}h ${minutes}m"
+        else -> "${minutes}m"
+    }
+}
+
+private const val MINUTES_PER_HOUR = 60L
+private const val MINUTES_PER_DAY = 24L * 60L
 
 /** One-line session description shared by the report and the screen row. */
 internal fun MusicCardState?.described(): String =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReport.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReport.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.ui.diagnostics
 
 import io.github.seijikohara.femto.data.music.MusicCardState
 import io.github.seijikohara.femto.data.system.PerformanceSnapshot
+import java.util.Locale
 
 /**
  * Render the diagnostics state as a Markdown report for the clipboard.
@@ -66,7 +67,12 @@ private fun StringBuilder.appendPerformance(performance: PerformanceSnapshot) {
     appendLine()
     appendLine("## Performance")
     appendLine()
-    val headroom = performance.thermalHeadroom?.let { " (headroom %.2f)".format(it) }.orEmpty()
+    // Locale.ROOT keeps the decimal point: the report's grep-stable wording
+    // contract must hold on comma-decimal devices too.
+    val headroom =
+        performance.thermalHeadroom
+            ?.let { " (headroom %.2f)".format(Locale.ROOT, it) }
+            .orEmpty()
     appendLine("- Thermal: ${performance.thermal.name}$headroom")
     appendLine("- Power save: ${if (performance.powerSaveMode) "ON" else "off"}")
     appendLine(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
@@ -27,6 +27,7 @@ import com.composables.icons.lucide.Lucide
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.music.SpectrumDiagnosis
 import io.github.seijikohara.femto.data.system.DiagnosticsSnapshot
+import io.github.seijikohara.femto.data.system.PerformanceSnapshot
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
@@ -68,6 +69,7 @@ internal fun DiagnosticsScreen(
         PermissionsSection(snapshot)
         MusicSection(uiState)
         NetworkSection(snapshot)
+        uiState.performance?.let { PerformanceSection(it) }
         LogsSection(snapshot.recentWarningLogs)
     } ?: run {
         Text(
@@ -195,6 +197,63 @@ private fun NetworkSection(snapshot: DiagnosticsSnapshot) =
     }
 
 @Composable
+private fun PerformanceSection(performance: PerformanceSnapshot) {
+    Section(title = stringResource(R.string.diagnostics_section_performance)) {
+        StatusRow(
+            label = stringResource(R.string.diagnostics_thermal),
+            value =
+                performance.thermal.name +
+                    (performance.thermalHeadroom?.let { " (%.2f)".format(it) }.orEmpty()),
+            healthy = !performance.thermal.isThrottling,
+        )
+        StatusRow(
+            label = stringResource(R.string.diagnostics_device_memory),
+            value = "${performance.availMemMb} / ${performance.totalMemMb} MB",
+            healthy = !performance.lowMemory,
+        )
+        ValueRow(
+            label =
+                stringResource(
+                    R.string.diagnostics_app_memory,
+                    performance.appPssMb,
+                    performance.javaHeapUsedMb,
+                    performance.javaHeapMaxMb,
+                    performance.nativeHeapMb,
+                ),
+        )
+        ValueRow(
+            label =
+                stringResource(
+                    R.string.diagnostics_uptime,
+                    performance.processUptimeMinutes / 60,
+                    performance.processUptimeMinutes % 60,
+                    performance.deviceUptimeMinutes / 60,
+                    performance.deviceUptimeMinutes % 60,
+                ),
+        )
+        performance.frameStats?.let { frames ->
+            StatusRow(
+                label = stringResource(R.string.diagnostics_frames),
+                value =
+                    stringResource(
+                        R.string.diagnostics_frames_value,
+                        frames.medianMs,
+                        frames.worstMs,
+                        frames.delayedPercent,
+                    ),
+                healthy = frames.delayedPercent < DELAYED_HEALTHY_MAX_PERCENT,
+            )
+        }
+        ValueRow(label = performance.webViewVersion ?: stringResource(R.string.diagnostics_webview_unknown))
+    }
+    Section(title = stringResource(R.string.diagnostics_section_map_settings)) {
+        performance.mapSettings.forEach { entry ->
+            ValueRow(label = "${entry.label}: ${entry.value}")
+        }
+    }
+}
+
+@Composable
 private fun LogsSection(logs: List<String>) =
     Section(title = stringResource(R.string.diagnostics_section_logs, logs.size)) {
         if (logs.isEmpty()) {
@@ -273,6 +332,10 @@ private fun spectrumLabel(diagnosis: SpectrumDiagnosis?): String =
             null -> R.string.diagnostics_spectrum_not_probed
         },
     )
+
+// A delayed-frame share below this reads as healthy on the status row; above
+// it the row flags the UI thread as a sluggishness suspect.
+private const val DELAYED_HEALTHY_MAX_PERCENT = 10
 
 @PreviewLightDark
 @Composable

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
@@ -31,6 +31,7 @@ import io.github.seijikohara.femto.data.system.PerformanceSnapshot
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+import java.util.Locale
 
 /**
  * Per-feature health readout: which gate (grant, listener, capture engine,
@@ -203,7 +204,7 @@ private fun PerformanceSection(performance: PerformanceSnapshot) {
             label = stringResource(R.string.diagnostics_thermal),
             value =
                 performance.thermal.name +
-                    (performance.thermalHeadroom?.let { " (%.2f)".format(it) }.orEmpty()),
+                    (performance.thermalHeadroom?.let { " (%.2f)".format(Locale.ROOT, it) }.orEmpty()),
             healthy = !performance.thermal.isThrottling,
         )
         StatusRow(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
@@ -203,8 +203,14 @@ private fun PerformanceSection(performance: PerformanceSnapshot) {
         StatusRow(
             label = stringResource(R.string.diagnostics_thermal),
             value =
-                performance.thermal.name +
-                    (performance.thermalHeadroom?.let { " (%.2f)".format(Locale.ROOT, it) }.orEmpty()),
+                performance.thermalHeadroom
+                    ?.let {
+                        stringResource(
+                            R.string.diagnostics_thermal_headroom,
+                            performance.thermal.name,
+                            "%.2f".format(Locale.ROOT, it),
+                        )
+                    } ?: performance.thermal.name,
             healthy = !performance.thermal.isThrottling,
         )
         StatusRow(
@@ -245,7 +251,12 @@ private fun PerformanceSection(performance: PerformanceSnapshot) {
                 healthy = frames.delayedPercent < DELAYED_HEALTHY_MAX_PERCENT,
             )
         }
-        ValueRow(label = performance.webViewVersion ?: stringResource(R.string.diagnostics_webview_unknown))
+        ValueRow(
+            label =
+                performance.webViewVersion
+                    ?.let { stringResource(R.string.diagnostics_webview_value, it) }
+                    ?: stringResource(R.string.diagnostics_webview_unknown),
+        )
     }
     Section(title = stringResource(R.string.diagnostics_section_map_settings)) {
         performance.mapSettings.forEach { entry ->

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsUiState.kt
@@ -3,6 +3,7 @@ package io.github.seijikohara.femto.ui.diagnostics
 import io.github.seijikohara.femto.data.music.MusicCardState
 import io.github.seijikohara.femto.data.music.SpectrumDiagnosis
 import io.github.seijikohara.femto.data.system.DiagnosticsSnapshot
+import io.github.seijikohara.femto.data.system.PerformanceSnapshot
 
 internal data class DiagnosticsUiState(
     val isLoading: Boolean = true,
@@ -13,6 +14,9 @@ internal data class DiagnosticsUiState(
     // while music is playing, which the screen calls out.
     val spectrum: SpectrumDiagnosis? = null,
     val musicState: MusicCardState? = null,
+    // null until the first collection lands; degrades independently like the
+    // other probes.
+    val performance: PerformanceSnapshot? = null,
 ) {
     companion object {
         val Initial: DiagnosticsUiState = DiagnosticsUiState()

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsViewModel.kt
@@ -13,6 +13,8 @@ import io.github.seijikohara.femto.data.music.MusicSessionRepository
 import io.github.seijikohara.femto.data.music.SpectrumDiagnosis
 import io.github.seijikohara.femto.data.system.DiagnosticsRepository
 import io.github.seijikohara.femto.data.system.DiagnosticsSnapshot
+import io.github.seijikohara.femto.data.system.PerformanceProbe
+import io.github.seijikohara.femto.data.system.PerformanceSnapshot
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +37,7 @@ internal class DiagnosticsViewModel(
     private val collectSnapshot: suspend () -> DiagnosticsSnapshot,
     private val probeSpectrum: suspend () -> SpectrumDiagnosis,
     musicStateFlow: Flow<MusicCardState>,
+    private val collectPerformance: suspend () -> PerformanceSnapshot? = { null },
 ) : ViewModel() {
     private val probes = MutableStateFlow(DiagnosticsUiState.Initial)
 
@@ -69,8 +72,16 @@ internal class DiagnosticsViewModel(
             // snapshot's log tail must be captured after it so the report
             // carries the exact Visualizer error rather than predating it.
             val spectrum = runCatchingOrNull("spectrum probe") { probeSpectrum() }
+            val performance = runCatchingOrNull("performance probe") { collectPerformance() }
             val snapshot = runCatchingOrNull("snapshot") { collectSnapshot() }
-            probes.update { it.copy(isLoading = false, snapshot = snapshot, spectrum = spectrum) }
+            probes.update {
+                it.copy(
+                    isLoading = false,
+                    snapshot = snapshot,
+                    spectrum = spectrum,
+                    performance = performance,
+                )
+            }
         }
     }
 
@@ -96,6 +107,7 @@ internal val DiagnosticsViewModelFactory: ViewModelProvider.Factory =
                 collectSnapshot = DiagnosticsRepository(application)::snapshot,
                 probeSpectrum = AudioSpectrumRepository(application)::diagnose,
                 musicStateFlow = MusicSessionRepository(application).stateFlow(),
+                collectPerformance = PerformanceProbe(application)::snapshot,
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,6 +253,8 @@
     <string name="diagnostics_uptime">Uptime: process %1$dh %2$dm · device %3$dh %4$dm</string>
     <string name="diagnostics_frames">UI frames</string>
     <string name="diagnostics_frames_value">med %1$d ms · worst %2$d ms · delayed %3$d%%</string>
+    <string name="diagnostics_thermal_headroom">%1$s · headroom %2$s</string>
+    <string name="diagnostics_webview_value">WebView: %1$s</string>
     <string name="diagnostics_webview_unknown">WebView: unknown provider</string>
     <string name="diagnostics_granted">Granted</string>
     <string name="diagnostics_denied">Denied</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,6 +245,15 @@
     <string name="diagnostics_section_music">Music</string>
     <string name="diagnostics_section_network">Network</string>
     <string name="diagnostics_section_logs">Recent warnings (%1$d)</string>
+    <string name="diagnostics_section_performance">Performance</string>
+    <string name="diagnostics_section_map_settings">Map settings</string>
+    <string name="diagnostics_thermal">Thermal status</string>
+    <string name="diagnostics_device_memory">Device memory free</string>
+    <string name="diagnostics_app_memory">App: PSS %1$d MB · Java heap %2$d/%3$d MB · native %4$d MB</string>
+    <string name="diagnostics_uptime">Uptime: process %1$dh %2$dm · device %3$dh %4$dm</string>
+    <string name="diagnostics_frames">UI frames</string>
+    <string name="diagnostics_frames_value">med %1$d ms · worst %2$d ms · delayed %3$d%%</string>
+    <string name="diagnostics_webview_unknown">WebView: unknown provider</string>
     <string name="diagnostics_granted">Granted</string>
     <string name="diagnostics_denied">Denied</string>
     <string name="diagnostics_enabled">Enabled</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/system/FrameStatsTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/system/FrameStatsTest.kt
@@ -1,0 +1,29 @@
+package io.github.seijikohara.femto.data.system
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FrameStatsTest {
+    @Test
+    fun `reduces intervals to median worst and delayed share`() {
+        // 8 smooth frames + 2 stalls: median stays at the vsync cadence,
+        // worst surfaces the longest stall, 2/10 cross the delayed bar.
+        val intervals = listOf(16L, 16L, 17L, 16L, 16L, 17L, 16L, 16L, 50L, 120L)
+        val stats = computeFrameStats(intervals)
+        assertEquals(10, stats?.sampledFrames)
+        assertEquals(16L, stats?.medianMs)
+        assertEquals(120L, stats?.worstMs)
+        assertEquals(20, stats?.delayedPercent)
+    }
+
+    @Test
+    fun `a fully smooth sample reports zero delayed`() {
+        assertEquals(0, computeFrameStats(List(60) { 16L })?.delayedPercent)
+    }
+
+    @Test
+    fun `an empty sample is null not a division by zero`() {
+        assertNull(computeFrameStats(emptyList()))
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakePerformanceSnapshot.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakePerformanceSnapshot.kt
@@ -1,0 +1,33 @@
+package io.github.seijikohara.femto.testfixtures
+
+import io.github.seijikohara.femto.data.system.DiagnosticEntry
+import io.github.seijikohara.femto.data.system.FrameStats
+import io.github.seijikohara.femto.data.system.PerformanceSnapshot
+import io.github.seijikohara.femto.data.system.ThermalLevel
+
+internal fun fakePerformanceSnapshot(
+    thermal: ThermalLevel = ThermalLevel.NONE,
+    lowMemory: Boolean = false,
+    frameStats: FrameStats? = FrameStats(sampledFrames = 120, medianMs = 16, worstMs = 48, delayedPercent = 4),
+): PerformanceSnapshot =
+    PerformanceSnapshot(
+        thermal = thermal,
+        thermalHeadroom = 0.42f,
+        powerSaveMode = false,
+        availMemMb = 1024,
+        totalMemMb = 3962,
+        lowMemory = lowMemory,
+        appPssMb = 210,
+        javaHeapUsedMb = 48,
+        javaHeapMaxMb = 256,
+        nativeHeapMb = 88,
+        processUptimeMinutes = 133,
+        deviceUptimeMinutes = 7444,
+        frameStats = frameStats,
+        webViewVersion = "com.google.android.webview 110.0.5481.154",
+        mapSettings =
+            listOf(
+                DiagnosticEntry("Map render mode", "LIVE"),
+                DiagnosticEntry("Location interval", "1000 ms"),
+            ),
+    )

--- a/app/src/test/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReportTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReportTest.kt
@@ -4,6 +4,7 @@ import io.github.seijikohara.femto.data.music.MusicCardState
 import io.github.seijikohara.femto.data.music.SpectrumDiagnosis
 import io.github.seijikohara.femto.testfixtures.fakeDiagnosticsSnapshot
 import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
+import io.github.seijikohara.femto.testfixtures.fakePerformanceSnapshot
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,8 +20,46 @@ class DiagnosticsReportTest {
             diagnosticsReport(
                 DiagnosticsUiState(isLoading = false, snapshot = fakeDiagnosticsSnapshot()),
             )
-        assertTrue(report.contains("ACCESS_FINE_LOCATION: granted"))
-        assertTrue(report.contains("RECORD_AUDIO: DENIED"))
+        assertTrue(report.contains("| ACCESS_FINE_LOCATION | granted |"))
+        assertTrue(report.contains("| RECORD_AUDIO | DENIED |"))
+    }
+
+    @Test
+    fun `report is markdown with a title heading and a fenced log block`() {
+        val report =
+            diagnosticsReport(
+                DiagnosticsUiState(isLoading = false, snapshot = fakeDiagnosticsSnapshot()),
+            )
+        assertTrue(report.startsWith("# Femto Car Launcher diagnostics"))
+        assertTrue(report.contains("## Permissions"))
+        assertTrue(report.contains("```text\n06-12 12:00:00.000 W/AudioSpectrumRepo: sample warning\n```"))
+    }
+
+    @Test
+    fun `report renders the performance section with thermal and frame stats`() {
+        val report =
+            diagnosticsReport(
+                DiagnosticsUiState(
+                    isLoading = false,
+                    snapshot = fakeDiagnosticsSnapshot(),
+                    performance = fakePerformanceSnapshot(),
+                ),
+            )
+        assertTrue(report.contains("## Performance"))
+        assertTrue(report.contains("- Thermal: NONE (headroom 0.42)"))
+        assertTrue(report.contains("- UI frames (120 sampled): median 16 ms, worst 48 ms, delayed 4%"))
+        assertTrue(report.contains("- Uptime: process 2h 13m, device 5d 4h"))
+        assertTrue(report.contains("## Map settings"))
+        assertTrue(report.contains("- Map render mode: LIVE"))
+    }
+
+    @Test
+    fun `a missing performance probe omits the section`() {
+        val report =
+            diagnosticsReport(
+                DiagnosticsUiState(isLoading = false, snapshot = fakeDiagnosticsSnapshot()),
+            )
+        assertTrue(!report.contains("## Performance"))
     }
 
     @Test

--- a/app/src/test/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsViewModelTest.kt
@@ -5,6 +5,7 @@ import io.github.seijikohara.femto.data.music.MusicCardState
 import io.github.seijikohara.femto.data.music.SpectrumDiagnosis
 import io.github.seijikohara.femto.testfixtures.fakeDiagnosticsSnapshot
 import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
+import io.github.seijikohara.femto.testfixtures.fakePerformanceSnapshot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -51,6 +52,25 @@ class DiagnosticsViewModelTest {
                 assertEquals(snapshot, state.snapshot)
                 assertEquals(SpectrumDiagnosis.SILENT, state.spectrum)
                 assertEquals(MusicCardState.Playing(fakeNowPlaying()), state.musicState)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `refresh lands the performance snapshot independently`() =
+        runTest {
+            val performance = fakePerformanceSnapshot()
+            val viewModel =
+                DiagnosticsViewModel(
+                    collectSnapshot = { error("collector broke") },
+                    probeSpectrum = { SpectrumDiagnosis.SILENT },
+                    musicStateFlow = flowOf(MusicCardState.NoActiveSession),
+                    collectPerformance = { performance },
+                )
+            viewModel.uiState.test {
+                val state = awaitItem()
+                assertEquals(null, state.snapshot)
+                assertEquals(performance, state.performance)
                 cancelAndIgnoreRemainingEvents()
             }
         }


### PR DESCRIPTION
## Summary

Follow-up to the sluggishness investigation (no code regression found between the smooth baseline and main): the Diagnostics sheet — the remote-debug surface for adb-unreachable head units — now turns "the launcher feels heavy" into numbers, and the copyable report becomes Markdown (user request).

### Performance section (new `PerformanceProbe` in `data/system`)

- **Thermal** status (+ headroom via `getThermalHeadroom`) and power-save state — the first suspects for a dashboard-mounted unit in summer; throttling levels flag unhealthy
- **Memory**: device free/total + low-memory flag, app PSS / Java heap / native heap
- **Uptime**: process and device — long-uptime accumulation suspects
- **UI frames**: a ~2 s Choreographer vsync-interval sample (median / worst / delayed%) — main-thread health independent of GPU load; ≥10% delayed flags unhealthy
- **WebView provider version** — device WebView drift is otherwise invisible
- **Map settings snapshot**: render mode, 3D/terrain, zoom/tilt, snapshot percent, location quality/interval/min-distance — the heavy-map configuration suspects

The probe degrades to null independently like the existing snapshot/spectrum probes; `computeFrameStats` is a pure JVM-tested function.

### Markdown report

The report's destination is an issue tracker or chat: `#`/`##` headings, a permissions table, and a fenced ` ```text ` log block survive the paste with structure intact and keep log lines grep-able. Wording stays English/unlocalized per the existing contract (now locale-pinned via `Locale.ROOT` for the one float).

## Testing

- `./gradlew spotlessCheck test lint assembleDebug` — green, lint findings unchanged from baseline
- New `FrameStatsTest`; `DiagnosticsReportTest` re-pinned to the Markdown shape (+ performance section cases); `DiagnosticsViewModelTest` proves the performance probe lands even when the snapshot collector breaks
- Emulator end-to-end: all rows render; the UI-frames row correctly flagged the saturated emulator (delayed 24%, error-coloured) while median stayed 16 ms — exactly the GPU-vs-main-thread distinction the metric is for