### PR TITLE
fix(home): route relaxed text sizes through Type.kt and restore tap-target floors

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -26,7 +26,9 @@ with automotive overrides on top.
   (`AccentColor` + `accentSeedColor` + MaterialKolor's
   `rememberDynamicColorScheme`); `FemtoTheme(accent = ...)` selects
   between them. Either way, pull from `MaterialTheme.colorScheme.*`;
-  the seed colors in `ui/theme/AccentColors.kt` are the only hardcoded
+  the seed colors in `ui/theme/AccentColors.kt` and the curated
+  weather-glyph palette in `ui/theme/WeatherGlyphColors.kt` (warm/cool
+  distinctions dynamic color cannot produce) are the only hardcoded
   hex outside `Color.kt`.
 - Shape: M3 default `Shapes` (squircles). Do not customise.
 - Elevation: M3 standard — express surface hierarchy with the

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -36,6 +36,7 @@ import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.TabularFigures
 import io.github.seijikohara.femto.ui.theme.bigNumber
+import io.github.seijikohara.femto.ui.theme.glanceMetric
 import io.github.seijikohara.femto.ui.theme.sectionLabel
 import java.time.LocalDate
 import java.time.LocalTime
@@ -203,13 +204,7 @@ private fun DayRow(
         )
         Text(
             text = "${day.date.dayOfMonth}",
-            style =
-                MaterialTheme.typography.titleSmall.copy(
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    lineHeight = 18.sp,
-                    fontFeatureSettings = TabularFigures,
-                ),
+            style = MaterialTheme.typography.glanceMetric().copy(lineHeight = 18.sp),
             color = accent,
             maxLines = 1,
             softWrap = false,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
@@ -8,17 +8,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.em
-import androidx.compose.ui.unit.sp
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.rememberHazeState
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
-import io.github.seijikohara.femto.ui.theme.TabularFigures
+import io.github.seijikohara.femto.ui.theme.heroNumeral
 import kotlinx.coroutines.delay
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -73,14 +70,7 @@ internal fun ClockOverlay(
         }
     Text(
         text = now.format(formatter),
-        style =
-            MaterialTheme.typography.displayMedium.copy(
-                fontSize = 40.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = (-0.04f).em,
-                lineHeight = 40.sp,
-                fontFeatureSettings = TabularFigures,
-            ),
+        style = MaterialTheme.typography.heroNumeral(trackingEm = -0.04f),
         color = MaterialTheme.colorScheme.onSurface,
         modifier =
             modifier

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -130,7 +131,9 @@ private fun HorizontalDock(
     dividerAtBottom: Boolean,
     modifier: Modifier = Modifier,
 ) = Surface(
-    modifier = modifier.height(FemtoDimens.DockThickness),
+    // The hairline divider draws inside the Surface; oversize by its thickness
+    // so the button row keeps the full DockThickness (= the tap-target floor).
+    modifier = modifier.height(FemtoDimens.DockThickness + DividerDefaults.Thickness),
     color = MaterialTheme.colorScheme.surface,
 ) {
     Column {
@@ -196,7 +199,8 @@ private fun VerticalDock(
     dividerAtStart: Boolean,
     modifier: Modifier = Modifier,
 ) = Surface(
-    modifier = modifier.width(FemtoDimens.DockThickness),
+    // Same divider-thickness oversize as HorizontalDock, on the width.
+    modifier = modifier.width(FemtoDimens.DockThickness + DividerDefaults.Thickness),
     color = MaterialTheme.colorScheme.surface,
 ) {
     Row {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCard.kt
@@ -141,14 +141,14 @@ private fun MusicCardPlayingPreview() {
                 MusicCardState.Playing(
                     nowPlaying =
                         NowPlaying(
-                            title = "Sunset Lover",
-                            artist = "Petit Biscuit",
-                            album = "Petit Biscuit",
+                            title = "Midnight Drive",
+                            artist = "The Wayfinders",
+                            album = "Night Routes",
                             albumArt = null,
                             isPlaying = true,
                             positionMs = 98_000,
                             durationMs = 168_000,
-                            packageName = "com.spotify.music",
+                            packageName = "com.example.music",
                         ),
                 ),
             onCommand = {},

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCardTransport.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCardTransport.kt
@@ -25,9 +25,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Pause
 import com.composables.icons.lucide.Play
@@ -36,7 +34,7 @@ import com.composables.icons.lucide.SkipForward
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.music.MusicCommand
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
-import io.github.seijikohara.femto.ui.theme.TabularFigures
+import io.github.seijikohara.femto.ui.theme.progressCaption
 import kotlinx.coroutines.delay
 
 @Composable
@@ -46,6 +44,7 @@ internal fun Progress(
     positionUpdateTimeMs: Long,
     isPlaying: Boolean,
     playbackSpeed: Float,
+    modifier: Modifier = Modifier,
 ) {
     // Interpolate the displayed position from the PlaybackState basis while
     // playing, so the bar and elapsed label advance smoothly without waiting for
@@ -80,18 +79,13 @@ internal fun Progress(
             0f
         }
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Text(
             text = formatMillis(livePosition),
-            style =
-                MaterialTheme.typography.labelMedium.copy(
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.Medium,
-                    fontFeatureSettings = TabularFigures,
-                ),
+            style = MaterialTheme.typography.progressCaption(),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
         )
@@ -114,12 +108,7 @@ internal fun Progress(
         }
         Text(
             text = formatMillis(durationMs),
-            style =
-                MaterialTheme.typography.labelMedium.copy(
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.Medium,
-                    fontFeatureSettings = TabularFigures,
-                ),
+            style = MaterialTheme.typography.progressCaption(),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
         )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -50,7 +50,8 @@ import io.github.seijikohara.femto.ui.locale.tripDistanceFromMeters
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
-import io.github.seijikohara.femto.ui.theme.TabularFigures
+import io.github.seijikohara.femto.ui.theme.glanceMetric
+import io.github.seijikohara.femto.ui.theme.heroNumeral
 import io.github.seijikohara.femto.ui.theme.sectionLabel
 import kotlin.math.exp
 import kotlin.math.roundToInt
@@ -213,14 +214,7 @@ private fun NowMetric(
 ) {
     Text(
         text = value,
-        style =
-            MaterialTheme.typography.displayMedium.copy(
-                fontSize = 40.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = (-0.03f).em,
-                lineHeight = 40.sp,
-                fontFeatureSettings = TabularFigures,
-            ),
+        style = MaterialTheme.typography.heroNumeral(trackingEm = -0.03f),
         color = MaterialTheme.colorScheme.onSurface,
         maxLines = 1,
         // Reserve a stable width sized for the clamped 3-digit range and
@@ -266,13 +260,7 @@ private fun SecondaryMetric(
     )
     Text(
         text = value,
-        style =
-            MaterialTheme.typography.titleSmall.copy(
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold,
-                letterSpacing = (-0.01f).em,
-                fontFeatureSettings = TabularFigures,
-            ),
+        style = MaterialTheme.typography.glanceMetric().copy(letterSpacing = (-0.01f).em),
         color = MaterialTheme.colorScheme.onSurface,
         maxLines = 1,
     )
@@ -321,10 +309,9 @@ private fun AddressRow(
 }
 
 // Trailing reset control for the trip metrics, anchored to the overlay's
-// top-right (the end of the metric row). Sized below MinTouchTarget so it does
-// not crowd the metric cells on a narrow overlay — a deliberate in-overlay
-// exception (CLAUDE.md#automotive-overrides keeps 64 dp the default), the same
-// relaxation the calendar strip takes; also trims the metric row's height.
+// top-right (the end of the metric row). Full MinTouchTarget size: the
+// tap-target floor (CLAUDE.md#automotive-overrides) has no persisted exception
+// for this control, and a mis-tap while driving resets the trip.
 @Composable
 private fun ResetButton(
     onReset: () -> Unit,
@@ -332,7 +319,7 @@ private fun ResetButton(
 ) = Box(
     modifier =
         modifier
-            .size(RESET_BUTTON_SIZE)
+            .size(FemtoDimens.MinTouchTarget)
             .clip(CircleShape)
             .clickable(onClick = onReset),
     contentAlignment = Alignment.Center,
@@ -391,10 +378,6 @@ private const val NO_SPEED_PLACEHOLDER = "—"
 // Shown in the address row until a fix / reverse-geocode resolves, so the overlay
 // reserves the row instead of collapsing (and the MapPin still reads as "location").
 private const val NO_ADDRESS_PLACEHOLDER = "—"
-
-// Reset control size: narrower than MinTouchTarget so it leaves the metric cells
-// more room on a compact overlay and shortens the metric row (see ResetButton).
-private val RESET_BUTTON_SIZE = 48.dp
 
 @PreviewLightDark
 @Preview(name = "Speed overlay", widthDp = 560, heightDp = 160)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -52,6 +52,7 @@ import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.TabularFigures
 import io.github.seijikohara.femto.ui.theme.WeatherGlyphColors
 import io.github.seijikohara.femto.ui.theme.bigNumber
+import io.github.seijikohara.femto.ui.theme.cardMeta
 import io.github.seijikohara.femto.ui.theme.sectionLabel
 import io.github.seijikohara.femto.ui.theme.weatherGlyphs
 import java.time.Instant
@@ -135,7 +136,7 @@ private fun Head(
         Row(verticalAlignment = Alignment.Top) {
             Text(
                 text = tempLabel,
-                style = MaterialTheme.typography.bigNumber().copy(fontSize = 46.sp, lineHeight = 42.sp),
+                style = MaterialTheme.typography.bigNumber(size = 46.sp),
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
             )
@@ -210,10 +211,8 @@ private fun Metric(
     Text(
         text = value,
         style =
-            MaterialTheme.typography.bodyMedium.copy(
-                fontSize = 14.sp,
+            MaterialTheme.typography.cardMeta().copy(
                 fontWeight = FontWeight.SemiBold,
-                lineHeight = 16.sp,
                 fontFeatureSettings = TabularFigures,
             ),
         color = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 
@@ -68,14 +69,58 @@ internal val TabularFigures = "tnum"
  * Return the shared big-number display style used for the calendar big-day and
  * the weather big-temperature anchors. Derived from [Typography.displayLarge]
  * with the Bold Minimal tuning the cards apply verbatim, plus tabular figures
- * so the large numeral never reflows the row beside it.
+ * so the large numeral never reflows the row beside it. [size] defaults to the
+ * [FemtoDimens.BigNumberFontSize] anchor; a card with tighter geometry (the
+ * weather hero temperature) passes its own size and inherits the same 0.92
+ * leading ratio.
  */
-internal fun Typography.bigNumber(): TextStyle =
+internal fun Typography.bigNumber(size: TextUnit = FemtoDimens.BigNumberFontSize): TextStyle =
     displayLarge.copy(
-        fontSize = FemtoDimens.BigNumberFontSize,
+        fontSize = size,
         fontWeight = FontWeight.Bold,
         letterSpacing = (-0.045f).em,
-        lineHeight = (FemtoDimens.BigNumberFontSize.value * 0.92f).sp,
+        lineHeight = (size.value * 0.92f).sp,
+        fontFeatureSettings = TabularFigures,
+    )
+
+/**
+ * Return the glass-overlay hero numeral style (the clock readout, the speed
+ * value). 40sp Bold tabular digits on a fixed 40sp line; callers pass the
+ * tracking their glyph run needs (the clock's colon tolerates tighter
+ * tracking than the speed's digit run).
+ */
+internal fun Typography.heroNumeral(trackingEm: Float): TextStyle =
+    displayMedium.copy(
+        fontSize = 40.sp,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = trackingEm.em,
+        lineHeight = 40.sp,
+        fontFeatureSettings = TabularFigures,
+    )
+
+/**
+ * Return the 16sp glance metric-value style (speed-overlay trip metrics, the
+ * calendar day-gutter numeral) — a sanctioned card relaxation of the 18sp
+ * floor (CLAUDE.md#automotive-overrides), with tabular figures so ticking
+ * values keep a fixed digit advance.
+ */
+internal fun Typography.glanceMetric(): TextStyle =
+    titleSmall.copy(
+        fontSize = 16.sp,
+        fontWeight = FontWeight.SemiBold,
+        fontFeatureSettings = TabularFigures,
+    )
+
+/**
+ * Return the music transport's position / duration caption style. Sized at
+ * the [FemtoDimens.GlanceTextSize] glance floor — the progress-caption
+ * relaxation CLAUDE.md#automotive-overrides routes through that token — with
+ * tabular figures so the ticking position never reflows the progress row.
+ */
+internal fun Typography.progressCaption(): TextStyle =
+    labelMedium.copy(
+        fontSize = FemtoDimens.GlanceTextSize,
+        fontWeight = FontWeight.Medium,
         fontFeatureSettings = TabularFigures,
     )
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/WeatherGlyphColors.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/WeatherGlyphColors.kt
@@ -2,7 +2,6 @@ package io.github.seijikohara.femto.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 
@@ -14,7 +13,6 @@ import androidx.compose.ui.graphics.Color
  * accent. The dashboard relies on those distinctions being immediately
  * readable at a glance, so the glyph palette is curated separately.
  */
-@Immutable
 data class WeatherGlyphColors(
     val sun: Color,
     val moon: Color,


### PR DESCRIPTION
## Summary

Part 4 of the comprehensive-review fixes (PR 4/8) — the automotive-floor findings (CLAUDE.md#automotive-overrides).

### Typography (sizes must live in a token or a named `Type.kt` extension)

| Site | Before | After |
| --- | --- | --- |
| `MusicCardTransport` position/duration captions ×2 | `11.sp` literal (below even the 13sp glance floor) | new `progressCaption()` on `FemtoDimens.GlanceTextSize` |
| `SpeedOverlay` secondary metrics / `CalendarCard` day-gutter numeral | `16.sp` literals | new `glanceMetric()` |
| `ClockOverlay` / `SpeedOverlay` hero numerals | near-identical 40sp `displayMedium.copy` ×2 | new `heroNumeral(trackingEm)` |
| `WeatherCard` hero temperature | `bigNumber().copy(fontSize = 46.sp, lineHeight = 42.sp)` | `bigNumber(size = 46.sp)` — size param inherits the shared 0.92 leading ratio |
| `WeatherCard` metric values | `14.sp` literal | derive from `cardMeta()` |

### Tap targets

- **SpeedOverlay trip-reset button 48dp → `MinTouchTarget` (64dp).** The in-code exception comment cited "the same relaxation the calendar strip takes", but the current calendar agenda has no tap targets — the reference was stale, and unlike the map-controls pill (PR #152) no owner exception was ever persisted. A mis-tap here resets the trip, so the floor applies.
- **DashboardDock buttons measured 63dp on the divider axis**: the 1dp hairline draws inside the 64dp Surface. The Surface is now oversized by `DividerDefaults.Thickness` so the button row keeps the full floor.

### Cleanups

- Drop speculative `@Immutable` on `WeatherGlyphColors` (compose.md: never annotate speculatively).
- `Progress()` gains the standard `modifier` parameter (compose.md rule; the ktlint check missed it).
- Neutralize branded preview data in `MusicCard` (`com.example.music`, fictional track/artist) per the brand-neutral-content decision (PR #51). `sourceLabel()`'s real-package mapping is functional production code and stays.
- `design-system.md`: record `WeatherGlyphColors.kt` as the second sanctioned hardcoded-hex home (the rule said `AccentColors.kt` was the only one — rule/code drift).

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — all green. Visual deltas: progress captions 11→13sp, reset button 48→64dp, dock +1dp on the divider axis; worth a glance on the emulator at next on-device pass.