### PR TITLE
chore: align Renovate config with shared best practices

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,52 +1,73 @@
-// Renovate configuration, in JSON5 so each policy can be annotated in place.
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  // Shared Renovate policy across seijikohara repositories.
+  // Schema: https://docs.renovatebot.com/renovate-schema.json
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    // Maintainer-recommended superset of config:recommended: pins GitHub Action
-    // digests (kept for supply-chain safety) and enables config migration.
-    'config:best-practices',
-    // Conventional Commits subjects (fix(deps)/chore(deps)) to match the repo.
-    ':semanticCommits',
-    // Do not pin npm package versions: keep the existing semver ranges and just
-    // upgrade in place. Overrides best-practices' :pinDevDependencies. GitHub
-    // Action digest pinning is unaffected (it is governed by pinDigests, not
-    // rangeStrategy) and intentionally stays on.
-    ':preserveSemverRanges',
+    // Maintainer-recommended superset of config:recommended. Pins GitHub Action
+    // and Docker digests, enables config migration, dev-dependency pinning,
+    // weekly lock file maintenance, and the npm minimum-release-age cooldown.
+    "config:best-practices",
+    // Conventional Commits with a unified `chore(deps): ...` subject.
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":semanticCommitScope(deps)",
   ],
-  timezone: 'Asia/Tokyo',
-  // Keep update branches rebased whenever they fall behind main.
-  rebaseWhen: 'behind-base-branch',
-  // Renovate merges by itself (squash, matching the repo's linear history) on
-  // the first run after the Validate check passes. Platform auto-merge stays
-  // off so the merge method never depends on the repository's GitHub merge
-  // settings.
-  platformAutomerge: false,
-  automergeStrategy: 'squash',
-  // Weekly pnpm-lock.yaml refresh for webmap/, automerged like any other update.
-  lockFileMaintenance: {
-    enabled: true,
-    automerge: true,
-  },
+  timezone: "Asia/Tokyo",
+  schedule: ["before 9am on monday"],
+  labels: ["dependencies"],
+  // Keep update branches rebased on main and merge via rebase once CI passes.
+  rebaseWhen: "behind-base-branch",
+  platformAutomerge: true,
+  automergeStrategy: "rebase",
+  // Hold every release for 3 days so a hijacked publish cannot ride automerge on day zero.
+  minimumReleaseAge: "3 days",
+  // Auto-merge the weekly webmap pnpm-lock.yaml refresh together with regular updates.
+  lockFileMaintenance: { automerge: true },
   packageRules: [
     {
-      description: 'Automerge every update once CI is green, majors included',
-      matchUpdateTypes: ['major', 'minor', 'patch', 'pinDigest', 'digest'],
+      description: "Auto-merge non-major updates once CI passes",
+      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
       automerge: true,
     },
     {
-      description: 'Cooldown so a hijacked npm release cannot ride automerge on day zero',
-      matchDatasources: ['npm'],
-      minimumReleaseAge: '3 days',
+      description: "Hold major updates for manual review via the dependency dashboard",
+      matchUpdateTypes: ["major"],
+      automerge: false,
+      dependencyDashboardApproval: true,
+      addLabels: ["major"],
+    },
+    {
+      description: "Group and label GitHub Actions updates",
+      matchManagers: ["github-actions"],
+      groupName: "github-actions",
+      addLabels: ["github-actions"],
+    },
+    {
+      description: "Group the Gradle version catalog and wrapper",
+      matchManagers: ["gradle", "gradle-wrapper"],
+      groupName: "gradle",
+    },
+    {
+      description: "Group the webmap (pnpm) toolchain",
+      matchManagers: ["npm"],
+      groupName: "webmap",
     },
   ],
   customManagers: [
     {
-      customType: 'regex',
-      description: 'Node / pnpm pins in the node-gradle block, annotated with renovate comments',
-      managerFilePatterns: ['/(^|/)build\\.gradle\\.kts$/'],
+      customType: "regex",
+      description: "Node / pnpm pins in the node-gradle block, annotated with renovate comments",
+      managerFilePatterns: ["/(^|/)build\\.gradle\\.kts$/"],
       matchStrings: [
-        '// renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s*\\n\\s*\\w+ = "(?<currentValue>[^"]+)"',
+        "// renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s*\\n\\s*\\w+ = \"(?<currentValue>[^\"]+)\"",
       ],
     },
   ],
+  vulnerabilityAlerts: {
+    description: "Raise security fixes immediately and require manual review",
+    schedule: ["at any time"],
+    minimumReleaseAge: null,
+    addLabels: ["security"],
+    automerge: false,
+  },
 }


### PR DESCRIPTION
## Summary

Align the existing Renovate configuration with the shared best-practices policy used across the other repositories.

## Policy (shared across seijikohara repositories)

- Extends `config:best-practices`: pins GitHub Action and Docker digests, enables config migration, dev-dependency pinning, weekly lock file maintenance, and the npm release-age cooldown.
- Conventional Commits with a unified `chore(deps): ...` subject (`:semanticCommits` + `chore` / `deps`).
- Auto-merges `minor` / `patch` / `pin` / `digest` updates once CI passes; `major` updates are held for manual review via the Dependency Dashboard (`dependencyDashboardApproval`).
- Keeps branches rebased on `main` (`rebaseWhen: behind-base-branch`) and merges via rebase (`automergeStrategy: rebase`, platform automerge).
- 3-day `minimumReleaseAge` cooldown blunts day-zero supply-chain attacks; security fixes bypass the cooldown and are raised immediately (`vulnerabilityAlerts`).
- Unified labels (`dependencies`, plus `github-actions` / `major` / `security`) and grouping.
- Weekly schedule, `Asia/Tokyo` timezone.

## Validation

- `renovate-config-validator` (v43.235.2) passes.
