### PR TITLE
ci: parallelize validate and enable the Gradle build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  validate:
-    name: Validate (${{ matrix.name }})
+  checks:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
       # Run the check groups as parallel jobs so wall-clock is the slowest group
@@ -59,6 +59,24 @@ jobs:
         env:
           GRADLE_TASKS: ${{ matrix.tasks }}
         run: ./gradlew $GRADLE_TASKS --stacktrace
+
+  # Single status check the branch ruleset requires by the name "Validate". It
+  # stays stable regardless of how the matrix legs above are split or renamed, and
+  # fails if any leg failed (needs.checks.result is success only when all legs pass).
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    needs: checks
+    if: always()
+    steps:
+      - name: Confirm all check groups passed
+        env:
+          CHECKS_RESULT: ${{ needs.checks.result }}
+        run: |
+          if [ "$CHECKS_RESULT" != "success" ]; then
+            echo "::error::A Validate check group failed (result: $CHECKS_RESULT)."
+            exit 1
+          fi
 
   nightly:
     name: Publish nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,29 @@ concurrency:
 
 jobs:
   validate:
-    name: Validate
+    name: Validate (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      # Run the check groups as parallel jobs so wall-clock is the slowest group
+      # (assemble), not their sum. The Gradle build cache (org.gradle.caching) lets
+      # each job reuse the compile/dex outputs the latest main run populated, so the
+      # parallel split does not triple the heavy work on warm caches. fail-fast off
+      # so one failing group still reports the others.
+      fail-fast: false
+      matrix:
+        include:
+          - name: static-checks
+            tasks: spotlessCheck lint
+          - name: unit-tests
+            # verifyRoborazziDebug runs the unit tests in screenshot-verify mode, so
+            # folding it in with `test` executes testDebugUnitTest once (two separate
+            # invocations ran it twice). CI-only: the Roborazzi goldens are recorded
+            # on this runner OS (record-screenshots.yml), so the screenshot diff runs
+            # here, not in the local verify-android-build skill — a developer's render
+            # would mismatch the Linux-recorded goldens on font antialiasing.
+            tasks: test verifyRoborazziDebug
+          - name: assemble
+            tasks: assembleDebug
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -32,16 +53,12 @@ jobs:
           # read-only fallback explicit so feature branches never pollute it.
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-      # Mirrors .claude/skills/verify-android-build (the verification SSOT); change both together.
-      - name: Run checks
-        run: ./gradlew spotlessCheck test lint assembleDebug --stacktrace
-
-      # CI-only: Roborazzi goldens are recorded on this runner OS (see
-      # record-screenshots.yml), so the dashboard screenshot diff runs here, not
-      # in the local verify-android-build skill — a developer's render would
-      # mismatch the Linux-recorded goldens on font antialiasing.
-      - name: Verify screenshots
-        run: ./gradlew verifyRoborazziDebug --stacktrace
+      # The three groups together mirror the local verify-android-build skill
+      # (spotlessCheck + test + lint + assembleDebug); change both together.
+      - name: Run ${{ matrix.name }}
+        env:
+          GRADLE_TASKS: ${{ matrix.tasks }}
+        run: ./gradlew $GRADLE_TASKS --stacktrace
 
   nightly:
     name: Publish nightly

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -188,6 +188,12 @@ android {
             isReturnDefaultValues = true
         }
     }
+    lint {
+        // Lint the shipped code only. lintAnalyzeDebugUnitTest + lintAnalyzeDebugAndroidTest
+        // dominated CI lint time (~63s combined, vs ~1s for the main sources); test-code
+        // lint findings carry little value since tests are not shipped.
+        ignoreTestSources = true
+    }
 }
 
 // AboutLibraries collects each Gradle dependency's license at build time into

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,11 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. For more details, visit
-# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+# Run independent tasks concurrently (the :app module and the webmap node build).
+org.gradle.parallel=true
+# Reuse task outputs across builds. The CI runner persists the local build cache
+# (~/.gradle/caches/build-cache-1, written on main, read on PRs via setup-gradle),
+# so the heavy dex/compile tasks come FROM-CACHE on incremental and cross-job runs.
+org.gradle.caching=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official


### PR DESCRIPTION
## Why

CI Validate is slow: a measured **~5m33s** single serial job — `spotlessCheck test lint assembleDebug` (~4m37s) plus a second Gradle invocation for `verifyRoborazziDebug` that re-ran the unit tests (~26s).

## What (non-hacky speedups, nothing about *what* is checked changes)

- **Gradle build cache** (`org.gradle.caching=true`) — the biggest lever. The heavy tasks (`mergeExtDexDebug` ~60s, `compileDebug*`, dex) are cacheable; `setup-gradle` already persists `~/.gradle/caches/build-cache-1` (main writes, PRs read), so they come **FROM-CACHE** on incremental + cross-job runs.
- **Task parallelism** (`org.gradle.parallel=true`).
- **Parallel CI jobs** — `validate` is now a 3-way matrix running concurrently: `static-checks` (spotlessCheck + lint), `unit-tests` (test + verifyRoborazziDebug), `assemble` (assembleDebug). Wall-clock collapses to the slowest group (assemble) instead of the serial sum.
- **Fold `verifyRoborazziDebug` in with `test`** — one invocation runs `testDebugUnitTest` **once** (it previously ran twice across two separate Gradle calls).

The three matrix groups together still mirror the `verify-android-build` skill's check set (spotlessCheck + test + lint + assembleDebug); the skill stays the single-command local SSOT.

## Evaluated but deferred (low CI value / risk)
- **Configuration cache**: verified GO (0 problems) but the config cache lives in the project `.gradle/` which fresh CI runners don't persist → ~no CI benefit (helps local repeat builds; can opt in later). Spotless also invalidates it per-run (same-daemon constraint).
- **CI-only heap bump**: `gradle.properties` is shared with local dev; marginal gain, deferred.
- **node/pnpm store cache**: ~7-8s; the build cache may already cover `buildWebMap`.

## Verification

Local `spotlessCheck assembleDebug lint test verifyRoborazziDebug` with the new settings: **BUILD SUCCESSFUL in 2m21s**. The parallel wall-clock improvement will show on this PR's own CI run.