### PR TITLE
refactor: derive sheet heights from window size via a shared helper

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/assistant/AssistantSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/assistant/AssistantSheet.kt
@@ -7,9 +7,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
+import io.github.seijikohara.femto.ui.common.rememberSheetHeight
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
 /**
@@ -36,7 +36,7 @@ internal fun AssistantSheet(
     fullscreen: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
+    val sheetHeight = rememberSheetHeight(FemtoDimens.DrawerSheetHeightFraction)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/common/SheetHeight.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/common/SheetHeight.kt
@@ -1,0 +1,26 @@
+package io.github.seijikohara.femto.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Return a modal-sheet height as [fraction] of the current window height.
+ *
+ * Reads the window content size from [LocalWindowInfo] (`containerSize`, in
+ * pixels) rather than the lint-flagged `LocalConfiguration.screenHeightDp`,
+ * converting to [Dp] through the current density. The shared helper is the SSOT
+ * for the launcher's bottom-sheet heights (drawer, settings, assistant,
+ * diagnostics, licenses, font picker).
+ */
+@Composable
+internal fun rememberSheetHeight(fraction: Float): Dp {
+    val containerHeightPx = LocalWindowInfo.current.containerSize.height
+    val density = LocalDensity.current
+    return remember(containerHeightPx, fraction, density) {
+        with(density) { (containerHeightPx * fraction).toDp() }
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsSheet.kt
@@ -8,9 +8,9 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
+import io.github.seijikohara.femto.ui.common.rememberSheetHeight
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
 /**
@@ -25,7 +25,7 @@ internal fun DiagnosticsSheet(
     fullscreen: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
+    val sheetHeight = rememberSheetHeight(FemtoDimens.DrawerSheetHeightFraction)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSheet.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -23,6 +22,7 @@ import io.github.seijikohara.femto.data.apps.DrawerIconSize
 import io.github.seijikohara.femto.data.apps.DrawerLayout
 import io.github.seijikohara.femto.data.apps.DrawerPreferences
 import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
+import io.github.seijikohara.femto.ui.common.rememberSheetHeight
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import kotlinx.coroutines.launch
 
@@ -77,7 +77,7 @@ internal fun AppDrawerSheet(
     // open because the sheet recomposes from scratch.
     var expanded by remember { mutableStateOf(false) }
 
-    val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
+    val sheetHeight = rememberSheetHeight(FemtoDimens.DrawerSheetHeightFraction)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/fontpicker/FontPickerSheet.kt
@@ -8,10 +8,10 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.data.fonts.FontSlot
 import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
+import io.github.seijikohara.femto.ui.common.rememberSheetHeight
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
 /**
@@ -29,7 +29,7 @@ internal fun FontPickerSheet(
     fullscreen: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.FontPickerSheetHeightFraction).dp
+    val sheetHeight = rememberSheetHeight(FemtoDimens.FontPickerSheetHeightFraction)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/licenses/LicensesSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/licenses/LicensesSheet.kt
@@ -8,9 +8,9 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
+import io.github.seijikohara.femto.ui.common.rememberSheetHeight
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
 /**
@@ -25,7 +25,7 @@ internal fun LicensesSheet(
     fullscreen: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
+    val sheetHeight = rememberSheetHeight(FemtoDimens.DrawerSheetHeightFraction)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
@@ -7,10 +7,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.data.fonts.FontSlot
 import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
+import io.github.seijikohara.femto.ui.common.rememberSheetHeight
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
 /**
@@ -39,7 +39,7 @@ internal fun SettingsSheet(
     fullscreen: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val sheetHeight = (LocalConfiguration.current.screenHeightDp * FemtoDimens.DrawerSheetHeightFraction).dp
+    val sheetHeight = rememberSheetHeight(FemtoDimens.DrawerSheetHeightFraction)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,


### PR DESCRIPTION
## Why

Follow-up from the cleanup sweep. The six modal bottom sheets each computed their height from `LocalConfiguration.screenHeightDp`, which Android Lint flags as **`ConfigurationScreenWidthHeight` (×6)** — the last actionable lint category.

## What

- New `ui/common/rememberSheetHeight(fraction)` helper reads `LocalWindowInfo.containerSize` (the lint-recommended API) and converts to `Dp` via the current density — one SSOT for sheet heights.
- All six sheets (drawer, settings, assistant, diagnostics, licenses, font picker) use it; the inline `screenHeightDp` computation and now-unused imports are gone.

Height is unchanged on the head-unit geometry (the math is identical at density 0.9375; verified on the emulator — the settings sheet opens at the same ~72%).

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL**. Lint is now down to `LogNotTimber`×56 (transitive-Timber false positive) + `OldTargetApi`×1 (deliberate) — **every fixable lint warning is cleared**. Emulator (TBox-Mock): settings sheet renders at the expected height, no crash.