### PR TITLE
feat(settings): add a theme-preset registry and picker

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
@@ -30,6 +30,13 @@ internal interface DisplaySettingsStore {
 
     suspend fun setAccentColor(value: AccentColor)
 
+    /**
+     * Apply a [ThemePreset]'s look bundle (accent + both map colour schemes) in one
+     * atomic write, so the dashboard restyles without flickering through an
+     * intermediate state of half-applied fields.
+     */
+    suspend fun applyThemePreset(preset: ThemePreset)
+
     suspend fun setSpeedUnit(value: SpeedUnitSetting)
 
     suspend fun setTemperatureUnit(value: TemperatureUnitSetting)
@@ -150,6 +157,14 @@ internal class DisplayPreferences(
 
     override suspend fun setAccentColor(value: AccentColor) {
         context.displayDataStore.editOrLog(TAG) { it[ACCENT_KEY] = value.name }
+    }
+
+    override suspend fun applyThemePreset(preset: ThemePreset) {
+        context.displayDataStore.editOrLog(TAG) {
+            it[ACCENT_KEY] = preset.accentColor.name
+            it[MAP_SCHEME_LIGHT_KEY] = preset.mapSchemeLight.name
+            it[MAP_SCHEME_DARK_KEY] = preset.mapSchemeDark.name
+        }
     }
 
     override suspend fun setSpeedUnit(value: SpeedUnitSetting) {

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/ThemePreset.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/ThemePreset.kt
@@ -1,0 +1,50 @@
+package io.github.seijikohara.femto.data.display
+
+/**
+ * A named bundle of the "look" settings — the data-driven separation of theme
+ * from the dashboard layout code (the CSS-to-HTML analogy: a preset is style, the
+ * Compose tree stays structure). Applying a preset writes its fields into
+ * [DisplaySettings] so the UI accent and both map colour schemes restyle at once.
+ *
+ * A preset carries only visual fields. Structural settings (dock edge, panel
+ * visibility, units) stay independent so a theme is a skin, not a relayout, and
+ * the automotive floors (CLAUDE.md#automotive-overrides) are never part of a
+ * preset — they are code-enforced and must not be themeable.
+ */
+internal data class ThemePreset(
+    val key: String,
+    val accentColor: AccentColor,
+    val mapSchemeLight: MapColorScheme,
+    val mapSchemeDark: MapColorScheme,
+)
+
+/**
+ * The shipped theme registry. Mass-producing a theme is one entry here plus its
+ * display-name string; the settings picker renders [all] and applying writes the
+ * bundle through [DisplaySettingsStore.applyThemePreset].
+ */
+internal object ThemePresets {
+    // Dynamic mirrors DisplaySettings.Default (wallpaper accent + adaptive map).
+    val Dynamic = ThemePreset("dynamic", AccentColor.DYNAMIC, MapColorScheme.ACCENT, MapColorScheme.ACCENT)
+    val Ocean = ThemePreset("ocean", AccentColor.BLUE, MapColorScheme.POSITRON, MapColorScheme.DARK_MATTER)
+    val Forest = ThemePreset("forest", AccentColor.GREEN, MapColorScheme.LIBERTY, MapColorScheme.FIORD)
+    val Dusk = ThemePreset("dusk", AccentColor.AMBER, MapColorScheme.BRIGHT, MapColorScheme.DARK)
+
+    val all: List<ThemePreset> = listOf(Dynamic, Ocean, Forest, Dusk)
+
+    /**
+     * The preset whose bundle matches the given look fields, or null when the
+     * user has fine-tuned away from every preset. Lets the picker highlight the
+     * active preset without storing a separate "selected preset" key.
+     */
+    fun matchingOrNull(
+        accentColor: AccentColor,
+        mapSchemeLight: MapColorScheme,
+        mapSchemeDark: MapColorScheme,
+    ): ThemePreset? =
+        all.firstOrNull {
+            it.accentColor == accentColor &&
+                it.mapSchemeLight == mapSchemeLight &&
+                it.mapSchemeDark == mapSchemeDark
+        }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -66,6 +66,8 @@ import io.github.seijikohara.femto.data.display.OrientationSetting
 import io.github.seijikohara.femto.data.display.SpeedUnitSetting
 import io.github.seijikohara.femto.data.display.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.display.ThemeMode
+import io.github.seijikohara.femto.data.display.ThemePreset
+import io.github.seijikohara.femto.data.display.ThemePresets
 import io.github.seijikohara.femto.data.fonts.FontSlot
 import io.github.seijikohara.femto.data.location.LocationQualitySetting
 import io.github.seijikohara.femto.ui.theme.DynamicAccentSweep
@@ -129,6 +131,15 @@ internal fun SettingsScreen(
             AccentRow(
                 selected = uiState.accentColor,
                 onSelect = { onAction(SettingsAction.SetAccentColor(it)) },
+            )
+            ThemePresetRow(
+                selectedPreset =
+                    ThemePresets.matchingOrNull(
+                        accentColor = uiState.accentColor,
+                        mapSchemeLight = uiState.mapSchemeLight,
+                        mapSchemeDark = uiState.mapSchemeDark,
+                    ),
+                onSelect = { onAction(SettingsAction.ApplyThemePreset(it)) },
             )
             SettingsSubheader(stringResource(R.string.settings_subheader_screen))
             ChoiceRow(
@@ -606,6 +617,90 @@ private fun AccentSwatch(
     }
 }
 
+// The theme-preset picker: named bundles of accent + map colour schemes from the
+// ThemePresets registry. Tapping one applies the whole look at once; the accent
+// and map-scheme controls then reflect it. The data-driven "theme as data"
+// surface — mass-producing a theme is a registry entry, not new UI here.
+@Composable
+private fun ThemePresetRow(
+    selectedPreset: ThemePreset?,
+    onSelect: (ThemePreset) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier =
+        modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+) {
+    Text(
+        text = stringResource(R.string.settings_group_theme_preset),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ThemePresets.all.forEach { preset ->
+            ThemePresetChip(
+                preset = preset,
+                selected = preset == selectedPreset,
+                onClick = { onSelect(preset) },
+            )
+        }
+    }
+}
+
+// One preset chip: the accent seed dot + the preset name, in a >= MinTouchTarget
+// tap target. Selected swaps to the secondaryContainer fill + a primary border
+// (the same color-agnostic emphasis the accent swatch uses).
+@Composable
+private fun ThemePresetChip(
+    preset: ThemePreset,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val seed = preset.accentColor.accentSeedColor()
+    val fill =
+        if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceContainerHigh
+    val border =
+        if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
+    val labelColor =
+        if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
+    Row(
+        modifier =
+            modifier
+                .heightIn(min = FemtoDimens.MinTouchTarget)
+                .clip(MaterialTheme.shapes.large)
+                .background(fill)
+                .border(width = if (selected) 2.dp else 1.dp, color = border, shape = MaterialTheme.shapes.large)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        val dot =
+            if (seed !=
+                null
+            ) {
+                Modifier.background(seed)
+            } else {
+                Modifier.background(Brush.sweepGradient(DynamicAccentSweep))
+            }
+        Box(modifier = Modifier.size(20.dp).clip(CircleShape).then(dot))
+        Text(
+            text = stringResource(preset.labelRes()),
+            style = MaterialTheme.typography.titleMedium,
+            color = labelColor,
+        )
+    }
+}
+
 // A single-choice row: shows the current value as its summary and opens a radio
 // dialog on tap (the Android ListPreference pattern).
 @Composable
@@ -904,6 +999,16 @@ private fun AccentColor.labelRes(): Int =
         AccentColor.RED -> R.string.settings_accent_red
         AccentColor.VIOLET -> R.string.settings_accent_violet
         AccentColor.PINK -> R.string.settings_accent_pink
+    }
+
+// The display name for a theme preset (keyed by ThemePreset.key, so the registry
+// stays free of any resource dependency).
+private fun ThemePreset.labelRes(): Int =
+    when (key) {
+        "ocean" -> R.string.theme_preset_ocean
+        "forest" -> R.string.theme_preset_forest
+        "dusk" -> R.string.theme_preset_dusk
+        else -> R.string.theme_preset_dynamic
     }
 
 // A font-slot row: the current family (or "System default") under the title,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -13,6 +13,7 @@ import io.github.seijikohara.femto.data.display.OrientationSetting
 import io.github.seijikohara.femto.data.display.SpeedUnitSetting
 import io.github.seijikohara.femto.data.display.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.display.ThemeMode
+import io.github.seijikohara.femto.data.display.ThemePreset
 import io.github.seijikohara.femto.data.location.LocationQualitySetting
 import io.github.seijikohara.femto.data.location.LocationSettings
 
@@ -105,6 +106,11 @@ internal sealed interface SettingsAction {
 
     data class SetAccentColor(
         val value: AccentColor,
+    ) : SettingsAction
+
+    /** Apply a whole theme preset (accent + both map schemes) at once. */
+    data class ApplyThemePreset(
+        val preset: ThemePreset,
     ) : SettingsAction
 
     data class SetSpeedUnit(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -78,6 +78,10 @@ internal class SettingsViewModel(
                     displayPreferences.setAccentColor(action.value)
                 }
 
+                is SettingsAction.ApplyThemePreset -> {
+                    displayPreferences.applyThemePreset(action.preset)
+                }
+
                 is SettingsAction.SetSpeedUnit -> {
                     displayPreferences.setSpeedUnit(action.value)
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,6 +179,11 @@
     <string name="settings_accent_red">Red</string>
     <string name="settings_accent_violet">Violet</string>
     <string name="settings_accent_pink">Pink</string>
+    <string name="settings_group_theme_preset">Theme preset</string>
+    <string name="theme_preset_dynamic">Dynamic</string>
+    <string name="theme_preset_ocean">Ocean</string>
+    <string name="theme_preset_forest">Forest</string>
+    <string name="theme_preset_dusk">Dusk</string>
     <string name="settings_speed_km">km/h</string>
     <string name="settings_speed_mi">mph</string>
     <string name="settings_temp_celsius">°C</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/display/ThemePresetTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/display/ThemePresetTest.kt
@@ -1,0 +1,59 @@
+package io.github.seijikohara.femto.data.display
+
+import io.github.seijikohara.femto.testfixtures.FakeDisplaySettingsStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class ThemePresetTest {
+    @Test
+    fun default_settings_match_the_dynamic_preset() {
+        // The picker highlights Dynamic out of the box, so its bundle must equal
+        // DisplaySettings.Default — keep the two in step when either changes.
+        assertEquals(
+            ThemePresets.Dynamic,
+            ThemePresets.matchingOrNull(
+                accentColor = DisplaySettings.Default.accentColor,
+                mapSchemeLight = DisplaySettings.Default.mapSchemeLight,
+                mapSchemeDark = DisplaySettings.Default.mapSchemeDark,
+            ),
+        )
+    }
+
+    @Test
+    fun applying_a_preset_writes_its_look_bundle() =
+        runTest {
+            val store = FakeDisplaySettingsStore()
+            store.applyThemePreset(ThemePresets.Ocean)
+            val settings = store.settings.first()
+            assertEquals(ThemePresets.Ocean.accentColor, settings.accentColor)
+            assertEquals(ThemePresets.Ocean.mapSchemeLight, settings.mapSchemeLight)
+            assertEquals(ThemePresets.Ocean.mapSchemeDark, settings.mapSchemeDark)
+        }
+
+    @Test
+    fun applying_a_preset_leaves_structural_settings_untouched() =
+        runTest {
+            // A theme is a skin, not a relayout: dock edge + panel visibility stay put.
+            val store = FakeDisplaySettingsStore()
+            store.applyThemePreset(ThemePresets.Forest)
+            val settings = store.settings.first()
+            assertEquals(DisplaySettings.Default.dockPosition, settings.dockPosition)
+            assertEquals(DisplaySettings.Default.showCalendar, settings.showCalendar)
+        }
+
+    @Test
+    fun fine_tuning_away_from_a_preset_matches_nothing() {
+        // BLUE accent with the default (ACCENT) map schemes is not any preset's
+        // exact bundle, so the picker shows no selection.
+        assertNull(
+            ThemePresets.matchingOrNull(
+                accentColor = AccentColor.BLUE,
+                mapSchemeLight = MapColorScheme.ACCENT,
+                mapSchemeDark = MapColorScheme.ACCENT,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -16,6 +16,7 @@ import io.github.seijikohara.femto.data.display.OrientationSetting
 import io.github.seijikohara.femto.data.display.SpeedUnitSetting
 import io.github.seijikohara.femto.data.display.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.display.ThemeMode
+import io.github.seijikohara.femto.data.display.ThemePreset
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -34,6 +35,15 @@ internal class FakeDisplaySettingsStore(
     override suspend fun setThemeMode(value: ThemeMode) = state.update { it.copy(themeMode = value) }
 
     override suspend fun setAccentColor(value: AccentColor) = state.update { it.copy(accentColor = value) }
+
+    override suspend fun applyThemePreset(preset: ThemePreset) =
+        state.update {
+            it.copy(
+                accentColor = preset.accentColor,
+                mapSchemeLight = preset.mapSchemeLight,
+                mapSchemeDark = preset.mapSchemeDark,
+            )
+        }
 
     override suspend fun setSpeedUnit(value: SpeedUnitSetting) = state.update { it.copy(speedUnit = value) }
 


### PR DESCRIPTION
## Why

First step of the "theme as data, mass-produce themes" idea (evaluated earlier): separate the **style** (theme) from the dashboard **layout code**, the CSS-to-HTML way — a preset is style; the responsive Compose tree stays structure. Kotlin-registry first (type-safe, previewable, no parser/cold-start cost); a TOML→codegen authoring layer can come later if non-code authoring is ever needed.

## What

- **`data/display/ThemePreset.kt`** — `ThemePreset` (key + accent + both map colour schemes) and a `ThemePresets` registry of 4 presets: **Dynamic** (= `DisplaySettings.Default`), **Ocean**, **Forest**, **Dusk**. `matchingOrNull(...)` highlights the active preset.
- **`DisplaySettingsStore.applyThemePreset`** — writes the bundle in one atomic DataStore `edit{}` (no flicker through a half-applied state).
- **Settings "Theme preset" picker** (`SettingsScreen`) — a row of chips below Accent; tapping applies the bundle. The existing accent / map-scheme controls then reflect it.
- A preset carries **only visual fields** (a theme is a skin, not a relayout) and **never the automotive floors** — those stay code-enforced and unthemeable.

Adding a theme = one registry entry + one display-name string. No new UI.

## Verification

- `./gradlew spotlessCheck assembleDebug lint test` — **BUILD SUCCESSFUL** (`ThemePresetTest` covers the apply contract + the Default/Dynamic match).
- **On the emulator**: opened Settings → Theme preset; the 4 chips render with accent dots; tapping **Ocean** moved the accent to Blue, switched the map to Positron, and highlighted Ocean; the change **persisted across an app restart**; resetting to Dynamic restored the default look.

## Scope

PoC per the agreed plan. Feature B (single source for the map-recolor rules) is a separate PR.