### PR TITLE
test(music): stop the spectrum frame loop from timing out the idle wait

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicCardTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/MusicCardTest.kt
@@ -110,6 +110,13 @@ class MusicCardTest {
     @Test
     fun spectrum_background_does_not_intercept_transport_taps() {
         var command: MusicCommand? = null
+        // A non-null spectrum drives SpectrumBackground's continuous
+        // withFrameNanos loop, which keeps the Compose frame clock perpetually
+        // busy and times out Espresso's idle wait at setContent. Pausing the
+        // clock parks the loop on its next-frame suspension, so waitForIdle no
+        // longer sees pending frame work; the static transport layout still
+        // composes and lays out, which is all this tap test needs.
+        rule.mainClock.autoAdvance = false
         rule.setContent {
             FemtoTheme {
                 MusicCard(


### PR DESCRIPTION
## Summary

Follow-up to the comprehensive-review sweep — resolves the one out-of-scope item the user opted to fix now: the pre-existing `MusicCardTest` idling failure.

`MusicCardTest.spectrum_background_does_not_intercept_transport_taps` failed deterministically on the TBox-Mock head-unit emulator (pre-existing since PR #145, tracked in project memory). A non-null injected spectrum drives `SpectrumBackground`'s continuous `withFrameNanos` loop, so the Compose frame clock never idles and Espresso's idle wait at `setContent` times out ("busy due to pending recompositions").

### Fix (test-only)

Pause the test clock with `rule.mainClock.autoAdvance = false` before `setContent`, so the frame loop parks on its next-frame suspension and `waitForIdle` no longer sees pending frame work. The static transport layout still composes and lays out — all this tap-routing test needs. **The production frame loop is unchanged**; the alternative (gating the loop off in tests) was rejected because it would push a test-only branch into production code (`LocalInspectionMode` covers previews, not instrumented tests).

## Verification

- `./gradlew spotlessCheck assembleDebugAndroidTest` — green.
- **On the TBox-Mock AVD (API 33, the documented head-unit target)**: `./gradlew connectedDebugAndroidTest` filtered to `MusicCardTest` runs **8/8 green**, including the previously-failing case.

## Scope note

This unblocks any future manual or CI `connectedAndroidTest` run of `MusicCardTest`. Wiring `androidTest` into CI on an emulator (with the GL/Visualizer exclusions the emulator requires) remains a separate, deferred decision per the discussion — not part of this PR.