### PR TITLE
chore(webmap): migrate biome config off the deprecated recommended field

### DIFF
--- a/webmap/biome.json
+++ b/webmap/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -16,7 +16,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"suspicious": {
 				"noVar": "error"
 			},


### PR DESCRIPTION
## Why

Project-review fix-at-source cleanup. Biome 2.5 reports `linter.rules.recommended` as **deprecated** ("will be removed in the next major version. Use preset instead."). `.claude/rules/webmap.md` calls for treating tool deprecations as failures during bumps, and `CLAUDE.md#no-suppress` rules out silencing it — so migrate now.

## What

`biome migrate --write` rewrote `webmap/biome.json`:
- `linter.rules.recommended: true` → `linter.rules.preset: "recommended"`
- `$schema` pin bumped `2.4.16` → `2.5.0`

The custom `noVar` / `useConst` rules and the `no-let.grit` plugin are unchanged. `biome check .` is now **info-free** (was 2 infos).

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL** (all 67 tasks, including `buildWebMap` → biome check + tsc + vitest + vite). Confirmed `biome check .` reports no infos after the migration.