### PR TITLE
test: cover the crash-containment seams that protect the HOME process

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
@@ -307,8 +307,9 @@ internal class DisplayPreferences(
 
 // Decode the render mode, migrating the short-lived three-mode values
 // (LIVE_HARDWARE / LIVE_SOFTWARE) back to LIVE, so anyone who picked a live map
-// keeps it after the software backend was removed.
-private fun String?.toMapRenderModeOr(fallback: MapRenderMode): MapRenderMode =
+// keeps it after the software backend was removed. internal so the migration is
+// unit-testable without a raw write to the private DataStore.
+internal fun String?.toMapRenderModeOr(fallback: MapRenderMode): MapRenderMode =
     when (this) {
         "LIVE_HARDWARE", "LIVE_SOFTWARE" -> MapRenderMode.LIVE
         else -> toEnumOr(fallback)

--- a/app/src/test/java/io/github/seijikohara/femto/data/common/PreferencesSupportTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/common/PreferencesSupportTest.kt
@@ -1,0 +1,137 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package io.github.seijikohara.femto.data.common
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.io.IOException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private enum class Sample { ALPHA, BETA }
+
+class PreferencesSupportTest {
+    // --- toEnumOr --------------------------------------------------------------
+
+    @Test
+    fun `toEnumOr decodes a known name`() {
+        assertEquals(Sample.BETA, "BETA".toEnumOr(Sample.ALPHA))
+    }
+
+    @Test
+    fun `toEnumOr falls back for an unknown name`() {
+        // A renamed / removed entry after a downgrade must not throw.
+        assertEquals(Sample.ALPHA, "GAMMA".toEnumOr(Sample.ALPHA))
+    }
+
+    @Test
+    fun `toEnumOr falls back for a null (absent key)`() {
+        assertEquals(Sample.ALPHA, null.toEnumOr(Sample.ALPHA))
+    }
+
+    // --- catchIoAsDefaults -----------------------------------------------------
+
+    @Test
+    fun `catchIoAsDefaults replaces an IOException with empty preferences`() =
+        runTest {
+            // A corrupted prefs file (e.g. power loss mid-write) must degrade to
+            // defaults rather than crash-loop the HOME launcher's cold start.
+            val recovered =
+                flow<Preferences> { throw IOException("corrupt") }
+                    .catchIoAsDefaults("test")
+                    .first()
+
+            assertEquals(emptyPreferences(), recovered)
+        }
+
+    @Test
+    fun `catchIoAsDefaults rethrows a non-IO exception`() =
+        runTest {
+            // Only IO (an unreadable file) is recoverable; a programming error must
+            // surface, not be masked as "empty preferences".
+            assertFailsWith<IllegalStateException> {
+                flow<Preferences> { throw IllegalStateException("bug") }
+                    .catchIoAsDefaults("test")
+                    .first()
+            }
+        }
+
+    @Test
+    fun `catchIoAsDefaults passes a successful read through untouched`() =
+        runTest {
+            val key = booleanPreferencesKey("flag")
+            val prefs = mutablePreferencesOf(key to true)
+
+            val read = flow { emit(prefs as Preferences) }.catchIoAsDefaults("test").first()
+
+            assertEquals(true, read[key])
+        }
+
+    // --- editOrLog -------------------------------------------------------------
+
+    @Test
+    fun `editOrLog applies the transform on success`() =
+        runTest {
+            val key = booleanPreferencesKey("flag")
+            val store = FakePreferencesDataStore()
+
+            store.editOrLog("test") { it[key] = true }
+
+            assertEquals(true, store.data.first()[key])
+        }
+
+    @Test
+    fun `editOrLog swallows an IOException instead of crashing the launcher`() =
+        runTest {
+            // Fire-and-forget writes: a failed edit must not escape and kill the
+            // HOME process. Losing one write is acceptable.
+            val store = FakePreferencesDataStore(failWith = IOException("disk full"))
+
+            // No exception escapes.
+            store.editOrLog("test") { it[booleanPreferencesKey("flag")] = true }
+        }
+
+    @Test
+    fun `editOrLog rethrows cancellation to keep structured concurrency intact`() =
+        runTest {
+            val store = FakePreferencesDataStore(failWith = CancellationException("cancelled"))
+
+            assertFailsWith<CancellationException> {
+                store.editOrLog("test") { it[booleanPreferencesKey("flag")] = true }
+            }
+        }
+}
+
+// Minimal DataStore that applies edits to an in-memory Preferences, or throws a
+// configured exception from updateData to drive editOrLog's failure paths.
+private class FakePreferencesDataStore(
+    private val failWith: Throwable? = null,
+) : DataStore<Preferences> {
+    private val state = MutableSharedFlow<Preferences>(replay = 1)
+
+    init {
+        state.tryEmit(emptyPreferences())
+    }
+
+    override val data: Flow<Preferences> = state
+
+    override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences {
+        failWith?.let { throw it }
+        val updated = transform(state.replayCache.first())
+        state.emit(updated)
+        return updated
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/display/DisplayPreferencesTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/display/DisplayPreferencesTest.kt
@@ -1,0 +1,62 @@
+package io.github.seijikohara.femto.data.display
+
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class DisplayPreferencesTest {
+    // The displayDataStore delegate is a process-wide singleton bound to the
+    // first Application's filesDir, while Robolectric hands each test method a
+    // fresh Application. All DataStore round-trip steps therefore live in one
+    // test method so the persisted file and the singleton never disagree across
+    // tests (mirrors DrawerPreferencesTest). The migration tests below touch no
+    // DataStore, so they stay separate.
+    @Test
+    fun `an empty store reads the defaults and resetToDefaults restores them`() =
+        runTest {
+            val store = DisplayPreferences(ApplicationProvider.getApplicationContext())
+
+            // Reset parity: every per-field read fallback is kept identical to
+            // DisplaySettings.Default, so a fresh key-less store reads exactly
+            // Default. A new field whose read fallback drifts from Default — the
+            // failure mode the SettingsViewModel fake store cannot catch — breaks
+            // this single equality.
+            assertEquals(DisplaySettings.Default, store.settings.first())
+
+            // Mutate a spread of fields across the stored types (enum / bool / int).
+            store.setThemeMode(ThemeMode.DARK)
+            store.setKeepScreenOn(false)
+            store.setMapZoom(DEFAULT_MAP_ZOOM + 2)
+            store.setMusicSpectrum(true)
+            assertNotEquals(DisplaySettings.Default, store.settings.first())
+
+            // resetToDefaults() clears every key, so the read falls back to Default
+            // for all 26 fields at once.
+            store.resetToDefaults()
+            assertEquals(DisplaySettings.Default, store.settings.first())
+        }
+
+    @Test
+    fun `the render mode migrates the retired three-mode values to LIVE`() {
+        // A user who picked a live map before the software backend was removed
+        // keeps a live map, not the SNAPSHOT floor.
+        assertEquals(MapRenderMode.LIVE, "LIVE_HARDWARE".toMapRenderModeOr(MapRenderMode.SNAPSHOT))
+        assertEquals(MapRenderMode.LIVE, "LIVE_SOFTWARE".toMapRenderModeOr(MapRenderMode.SNAPSHOT))
+    }
+
+    @Test
+    fun `the render mode decodes current values and falls back for unknowns`() {
+        assertEquals(MapRenderMode.LIVE, "LIVE".toMapRenderModeOr(MapRenderMode.SNAPSHOT))
+        assertEquals(MapRenderMode.SNAPSHOT, "SNAPSHOT".toMapRenderModeOr(MapRenderMode.LIVE))
+        assertEquals(MapRenderMode.SNAPSHOT, "REMOVED".toMapRenderModeOr(MapRenderMode.SNAPSHOT))
+        assertEquals(MapRenderMode.LIVE, null.toMapRenderModeOr(MapRenderMode.LIVE))
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/HomeViewModelTest.kt
@@ -18,6 +18,7 @@ import io.github.seijikohara.femto.ui.home.components.AppsBarShortcut
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -33,6 +34,7 @@ import org.robolectric.annotation.Config
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -85,6 +87,65 @@ class HomeViewModelTest {
                 assertEquals(calendar, state.calendar)
                 assertEquals(systemStatus, state.systemStatus)
                 assertEquals(tripState, state.tripState)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `a throwing source degrades only its own slot and never crashes the combine`() =
+        runTest {
+            // catchAsDefault must isolate a broken repository: a SecurityException
+            // (e.g. a permission revoked between check and register) in one source
+            // would otherwise cancel the shared combine and kill the HOME process.
+            val weather = fakeWeatherSnapshot()
+            val viewModel =
+                HomeViewModel(
+                    clockFlow = flow { throw SecurityException("clock source broke") },
+                    locationFlow = flowOf(fakeLocation()),
+                    addressFlow = flowOf(fakeAddress()),
+                    weatherFlow = flowOf(weather),
+                    musicStateFlow = flowOf(MusicCardState.Playing(fakeNowPlaying())),
+                    calendarFlow = flowOf(fakeCalendarSnapshot()),
+                    systemStatusFlow = flowOf(fakeSystemStatus()),
+                    tripStateFlow = flowOf(fakeTripState()),
+                )
+            viewModel.uiState.test {
+                val state = awaitItem()
+                // The broken clock holds its neutral Initial value...
+                assertEquals(HomeUiState.Initial.clock, state.clock)
+                // ...while every other card still shows its real value.
+                assertEquals(weather, state.weather)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `a source that fails after emitting falls back to its neutral value`() =
+        runTest {
+            // Documents the no-retry / no-hold-last-good policy: once a source that
+            // had been working throws, its card resets to the neutral default and
+            // stays there (until the process restarts), rather than freezing on the
+            // last good value.
+            val clock = ClockTick(LocalTime.of(14, 32), LocalDate.of(2026, 5, 1))
+            val viewModel =
+                HomeViewModel(
+                    clockFlow =
+                        flow {
+                            emit(clock)
+                            throw IllegalStateException("clock source broke after emitting")
+                        },
+                    locationFlow = flowOf(fakeLocation()),
+                    addressFlow = flowOf(fakeAddress()),
+                    weatherFlow = flowOf(fakeWeatherSnapshot()),
+                    musicStateFlow = flowOf(MusicCardState.Playing(fakeNowPlaying())),
+                    calendarFlow = flowOf(fakeCalendarSnapshot()),
+                    systemStatusFlow = flowOf(fakeSystemStatus()),
+                    tripStateFlow = flowOf(fakeTripState()),
+                )
+            viewModel.uiState.test {
+                val state = awaitItem()
+                assertNotEquals(clock, state.clock)
+                assertEquals(HomeUiState.Initial.clock, state.clock)
                 cancelAndIgnoreRemainingEvents()
             }
         }


### PR DESCRIPTION
## Summary

Part 8 of the comprehensive-review fixes (PR 8/8, final) — the highest-risk test-coverage gaps from the test-analyzer review. The launcher's error-isolation and corrupted-prefs defenses exist specifically to keep the HOME process alive, yet nothing pinned that behavior — a refactor could drop a `.catchAsDefault` wrapper or drift a default and regress it silently.

### `HomeViewModelTest` (+2)

A source flow that throws — both immediately and after emitting — degrades **only its own slot** to the neutral `HomeUiState.Initial` value while every other card keeps its real value, and never cancels the shared combine (the crash the per-source `catchAsDefault` exists to prevent). Pins the per-source isolation and the documented no-retry / no-hold-last-good policy.

### `PreferencesSupportTest` (new, 9)

The shared helpers behind **every** preferences store, previously untested:
- `toEnumOr` — known / unknown (downgrade) / null.
- `catchIoAsDefaults` — `IOException` → `emptyPreferences()` (the corrupted-file cold-start defense), non-IO → rethrow, success passthrough.
- `editOrLog` — applies on success, **swallows** `IOException` (fire-and-forget writes must not kill the launcher), **rethrows** `CancellationException` (structured concurrency). Same rethrow shape as `HomeViewModel.catchAsDefault`.

### `DisplayPreferencesTest` (new, 3)

Exercises the **real** decode path the `SettingsViewModel` fake store bypasses:
- A fresh key-less store reads exactly `DisplaySettings.Default`, and `resetToDefaults()` restores it — **reset parity across all 26 fields** in one equality. A new field whose read fallback drifts from `Default` breaks this.
- The `LIVE_HARDWARE` / `LIVE_SOFTWARE` → `LIVE` render-mode migration. `toMapRenderModeOr` widened `private` → `internal` (joining its delegate `toEnumOr`) so the migration is testable without a raw write to the private DataStore.

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — all green. New tests confirmed executed: PreferencesSupportTest 9, DisplayPreferencesTest 3, HomeViewModelTest 23 (+2), 0 failures.

## Out of scope

The test-analyzer also flagged that `connectedAndroidTest` is unexecuted in CI and `MusicCardTest` has a known idling failure on TBox-Mock (pre-existing since #145, tracked in project memory). That is a CI-infrastructure decision, not a code fix, and is left for a separate discussion.