### PR TITLE
refactor: consolidate glance text style and reuse SSOT helpers

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/apps/DrawerPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/apps/DrawerPreferences.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import io.github.seijikohara.femto.data.common.catchIoAsDefaults
 import io.github.seijikohara.femto.data.common.editOrLog
+import io.github.seijikohara.femto.data.common.toEnumOr
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -70,20 +71,12 @@ internal class DrawerPreferences(
     override val layout: Flow<DrawerLayout> =
         context.drawerDataStore.data
             .catchIoAsDefaults(TAG)
-            .map { prefs ->
-                prefs[LAYOUT_KEY]
-                    ?.let { name -> DrawerLayout.entries.firstOrNull { it.name == name } }
-                    ?: DrawerLayout.GRID
-            }
+            .map { prefs -> prefs[LAYOUT_KEY].toEnumOr(DrawerLayout.GRID) }
 
     override val iconSize: Flow<DrawerIconSize> =
         context.drawerDataStore.data
             .catchIoAsDefaults(TAG)
-            .map { prefs ->
-                prefs[ICON_SIZE_KEY]
-                    ?.let { name -> DrawerIconSize.entries.firstOrNull { it.name == name } }
-                    ?: DrawerIconSize.MEDIUM
-            }
+            .map { prefs -> prefs[ICON_SIZE_KEY].toEnumOr(DrawerIconSize.MEDIUM) }
 
     override val pinned: Flow<List<String>> =
         context.drawerDataStore.data

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -36,6 +36,7 @@ import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.TabularFigures
 import io.github.seijikohara.femto.ui.theme.bigNumber
+import io.github.seijikohara.femto.ui.theme.glanceBody
 import io.github.seijikohara.femto.ui.theme.glanceMetric
 import io.github.seijikohara.femto.ui.theme.sectionLabel
 import java.time.LocalDate
@@ -219,10 +220,7 @@ private fun DayRow(
             // an explicit line beats a bare dash for the one row that stays.
             Text(
                 text = stringResource(R.string.calendar_no_events),
-                style = MaterialTheme.typography.bodyMedium.copy(
-                    fontSize = FemtoDimens.GlanceTextSize,
-                    lineHeight = 18.sp,
-                ),
+                style = MaterialTheme.typography.glanceBody(),
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                 maxLines = 1,
             )
@@ -271,7 +269,7 @@ private fun EventRow(
     )
     Text(
         text = title,
-        style = MaterialTheme.typography.bodyMedium.copy(fontSize = FemtoDimens.GlanceTextSize, lineHeight = 18.sp),
+        style = MaterialTheme.typography.glanceBody(),
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         maxLines = 2,
         overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCardStates.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCardStates.kt
@@ -27,6 +27,7 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.cardCta
 import io.github.seijikohara.femto.ui.theme.cardCtaHint
+import io.github.seijikohara.femto.ui.theme.glanceBody
 
 @Composable
 internal fun MusicConnectState(onConnect: () -> Unit) =
@@ -44,7 +45,7 @@ internal fun MusicConnectState(onConnect: () -> Unit) =
                 imageVector = Lucide.Music,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(36.dp),
+                modifier = Modifier.size(FemtoDimens.HeroIconSize),
             )
             Box(modifier = Modifier.height(12.dp))
             Text(
@@ -86,7 +87,7 @@ internal fun MusicEmptyState() =
             imageVector = Lucide.Music,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-            modifier = Modifier.size(36.dp),
+            modifier = Modifier.size(FemtoDimens.HeroIconSize),
         )
         Box(modifier = Modifier.height(4.dp))
         Text(
@@ -98,11 +99,7 @@ internal fun MusicEmptyState() =
         Box(modifier = Modifier.height(4.dp))
         Text(
             text = stringResource(R.string.music_nothing_hint),
-            style =
-                MaterialTheme.typography.bodyMedium.copy(
-                    fontSize = FemtoDimens.GlanceTextSize,
-                    lineHeight = 18.sp,
-                ),
+            style = MaterialTheme.typography.glanceBody(),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
             maxLines = 2,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
@@ -112,6 +112,17 @@ internal fun Typography.glanceMetric(): TextStyle =
     )
 
 /**
+ * Return body text relaxed to the [FemtoDimens.GlanceTextSize] glance floor for
+ * dense card metadata — the calendar "no events" / event-title lines and the
+ * music "nothing playing" hint, per CLAUDE.md#automotive-overrides.
+ */
+internal fun Typography.glanceBody(): TextStyle =
+    bodyMedium.copy(
+        fontSize = FemtoDimens.GlanceTextSize,
+        lineHeight = 18.sp,
+    )
+
+/**
  * Return the music transport's position / duration caption style. Sized at
  * the [FemtoDimens.GlanceTextSize] glance floor — the progress-caption
  * relaxation CLAUDE.md#automotive-overrides routes through that token — with


### PR DESCRIPTION
## Why

Project-review SSOT/DRY cleanup. All changes are **behavior-preserving** (the values are unchanged — verified pixel-identical on the head-unit emulator).

## What

- **`Typography.glanceBody()`** added to `Type.kt`; replaces the **three** inline `bodyMedium.copy(fontSize = GlanceTextSize, lineHeight = 18.sp)` sites (`CalendarCard` ×2, `MusicCardStates` ×1), per the design-system rule that a recurring `.copy(fontSize = …)` becomes a named `Type.kt` extension.
- The two music hero icons now use the previously-orphaned **`FemtoDimens.HeroIconSize`** token instead of a raw `36.dp`.
- `DrawerPreferences` decodes its enums via the shared **`String?.toEnumOr(…)`** helper, matching every other preference store (it was the only one hand-rolling the decode).

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL**. Emulator (TBox-Mock): dashboard renders identically — calendar "no events"/event lines, the music connect hint, and the music hero icon all unchanged.