### PR TITLE
ci(renovate): stop pinning npm versions and automerge all green updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,11 +3,15 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     // Maintainer-recommended superset of config:recommended: pins GitHub Action
-    // digests, enables config migration, and keeps dependencies pinned where
-    // the ecosystem supports it.
+    // digests (kept for supply-chain safety) and enables config migration.
     'config:best-practices',
     // Conventional Commits subjects (fix(deps)/chore(deps)) to match the repo.
     ':semanticCommits',
+    // Do not pin npm package versions: keep the existing semver ranges and just
+    // upgrade in place. Overrides best-practices' :pinDevDependencies. GitHub
+    // Action digest pinning is unaffected (it is governed by pinDigests, not
+    // rangeStrategy) and intentionally stays on.
+    ':preserveSemverRanges',
   ],
   timezone: 'Asia/Tokyo',
   // Keep update branches rebased whenever they fall behind main.
@@ -18,16 +22,15 @@
   // settings.
   platformAutomerge: false,
   automergeStrategy: 'squash',
-  // Weekly pnpm-lock.yaml refresh for webmap/, automerged like any other
-  // non-major update.
+  // Weekly pnpm-lock.yaml refresh for webmap/, automerged like any other update.
   lockFileMaintenance: {
     enabled: true,
     automerge: true,
   },
   packageRules: [
     {
-      description: 'Automerge non-major updates once CI is green; majors stay manual',
-      matchUpdateTypes: ['minor', 'patch', 'pin', 'pinDigest', 'digest'],
+      description: 'Automerge every update once CI is green, majors included',
+      matchUpdateTypes: ['major', 'minor', 'patch', 'pinDigest', 'digest'],
       automerge: true,
     },
     {


### PR DESCRIPTION
## What

- Add `:preserveSemverRanges` to the Renovate `extends`, overriding the npm version pinning that `config:best-practices` enabled via `:pinDevDependencies`. Updates now upgrade in place and keep their semver ranges (`^`, `~`) instead of being pinned to exact versions.
- Add `major` to the automerge `matchUpdateTypes` so every update — majors included — merges automatically once the PR CI is green. The now-unused `pin` type is dropped.

## Why

The maintainer did not intend to pin dependencies, and wants every dependency update to merge when verified green by PR CI.

GitHub Action SHA digest pinning is **kept** — it is governed by `pinDigests` (from `helpers:pinGitHubActionDigests`), not `rangeStrategy`, so `:preserveSemverRanges` does not touch it. It stays on for supply-chain safety (tag-hijack protection). The npm `minimumReleaseAge: 3 days` cooldown also stays.

## Effect on the open pin PR

This obsoletes #121 (`chore(deps): pin dependencies`), which Renovate's `renovate/stability-days` check blocked indefinitely due to a [known limitation](https://github.com/renovatebot/renovate/issues/40288) where pin operations do not wire in release age. #121 will be closed.

## Verification

`renovate-config-validator` (latest) passes:

```
INFO: Validating renovate.json5 as global config
INFO: Config validated successfully against 1 file(s)
```