### PR TITLE
fix(data): surface silent failures across the data layer

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/apps/AppsRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/apps/AppsRepository.kt
@@ -66,7 +66,14 @@ internal class AppsRepository(
             .fold(
                 onSuccess = { true },
                 onFailure = { error ->
-                    if (error is ActivityNotFoundException) false else throw error
+                    if (error is ActivityNotFoundException) {
+                        // The only field trail for a dead tap on a stale tile —
+                        // head units are typically adb-unreachable.
+                        Log.w(TAG, "activity not found for ${componentName.flattenToShortString()}")
+                        false
+                    } else {
+                        throw error
+                    }
                 },
             )
 
@@ -82,6 +89,10 @@ internal class AppsRepository(
                 .getActivityList(packageName, Process.myUserHandle())
                 .firstOrNull()
                 ?.componentName
+        }.onFailure {
+            // Distinguish a lookup fault from the legitimate "no launchable
+            // activity" null — both end in a no-op tap on the music card.
+            Log.w(TAG, "launcher lookup failed for $packageName", it)
         }.getOrNull()
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarRepository.kt
@@ -264,6 +264,11 @@ internal class CalendarRepository(
                             true,
                             observer,
                         )
+                    }.onFailure {
+                        // Mirror readWindow's split: the revoke race is expected and
+                        // silent, but any other fault leaves the card stale until the
+                        // next rebuild-key change — that needs a trail.
+                        if (it !is SecurityException) Log.e(TAG, "calendar observer registration failed", it)
                     }.isSuccess
             awaitClose {
                 if (registered) context.contentResolver.unregisterContentObserver(observer)

--- a/app/src/main/java/io/github/seijikohara/femto/data/fonts/FontCache.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/fonts/FontCache.kt
@@ -1,6 +1,9 @@
 package io.github.seijikohara.femto.data.fonts
 
+import android.util.Log
 import java.io.File
+
+private const val TAG = "FontCache"
 
 /**
  * A downloaded typeface on disk. [Variable] is one file driving every weight via
@@ -73,7 +76,11 @@ internal class FontCache(
     ) {
         val keepDirs = (keep + alsoProtect).map { dirFor(it).name }.toSet()
         root.listFiles().orEmpty().forEach { dir ->
-            if (dir.isDirectory && dir.name !in keepDirs) dir.deleteRecursively()
+            // A failed delete silently leaks disk on a storage-constrained head
+            // unit; the next eviction pass retries, but leave a trail.
+            if (dir.isDirectory && dir.name !in keepDirs && !dir.deleteRecursively()) {
+                Log.w(TAG, "failed to evict font cache dir ${dir.name}")
+            }
         }
     }
 

--- a/app/src/main/java/io/github/seijikohara/femto/data/fonts/GoogleFontsApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/fonts/GoogleFontsApi.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
+import kotlin.coroutines.cancellation.CancellationException
 
 private const val TAG = "GoogleFontsApi"
 
@@ -53,8 +54,13 @@ internal class GoogleFontsApi(
                             .sortedBy { it.popularity }
                     }
                 }
-            }.onFailure { Log.w(TAG, "catalog failed", it) }
-                .getOrNull()
+            }.onFailure {
+                // runCatching also traps cancellation; rethrow so a cancelled
+                // call propagates instead of logging as a phantom outage
+                // (matches ReverseGeocoderRepository).
+                if (it is CancellationException) throw it
+                Log.w(TAG, "catalog failed", it)
+            }.getOrNull()
         }
 
     /**
@@ -81,8 +87,10 @@ internal class GoogleFontsApi(
                             .let(::planFrom)
                     }
                 }
-            }.onFailure { Log.w(TAG, "manifest failed for $family", it) }
-                .getOrNull()
+            }.onFailure {
+                if (it is CancellationException) throw it
+                Log.w(TAG, "manifest failed for $family", it)
+            }.getOrNull()
         }
 
     /** Download [url] into [target], replacing any partial file. Returns success. */
@@ -114,8 +122,10 @@ internal class GoogleFontsApi(
                         }
                     }
                 }
-            }.onFailure { Log.w(TAG, "download failed for $url", it) }
-                .getOrDefault(false)
+            }.onFailure {
+                if (it is CancellationException) throw it
+                Log.w(TAG, "download failed for $url", it)
+            }.getOrDefault(false)
         }
 
     private fun planFrom(refs: List<FileRef>): FontDownloadPlan? {

--- a/app/src/main/java/io/github/seijikohara/femto/data/geocoding/NominatimApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/geocoding/NominatimApi.kt
@@ -11,6 +11,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.util.Locale
+import kotlin.coroutines.cancellation.CancellationException
 
 private const val TAG = "NominatimApi"
 
@@ -67,12 +68,15 @@ internal class NominatimApi(
                         Log.w(TAG, "reverse geocode HTTP ${response.code}")
                         return@use null
                     }
-                    response.body?.string()?.let { body ->
-                        json.decodeFromString<NominatimResponse>(body)
-                    }
+                    json.decodeFromString<NominatimResponse>(response.body.string())
                 }
-            }.onFailure { Log.w(TAG, "reverse geocode failed", it) }
-                .getOrNull()
+            }.onFailure {
+                // runCatching also traps cancellation; rethrow so a cancelled
+                // call propagates instead of logging as a phantom outage
+                // (matches ReverseGeocoderRepository).
+                if (it is CancellationException) throw it
+                Log.w(TAG, "reverse geocode failed", it)
+            }.getOrNull()
         }
 
     @Serializable

--- a/app/src/main/java/io/github/seijikohara/femto/data/music/MusicSessionRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/music/MusicSessionRepository.kt
@@ -138,7 +138,10 @@ internal class MusicSessionRepository(
                 if (next !== watched) {
                     runCatching { watched?.unregisterCallback(watcher) }
                     watched = next
+                    // A refused registration freezes the card on stale metadata
+                    // while it looks healthy; leave a trail.
                     runCatching { watched?.registerCallback(watcher) }
+                        .onFailure { Log.w(TAG, "registerCallback failed for ${next?.packageName}", it) }
                 }
             }
 

--- a/app/src/main/java/io/github/seijikohara/femto/data/system/SystemStatusRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/system/SystemStatusRepository.kt
@@ -25,6 +25,7 @@ import android.os.Build
 import android.telephony.SignalStrength
 import android.telephony.TelephonyCallback
 import android.telephony.TelephonyManager
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import io.github.seijikohara.femto.data.location.LocationRepository
@@ -50,6 +51,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.transformLatest
+
+private const val TAG = "SystemStatusRepo"
 
 /**
  * Dock status cluster — Wi-Fi connectivity / signal strength, cellular
@@ -302,7 +305,12 @@ internal class SystemStatusRepository(
                     trySend(usedInFix)
                 }
             }
-            lm.registerGnssStatusCallback(context.mainExecutor, callback)
+            // Registration refusal is reported via the Boolean, not an exception,
+            // so no upstream catch ever sees it — the dock would read "searching"
+            // forever despite a working fix. Some head-unit GNSS HALs do refuse.
+            if (!lm.registerGnssStatusCallback(context.mainExecutor, callback)) {
+                Log.w(TAG, "GnssStatus callback registration refused; satellite count stays 0")
+            }
             awaitClose { lm.unregisterGnssStatusCallback(callback) }
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/data/voice/VoiceRecognizer.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/voice/VoiceRecognizer.kt
@@ -75,7 +75,12 @@ internal class VoiceRecognizer(
 
     /** Return to the ready state, discarding any result or error. */
     fun reset() {
-        if (isAvailable) _state.value = VoiceState.Idle
+        if (isAvailable) {
+            // Park the engine before the next start(): after onError some OEM
+            // recognizers silently no-op on a reused instance unless cancelled.
+            recognizer?.cancel()
+            _state.value = VoiceState.Idle
+        }
     }
 
     fun destroy() {

--- a/app/src/main/java/io/github/seijikohara/femto/data/weather/OpenMeteoApi.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/weather/OpenMeteoApi.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import kotlin.coroutines.cancellation.CancellationException
 
 private const val TAG = "OpenMeteoApi"
 
@@ -58,12 +59,15 @@ internal class OpenMeteoApi(
                         Log.w(TAG, "forecast HTTP ${response.code}")
                         return@use null
                     }
-                    response.body?.string()?.let { body ->
-                        json.decodeFromString<ForecastResponse>(body)
-                    }
+                    json.decodeFromString<ForecastResponse>(response.body.string())
                 }
-            }.onFailure { Log.w(TAG, "forecast failed", it) }
-                .getOrNull()
+            }.onFailure {
+                // runCatching also traps cancellation; rethrow so a cancelled
+                // call propagates instead of logging as a phantom outage
+                // (matches ReverseGeocoderRepository).
+                if (it is CancellationException) throw it
+                Log.w(TAG, "forecast failed", it)
+            }.getOrNull()
         }
 
     @Serializable

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -157,9 +157,11 @@ internal class HomeViewModel(
             is HomeAction.LaunchMusicSource -> {
                 // Resolve to the source app's launcher activity and reuse the app
                 // grid's launch path. A package with no launchable activity (a
-                // background-only media service) resolves to null and no-ops.
+                // background-only media service) resolves to null and no-ops —
+                // logged so the deliberate dead tap stays diagnosable in the field.
                 resolveMusicSourceComponent(action.packageName)
                     ?.let { mutableEvents.tryEmit(HomeEvent.LaunchComponent(it)) }
+                    ?: Log.d(TAG, "no launcher activity for ${action.packageName}; ignoring tap")
             }
 
             is HomeAction.Music -> {


### PR DESCRIPTION
## Summary

Part 2 of the comprehensive-review fixes (PR 2/8) — the silent-failure-audit findings. Every path below ended in user-visible dead UI with **no log trail**, invisible in the field on adb-unreachable head units where the diagnostics sheet's logcat tail is the only signal.

| Site | Hidden failure | Fix |
| --- | --- | --- |
| `AppsRepository.launch` | Tap on a stale tile after uninstall does nothing, zero log | `Log.w` on `ActivityNotFoundException` |
| `AppsRepository.launcherComponentFor` | `runCatching{}.getOrNull()` hid SecurityException etc. behind the legitimate null | `onFailure` log |
| `HomeViewModel.LaunchMusicSource` | Deliberate no-op indistinguishable from a broken touch target | `Log.d` on the null branch |
| `MusicSessionRepository.rewatch` | Refused `registerCallback` freezes the card on stale metadata | `onFailure` log |
| `SystemStatusRepository.gnssSatelliteFlow` | Registration refusal is a Boolean no catch ever sees — satellite count stays 0 forever | check + `Log.w` |
| `CalendarRepository.calendarChangeFlow` | Non-permission observer faults left the card stale silently | mirror `readWindow`'s SecurityException/fault split |
| `FontCache.evictExcept` | Failed delete leaks disk silently | log when `deleteRecursively` returns false |
| `OpenMeteoApi` / `NominatimApi` / `GoogleFontsApi` | `runCatching` logged cancelled calls as phantom outages | rethrow `CancellationException` (matches `ReverseGeocoderRepository`); also drop the unnecessary safe call on OkHttp 5's non-null `response.body` (fixes 2 compiler warnings) |
| `VoiceRecognizer.reset` | Reused engine can silently no-op after `onError` on some OEM recognizers | `cancel()` before returning to Idle |

No behavior change beyond logging, cancellation propagation, and the voice-engine park.

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — all green, zero compiler warnings.