### PR TITLE
fix(map): keep the self-marker clear of the speed overlay

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -21,6 +21,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -257,7 +259,7 @@ private fun MapPane(
     glassConfig: GlassConfig,
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
-) = Box(modifier = modifier) {
+) = BoxWithConstraints(modifier = modifier) {
     // Shared Haze state: the map registers as the blur source, the glass overlays
     // sample it for their backdrop blur. Only the snapshot backend (a Compose
     // Image) can be captured; the Live GL surface falls back to the opaque tint.
@@ -269,9 +271,23 @@ private fun MapPane(
     var following by remember { mutableStateOf(true) }
     var bearingDeg by remember { mutableFloatStateOf(0f) }
     var recenterNonce by remember { mutableIntStateOf(0) }
+    // Measure the speed overlay against the pane height so the map can clamp the
+    // self-marker above it (MapConfig.bottomSafeFraction): a short pane or a tall
+    // overlay shrinks the marker's drop range rather than burying the chevron.
+    var overlayHeightPx by remember { mutableIntStateOf(0) }
+    val bottomSafeFraction =
+        with(LocalDensity.current) {
+            val paneHeightPx = maxHeight.roundToPx()
+            if (paneHeightPx > 0) {
+                ((overlayHeightPx + (SpeedOverlayBottomGap + MarkerOverlayClearance).toPx()) / paneHeightPx)
+                    .coerceIn(0f, 0.5f)
+            } else {
+                0f
+            }
+        }
     MapPanel(
         location = uiState.location,
-        mapConfig = mapConfig,
+        mapConfig = mapConfig.copy(bottomSafeFraction = bottomSafeFraction),
         onTap = { onAction(HomeAction.OpenMaps) },
         modifier = Modifier.fillMaxSize().hazeSource(hazeState),
         recenterNonce = recenterNonce,
@@ -329,7 +345,8 @@ private fun MapPane(
         modifier =
             Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = 16.dp),
+                .padding(bottom = SpeedOverlayBottomGap)
+                .onSizeChanged { overlayHeightPx = it.height },
     )
 }
 
@@ -404,6 +421,13 @@ private val CompactWidthBreakpoint: Dp = 600.dp
 // defaults used on large panels.
 private val CompactScreenPadding: Dp = 12.dp
 private val CompactPaneGap: Dp = 10.dp
+
+// Gap between the speed overlay and the map pane's bottom edge, and the extra room
+// kept above the overlay so the self-marker chevron (and most of its ripple)
+// clears it. Together they form the bottom band the marker drop must avoid
+// (MapConfig.bottomSafeFraction).
+private val SpeedOverlayBottomGap: Dp = 16.dp
+private val MarkerOverlayClearance: Dp = 20.dp
 
 // Pane weights. The map is the dominant surface in landscape; in portrait it
 // sits a little taller than the info pane. The info pane splits its height

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapConfig.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapConfig.kt
@@ -20,6 +20,12 @@ internal data class MapConfig(
     val renderPercent: Int = 100,
     val renderMode: MapRenderMode = MapRenderMode.SNAPSHOT,
     val markerPos: Int = 70,
+    // Fraction (0..0.5) of the map height the bottom speed overlay occupies,
+    // measured at layout time (not a persisted setting). The marker drop is
+    // clamped against it so the chevron always clears the overlay regardless of
+    // markerPos or screen aspect; 0 means "unmeasured", leaving the MAX_MARKER_DROP
+    // cap as the only bound.
+    val bottomSafeFraction: Float = 0f,
     val buildings3d: Boolean = false,
     val terrain: Boolean = false,
 )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapSnapshot.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapSnapshot.kt
@@ -74,7 +74,7 @@ internal fun SnapshotMap(
     // The chevron sits at a fixed on-screen spot — centre X, markerPos height — and
     // the camera look-ahead aims the location there, so the map slides beneath a
     // still marker (car-nav style) rather than the marker drifting per frame.
-    val dropFraction = markerDropFraction(mapConfig.markerPos)
+    val dropFraction = markerDropFraction(mapConfig.markerPos, mapConfig.bottomSafeFraction)
     val markerXPx = widthPx / 2f
     val markerYPx = (heightPx * (0.5 + dropFraction)).toFloat()
 
@@ -152,6 +152,7 @@ internal fun SnapshotMap(
                             tiltDeg = mapConfig.tiltDeg,
                             zoom = mapConfig.zoom,
                             markerPos = mapConfig.markerPos,
+                            bottomSafeFraction = mapConfig.bottomSafeFraction,
                             renderHeightPx = renderHeightPx,
                         )
                     val rendered = snap.render(camera)
@@ -232,7 +233,15 @@ private suspend fun MapSnapshotter.render(camera: CameraPosition): Bitmap? =
 
 // The marker's drop below centre as a fraction of the map height, shared by the
 // camera look-ahead and the fixed on-screen marker spot so the two always agree.
-private fun markerDropFraction(markerPos: Int): Double = (markerPos.coerceIn(0, 100) / 100.0) * MAX_MARKER_DROP
+// The drop is capped at MAX_MARKER_DROP and additionally clamped so the chevron
+// stays above the bottom speed overlay: the lowest the centre may sit is
+// 0.5 - bottomSafeFraction (the overlay's measured footprint plus marker
+// clearance), so a tall overlay or a short map pane shrinks the usable range
+// rather than burying the marker.
+private fun markerDropFraction(
+    markerPos: Int,
+    bottomSafeFraction: Float,
+): Double = (markerPos.coerceIn(0, 100) / 100.0) * (0.5 - bottomSafeFraction).coerceIn(0.0, MAX_MARKER_DROP)
 
 private fun cameraFor(
     location: Location,
@@ -240,6 +249,7 @@ private fun cameraFor(
     tiltDeg: Int,
     zoom: Int,
     markerPos: Int,
+    bottomSafeFraction: Float,
     renderHeightPx: Int,
 ): CameraPosition {
     val bearing = location.carriedBearing(bearingHolder).toDouble()
@@ -252,7 +262,7 @@ private fun cameraFor(
     // fraction the chevron is pinned to regardless of renderPercent. The tilt makes
     // this approximate, but a fixed chevron stays steady rather than drifting with
     // the per-frame estimate.
-    val dropFraction = markerDropFraction(markerPos)
+    val dropFraction = markerDropFraction(markerPos, bottomSafeFraction)
     val lookAheadM = dropFraction * renderHeightPx * metersPerPixel(zoom, location.latitude)
     val target = LatLng(location.latitude, location.longitude).offsetForward(bearing, lookAheadM)
     return CameraPosition

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -307,6 +307,7 @@ internal fun WebMapView(
         mapConfig.zoom,
         mapConfig.tiltDeg,
         mapConfig.markerPos,
+        mapConfig.bottomSafeFraction,
         markerColor,
     ) {
         if (!pageReady.value) return@LaunchedEffect
@@ -314,7 +315,7 @@ internal fun WebMapView(
         webView.evaluateJavascript(
             "window.updateCamera && updateCamera(" +
                 "${location.latitude}, ${location.longitude}, $bearing, ${mapConfig.zoom}, ${mapConfig.tiltDeg}, " +
-                "${mapConfig.markerPos}, '$markerColor')",
+                "${mapConfig.markerPos}, ${mapConfig.bottomSafeFraction}, '$markerColor')",
             null,
         )
     }

--- a/webmap/src/main.ts
+++ b/webmap/src/main.ts
@@ -14,9 +14,8 @@ import {
 } from "./camera";
 import {
 	type AccentColors,
-	clampMarkerPos,
 	injectFeatures,
-	MAX_MARKER_DROP,
+	markerDrop,
 	markerPadTop,
 } from "./style";
 
@@ -34,6 +33,7 @@ declare global {
 			zoom: number,
 			tilt: number,
 			markerPos: number,
+			bottomSafe: number,
 			markerColor: string,
 		) => void;
 		setStyleUrl: (
@@ -130,6 +130,7 @@ const state = {
 		zoom: number;
 		tilt: number;
 		markerPos: number;
+		bottomSafe: number;
 	} | null,
 	// The zoom last pushed by the host; a change while detached is the user's
 	// +/- button, applied to the free camera around its own centre.
@@ -385,6 +386,7 @@ try {
 			padding: {
 				top: markerPadTop(
 					fix.markerPos,
+					fix.bottomSafe,
 					liveMap.getContainer().clientHeight || 0,
 				),
 				bottom: 0,
@@ -493,6 +495,7 @@ try {
 		zoom,
 		tilt,
 		markerPos,
+		bottomSafe,
 		markerColor,
 	) => {
 		// Measure the inter-fix interval BEFORE refreshing lastFixMs: the ease
@@ -521,6 +524,7 @@ try {
 			zoom: Number.isFinite(zoom) ? zoom : 16,
 			tilt: tilt || 0,
 			markerPos: markerPos || 0,
+			bottomSafe: bottomSafe || 0,
 		};
 		if (!state.following) {
 			// Detached (free pan): the camera stays the user's, the geo-anchored
@@ -536,8 +540,7 @@ try {
 			}
 			return;
 		}
-		const pos = clampMarkerPos(markerPos);
-		markerEl.style.top = `${50 + (pos / 100) * MAX_MARKER_DROP * 100}%`;
+		markerEl.style.top = `${50 + markerDrop(markerPos, bottomSafe) * 100}%`;
 		syncChevronTransform(tilt || 0, heading);
 		markerEl.style.display = "block";
 		const opts = {
@@ -546,7 +549,11 @@ try {
 			zoom: Number.isFinite(zoom) ? zoom : 16,
 			pitch: tilt || 0,
 			padding: {
-				top: markerPadTop(markerPos, liveMap.getContainer().clientHeight || 0),
+				top: markerPadTop(
+					markerPos,
+					bottomSafe,
+					liveMap.getContainer().clientHeight || 0,
+				),
 				bottom: 0,
 				left: 0,
 				right: 0,

--- a/webmap/src/style.test.ts
+++ b/webmap/src/style.test.ts
@@ -6,6 +6,7 @@ import {
 	injectFeatures,
 	MAPTERHORN_DEM_URL,
 	MAX_MARKER_DROP,
+	markerDrop,
 	markerPadTop,
 	roadClassOrNull,
 	vectorSourceId,
@@ -290,18 +291,48 @@ describe("roadClassOrNull", () => {
 	});
 });
 
-describe("markerPadTop", () => {
-	it("keeps the focal point centred at markerPos 0", () => {
-		expect(markerPadTop(0, 480)).toBe(0);
+describe("markerDrop", () => {
+	it("keeps the marker centred at markerPos 0", () => {
+		expect(markerDrop(0, 0)).toBe(0);
 	});
 
-	it("drops the focal point by 2 * MAX_MARKER_DROP of the height at markerPos 100", () => {
-		expect(markerPadTop(100, 480)).toBeCloseTo(2 * MAX_MARKER_DROP * 480);
+	it("drops by MAX_MARKER_DROP at markerPos 100 when the overlay leaves room", () => {
+		expect(markerDrop(100, 0)).toBeCloseTo(MAX_MARKER_DROP);
+	});
+
+	it("clamps the drop so the marker stays above the bottom overlay", () => {
+		// bottomSafe 0.4 caps the centre at 0.5 - 0.4 = 0.1, below MAX_MARKER_DROP.
+		expect(markerDrop(100, 0.4)).toBeCloseTo(0.1);
+		expect(markerDrop(50, 0.4)).toBeCloseTo(0.05);
+	});
+
+	it("never drops when the overlay leaves no room", () => {
+		expect(markerDrop(100, 0.5)).toBe(0);
+		expect(markerDrop(100, 0.8)).toBe(0);
 	});
 
 	it("clamps out-of-range positions", () => {
-		expect(markerPadTop(250, 480)).toBe(markerPadTop(100, 480));
-		expect(markerPadTop(-5, 480)).toBe(0);
+		expect(markerDrop(250, 0)).toBe(markerDrop(100, 0));
+		expect(markerDrop(-5, 0)).toBe(0);
+	});
+});
+
+describe("markerPadTop", () => {
+	it("keeps the focal point centred at markerPos 0", () => {
+		expect(markerPadTop(0, 0, 480)).toBe(0);
+	});
+
+	it("drops the focal point by 2 * MAX_MARKER_DROP of the height at markerPos 100", () => {
+		expect(markerPadTop(100, 0, 480)).toBeCloseTo(2 * MAX_MARKER_DROP * 480);
+	});
+
+	it("clamps out-of-range positions", () => {
+		expect(markerPadTop(250, 0, 480)).toBe(markerPadTop(100, 0, 480));
+		expect(markerPadTop(-5, 0, 480)).toBe(0);
+	});
+
+	it("tracks the overlay-clamped drop", () => {
+		expect(markerPadTop(100, 0.4, 480)).toBeCloseTo(2 * 0.1 * 480);
 	});
 });
 

--- a/webmap/src/style.ts
+++ b/webmap/src/style.ts
@@ -48,16 +48,30 @@ export function clampMarkerPos(markerPos: number): number {
 	return Math.max(0, Math.min(100, markerPos || 0));
 }
 
+// Marker drop below centre as a fraction of map height. Capped at MAX_MARKER_DROP
+// and additionally clamped so the chevron stays above the bottom speed overlay:
+// the lowest the centre may sit is 0.5 - bottomSafe, where bottomSafe is the
+// overlay's measured footprint (plus marker clearance) the host pushes. A short
+// map pane or a tall overlay shrinks the usable range instead of burying the
+// marker. Mirrors markerDropFraction in MapSnapshot.kt — keep in sync.
+export function markerDrop(markerPos: number, bottomSafe: number): number {
+	const maxDrop = Math.max(
+		0,
+		Math.min(MAX_MARKER_DROP, 0.5 - (bottomSafe || 0)),
+	);
+	return (clampMarkerPos(markerPos) / 100) * maxDrop;
+}
+
 // Top camera padding (px) that places the centred location at the height the
-// marker-position setting asks for. padTop shifts the focal point down, so the
-// location (and its marker) sits lower in the frame; markerPos 0 keeps it
-// centred, 100 drops it MAX_MARKER_DROP of the height toward the speed panel.
+// marker sits at. padTop shifts the focal point down so the location (and its
+// marker) sits lower in the frame; the 2x compensates the half-of-padding
+// geometry so the location lands exactly under the chevron.
 export function markerPadTop(
 	markerPos: number,
+	bottomSafe: number,
 	containerHeight: number,
 ): number {
-	const drop = (clampMarkerPos(markerPos) / 100) * MAX_MARKER_DROP;
-	return 2 * drop * containerHeight;
+	return 2 * markerDrop(markerPos, bottomSafe) * containerHeight;
 }
 
 // The first vector source id in a style (the OpenMapTiles source), so 3D


### PR DESCRIPTION
## Why

The map's self-location chevron rendered **behind the speed/trip overlay**. The marker drop was `markerPos/100 * MAX_MARKER_DROP` (cap 0.32 of map height), which never accounted for the overlay's real footprint. On the binding 5:3 head-unit geometry the overlay covers ~0.28 of the pane, so:
- default `markerPos=70` → chevron centre at 0.724, overlay top ~0.715 → tip + lower half behind the (translucent) overlay;
- `markerPos=100` → whole chevron behind it.

The `0.32 < 0.5` cap only guaranteed "bottom half," not clearance of the overlay.

## What

- **DashboardScaffold** (`MapPane` → `BoxWithConstraints` + `onSizeChanged`): measure the speed overlay against the map-pane height and push it as **`MapConfig.bottomSafeFraction`**.
- **Clamp the drop to `0.5 - bottomSafeFraction`** (still capped at `MAX_MARKER_DROP`). A short pane or tall overlay shrinks the usable range instead of burying the marker — fixes it at any `markerPos` and any screen aspect.
- Snapshot (`markerDropFraction`) and live (`markerDrop` in `style.ts`) share the formula; the live camera padding (`markerPadTop`) and the DOM chevron `top` take `bottomSafe` too; `WebMapView` pushes it via `updateCamera`.

## Verification

- webmap: `biome` + `tsc` clean, `vitest` **46 passed** incl. new `markerDrop` clamp cases.
- `./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL** (webmap rebuilt).
- Emulator (TBox-Mock, 2× res, LIVE map): the chevron now sits **above** the speed panel (was hidden before).