### PR TITLE
chore: remove dead code and clear actionable lint warnings

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -6,7 +6,6 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -26,6 +25,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -416,7 +416,7 @@ class MainActivity : ComponentActivity() {
 
     private fun openPrivacyPolicy() {
         val intent =
-            Intent(Intent.ACTION_VIEW, Uri.parse(PRIVACY_POLICY_URL))
+            Intent(Intent.ACTION_VIEW, PRIVACY_POLICY_URL.toUri())
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         tryStartActivity(intent)
     }
@@ -439,7 +439,7 @@ class MainActivity : ComponentActivity() {
         // A bare geo: URI lets whichever maps app the user has elected resolve
         // the position — no provider or package is hard-coded.
         val intent =
-            Intent(Intent.ACTION_VIEW, Uri.parse("geo:$latitude,$longitude?z=$MAPS_ZOOM_LEVEL"))
+            Intent(Intent.ACTION_VIEW, "geo:$latitude,$longitude?z=$MAPS_ZOOM_LEVEL".toUri())
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         tryStartActivity(intent)
     }
@@ -462,9 +462,7 @@ class MainActivity : ComponentActivity() {
                 if (!hasFineLocationPermission()) add(Manifest.permission.ACCESS_FINE_LOCATION)
                 if (!hasReadCalendarPermission()) add(Manifest.permission.READ_CALENDAR)
                 if (!hasReadPhoneStatePermission()) add(Manifest.permission.READ_PHONE_STATE)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !hasBluetoothConnectPermission()) {
-                    add(Manifest.permission.BLUETOOTH_CONNECT)
-                }
+                if (!hasBluetoothConnectPermission()) add(Manifest.permission.BLUETOOTH_CONNECT)
             }
         if (needed.isNotEmpty()) permissionsLauncher.launch(needed.toTypedArray())
     }

--- a/app/src/main/java/io/github/seijikohara/femto/data/location/LocationPermissions.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/LocationPermissions.kt
@@ -3,7 +3,6 @@ package io.github.seijikohara.femto.data.location
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
-import android.os.Build
 import androidx.core.content.ContextCompat
 
 /**
@@ -63,13 +62,11 @@ internal fun Context.hasRecordAudioPermission(): Boolean =
     ) == PackageManager.PERMISSION_GRANTED
 
 /**
- * `BLUETOOTH_CONNECT` is a runtime grant only on Android 12+ (API 31).
- * Below that, the permission is install-time and always considered granted.
+ * `BLUETOOTH_CONNECT` is a runtime grant on Android 12+ (API 31); the app's
+ * minSdk is 33, so it is always a runtime grant and never auto-granted.
  */
-internal fun Context.hasBluetoothConnectPermission(): Boolean {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
-    return ContextCompat.checkSelfPermission(
+internal fun Context.hasBluetoothConnectPermission(): Boolean =
+    ContextCompat.checkSelfPermission(
         this,
         Manifest.permission.BLUETOOTH_CONNECT,
     ) == PackageManager.PERMISSION_GRANTED
-}

--- a/app/src/main/java/io/github/seijikohara/femto/data/system/SystemStatusRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/system/SystemStatusRepository.kt
@@ -2,7 +2,6 @@
 
 package io.github.seijikohara.femto.data.system
 
-import android.Manifest
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
@@ -20,7 +19,6 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.BatteryManager
-import android.os.Build
 import android.telephony.SignalStrength
 import android.telephony.TelephonyCallback
 import android.telephony.TelephonyManager
@@ -29,6 +27,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import io.github.seijikohara.femto.data.location.LocationRepository
 import io.github.seijikohara.femto.data.location.TripRepository
+import io.github.seijikohara.femto.data.location.hasBluetoothConnectPermission
 import io.github.seijikohara.femto.data.location.hasFineLocationPermission
 import io.github.seijikohara.femto.data.location.hasReadPhoneStatePermission
 import kotlinx.coroutines.CoroutineDispatcher
@@ -359,7 +358,7 @@ internal class SystemStatusRepository(
             awaitClose { context.unregisterReceiver(receiver) }
         }
 
-    @SuppressLint("MissingPermission") // Permission is checked inside hasBluetoothConnect().
+    @SuppressLint("MissingPermission") // Permission is checked via hasBluetoothConnectPermission().
     private fun readBluetooth(adapter: BluetoothAdapter?): BluetoothReading {
         val enabled = adapter?.isEnabled == true
         if (!enabled) return BluetoothReading(enabled = false, connected = false)
@@ -367,7 +366,7 @@ internal class SystemStatusRepository(
         // pairing state is unknowable; treat an enabled adapter as connected so a
         // head unit paired to a phone is not under-reported.
         val connected =
-            if (!hasBluetoothConnect()) {
+            if (!context.hasBluetoothConnectPermission()) {
                 true
             } else {
                 val devices = bluetoothManager?.getConnectedDevices(BluetoothProfile.GATT) ?: emptyList()
@@ -378,14 +377,6 @@ internal class SystemStatusRepository(
                     BluetoothAdapter.STATE_CONNECTED
             }
         return BluetoothReading(enabled = true, connected = connected)
-    }
-
-    private fun hasBluetoothConnect(): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
-        return ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.BLUETOOTH_CONNECT,
-        ) == PackageManager.PERMISSION_GRANTED
     }
 
     private fun batteryFlow(): Flow<BatteryReading> =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -1,7 +1,6 @@
 package io.github.seijikohara.femto.ui.drawer
 
 import android.content.ComponentName
-import android.graphics.Bitmap
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -45,6 +44,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.createBitmap
 import com.composables.icons.lucide.Check
 import com.composables.icons.lucide.LayoutGrid
 import com.composables.icons.lucide.LayoutList
@@ -549,7 +549,7 @@ private fun CenteredMessage(
 @PreviewLightDark
 @Composable
 private fun AppDrawerContentPreview() {
-    val icon = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+    val icon = createBitmap(1, 1)
     FemtoTheme {
         AppDrawerScreen(
             uiState =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
@@ -1,7 +1,6 @@
 package io.github.seijikohara.femto.ui.drawer.components
 
 import android.content.ComponentName
-import android.graphics.Bitmap
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
@@ -45,6 +44,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.core.graphics.createBitmap
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.ArrowRight
 import com.composables.icons.lucide.Lucide
@@ -318,7 +318,7 @@ private fun DockTile(
 @PreviewLightDark
 @Composable
 private fun PinnedDockPreview() {
-    val icon = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+    val icon = createBitmap(1, 1)
     FemtoTheme {
         PinnedDock(
             apps =

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,7 +82,6 @@
     <!-- Count of satellites used in the current GPS fix, shown under the footer's satellite icon. -->
     <string name="status_gps_satellites">%1$d</string>
     <string name="status_battery">Battery</string>
-    <string name="status_charging">Charging</string>
     <string name="battery_percent">%1$d%%</string>
 
     <!-- App drawer -->


### PR DESCRIPTION
## Why

Part of the project-wide review/cleanup. Behavior-preserving removal of dead code and resolution of the *actionable* lint warnings.

## What

- **Dead resources**: delete `R.color.black`, `R.color.white` (the whole `colors.xml`), and `R.string.status_charging` (verified zero references; the dock shows charging via glyph+tint, asserted by `DashboardDockTest`).
- **Dead `SDK_INT < S` guards** (minSdk 33): `hasBluetoothConnectPermission()` becomes a single expression; `SystemStatusRepository` drops its byte-identical private `hasBluetoothConnect()` for the shared extension; `MainActivity`'s `BLUETOOTH_CONNECT` request drops its always-true `SDK_INT` check.
- **KTX helpers**: `createBitmap(...)` and `String.toUri()`.

Clears the **UnusedResources, ObsoleteSdkInt, UseKtx** lint categories (10 warnings) and removes a duplicated permission check.

The remaining `LogNotTimber` warnings (56) are a **false positive** from MapLibre's transitive Timber dependency — the app deliberately uses `android.util.Log` and `CLAUDE.md#no-suppress` disallows baselining/suppression, so they are intentionally left. `ConfigurationScreenWidthHeight` (6) is a separate behavioral change tracked for later; `OldTargetApi` (1) is deliberate.

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL**; lint down to LogNotTimber×56 + ConfigurationScreenWidthHeight×6 + OldTargetApi×1.