### PR TITLE
refactor: remove suppressions by fixing at the source

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/system/SystemStatusRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/system/SystemStatusRepository.kt
@@ -19,7 +19,6 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
-import android.net.wifi.WifiManager
 import android.os.BatteryManager
 import android.os.Build
 import android.telephony.SignalStrength
@@ -154,16 +153,19 @@ internal class SystemStatusRepository(
 
     // NetworkCapabilities.getSignalStrength() (API 30) returns the Wi-Fi RSSI in
     // dBm reactively via onCapabilitiesChanged, so no RSSI_CHANGED_ACTION poll is
-    // needed. WifiManager.calculateSignalLevel(rssi, numLevels) maps it onto
-    // 0..numLevels-1; SIGNAL_LEVEL_COUNT keeps that aligned with the shared
-    // 0..MAX_SIGNAL_LEVEL graduated icon range so no rescale is required.
-    @Suppress("DEPRECATION") // The numLevels overload is the only one that pins a fixed 0..4 range.
+    // needed. The level map is computed locally over the same -100..-55 dBm
+    // window the platform's legacy calculateSignalLevel(rssi, numLevels) used:
+    // that overload is deprecated, and its replacement instance overload reads
+    // an OEM-configurable ceiling through the Wi-Fi service, which neither pins
+    // the dock's fixed 0..MAX_SIGNAL_LEVEL range nor runs under Robolectric.
     private fun wifiLevelFrom(caps: NetworkCapabilities): Int {
         val rssi = caps.signalStrength
         if (rssi == Int.MIN_VALUE) return 0
-        return WifiManager
-            .calculateSignalLevel(rssi, SIGNAL_LEVEL_COUNT)
-            .coerceIn(0, MAX_SIGNAL_LEVEL)
+        return when {
+            rssi <= WIFI_MIN_RSSI_DBM -> 0
+            rssi >= WIFI_MAX_RSSI_DBM -> MAX_SIGNAL_LEVEL
+            else -> (rssi - WIFI_MIN_RSSI_DBM) * MAX_SIGNAL_LEVEL / (WIFI_MAX_RSSI_DBM - WIFI_MIN_RSSI_DBM)
+        }
     }
 
     /**
@@ -454,10 +456,11 @@ internal class SystemStatusRepository(
         // range.
         private const val MAX_SIGNAL_LEVEL = 4
 
-        // Number of buckets WifiManager.calculateSignalLevel(rssi, numLevels) maps
-        // the RSSI onto; numLevels - 1 is the top index, so this pins the Wi-Fi
-        // output to the same 0..MAX_SIGNAL_LEVEL range as cellular.
-        private const val SIGNAL_LEVEL_COUNT = MAX_SIGNAL_LEVEL + 1
+        // Bounds of the linear RSSI→level window used by wifiLevelFrom; the same
+        // -100..-55 dBm range the platform's legacy
+        // calculateSignalLevel(rssi, numLevels) mapped onto its buckets.
+        private const val WIFI_MIN_RSSI_DBM = -100
+        private const val WIFI_MAX_RSSI_DBM = -55
 
         // How long a GPS fix counts as "fresh" before gpsFlow flips back to
         // searching. A live LocationRepository fix arrives roughly every second,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -140,20 +140,17 @@ object FemtoDimens {
      * the Live map backend (no captured backdrop) the panel falls back to an opaque
      * surface base under this tint, so it stays legible there too.
      *
-     * The glass alpha tokens keep the PascalCase token vocabulary of this object
-     * rather than ktlint's SCREAMING_SNAKE_CASE for `const val`, so they read as
-     * siblings of the dp tokens above.
+     * The scalar tokens here are plain `val`, not `const val`: ktlint mandates
+     * SCREAMING_SNAKE_CASE for compile-time constants, and these must read as
+     * PascalCase siblings of the dp tokens above.
      */
-    @Suppress("ktlint:standard:property-naming")
-    const val GlassBgAlphaLight = 0.6f
+    val GlassBgAlphaLight = 0.6f
 
     /** Glass overlay tint opacity in dark theme — more translucent so the darker blurred map reads through. */
-    @Suppress("ktlint:standard:property-naming")
-    const val GlassBgAlphaDark = 0.42f
+    val GlassBgAlphaDark = 0.42f
 
     /** Glass overlay hairline border opacity, shared across light and dark themes. */
-    @Suppress("ktlint:standard:property-naming")
-    const val GlassBorderAlpha = 0.6f
+    val GlassBorderAlpha = 0.6f
 
     /** Backdrop blur radius for the glass overlays (clock / speed) over the map. */
     val GlassBlurRadius = 24.dp
@@ -163,14 +160,12 @@ object FemtoDimens {
      * dashboard stays visible behind the scrim. Keyed off screen height, never a
      * specific device.
      */
-    @Suppress("ktlint:standard:property-naming")
-    const val DrawerSheetHeightFraction = 0.72f
+    val DrawerSheetHeightFraction = 0.72f
 
     /**
      * Font-picker bottom-sheet height as a fraction of the viewport. Taller than
      * the drawer / settings sheets because the picker is a long, scrollable list
      * of every Google Fonts family and benefits from the extra rows.
      */
-    @Suppress("ktlint:standard:property-naming")
-    const val FontPickerSheetHeightFraction = 0.92f
+    val FontPickerSheetHeightFraction = 0.92f
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
@@ -58,11 +58,11 @@ internal fun femtoTypography(family: FontFamily): Typography =
  * advance width so changing numbers (clock, speed, temperature, day) do not
  * shift surrounding layout as their glyphs change.
  *
- * Keeps its PascalCase SSOT name across callers rather than ktlint's
- * SCREAMING_SNAKE_CASE for `const val`.
+ * A plain `val`, not `const val`: ktlint mandates SCREAMING_SNAKE_CASE for
+ * compile-time constants, and this keeps its PascalCase SSOT name across
+ * callers.
  */
-@Suppress("ktlint:standard:property-naming")
-internal const val TabularFigures = "tnum"
+internal val TabularFigures = "tnum"
 
 /**
  * Return the shared big-number display style used for the calendar big-day and

--- a/app/src/test/java/io/github/seijikohara/femto/data/system/SystemStatusRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/system/SystemStatusRepositoryTest.kt
@@ -36,7 +36,6 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowConnectivityManager
 import org.robolectric.shadows.ShadowNetwork
 import org.robolectric.shadows.ShadowNetworkCapabilities
-import org.robolectric.shadows.ShadowWifiManager
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -160,11 +159,9 @@ class SystemStatusRepositoryTest {
     @Test
     fun `wifiSignalLevel maps the capability RSSI onto a graduated level`() =
         runTest {
-            // ShadowWifiManager.calculateSignalLevel(rssi, numLevels) returns
-            // floor(percent * (numLevels - 1)); 0.75 over the 5-bucket range pins
-            // the top index to 3. The capability must carry a real (non-unspecified)
-            // RSSI for wifiLevelFrom to consult the level at all.
-            ShadowWifiManager.setSignalLevelInPercent(0.75f)
+            // wifiLevelFrom maps the RSSI linearly over the -100..-55 dBm window
+            // onto 0..4: -66 dBm sits at (34 * 4) / 45 = 3. The capability must
+            // carry a real (non-unspecified) RSSI for the level to be read at all.
             val connectivity = application.getSystemService<ConnectivityManager>()!!
             val shadowConnectivity = shadowOf(connectivity)
 
@@ -172,7 +169,7 @@ class SystemStatusRepositoryTest {
                 assertEquals(0, awaitItem().wifiSignalLevel)
 
                 val callback = awaitRegisteredNetworkCallback(shadowConnectivity)
-                callback.onCapabilitiesChanged(WIFI_NETWORK, validatedWifiCapabilities(rssiDbm = -55))
+                callback.onCapabilitiesChanged(WIFI_NETWORK, validatedWifiCapabilities(rssiDbm = -66))
 
                 assertEquals(3, awaitItem().wifiSignalLevel)
                 cancelAndIgnoreRemainingEvents()


### PR DESCRIPTION
## Summary

Part 3 of the comprehensive-review fixes (PR 3/8) — the no-suppress-policy findings (CLAUDE.md#no-suppress).

### `@Suppress("DEPRECATION")` in `SystemStatusRepository.wifiLevelFrom`

Removed by computing the RSSI→level map locally over the same −100..−55 dBm window the deprecated static `WifiManager.calculateSignalLevel(rssi, numLevels)` used. The review originally suggested migrating to the instance overload, but verification showed it is **not** a drop-in:

- the instance overload's ceiling (`getMaxSignalLevel`) is OEM-configurable, so it does not pin the dock's fixed 0..4 graduated range (`MAX_SIGNAL_LEVEL`), and
- Robolectric's `ShadowWifiManager` only shadows the static overload, so the existing signal-level test would silently stop exercising anything.

The local linear map keeps the legacy platform behavior bit-for-bit, needs no Wi-Fi service round-trip, and stays unit-testable. The test now drives a real RSSI (−66 dBm → level 3) instead of the shadow's percent knob.

### `@Suppress("ktlint:standard:property-naming")` ×6 in `FemtoDimens` / `Type.kt`

Removed by demoting the scalar tokens (`GlassBgAlpha*`, `GlassBorderAlpha`, `*SheetHeightFraction`, `TabularFigures`) from `const val` to plain `val`: ktlint's SCREAMING_SNAKE_CASE mandate applies only to compile-time constants, so the PascalCase token vocabulary stays intact with no suppression. No call-site changes.

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — all green, zero warnings. Remaining `@Suppress`/`@SuppressLint` in the tree are the sanctioned `UNCHECKED_CAST` factory casts, caller-gated `MissingPermission` lint hints, and `SetJavaScriptEnabled` for the map WebView.