### PR TITLE
fix(ui): bound truncation-prone text on settings, diagnostics, licenses

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.Lucide
@@ -321,6 +322,10 @@ private fun StatusRow(
         text = label,
         style = MaterialTheme.typography.bodyLarge,
         color = MaterialTheme.colorScheme.onSurface,
+        // The label ellipsizes (it is the fixed caption); the value keeps its
+        // intrinsic width — it is the diagnostic payload and must stay readable.
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
         modifier = Modifier.weight(1f),
     )
     Text(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/licenses/LicensesScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/licenses/LicensesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.ChevronRight
@@ -165,6 +166,11 @@ private fun Header(
         text = title,
         style = MaterialTheme.typography.headlineMedium,
         color = MaterialTheme.colorScheme.onBackground,
+        // The detail view reuses this Header with the library name as the title, so
+        // a long artifact id must bound to the row instead of wrapping to 3-4 lines.
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.weight(1f),
     )
 }
 
@@ -204,12 +210,16 @@ private fun LibraryRow(
             text = item.name,
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
         item.licenseName?.let { name ->
             Text(
                 text = name,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.ChevronRight
@@ -725,6 +726,12 @@ private fun SliderRow(
             text = title,
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurface,
+            // A long localized title shares the row with the value via SpaceBetween;
+            // weight(fill = false) keeps short titles in place but caps a long one so
+            // it ellipsizes instead of wrapping and shoving the value off the row.
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f, fill = false),
         )
         Text(
             text = valueLabel,


### PR DESCRIPTION
## Why

Responsive audit (non-home screens): several label/value rows had text that wraps or pushes a sibling off the row when localized or font-scaled.

## What

- **Settings `SliderRow`**: title shared a `SpaceBetween` row with the value with no weight → `weight(fill = false) + maxLines = 1 + Ellipsis` so a long localized title ellipsizes instead of shoving the value off the row (short titles keep their place).
- **Diagnostics `StatusRow`**: the weighted label gains `maxLines = 1 + Ellipsis`; the value keeps its intrinsic width (it's the diagnostic payload, must stay readable).
- **Licenses `LibraryRow`** name / license-id and the shared **`Header`** title (reused with a library name in the detail view) gain `maxLines + Ellipsis` (+ `weight` on the header title) so a long artifact id bounds to the row.

Completes the responsive-text sweep (#195 infra + calendar weekday, #196 home cards, this = other screens).

## Verification

`./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL** (no lint findings).