### PR TITLE
ci(release): add a tag-driven production release workflow

### DIFF
--- a/.github/PLAY_RELEASE.md
+++ b/.github/PLAY_RELEASE.md
@@ -3,6 +3,20 @@
 This file records the Play Console declarations that cannot live in the repo.
 Code-side release wiring is in `app/build.gradle.kts` and `.github/RELEASING.md`.
 
+## Status (free-launch audit, 2026-06-17)
+
+**No hard code/policy blocker remains.** Code-side is ready: `targetSdk 36`
+(clears the API-35 floor and the Aug-2026 API-36 deadline), signed **AAB**
+built by the tag-driven [`release.yml`](workflows/release.yml), manifest hygiene
+(no `QUERY_ALL_PACKAGES`, no `ACCESS_BACKGROUND_LOCATION`, FGS `location` type
+declared, all components `exported`-explicit, location prefs excluded from
+backup), all external resources free + ToS-compliant (MET Norway / OpenFreeMap /
+Google Fonts / on-device geocoder), privacy policy shipped, adaptive + 512px
+icons present.
+
+The remaining gates are all in this file (Console paperwork) plus, for a **new
+personal developer account**, the closed-testing requirement below.
+
 ## Privacy policy
 
 - URL: <https://github.com/seijikohara/femto-car-launcher/blob/main/PRIVACY.md>
@@ -43,15 +57,39 @@ be declared "not shared."
 ## Sensitive permission declarations
 
 - **Location** (`ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION`): map, address,
-  weather, trip. No `ACCESS_BACKGROUND_LOCATION`.
+  weather, trip. No `ACCESS_BACKGROUND_LOCATION`, so the heavyweight background-
+  location Permissions Declaration Form is NOT required — only the foreground
+  prominent disclosure + the FGS declaration above.
 - **Microphone** (`RECORD_AUDIO`): voice assistant + music spectrum; runtime-requested
-  on user action.
+  on user action. No declaration form, but needs a prominent disclosure.
 - **`READ_PHONE_STATE`**: cellular signal level only (not Call Log / SMS group).
+- **Notification listener** (`BIND_NOTIFICATION_LISTENER_SERVICE`,
+  `MusicSessionListenerService`): reads the active media session for the
+  now-playing card. No formal declaration form, but notification access draws
+  review scrutiny — keep the in-app prominent disclosure + affirmative consent
+  before requesting access, and justify the media-control use case.
+
+## Content rating, account, and testing
+
+- **Content rating**: complete the IARC questionnaire at **App content → Content
+  rating**.
+- **Account deletion**: N/A — the app has no user accounts / sign-in.
+- **Closed-testing requirement (new personal accounts only)**: a personal
+  developer account created after 2023-11-13 must run a **closed test with ≥12
+  testers opted-in continuously for ≥14 days** before applying for production
+  access. Recruit via friends / mutual-testing communities (real people on real
+  devices — bot/fake testers risk account termination). An **organization**
+  account is exempt (requires a D-U-N-S number). Plan ~3 weeks lead time
+  (14-day test + ~7-day production-access review).
+- One-time account setup: **$25** registration + identity verification.
 
 ## Release artifact
 
-- Upload an **App Bundle (.aab)**, not an APK (see the AAB CI work / `bundleRelease`).
-- Use a release `versionCode` / `versionName` distinct from the nightly channel.
-- Prepare store assets the repo cannot hold: 512×512 hi-res icon (export
-  `logo.svg`), feature graphic, and screenshots (landscape head-unit + portrait
-  phone).
+- Cut the build by pushing a `vMAJOR.MINOR.PATCH` tag → [`release.yml`](workflows/release.yml)
+  produces the **signed AAB** (and an APK) with a production version derived from
+  the tag, and attaches them to the GitHub release. Upload the `.aab` to the Play
+  Console. See `.github/RELEASING.md`.
+- Upload an **App Bundle (.aab)**, not an APK.
+- Store assets: the **512×512 icon** lives in `art/play/`; the **feature graphic
+  (1024×500)** and **screenshots** (landscape head-unit + portrait phone) also
+  live in `art/play/`. Short/long descriptions are authored in the Console.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -11,6 +11,29 @@ Play Console -> Testing/Production -> Create release. Local
 signing config is registered only when `RELEASE_KEYSTORE_PATH` is set, so
 contributor builds keep working with no keystore.
 
+## Production release (tag-driven)
+
+Cut a production build by pushing a semver tag, which triggers
+[`release.yml`](workflows/release.yml):
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+The workflow derives the version from the tag — `versionName` is the tag
+without the `v` (e.g. `1.0.0`), and `versionCode` is packed as
+`major*10000 + minor*100 + patch` (so `v1.0.0` → `10000`, monotonic with
+semver; minor and patch must each be `< 100`). It builds the **signed AAB
+and APK**, then attaches both to a GitHub release for that tag. Download
+the `.aab` and upload it under **Play Console → Testing/Production →
+Create release**. (`workflow_dispatch` with a `version` input is the
+manual fallback when you'd rather not push a tag.)
+
+The nightly job uses the same signing secrets but stamps a
+`nightly-<run>-<sha>` version; only tagged builds carry a clean
+production version.
+
 ## Signing secrets
 
 A maintainer must add four repository secrets (Settings -> Secrets and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-          NIGHTLY_VERSION_CODE: ${{ github.run_number }}
-          NIGHTLY_VERSION_NAME: nightly-${{ github.run_number }}-${{ github.sha }}
+          VERSION_CODE: ${{ github.run_number }}
+          VERSION_NAME: nightly-${{ github.run_number }}-${{ github.sha }}
         # AAB is the Play upload format (required for new apps); APK stays for
         # direct sideload onto AI boxes / head units off the GitHub release.
         run: ./gradlew assembleRelease bundleRelease --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Release
+
+# Cut a production build from a version tag (e.g. v1.0.0): build the signed
+# Android App Bundle (the Play upload format) plus an APK (direct sideload) and
+# attach both to a GitHub release. The .aab is uploaded to the Play Console
+# manually — see .github/RELEASING.md.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to build, e.g. v1.0.0"
+        required: true
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build signed release
+    runs-on: ubuntu-latest
+    permissions:
+      # gh release create needs write access to repo contents.
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Resolve version
+        id: version
+        # The tag (push) or the dispatch input arrives only through this env var,
+        # never interpolated into the script body, and is validated against a
+        # strict semver pattern before use (workflow-injection safety).
+        env:
+          REF_VERSION: ${{ github.event.inputs.version || github.ref_name }}
+        run: |
+          name="${REF_VERSION#v}"
+          if ! printf '%s' "$name" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version must be vMAJOR.MINOR.PATCH (got '$REF_VERSION')"
+            exit 1
+          fi
+          IFS=. read -r major minor patch <<< "$name"
+          if [ "$minor" -ge 100 ] || [ "$patch" -ge 100 ]; then
+            echo "::error::minor and patch must each be < 100 for the versionCode packing"
+            exit 1
+          fi
+          # Pack semver into a monotonic versionCode: major*10000 + minor*100 + patch.
+          code=$(( major * 10000 + minor * 100 + patch ))
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "Resolved versionName=$name versionCode=$code"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+        with:
+          cache-read-only: true
+
+      - name: Verify signing secrets are present
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          # Fail fast (and clearly) if any signing secret is missing, so the job
+          # never reaches Gradle half-configured and never publishes an unsigned build.
+          missing=""
+          [ -z "$RELEASE_KEYSTORE_BASE64" ] && missing="$missing RELEASE_KEYSTORE_BASE64"
+          [ -z "$RELEASE_KEYSTORE_PASSWORD" ] && missing="$missing RELEASE_KEYSTORE_PASSWORD"
+          [ -z "$RELEASE_KEY_ALIAS" ] && missing="$missing RELEASE_KEY_ALIAS"
+          [ -z "$RELEASE_KEY_PASSWORD" ] && missing="$missing RELEASE_KEY_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing signing secret(s):$missing. Add all four (RELEASE_KEYSTORE_BASE64, RELEASE_KEYSTORE_PASSWORD, RELEASE_KEY_ALIAS, RELEASE_KEY_PASSWORD) so the release can be signed. Refusing to publish an unsigned build."
+            exit 1
+          fi
+
+      - name: Decode keystore
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          # Write outside the checked-out tree; $RUNNER_TEMP is auto-cleaned.
+          echo "$RELEASE_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
+
+      - name: Build signed release AAB and APK
+        env:
+          RELEASE_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          VERSION_CODE: ${{ steps.version.outputs.code }}
+          VERSION_NAME: ${{ steps.version.outputs.name }}
+        run: ./gradlew bundleRelease assembleRelease --stacktrace
+
+      - name: Stage artifacts with version-stamped names
+        env:
+          V: ${{ steps.version.outputs.name }}
+        run: |
+          cp app/build/outputs/bundle/release/app-release.aab "$RUNNER_TEMP/femto-car-launcher-$V.aab"
+          cp app/build/outputs/apk/release/app-release.apk "$RUNNER_TEMP/femto-car-launcher-$V.apk"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          V: ${{ steps.version.outputs.name }}
+          CODE: ${{ steps.version.outputs.code }}
+          TAG: ${{ github.event.inputs.version || github.ref_name }}
+        run: |
+          # On a tag push the tag already exists; on workflow_dispatch this creates
+          # it against the current commit. The .aab is the artifact to upload to
+          # the Play Console (.github/RELEASING.md).
+          gh release create "$TAG" \
+            "$RUNNER_TEMP/femto-car-launcher-$V.aab" \
+            "$RUNNER_TEMP/femto-car-launcher-$V.apk" \
+            --title "v$V" \
+            --notes "Production build $V (versionCode $CODE). Upload the .aab to the Play Console; see .github/RELEASING.md." \
+            --latest

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,10 +105,12 @@ android {
         applicationId = "io.github.seijikohara.femto"
         minSdk = 33
         targetSdk = 36
-        // CI injects a monotonically increasing versionCode/versionName for the
-        // nightly channel; local builds fall back to the committed 1 / "1.0".
-        versionCode = System.getenv("NIGHTLY_VERSION_CODE")?.toIntOrNull() ?: 1
-        versionName = System.getenv("NIGHTLY_VERSION_NAME") ?: "1.0"
+        // CI injects versionCode/versionName: the nightly job uses the run
+        // number, the tag-driven release workflow derives them from the version
+        // tag (see .github/workflows/{ci,release}.yml). Local builds fall back to
+        // the committed 1 / "1.0".
+        versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
+        versionName = System.getenv("VERSION_NAME") ?: "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
## Why

Free-launch audit finding: CI only versioned the **nightly** channel, so a production build fell back to `1`/`"1.0"` and there was **no signed, production-versioned AAB path**.

## What

- **`release.yml`** (new): pushing a `vMAJOR.MINOR.PATCH` tag (or `workflow_dispatch` with a `version` input) derives `versionName` from the tag and `versionCode` as `major*10000 + minor*100 + patch` (v1.0.0 → 10000, monotonic with semver), builds the **signed AAB + APK**, and attaches them to a GitHub release for manual Play upload. The version arrives only via an env var and is **validated against a strict semver pattern** before use (workflow-injection-safe).
- **build.gradle**: generalize the version env `NIGHTLY_VERSION_*` → `VERSION_*` so the nightly job and the release workflow feed the same fields; nightly job updated to match.
- **Docs**: `RELEASING.md` documents the tag-driven flow; `PLAY_RELEASE.md` refreshed with the 2026-06-17 free-launch audit (code-side clear; remaining gates are Console paperwork + the new-personal-account closed-testing requirement, with the notification-listener disclosure added).

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL**. Verified locally: the version-derivation logic (v1.0.0→10000, v2.10.5→21005; rejects `v1.0`/`foo`/`v1.100.0`), and that the build reads `VERSION_CODE`/`VERSION_NAME` (merged manifest shows `versionCode=10203 versionName=1.2.3` for a sample). The GitHub-release publish step mirrors the proven nightly job.