### PR TITLE
feat(calendar): respect per-calendar visibility on the dashboard

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarRepository.kt
@@ -183,7 +183,10 @@ internal class CalendarRepository(
                         CalendarContract.Instances.TITLE,
                         CalendarContract.Instances.ALL_DAY,
                     ),
-                    null,
+                    // Respect the user's per-calendar visibility: events from a
+                    // calendar hidden in the calendar app must not surface on the
+                    // dashboard. Instances joins Calendars, so VISIBLE filters here.
+                    "${CalendarContract.Calendars.VISIBLE} = 1",
                     null,
                     "${CalendarContract.Instances.BEGIN} ASC",
                 )?.use { cursor ->


### PR DESCRIPTION
## Why

The dashboard calendar card showed events from **every** calendar, including ones the user has hidden in their calendar app. The `Instances` window query passed `selection = null`.

## What

Filter `Calendars.VISIBLE = 1` in the `Instances` query (`Instances` joins `Calendars`, so the column is selectable). The card now mirrors the user's per-calendar visibility choices.

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL**. Emulator-verified: with a personal calendar set `visible=0`, its events disappear from the card while events from `visible=1` calendars still show. (No unit test — the calendar path is Android `ContentProvider` glue, outside the project's pure-logic test strategy; behavior is covered by the emulator check.)