### PR TITLE
feat(ui): add FitText auto-sizing helper; fix calendar weekday truncation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,6 +149,12 @@ android {
                 "proguard-rules.pro",
             )
         }
+        debug {
+            // Pseudolocales surface text-fit / RTL regressions on debug builds without
+            // authoring translations: en-XA accents and lengthens Latin text (~+30%),
+            // ar-XB mirrors the layout right-to-left. Debug-only; never shipped.
+            isPseudoLocalesEnabled = true
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/theme/FitTextTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/theme/FitTextTest.kt
@@ -1,0 +1,59 @@
+package io.github.seijikohara.femto.ui.theme
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertTrue
+
+/**
+ * FitText contract: the font shrinks within `minFontSize .. style.fontSize` to
+ * fit the available width, and never drops below the floor — it ellipsizes at the
+ * floor instead of shrinking past it. Uses [calendarWeekday] (20sp, floor 18sp)
+ * as the exemplar style.
+ */
+class FitTextTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    // Resolved on-screen font size (sp) FitText settled on for [text] in [widthDp].
+    private fun resolvedSpFor(
+        text: String,
+        widthDp: Int,
+    ): Float {
+        var resolvedSp = -1f
+        rule.setContent {
+            FemtoTheme {
+                Box(modifier = Modifier.width(widthDp.dp)) {
+                    FitText(
+                        text = text,
+                        style = MaterialTheme.typography.calendarWeekday(),
+                        onTextLayout = { resolvedSp = it.layoutInput.style.fontSize.value },
+                    )
+                }
+            }
+        }
+        rule.waitForIdle()
+        return resolvedSp
+    }
+
+    @Test
+    fun keepsTheDesignSizeWhenItFits() {
+        // A short weekday in an ample box renders at the full 20sp design size.
+        assertTrue(resolvedSpFor("Mon", widthDp = 300) >= 20f)
+    }
+
+    @Test
+    fun shrinksToFitButNeverBelowTheFloor() {
+        val narrow = resolvedSpFor("Wednesday", widthDp = 70)
+        assertTrue(narrow < 20f, "expected shrink below the 20sp design size, got ${narrow}sp")
+        assertTrue(
+            narrow >= FemtoDimens.MinBodyTextSize.value,
+            "auto-size dropped below the ${FemtoDimens.MinBodyTextSize} floor: ${narrow}sp",
+        )
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -33,9 +33,12 @@ import io.github.seijikohara.femto.data.calendar.DayCell
 import io.github.seijikohara.femto.data.calendar.EventItem
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.FitText
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+import io.github.seijikohara.femto.ui.theme.PreviewTextStress
 import io.github.seijikohara.femto.ui.theme.TabularFigures
 import io.github.seijikohara.femto.ui.theme.bigNumber
+import io.github.seijikohara.femto.ui.theme.calendarWeekday
 import io.github.seijikohara.femto.ui.theme.glanceBody
 import io.github.seijikohara.femto.ui.theme.glanceMetric
 import io.github.seijikohara.femto.ui.theme.sectionLabel
@@ -140,24 +143,22 @@ private fun Head(snapshot: CalendarSnapshot) =
             maxLines = 1,
         )
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text(
+            FitText(
                 text = snapshot.weekday,
-                style =
-                    MaterialTheme.typography.titleLarge.copy(
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        letterSpacing = (-0.01f).em,
-                        lineHeight = 20.sp,
-                    ),
+                style = MaterialTheme.typography.calendarWeekday(),
                 color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+                // The weekday is glance metadata beside the big day number, so it may
+                // relax below the 18sp body floor to GlanceTextSize to keep the full
+                // localized name (e.g. "Wednesday") on the narrow head-unit card
+                // (CLAUDE.md#automotive-overrides). It shrinks only as far as needed.
+                minFontSize = FemtoDimens.GlanceTextSize,
             )
             Text(
                 text = snapshot.monthLabel.uppercase(),
                 style = MaterialTheme.typography.sectionLabel(11, 0.14f),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }
@@ -303,6 +304,7 @@ private fun eventTimeFormatter(is24Hour: Boolean): DateTimeFormatter =
 // Sized to the head-unit binding: each top-row card is ~165 x 207 dp (half the
 // info pane on the 853 x 512 dp / 5:3 projection). Wider panels only add slack.
 @PreviewLightDark
+@PreviewTextStress
 @Preview(name = "Calendar card", widthDp = 165, heightDp = 207)
 @Composable
 private fun CalendarCardPreview() {
@@ -311,8 +313,10 @@ private fun CalendarCardPreview() {
             snapshot =
                 CalendarSnapshot(
                     today = LocalDate.of(2026, 3, 30),
-                    weekday = "Monday",
-                    monthLabel = "March 2026",
+                    // The longest common English weekday / month exercise the head's
+                    // FitText fit-to-width on the narrow card.
+                    weekday = "Wednesday",
+                    monthLabel = "September 2026",
                     days =
                         listOf(
                             DayCell(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FitText.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FitText.kt
@@ -1,0 +1,63 @@
+package io.github.seijikohara.femto.ui.theme
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.TextAutoSize
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.takeOrElse
+
+/**
+ * Fit-to-width glance text — the SSOT for a single-line label that must stay
+ * readable as its content length changes across locales and screen widths (the
+ * weekday name, a track title, a metric value). The font shrinks within
+ * `[minFontSize] .. style.fontSize` to fit [maxLines] in the available width,
+ * then ellipsizes if even [minFontSize] overflows — so the automotive minimum is
+ * never breached silently by auto-shrinking past it.
+ *
+ * Wraps the stable foundation auto-size path (`BasicText` +
+ * `TextAutoSize.StepBased`, Stable in the pinned Compose foundation — verified
+ * via javap; the material3 `Text(autoSize = …)` overload ships from an alpha
+ * artifact). `BasicText` is theme-unaware, so this is the one place that injects
+ * the Material content colour and a [Type.kt] style; callers pass a named
+ * `Typography` extension / M3 role and never construct a `TextStyle` or touch
+ * `BasicText` directly (see `.claude/rules/design-system.md`).
+ *
+ * The font only ever shrinks from the style's design size — `maxFontSize` is
+ * pinned to `style.fontSize`, so auto-size is a fit-to-width safety valve, not a
+ * free resizer that would break the Bold-Minimal scale.
+ */
+@Composable
+internal fun FitText(
+    text: String,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    minFontSize: TextUnit = FemtoDimens.MinBodyTextSize,
+    maxLines: Int = 1,
+    overflow: TextOverflow = TextOverflow.Ellipsis,
+    textAlign: TextAlign? = null,
+    onTextLayout: ((TextLayoutResult) -> Unit)? = null,
+) {
+    val resolved = color.takeOrElse { LocalContentColor.current }
+    // The style's own size is the ceiling; fall back to the floor when a caller
+    // passes a size-less style so StepBased always gets max >= min.
+    val ceiling = style.fontSize.takeOrElse { minFontSize }
+    BasicText(
+        text = text,
+        modifier = modifier,
+        style = if (textAlign != null) style.copy(textAlign = textAlign) else style,
+        color = { resolved },
+        onTextLayout = onTextLayout,
+        overflow = overflow,
+        maxLines = maxLines,
+        autoSize = TextAutoSize.StepBased(minFontSize = minFontSize, maxFontSize = ceiling),
+    )
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/PreviewTextStress.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/PreviewTextStress.kt
@@ -1,0 +1,17 @@
+package io.github.seijikohara.femto.ui.theme
+
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * Text-fit stress previews: pseudolocale `en-XA` (accented, ~30 % longer Latin
+ * text), `ar-XB` (right-to-left mirror), and the two accessibility font scales.
+ * Apply alongside [PreviewLightDark] to the text-heavy components so truncation /
+ * overflow / RTL regressions surface in the preview pane, not on a device. Kept
+ * separate from [PreviewLightDark] so only the exposed components opt in rather
+ * than every preview multiplying.
+ */
+@Preview(name = "en-XA long", locale = "en-XA", showBackground = true)
+@Preview(name = "ar-XB RTL", locale = "ar-XB", showBackground = true)
+@Preview(name = "fontScale 1.3", fontScale = 1.3f, showBackground = true)
+@Preview(name = "fontScale 2.0", fontScale = 2.0f, showBackground = true)
+annotation class PreviewTextStress

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/Type.kt
@@ -166,6 +166,17 @@ internal fun Typography.sectionLabel(
         fontFeatureSettings = TabularFigures,
     )
 
+// The calendar head's weekday name: titleLarge tightened a notch for the head
+// unit. Rendered through [FitText] so a long localized weekday ("Wednesday",
+// "Mittwoch") shrinks to fit the narrow head column instead of truncating.
+internal fun Typography.calendarWeekday(): TextStyle =
+    titleLarge.copy(
+        fontSize = 20.sp,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = (-0.01f).em,
+        lineHeight = 20.sp,
+    )
+
 // Shared line-box policy for the styles whose rows aim at a stable height:
 // centred, untrimmed, Fixed mode. NOTE measured on-device: this alone does
 // NOT pin a line that renders through a FALLBACK face — Android applies


### PR DESCRIPTION
## Why

The calendar head rendered the full localized weekday (`getDisplayName(TextStyle.FULL)`) with `maxLines=1 + Ellipsis`, so a long weekday ("Wednesday", German "Mittwoch") truncated to **"Wedn…"** on the narrow head-unit card — every non-CJK locale. Reported by the user. This PR establishes the **responsive-text infrastructure** and fixes the headline case; follow-ups apply it to the remaining cards and screens (per the audit).

## What

- **`FitText`** (`ui/theme/FitText.kt`) — the SSOT for fit-to-width glance text, wrapping the **stable** foundation `BasicText` auto-size path (`TextAutoSize.StepBased` — javap-verified Stable in the pinned BOM 2026.05; the `material3.Text(autoSize=)` overload ships from an **alpha** artifact). Shrinks within `minFontSize..style.fontSize`, **ellipsizes at the floor** instead of shrinking past it, and injects the Material content colour + a `Type.kt` style (BasicText is theme-unaware), so call sites never touch `BasicText` or build a `TextStyle`.
- **CalendarCard** — weekday now renders through `FitText` with the floor relaxed to `GlanceTextSize` (the sanctioned glance relaxation) so the **full** localized name fits by shrinking only as needed; the month label gains `Ellipsis` (it was hard-clipping, no `overflow` set).
- **Type.kt** — extract the weekday's ad-hoc `.copy` style to a named `calendarWeekday()` (design-system rule: no ad-hoc `TextStyle`).
- **Verification scaffolding** — `PreviewTextStress` (en-XA / ar-XB / fontScale 1.3 & 2.0), `isPseudoLocalesEnabled` on debug, and `FitTextTest` (floor + ceiling contract).

## Verification

- `./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL**; androidTest compiles.
- **`FitTextTest` passes on the emulator** (validates auto-size reports the resolved size, floor never breached).
- Emulator (TBox-Mock 800×480, en-US): the weekday renders in full — **"Wednesday"**, no truncation.