### PR TITLE
refactor: relocate drawer-only components to ui/drawer

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -58,9 +58,9 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.apps.AppEntry
 import io.github.seijikohara.femto.data.apps.DrawerIconSize
 import io.github.seijikohara.femto.data.apps.DrawerLayout
+import io.github.seijikohara.femto.ui.drawer.components.AppListRow
+import io.github.seijikohara.femto.ui.drawer.components.AppTile
 import io.github.seijikohara.femto.ui.drawer.components.PinnedDock
-import io.github.seijikohara.femto.ui.home.components.AppListRow
-import io.github.seijikohara.femto.ui.home.components.AppTile
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/AppListRow.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/AppListRow.kt
@@ -1,4 +1,4 @@
-package io.github.seijikohara.femto.ui.home.components
+package io.github.seijikohara.femto.ui.drawer.components
 
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/AppTile.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/AppTile.kt
@@ -1,4 +1,4 @@
-package io.github.seijikohara.femto.ui.home.components
+package io.github.seijikohara.femto.ui.drawer.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable


### PR DESCRIPTION
## Why

Project-review architecture cleanup. `AppListRow` and `AppTile` lived under `ui/home/components/` but are consumed **only** by the app drawer (`AppDrawerScreen`) — HOME no longer references either. This was the launcher's only cross-area UI dependency (`drawer -> ui.home.components`).

## What

- `git mv` `AppListRow.kt` and `AppTile.kt` to `ui/drawer/components/` (beside `PinnedDock`).
- Update their package declarations and the single consumer's imports.

Pure relocation — no behaviour or visual change. (Kotlin `internal` is module-scoped, so the move needs no visibility changes.)

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL**.