### PR TITLE
refactor: extract the monospace reference text style to Type.kt

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
@@ -31,6 +31,7 @@ import io.github.seijikohara.femto.data.system.PerformanceSnapshot
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+import io.github.seijikohara.femto.ui.theme.monoReference
 import java.util.Locale
 
 /**
@@ -280,11 +281,7 @@ private fun LogsSection(logs: List<String>) =
                 // they take the sanctioned GlanceTextSize relaxation.
                 Text(
                     text = line,
-                    style =
-                        MaterialTheme.typography.bodySmall.copy(
-                            fontSize = FemtoDimens.GlanceTextSize,
-                            fontFamily = FontFamily.Monospace,
-                        ),
+                    style = MaterialTheme.typography.monoReference(),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/licenses/LicensesScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/licenses/LicensesScreen.kt
@@ -30,6 +30,7 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+import io.github.seijikohara.femto.ui.theme.monoReference
 
 /**
  * Open-source attribution surface: the auto-collected library list (tap a row to
@@ -142,11 +143,7 @@ private fun LicenseDetail(
         text = item.licenseText ?: stringResource(R.string.licenses_unavailable),
         // Dense legal reference text in a sub-sheet: the same GlanceTextSize +
         // monospace relaxation the diagnostics log tail uses.
-        style =
-            MaterialTheme.typography.bodySmall.copy(
-                fontSize = FemtoDimens.GlanceTextSize,
-                fontFamily = FontFamily.Monospace,
-            ),
+        style = MaterialTheme.typography.monoReference(),
         color = MaterialTheme.colorScheme.onSurface,
     )
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
@@ -136,6 +136,18 @@ internal fun Typography.progressCaption(): TextStyle =
     )
 
 /**
+ * Return the dense monospace reference-text style for legal / log content shown
+ * in sub-sheets (the open-source licenses body and the diagnostics log tail).
+ * Relaxed to the [FemtoDimens.GlanceTextSize] glance floor per
+ * CLAUDE.md#automotive-overrides.
+ */
+internal fun Typography.monoReference(): TextStyle =
+    bodySmall.copy(
+        fontSize = FemtoDimens.GlanceTextSize,
+        fontFamily = FontFamily.Monospace,
+    )
+
+/**
  * Return an uppercase eyebrow / section-label style derived from
  * [Typography.labelSmall]. Callers pass the explicit size and tracking the
  * design SSOT specifies for each strip, so the relaxed sub-18sp eyebrow sizes


### PR DESCRIPTION
## Why

Follow-up cleanup. The open-source-licenses body and the diagnostics log tail inlined the **same** `bodySmall.copy(fontSize = GlanceTextSize, fontFamily = Monospace)` — the licenses comment even named the duplication ("the same … relaxation the diagnostics log tail uses").

## What

- Add `Typography.monoReference()` to `Type.kt` and use it at both sites, per the design-system rule that a recurring `.copy(...)` becomes a named extension. Pixel-identical; the now-unused `FontFamily` imports drop out.

The other "TextStyle one-offs" flagged in the review were left intentionally: the glance-metric variants have **different base styles** (`labelLarge` vs `cardMeta()`) so a shared extension would be wrong, and `DockStatusCluster.statusMetricStyle()` is already a single local helper.

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL**.