### PR TITLE
fix(theme): follow the rendered theme, not the system, for forced ThemeMode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,11 @@ ktlint_standard_function-naming = disabled
 # form, which is the opposite of the project's intent. Disable it so the
 # expression-chain style survives `./gradlew spotlessApply`.
 ktlint_standard_multiline-expression-wrapping = disabled
+# The one sanctioned CompositionLocal: FemtoTheme's resolved dark flag.
+# Consumers (weather glyphs, glass alpha, AUTO map style) must follow the
+# rendered theme, which only FemtoTheme knows once the user forces a
+# ThemeMode — isSystemInDarkTheme() would follow the system instead.
+compose_allowed_composition_locals = LocalFemtoDarkTheme
 
 [*.{xml,json,yml,yaml,toml}]
 indent_size = 2

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/GlassOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/GlassOverlay.kt
@@ -1,7 +1,6 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,6 +12,7 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeTint
 import dev.chrisbanes.haze.hazeEffect
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.LocalFemtoDarkTheme
 
 /**
  * Glass blur strength for the map overlays, threaded from [DisplaySettings] down
@@ -36,7 +36,7 @@ internal fun Modifier.glassEffect(
     blurRadius: Dp,
     tintScale: Int,
 ): Modifier {
-    val baseAlpha = if (isSystemInDarkTheme()) FemtoDimens.GlassBgAlphaDark else FemtoDimens.GlassBgAlphaLight
+    val baseAlpha = if (LocalFemtoDarkTheme.current) FemtoDimens.GlassBgAlphaDark else FemtoDimens.GlassBgAlphaLight
     val tintAlpha = glassTintAlpha(baseAlpha, tintScale)
     // Capture the surface color outside the draw-time hazeEffect block, which
     // cannot read MaterialTheme.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapSnapshot.kt
@@ -9,7 +9,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -32,6 +31,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import io.github.seijikohara.femto.data.display.MapStyleSetting
+import io.github.seijikohara.femto.ui.theme.LocalFemtoDarkTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -57,7 +57,7 @@ internal fun SnapshotMap(
     val context = LocalContext.current
     val isDark =
         when (mapConfig.style) {
-            MapStyleSetting.AUTO -> isSystemInDarkTheme()
+            MapStyleSetting.AUTO -> LocalFemtoDarkTheme.current
             MapStyleSetting.LIGHT -> false
             MapStyleSetting.DARK -> true
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -14,7 +14,6 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -51,6 +50,7 @@ import io.github.seijikohara.femto.BuildConfig
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.MapStyleSetting
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.LocalFemtoDarkTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import kotlinx.coroutines.delay
 
@@ -120,7 +120,7 @@ internal fun WebMapView(
     val bearingHolder = remember { floatArrayOf(0f) }
     val isDark =
         when (mapConfig.style) {
-            MapStyleSetting.AUTO -> isSystemInDarkTheme()
+            MapStyleSetting.AUTO -> LocalFemtoDarkTheme.current
             MapStyleSetting.LIGHT -> false
             MapStyleSetting.DARK -> true
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoTheme.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoTheme.kt
@@ -8,12 +8,27 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontFamily
 import com.materialkolor.rememberDynamicColorScheme
 import io.github.seijikohara.femto.data.display.AccentColor
+
+/**
+ * The dark flag FemtoTheme actually rendered with, as opposed to the system
+ * state [isSystemInDarkTheme] reports: when the user forces a ThemeMode in
+ * Settings the two diverge, and theme-dependent reads outside the color
+ * scheme (weather glyph palette, glass tint alpha, the AUTO map style) must
+ * follow the rendered theme. The error default enforces the FemtoTheme
+ * wrapping rule (design-system.md) instead of silently rendering light.
+ */
+internal val LocalFemtoDarkTheme =
+    staticCompositionLocalOf<Boolean> {
+        error("LocalFemtoDarkTheme read outside FemtoTheme — wrap the composable in FemtoTheme")
+    }
 
 /**
  * Root theme for the launcher.
@@ -57,11 +72,13 @@ fun FemtoTheme(
 
             else -> dynamicLightColorScheme(context)
         }
-    MaterialTheme(
-        colorScheme = target.animated(),
-        typography = femtoTypography(fontFamily),
-        content = content,
-    )
+    CompositionLocalProvider(LocalFemtoDarkTheme provides darkTheme) {
+        MaterialTheme(
+            colorScheme = target.animated(),
+            typography = femtoTypography(fontFamily),
+            content = content,
+        )
+    }
 }
 
 // How long a theme change (Light <-> Dark, accent, wallpaper) takes to cross-fade.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/WeatherGlyphColors.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/WeatherGlyphColors.kt
@@ -1,6 +1,5 @@
 package io.github.seijikohara.femto.ui.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
@@ -39,11 +38,11 @@ internal val LightWeatherGlyphs =
 /**
  * Resolve the weather glyph palette for the current theme.
  *
- * Exposed as a `@Composable` function (rather than a `CompositionLocal`)
- * because ktlint's Compose rules discourage adding new CompositionLocals
- * unless they are unavoidable, and the dark / light selection is a single
- * `isSystemInDarkTheme()` check.
+ * Reads [LocalFemtoDarkTheme] (not `isSystemInDarkTheme()`) so the palette
+ * follows the rendered theme when the user forces a ThemeMode in Settings —
+ * the system flag would put light-palette glyphs on dark surfaces.
  */
 @Composable
 @ReadOnlyComposable
-internal fun weatherGlyphs(): WeatherGlyphColors = if (isSystemInDarkTheme()) DarkWeatherGlyphs else LightWeatherGlyphs
+internal fun weatherGlyphs(): WeatherGlyphColors =
+    if (LocalFemtoDarkTheme.current) DarkWeatherGlyphs else LightWeatherGlyphs


### PR DESCRIPTION
## Summary

Part 5 of the comprehensive-review fixes (PR 5/8) — the forced-ThemeMode finding.

`MainActivity` resolves the dark flag from the user's `ThemeMode` (SYSTEM / LIGHT / DARK) and passes it to `FemtoTheme`. But three theme-dependent reads **outside the color scheme** called `isSystemInDarkTheme()` directly:

- `WeatherGlyphColors.weatherGlyphs()` — the curated warm/cool glyph palette
- `GlassOverlay.glassEffect()` — the glass tint base alpha (light vs dark)
- `WebMapView` / `MapSnapshot` — the `MapStyleSetting.AUTO` light/dark map style

With `ThemeMode` forced to DARK on a light system (or vice versa), those three followed the **system**, not the rendered theme — e.g. light-palette weather glyphs on dark dashboard surfaces.

### Fix

Introduce `LocalFemtoDarkTheme`, a `staticCompositionLocalOf<Boolean>` that `FemtoTheme` provides with the exact `darkTheme` flag it renders with. The four consumers read it instead of `isSystemInDarkTheme()`. Its `error()` default enforces the "wrap in FemtoTheme" rule (design-system.md). `MainActivity` and `FemtoTheme` keep `isSystemInDarkTheme()` as the SYSTEM-mode source — that's correct, it's where the system state should enter.

### Lint config

The new CompositionLocal is added to `compose_allowed_composition_locals` in `.editorconfig` — the ktlint / Android Studio config SSOT (kotlin-style.md). This is the compose-rules allowlist's intended configuration knob, **not** a `suppressLintsFor` / per-line suppression, so it's consistent with CLAUDE.md#no-suppress (which bars suppressions, not rule configuration). It is the one sanctioned CompositionLocal in the tree.

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — all green. All androidTest renders of the affected composables already wrap in `FemtoTheme`, so the error-default is satisfied; `MapSnapshotRenderTest` uses `MapSnapshotter` directly (no composition) and is unaffected.