### PR TITLE
feat(weather): surface stale data with an "as of HH:mm" caption

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/WeatherCardTest.kt
@@ -13,7 +13,9 @@ import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Rule
 import org.junit.Test
+import java.time.Instant
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 class WeatherCardTest {
@@ -129,6 +131,46 @@ class WeatherCardTest {
         // pattern because the meridiem word is locale-dependent ("PM" / "午後").
         val expected = LocalTime.of(12, 0).format(DateTimeFormatter.ofPattern("h a"))
         rule.onNodeWithText(expected).assertIsDisplayed()
+    }
+
+    @Test
+    fun shows_as_of_caption_when_data_is_stale() {
+        // The fixture's default fetchedAt is weeks old, so the snapshot reads as
+        // stale against the wall clock and the card surfaces the "as of" eyebrow.
+        val fetchedAt = Instant.parse("2026-05-01T05:32:00Z")
+        val expectedTime =
+            fetchedAt
+                .atZone(ZoneId.systemDefault())
+                .toLocalTime()
+                .format(DateTimeFormatter.ofPattern("HH:mm"))
+        rule.setContent {
+            FemtoTheme {
+                WeatherCard(
+                    snapshot = fakeWeatherSnapshot(fetchedAt = fetchedAt),
+                    temperatureUnit = TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
+                    onOpen = {},
+                )
+            }
+        }
+        rule.onNodeWithText("as of $expectedTime").assertIsDisplayed()
+    }
+
+    @Test
+    fun hides_as_of_caption_when_data_is_fresh() {
+        rule.setContent {
+            FemtoTheme {
+                WeatherCard(
+                    snapshot = fakeWeatherSnapshot(fetchedAt = Instant.now()),
+                    temperatureUnit = TemperatureUnit.CELSIUS,
+                    speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
+                    onOpen = {},
+                )
+            }
+        }
+        rule.onNodeWithText("as of ", substring = true).assertDoesNotExist()
     }
 
     @Test

--- a/app/src/main/java/io/github/seijikohara/femto/data/weather/WeatherSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/weather/WeatherSnapshot.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.data.weather
 
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -18,6 +19,22 @@ internal data class WeatherSnapshot(
     val daily: List<DailyForecast>,
     val fetchedAt: Instant,
 )
+
+// A snapshot older than this reads as stale. Under normal operation the weather
+// refreshes every REFRESH_INTERVAL (30 min), so crossing 2x that means at least
+// two missed refresh windows — a real outage (e.g. a 429 on the shared public
+// Open-Meteo endpoint), not a routine gap. The card surfaces an "as of HH:mm"
+// caption past this age so hours-old data is never shown as current.
+internal val WEATHER_STALE_THRESHOLD: Duration = Duration.ofMinutes(60)
+
+/**
+ * Return whether this snapshot is older than [WEATHER_STALE_THRESHOLD] at [now].
+ * `abs()` tolerates a clock that moved backwards between fetch and read (NTP
+ * correction, manual time change) rather than reporting a future fetch as fresh
+ * forever.
+ */
+internal fun WeatherSnapshot.isStale(now: Instant): Boolean =
+    Duration.between(fetchedAt, now).abs() >= WEATHER_STALE_THRESHOLD
 
 internal data class HourlyForecast(
     val time: LocalTime,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -41,6 +42,7 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.weather.HourlyForecast
 import io.github.seijikohara.femto.data.weather.WeatherCode
 import io.github.seijikohara.femto.data.weather.WeatherSnapshot
+import io.github.seijikohara.femto.data.weather.isStale
 import io.github.seijikohara.femto.ui.locale.SpeedUnit
 import io.github.seijikohara.femto.ui.locale.TemperatureUnit
 import io.github.seijikohara.femto.ui.locale.fromCelsius
@@ -55,8 +57,10 @@ import io.github.seijikohara.femto.ui.theme.bigNumber
 import io.github.seijikohara.femto.ui.theme.cardMeta
 import io.github.seijikohara.femto.ui.theme.sectionLabel
 import io.github.seijikohara.femto.ui.theme.weatherGlyphs
+import kotlinx.coroutines.delay
 import java.time.Instant
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlin.math.roundToInt
 
@@ -94,6 +98,16 @@ internal fun WeatherCard(
     color = MaterialTheme.colorScheme.surfaceContainer,
 ) {
     if (snapshot != null) {
+        // During a refresh outage the repository serves the same cached snapshot
+        // (identical fetchedAt, conflated by the StateFlow), so the card ages it
+        // locally: past WEATHER_STALE_THRESHOLD it surfaces an "as of HH:mm"
+        // caption rather than presenting hours-old data as current.
+        val asOf =
+            if (rememberWeatherFresh(snapshot)) {
+                null
+            } else {
+                stringResource(R.string.weather_as_of, asOfTimeLabel(snapshot.fetchedAt, is24Hour))
+            }
         // verticalScroll is a safety net: fillMaxWidth (not fillMaxSize) lets the
         // content keep its intrinsic height, so on a card too short for the full
         // head + metrics + forecast it scrolls instead of clipping; on a tall
@@ -108,7 +122,7 @@ internal fun WeatherCard(
                     .padding(FemtoDimens.CardPaddingCompact),
             verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGapCompact),
         ) {
-            Head(snapshot, temperatureUnit)
+            Head(snapshot, temperatureUnit, asOf)
             Metrics(snapshot, temperatureUnit, speedUnit)
             Forecast(snapshot.hourly, snapshot.sunrise, snapshot.sunset, temperatureUnit, is24Hour)
         }
@@ -117,10 +131,45 @@ internal fun WeatherCard(
     }
 }
 
+/**
+ * Re-evaluate [snapshot] freshness on a tick so the card surfaces an "as of"
+ * caption once the data ages past [WEATHER_STALE_THRESHOLD] during an outage.
+ * The cached snapshot's `fetchedAt` does not change while the repository keeps
+ * serving it (and the StateFlow conflates the identical value), so without this
+ * local tick the card would show hours-old data as current. Mirrors
+ * [rememberLocationFresh]; once stale, the loop stops until a new snapshot.
+ */
+@Composable
+private fun rememberWeatherFresh(snapshot: WeatherSnapshot): Boolean =
+    produceState(initialValue = !snapshot.isStale(Instant.now()), snapshot) {
+        while (value) {
+            delay(STALE_RECHECK_INTERVAL_MS)
+            value = !snapshot.isStale(Instant.now())
+        }
+    }.value
+
+// Cadence of the staleness re-check; the threshold is an hour, so a minute's
+// granularity flips the caption within a minute of crossing it.
+private const val STALE_RECHECK_INTERVAL_MS = 60_000L
+
+private val AsOfFormatter12: DateTimeFormatter = DateTimeFormatter.ofPattern("h:mm a")
+
+// "as of" needs minute precision, so it cannot reuse the forecast's hour-only
+// 12h formatter; the 24h "HH:mm" formatter already carries minutes.
+private fun asOfTimeLabel(
+    fetchedAt: Instant,
+    is24Hour: Boolean,
+): String =
+    fetchedAt
+        .atZone(ZoneId.systemDefault())
+        .toLocalTime()
+        .format(if (is24Hour) ForecastHourFormatter24 else AsOfFormatter12)
+
 @Composable
 private fun Head(
     snapshot: WeatherSnapshot,
     temperatureUnit: TemperatureUnit,
+    asOfLabel: String?,
 ) {
     val tempLabel = "${temperatureUnit.fromCelsius(snapshot.tempC).roundToInt()}"
     val glyphs = weatherGlyphs()
@@ -133,24 +182,36 @@ private fun Head(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        Row(verticalAlignment = Alignment.Top) {
-            Text(
-                text = tempLabel,
-                style = MaterialTheme.typography.bigNumber(size = 46.sp),
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-            )
-            Text(
-                text = temperatureUnit.label(),
-                style =
-                    MaterialTheme.typography.titleMedium.copy(
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        lineHeight = 20.sp,
-                    ),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 4.dp, start = 2.dp),
-            )
+        Column {
+            // Stale-data eyebrow: only present once the snapshot ages past the
+            // staleness threshold, so fresh readings carry no extra chrome.
+            if (asOfLabel != null) {
+                Text(
+                    text = asOfLabel,
+                    style = MaterialTheme.typography.sectionLabel(10, 0.08f),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
+            Row(verticalAlignment = Alignment.Top) {
+                Text(
+                    text = tempLabel,
+                    style = MaterialTheme.typography.bigNumber(size = 46.sp),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                )
+                Text(
+                    text = temperatureUnit.label(),
+                    style =
+                        MaterialTheme.typography.titleMedium.copy(
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            lineHeight = 20.sp,
+                        ),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp, start = 2.dp),
+                )
+            }
         }
         Icon(
             imageVector = glyphIconFor(snapshot.code, snapshot.isDay),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <!-- Weather card -->
     <string name="weather_unavailable">Weather unavailable</string>
     <string name="weather_open_app">Open weather</string>
+    <!-- Shown on the weather card when the data is stale (a refresh outage); %1$s is the local fetch time. -->
+    <string name="weather_as_of">as of %1$s</string>
     <string name="weather_metric_feels">FEELS</string>
     <string name="weather_metric_wind">WIND</string>
     <string name="weather_metric_humidity">HUMID.</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/weather/WeatherSnapshotTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/weather/WeatherSnapshotTest.kt
@@ -1,0 +1,43 @@
+package io.github.seijikohara.femto.data.weather
+
+import io.github.seijikohara.femto.testfixtures.fakeWeatherSnapshot
+import org.junit.Test
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WeatherSnapshotTest {
+    private val fetchedAt = Instant.parse("2026-05-01T05:32:00Z")
+    private val snapshot = fakeWeatherSnapshot(fetchedAt = fetchedAt)
+
+    @Test
+    fun `a just-fetched snapshot is fresh`() {
+        assertFalse(snapshot.isStale(fetchedAt))
+    }
+
+    @Test
+    fun `a snapshot just under the threshold is fresh`() {
+        val now = fetchedAt + WEATHER_STALE_THRESHOLD - Duration.ofSeconds(1)
+        assertFalse(snapshot.isStale(now))
+    }
+
+    @Test
+    fun `a snapshot exactly at the threshold is stale`() {
+        // Threshold is inclusive: two full missed refresh windows is an outage.
+        assertTrue(snapshot.isStale(fetchedAt + WEATHER_STALE_THRESHOLD))
+    }
+
+    @Test
+    fun `a snapshot well past the threshold is stale`() {
+        assertTrue(snapshot.isStale(fetchedAt + Duration.ofHours(3)))
+    }
+
+    @Test
+    fun `a snapshot fetched in the future is stale once the skew exceeds the threshold`() {
+        // A clock moved backwards (NTP correction) must not read a future fetch as
+        // fresh forever; abs() treats the skew the same as an equal age.
+        val now = fetchedAt - Duration.ofHours(2)
+        assertTrue(snapshot.isStale(now))
+    }
+}


### PR DESCRIPTION
## Summary

Part 7 of the comprehensive-review fixes (PR 7/8) — the silent-failure-audit Medium finding on unbounded stale weather.

During a refresh outage (e.g. a 429 on the shared public Open-Meteo endpoint — a documented scenario in project memory) `WeatherRepository` deliberately keeps serving the last cached snapshot. But the card rendered hours-old temperature **as if current**, with no affordance — unlike the map marker, which greys out via `rememberLocationFresh` when fixes stop. Weather staleness was surfaced nowhere.

### Change

- **`WeatherSnapshot.isStale(now)` + `WEATHER_STALE_THRESHOLD`** (data layer). 60 min = 2× the repository's 30-min refresh interval, so crossing it means at least two missed refresh windows — a real outage, not a routine gap. `abs()` tolerates a backwards clock jump (NTP / manual change) rather than reading a future fetch as fresh forever.
- **`WeatherCard` ages the snapshot locally** via `rememberWeatherFresh`, a ticking `produceState` that mirrors `rememberLocationFresh`. This is necessary, not incidental: during an outage the repository serves the *same* cached snapshot (identical `fetchedAt`), and the `StateFlow` conflates the identical value — so a UiState-propagated flag could never notice the data aging. The card must tick itself.
- **Past the threshold the head shows an "as of HH:mm" eyebrow** (12/24h honoured, formatted in the system zone). Fresh data carries no extra chrome. "as of %1$s" is a new string resource.

### Why a caption, not dimming

The reviewer offered "dim the card or show 'as of HH:mm'". The caption is more informative — the data is still usable, just old — and matches the existing precedent of *surfacing* staleness (the location marker). Dimming would also fight the narrow head-unit card's contrast budget.

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — all green. `isStale` is unit-tested (fresh / sub-threshold / at-threshold / past / backwards-clock skew); the caption's presence-when-stale and absence-when-fresh are covered by Compose tests (androidTest, manual suite per project memory).