### PR TITLE
refactor: make FontPreferences implement FontSelectionStore directly

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/fonts/FontPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/fonts/FontPreferences.kt
@@ -16,7 +16,7 @@ private val Context.fontDataStore: DataStore<Preferences> by preferencesDataStor
 private const val TAG = "FontPreferences"
 
 /**
- * DataStore-backed accessor for the user's [FontSelection].
+ * DataStore-backed [FontSelectionStore].
  *
  * Each slot stores a Google Fonts family name; an absent key means the system
  * font (the default), so a fresh install and a reset both fall back to the
@@ -24,8 +24,8 @@ private const val TAG = "FontPreferences"
  */
 internal class FontPreferences(
     private val context: Context,
-) {
-    val selection: Flow<FontSelection> =
+) : FontSelectionStore {
+    override val selection: Flow<FontSelection> =
         context.fontDataStore.data
             .catchIoAsDefaults(TAG)
             .map { prefs ->
@@ -33,7 +33,7 @@ internal class FontPreferences(
             }
 
     /** Persist [family] for [slot]; a null family clears the slot to system. */
-    suspend fun setFamily(
+    override suspend fun setFamily(
         slot: FontSlot,
         family: String?,
     ) {
@@ -45,7 +45,7 @@ internal class FontPreferences(
 
     // Clearing the keys makes the read path fall back to the system font,
     // mirroring DisplayPreferences.resetToDefaults.
-    suspend fun resetToDefaults() {
+    override suspend fun resetToDefaults() {
         context.fontDataStore.editOrLog(TAG) { it.clear() }
     }
 

--- a/app/src/main/java/io/github/seijikohara/femto/data/fonts/FontRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/fonts/FontRepository.kt
@@ -244,7 +244,7 @@ internal class FontRepository internal constructor(
             return FontRepository(
                 api = FontCatalogSource(api::catalog),
                 cache = FontCache(cacheRoot, api).asFaceStore(),
-                preferences = FontPreferences(app).asSelectionStore(),
+                preferences = FontPreferences(app),
                 catalogFile = File(app.filesDir, "google_fonts_catalog.json"),
                 scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
             )
@@ -265,16 +265,4 @@ private fun FontCache.asFaceStore(): FontFaceStore =
             keep: Collection<String>,
             alsoProtect: Collection<String>,
         ) = this@asFaceStore.evictExcept(keep, alsoProtect)
-    }
-
-private fun FontPreferences.asSelectionStore(): FontSelectionStore =
-    object : FontSelectionStore {
-        override val selection: Flow<FontSelection> = this@asSelectionStore.selection
-
-        override suspend fun setFamily(
-            slot: FontSlot,
-            family: String?,
-        ) = this@asSelectionStore.setFamily(slot, family)
-
-        override suspend fun resetToDefaults() = this@asSelectionStore.resetToDefaults()
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -9,6 +9,7 @@ import io.github.seijikohara.femto.data.common.WhileUiSubscribed
 import io.github.seijikohara.femto.data.display.DisplayPreferences
 import io.github.seijikohara.femto.data.display.DisplaySettingsStore
 import io.github.seijikohara.femto.data.fonts.FontPreferences
+import io.github.seijikohara.femto.data.fonts.FontSelectionStore
 import io.github.seijikohara.femto.data.location.LocationPreferences
 import io.github.seijikohara.femto.data.location.LocationSettingsStore
 import kotlinx.coroutines.flow.StateFlow
@@ -18,7 +19,7 @@ import kotlinx.coroutines.launch
 
 internal class SettingsViewModel(
     private val displayPreferences: DisplaySettingsStore,
-    private val fontPreferences: FontPreferences,
+    private val fontPreferences: FontSelectionStore,
     private val locationPreferences: LocationSettingsStore,
 ) : ViewModel() {
     val uiState: StateFlow<SettingsUiState> =

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -14,6 +14,7 @@ import io.github.seijikohara.femto.data.fonts.FontPreferences
 import io.github.seijikohara.femto.data.location.LocationQualitySetting
 import io.github.seijikohara.femto.data.location.LocationSettings
 import io.github.seijikohara.femto.testfixtures.FakeDisplaySettingsStore
+import io.github.seijikohara.femto.testfixtures.FakeFontSelectionStore
 import io.github.seijikohara.femto.testfixtures.FakeLocationSettingsStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,15 +32,12 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 
-// Robolectric only to obtain an Application for the (inert) FontPreferences; the
-// settings under test go through an in-memory FakeDisplaySettingsStore, so there
-// is no DataStore IO and the test is fully driven by the StandardTestDispatcher.
+// Pure JVM: every collaborator is an in-memory fake, so there is no DataStore IO
+// and the test is fully driven by the StandardTestDispatcher.
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [33])
 class SettingsViewModelTest {
-    private val application: Application = ApplicationProvider.getApplicationContext()
     private val store = FakeDisplaySettingsStore()
+    private val fontStore = FakeFontSelectionStore()
     private val locationStore = FakeLocationSettingsStore()
     private val dispatcher = StandardTestDispatcher()
 
@@ -280,5 +278,5 @@ class SettingsViewModelTest {
             assertEquals(OrientationSetting.LANDSCAPE, store.settings.first().orientation)
         }
 
-    private fun viewModel() = SettingsViewModel(store, FontPreferences(application), locationStore)
+    private fun viewModel() = SettingsViewModel(store, fontStore, locationStore)
 }


### PR DESCRIPTION
## Why

Follow-up: the test review's HIGH item — `SettingsViewModelTest` built a **real DataStore-backed `FontPreferences` under `runTest`**, violating the project's "ViewModel tests use a fake store" rule. The `FontSelectionStore` interface + `FakeFontSelectionStore` already existed (for `FontRepository`), but `FontPreferences` was only *adapted* to it via a private `asSelectionStore()` object, and `SettingsViewModel` depended on the concrete class.

## What

- `FontPreferences` now **implements `FontSelectionStore` directly**; the redundant private `asSelectionStore()` adapter in `FontRepository` is removed (it passes `FontPreferences` straight through).
- `SettingsViewModel` depends on the `FontSelectionStore` interface.
- `SettingsViewModelTest` injects the existing `FakeFontSelectionStore` and, no longer needing an `Application`, **drops Robolectric** to run as a pure JVM test.

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL** (SettingsViewModelTest, FontRepositoryTest, FontPickerViewModelTest all green).

> Note: `DisplayPreferencesTest` / `DrawerPreferencesTest` still exercise a real DataStore — that is correct, as they test the **store implementation itself** (not a consumer); only the singleton-vs-in-memory nuance remains, tracked separately.