### PR TITLE
feat(billing): gate Mapbox behind subscription with upsell paywall

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -472,18 +472,17 @@ class MainActivity : ComponentActivity() {
     /**
      * Open the Play Store subscription management page for the active Femto Plus plan.
      * Uses a deep link so the user lands directly on their subscription rather than the
-     * top-level account page. Falls back silently if the Play Store is unavailable.
+     * top-level account page. Head units without the Play Store log a warning via
+     * tryStartActivity rather than silently swallowing the failure.
      */
     private fun openManageSubscription() {
-        runCatching {
-            startActivity(
-                Intent(
-                    Intent.ACTION_VIEW,
-                    "https://play.google.com/store/account/subscriptions?sku=$FEMTO_PLUS_PRODUCT_ID&package=$packageName"
-                        .toUri(),
-                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-            )
-        }
+        val intent =
+            Intent(
+                Intent.ACTION_VIEW,
+                "https://play.google.com/store/account/subscriptions?sku=$FEMTO_PLUS_PRODUCT_ID&package=$packageName"
+                    .toUri(),
+            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        tryStartActivity(intent)
     }
 
     private fun launchAppCategory(category: String) {

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -36,12 +36,14 @@ import androidx.lifecycle.repeatOnLifecycle
 import io.github.seijikohara.femto.data.apps.AppsRepository
 import io.github.seijikohara.femto.data.billing.BillingRepository
 import io.github.seijikohara.femto.data.billing.Entitlement
+import io.github.seijikohara.femto.data.billing.FEMTO_PLUS_PRODUCT_ID
 import io.github.seijikohara.femto.data.billing.effectiveBackend
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.ClockSetting
 import io.github.seijikohara.femto.data.display.DisplayPreferences
 import io.github.seijikohara.femto.data.display.DisplaySettings
 import io.github.seijikohara.femto.data.display.FullscreenSetting
+import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.display.OrientationSetting
 import io.github.seijikohara.femto.data.display.ThemeMode
 import io.github.seijikohara.femto.data.fonts.FontRepository
@@ -69,6 +71,7 @@ import io.github.seijikohara.femto.ui.locale.resolved
 import io.github.seijikohara.femto.ui.settings.SettingsSheet
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.buildFontFamily
+import io.github.seijikohara.femto.ui.upsell.UpsellSheet
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -172,6 +175,8 @@ class MainActivity : ComponentActivity() {
                 var showDiagnostics by rememberSaveable { mutableStateOf(false) }
                 // The open-source licenses sheet opens over settings, like diagnostics.
                 var showLicenses by rememberSaveable { mutableStateOf(false) }
+                // The upsell paywall; triggered from the Settings Mapbox option when locked.
+                var showUpsell by rememberSaveable { mutableStateOf(false) }
                 HomeRoute(
                     is24Hour = resolveIs24Hour(display.clock),
                     showClockSeconds = display.showClockSeconds,
@@ -250,6 +255,9 @@ class MainActivity : ComponentActivity() {
                         onOpenDiagnostics = { showDiagnostics = true },
                         onOpenLicenses = { showLicenses = true },
                         onOpenPrivacyPolicy = ::openPrivacyPolicy,
+                        onShowUpsell = { showUpsell = true },
+                        onManageSubscription = ::openManageSubscription,
+                        onRestorePurchases = { lifecycleScope.launch { billingRepository.refresh() } },
                         onDismiss = { showSettings = false },
                         fullscreen = fullscreen,
                     )
@@ -276,6 +284,23 @@ class MainActivity : ComponentActivity() {
                     LicensesSheet(
                         onDismiss = { showLicenses = false },
                         fullscreen = fullscreen,
+                    )
+                }
+                if (showUpsell) {
+                    UpsellSheet(
+                        onDismiss = { showUpsell = false },
+                        fullscreen = fullscreen,
+                        onLaunchPurchase = { offerToken ->
+                            // billingRepository.launchPurchase requires a live Activity; this is
+                            // the only point in the call tree that holds one.
+                            billingRepository.launchPurchase(this@MainActivity, offerToken)
+                        },
+                        onPurchaseComplete = {
+                            // Auto-switch the persisted backend to Mapbox so the map upgrades
+                            // immediately without the user visiting Settings again.
+                            lifecycleScope.launch { displayPreferences.setMapBackend(MapBackend.MAPBOX) }
+                            showUpsell = false
+                        },
                     )
                 }
             }
@@ -442,6 +467,23 @@ class MainActivity : ComponentActivity() {
             Intent(Intent.ACTION_VIEW, PRIVACY_POLICY_URL.toUri())
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         tryStartActivity(intent)
+    }
+
+    /**
+     * Open the Play Store subscription management page for the active Femto Plus plan.
+     * Uses a deep link so the user lands directly on their subscription rather than the
+     * top-level account page. Falls back silently if the Play Store is unavailable.
+     */
+    private fun openManageSubscription() {
+        runCatching {
+            startActivity(
+                Intent(
+                    Intent.ACTION_VIEW,
+                    "https://play.google.com/store/account/subscriptions?sku=$FEMTO_PLUS_PRODUCT_ID&package=$packageName"
+                        .toUri(),
+                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            )
+        }
     }
 
     private fun launchAppCategory(category: String) {

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -35,6 +35,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import io.github.seijikohara.femto.data.apps.AppsRepository
 import io.github.seijikohara.femto.data.billing.BillingRepository
+import io.github.seijikohara.femto.data.billing.Entitlement
+import io.github.seijikohara.femto.data.billing.effectiveBackend
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.ClockSetting
 import io.github.seijikohara.femto.data.display.DisplayPreferences
@@ -114,6 +116,11 @@ class MainActivity : ComponentActivity() {
             val display by displayPreferences.settings.collectAsStateWithLifecycle(
                 initialValue = DisplaySettings.Default,
             )
+            // Gate the rendered map backend on the active subscription; the stored
+            // preference is untouched so re-subscribing restores Mapbox automatically.
+            val entitlement by billingRepository.entitlement.collectAsStateWithLifecycle(
+                initialValue = Entitlement.Locked,
+            )
             // The resolved Google Fonts faces (or system default) drive the theme;
             // they swap in reactively when a freshly chosen family finishes downloading.
             val resolvedFonts by fontRepository.resolved.collectAsStateWithLifecycle()
@@ -182,7 +189,7 @@ class MainActivity : ComponentActivity() {
                             markerPos = display.mapMarkerPos,
                             buildings3d = display.map3dBuildings,
                             terrain = display.mapTerrain,
-                            backend = display.mapBackend,
+                            backend = effectiveBackend(display.mapBackend, entitlement.mapboxUnlocked),
                             mapboxStyle = display.mapboxStyle,
                             mapboxTraffic = display.mapboxTraffic,
                         ),

--- a/app/src/main/java/io/github/seijikohara/femto/data/billing/MapAccess.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/billing/MapAccess.kt
@@ -1,0 +1,10 @@
+package io.github.seijikohara.femto.data.billing
+
+import io.github.seijikohara.femto.data.display.MapBackend
+
+// The rendered backend is gated on entitlement: a stored MAPBOX preference only
+// takes effect while the subscription is active. The stored preference is kept as-is
+// (sub-project C never rewrites it here), so a lapsed-then-renewed subscription
+// restores Mapbox automatically.
+internal fun effectiveBackend(stored: MapBackend, mapboxUnlocked: Boolean): MapBackend =
+    if (mapboxUnlocked && stored == MapBackend.MAPBOX) MapBackend.MAPBOX else MapBackend.OSM

--- a/app/src/main/java/io/github/seijikohara/femto/data/billing/MapAccess.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/billing/MapAccess.kt
@@ -6,5 +6,7 @@ import io.github.seijikohara.femto.data.display.MapBackend
 // takes effect while the subscription is active. The stored preference is kept as-is
 // (sub-project C never rewrites it here), so a lapsed-then-renewed subscription
 // restores Mapbox automatically.
-internal fun effectiveBackend(stored: MapBackend, mapboxUnlocked: Boolean): MapBackend =
-    if (mapboxUnlocked && stored == MapBackend.MAPBOX) MapBackend.MAPBOX else MapBackend.OSM
+internal fun effectiveBackend(
+    stored: MapBackend,
+    mapboxUnlocked: Boolean,
+): MapBackend = if (mapboxUnlocked && stored == MapBackend.MAPBOX) MapBackend.MAPBOX else MapBackend.OSM

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsRoute.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.fonts.FontSlot
 import io.github.seijikohara.femto.data.location.hasRecordAudioPermission
 
@@ -19,6 +20,10 @@ import io.github.seijikohara.femto.data.location.hasRecordAudioPermission
  * forwards persisted changes to the VM. Host-level navigation / system intents (back, the
  * notification-access screen, the OS settings root) flow up to [MainActivity] via
  * the callbacks so this route owns no Activity concerns.
+ *
+ * [onShowUpsell] is called instead of persisting [SettingsAction.SetMapBackend] when the
+ * user picks Mapbox without an active subscription, mirroring the DiagnosticsRoute
+ * LaunchPurchase intercept pattern.
  */
 @Composable
 internal fun SettingsRoute(
@@ -29,6 +34,9 @@ internal fun SettingsRoute(
     onOpenDiagnostics: () -> Unit,
     onOpenLicenses: () -> Unit,
     onOpenPrivacyPolicy: () -> Unit,
+    onShowUpsell: () -> Unit,
+    onManageSubscription: () -> Unit,
+    onRestorePurchases: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -51,10 +59,21 @@ internal fun SettingsRoute(
             contract = ActivityResultContracts.RequestPermission(),
         ) { viewModel.onAction(SettingsAction.SetMusicSpectrum(true)) }
     val onAction: (SettingsAction) -> Unit = { action ->
-        if (action is SettingsAction.SetMusicSpectrum && action.value && !context.hasRecordAudioPermission()) {
-            recordAudioLauncher.launch(Manifest.permission.RECORD_AUDIO)
-        } else {
-            viewModel.onAction(action)
+        when {
+            action is SettingsAction.SetMusicSpectrum && action.value && !context.hasRecordAudioPermission() -> {
+                recordAudioLauncher.launch(Manifest.permission.RECORD_AUDIO)
+            }
+
+            // Intercept the Mapbox selection when locked: surface the upsell instead
+            // of persisting the backend switch (mirrors DiagnosticsRoute LaunchPurchase).
+            action is SettingsAction.SetMapBackend &&
+                action.value == MapBackend.MAPBOX && !uiState.mapboxUnlocked -> {
+                onShowUpsell()
+            }
+
+            else -> {
+                viewModel.onAction(action)
+            }
         }
     }
     SettingsScreen(
@@ -67,6 +86,9 @@ internal fun SettingsRoute(
         onOpenDiagnostics = onOpenDiagnostics,
         onOpenLicenses = onOpenLicenses,
         onOpenPrivacyPolicy = onOpenPrivacyPolicy,
+        onShowUpsell = onShowUpsell,
+        onManageSubscription = onManageSubscription,
+        onRestorePurchases = onRestorePurchases,
         modifier = modifier,
     )
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -272,8 +272,11 @@ internal fun SettingsScreen(
         }
 
         SettingsSection(title = stringResource(R.string.settings_section_map)) {
-            // Show a lock icon when Mapbox is not yet unlocked to signal that selecting it
-            // will open the upsell rather than switching immediately.
+            // Show a lock icon only when Mapbox is both the currently selected provider
+            // and the subscription has lapsed — this is the "locked in place" state.
+            // When OSM is selected the row shows the normal ChevronRight; forward
+            // discovery (free user tapping Mapbox in the dialog) is handled by the
+            // SettingsRoute intercept, not by this icon.
             ChoiceRow(
                 title = stringResource(R.string.settings_map_backend),
                 options =
@@ -283,7 +286,13 @@ internal fun SettingsScreen(
                     ),
                 selected = uiState.mapBackend,
                 onSelect = { onAction(SettingsAction.SetMapBackend(it)) },
-                trailingIcon = if (!uiState.mapboxUnlocked) Lucide.Lock else null,
+                trailingIcon = if (uiState.mapBackend == MapBackend.MAPBOX &&
+                    !uiState.mapboxUnlocked
+                ) {
+                    Lucide.Lock
+                } else {
+                    null
+                },
             )
             AnimatedVisibility(visible = uiState.mapBackend == MapBackend.MAPBOX) {
                 Column {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.ChevronRight
 import com.composables.icons.lucide.ExternalLink
+import com.composables.icons.lucide.Lock
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.RotateCcw
 import io.github.seijikohara.femto.R
@@ -101,6 +102,9 @@ internal fun SettingsScreen(
     onOpenDiagnostics: () -> Unit,
     onOpenLicenses: () -> Unit,
     onOpenPrivacyPolicy: () -> Unit,
+    onShowUpsell: () -> Unit,
+    onManageSubscription: () -> Unit,
+    onRestorePurchases: () -> Unit,
     modifier: Modifier = Modifier,
 ) = Surface(
     modifier = modifier.fillMaxSize(),
@@ -268,6 +272,8 @@ internal fun SettingsScreen(
         }
 
         SettingsSection(title = stringResource(R.string.settings_section_map)) {
+            // Show a lock icon when Mapbox is not yet unlocked to signal that selecting it
+            // will open the upsell rather than switching immediately.
             ChoiceRow(
                 title = stringResource(R.string.settings_map_backend),
                 options =
@@ -277,6 +283,7 @@ internal fun SettingsScreen(
                     ),
                 selected = uiState.mapBackend,
                 onSelect = { onAction(SettingsAction.SetMapBackend(it)) },
+                trailingIcon = if (!uiState.mapboxUnlocked) Lucide.Lock else null,
             )
             AnimatedVisibility(visible = uiState.mapBackend == MapBackend.MAPBOX) {
                 Column {
@@ -461,6 +468,24 @@ internal fun SettingsScreen(
                 checked = uiState.musicSpectrum,
                 onCheckedChange = { onAction(SettingsAction.SetMusicSpectrum(it)) },
                 summary = stringResource(R.string.settings_panel_music_spectrum_desc),
+            )
+        }
+
+        SettingsSection(title = stringResource(R.string.settings_section_subscription)) {
+            if (!uiState.mapboxUnlocked) {
+                ActionRow(
+                    title = stringResource(R.string.settings_upgrade_mapbox),
+                    onClick = onShowUpsell,
+                )
+            } else {
+                ActionRow(
+                    title = stringResource(R.string.settings_manage_subscription),
+                    onClick = onManageSubscription,
+                )
+            }
+            ActionRow(
+                title = stringResource(R.string.settings_restore_purchases),
+                onClick = onRestorePurchases,
             )
         }
 
@@ -728,7 +753,9 @@ private fun ThemePresetChip(
 }
 
 // A single-choice row: shows the current value as its summary and opens a radio
-// dialog on tap (the Android ListPreference pattern).
+// dialog on tap (the Android ListPreference pattern). An optional [trailingIcon]
+// overrides the default ChevronRight — used to surface a lock when the row
+// requires an active subscription.
 @Composable
 private fun <T> ChoiceRow(
     title: String,
@@ -736,6 +763,7 @@ private fun <T> ChoiceRow(
     selected: T,
     onSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
+    trailingIcon: ImageVector? = null,
 ) {
     var dialogOpen by remember { mutableStateOf(false) }
     SettingRow(
@@ -743,7 +771,7 @@ private fun <T> ChoiceRow(
         modifier = modifier.clickable { dialogOpen = true },
         summary = options.firstOrNull { it.first == selected }?.second,
     ) {
-        TrailingIcon(Lucide.ChevronRight)
+        TrailingIcon(trailingIcon ?: Lucide.ChevronRight)
     }
     if (dialogOpen) {
         ChoiceDialog(
@@ -1068,6 +1096,9 @@ private fun SettingsScreenPreview() {
             onOpenDiagnostics = {},
             onOpenLicenses = {},
             onOpenPrivacyPolicy = {},
+            onShowUpsell = {},
+            onManageSubscription = {},
+            onRestorePurchases = {},
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
@@ -35,6 +35,9 @@ internal fun SettingsSheet(
     onOpenDiagnostics: () -> Unit,
     onOpenLicenses: () -> Unit,
     onOpenPrivacyPolicy: () -> Unit,
+    onShowUpsell: () -> Unit,
+    onManageSubscription: () -> Unit,
+    onRestorePurchases: () -> Unit,
     onDismiss: () -> Unit,
     fullscreen: Boolean,
     modifier: Modifier = Modifier,
@@ -59,6 +62,9 @@ internal fun SettingsSheet(
                 onOpenDiagnostics = onOpenDiagnostics,
                 onOpenLicenses = onOpenLicenses,
                 onOpenPrivacyPolicy = onOpenPrivacyPolicy,
+                onShowUpsell = onShowUpsell,
+                onManageSubscription = onManageSubscription,
+                onRestorePurchases = onRestorePurchases,
             )
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -58,6 +58,8 @@ internal data class SettingsUiState(
     val mapBackend: MapBackend = DisplaySettings.Default.mapBackend,
     val mapboxStyle: MapboxStyle = DisplaySettings.Default.mapboxStyle,
     val mapboxTraffic: Boolean = DisplaySettings.Default.mapboxTraffic,
+    // True when the active subscription entitles the user to Mapbox maps; false locks the option.
+    val mapboxUnlocked: Boolean = false,
 ) {
     companion object {
         // Seeded from the persistence defaults so the default values live in one
@@ -100,6 +102,7 @@ internal data class SettingsUiState(
                 mapBackend = DisplaySettings.Default.mapBackend,
                 mapboxStyle = DisplaySettings.Default.mapboxStyle,
                 mapboxTraffic = DisplaySettings.Default.mapboxTraffic,
+                mapboxUnlocked = false,
             )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import io.github.seijikohara.femto.data.billing.BillingRepository
+import io.github.seijikohara.femto.data.billing.Entitlement
 import io.github.seijikohara.femto.data.common.WhileUiSubscribed
 import io.github.seijikohara.femto.data.display.DisplayPreferences
 import io.github.seijikohara.femto.data.display.DisplaySettingsStore
@@ -21,13 +23,17 @@ internal class SettingsViewModel(
     private val displayPreferences: DisplaySettingsStore,
     private val fontPreferences: FontSelectionStore,
     private val locationPreferences: LocationSettingsStore,
+    // Injected so the subscription gate can react to entitlement changes without
+    // coupling the View layer to BillingRepository.
+    entitlement: StateFlow<Entitlement>,
 ) : ViewModel() {
     val uiState: StateFlow<SettingsUiState> =
         combine(
             displayPreferences.settings,
             fontPreferences.selection,
             locationPreferences.settings,
-        ) { display, font, location ->
+            entitlement,
+        ) { display, font, location, ent ->
             SettingsUiState(
                 themeMode = display.themeMode,
                 accentColor = display.accentColor,
@@ -59,6 +65,7 @@ internal class SettingsViewModel(
                 mapBackend = display.mapBackend,
                 mapboxStyle = display.mapboxStyle,
                 mapboxTraffic = display.mapboxTraffic,
+                mapboxUnlocked = ent.mapboxUnlocked,
                 latinFont = font.latinFamily,
                 cjkFont = font.cjkFamily,
                 locationQuality = location.quality,
@@ -234,6 +241,7 @@ internal class SettingsViewModelFactory(
             displayPreferences = DisplayPreferences(application),
             fontPreferences = FontPreferences(application),
             locationPreferences = LocationPreferences(application),
+            entitlement = BillingRepository.get(application).entitlement,
         ) as T
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellRoute.kt
@@ -1,0 +1,46 @@
+package io.github.seijikohara.femto.ui.upsell
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@Composable
+internal fun UpsellRoute(
+    onPurchaseComplete: () -> Unit,
+    // Bubbles up to the Activity because BillingRepository.launchPurchase
+    // needs a live Activity reference; neither the ViewModel nor the Route
+    // can provide one.
+    onLaunchPurchase: (offerToken: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val viewModel: UpsellViewModel = viewModel(factory = UpsellViewModelFactory)
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // rememberUpdatedState captures the latest lambda so the LaunchedEffect
+    // key can stay on the state value without referencing a captured-by-restart
+    // lambda directly — avoids the ktlint compose:lambda-param-in-effect finding.
+    val currentOnPurchaseComplete by rememberUpdatedState(onPurchaseComplete)
+
+    // A completed purchase flips mapboxUnlocked; dismiss the sheet automatically
+    // so the user is not left on the paywall after subscribing.
+    LaunchedEffect(uiState.mapboxUnlocked) {
+        if (uiState.mapboxUnlocked) currentOnPurchaseComplete()
+    }
+
+    UpsellScreen(
+        uiState = uiState,
+        onAction = { action ->
+            // Subscribe must not reach the ViewModel — it requires a live Activity.
+            // Route it to the caller which has access to onLaunchPurchase.
+            when (action) {
+                is UpsellAction.Subscribe -> onLaunchPurchase(action.offerToken)
+                else -> viewModel.onAction(action)
+            }
+        },
+        modifier = modifier,
+    )
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellScreen.kt
@@ -1,0 +1,149 @@
+package io.github.seijikohara.femto.ui.upsell
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.billing.SubscriptionOffer
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+
+/**
+ * Paywall surface listing Mapbox subscription offers. When offers are
+ * unavailable or the billing connection is down the screen shows a
+ * friendly error and a Retry button instead of leaving the user stuck.
+ */
+@Composable
+internal fun UpsellScreen(
+    uiState: UpsellUiState,
+    onAction: (UpsellAction) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier =
+        modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+    verticalArrangement = Arrangement.spacedBy(16.dp),
+) {
+    Text(
+        text = stringResource(R.string.upsell_title),
+        style = MaterialTheme.typography.headlineMedium,
+        color = MaterialTheme.colorScheme.onBackground,
+    )
+    Text(
+        text = stringResource(R.string.upsell_subtitle),
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    if (uiState.offers.isEmpty() || !uiState.connected) {
+        UnavailableContent(onAction = onAction)
+    } else {
+        uiState.offers.forEach { offer -> OfferCard(offer = offer, onAction = onAction) }
+    }
+}
+
+@Composable
+private fun OfferCard(
+    offer: SubscriptionOffer,
+    onAction: (UpsellAction) -> Unit,
+) = Card(
+    modifier = Modifier.fillMaxWidth(),
+    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+) {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = billingPeriodLabel(offer.billingPeriod),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = offer.formattedPrice,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Button(
+            onClick = { onAction(UpsellAction.Subscribe(offer.offerToken)) },
+            modifier = Modifier.fillMaxWidth().heightIn(min = FemtoDimens.MinTouchTarget),
+        ) {
+            Text(
+                text = stringResource(
+                    if (offer.isTrial) R.string.upsell_try_free else R.string.upsell_subscribe,
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun UnavailableContent(onAction: (UpsellAction) -> Unit) =
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = stringResource(R.string.upsell_unavailable),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OutlinedButton(
+            onClick = { onAction(UpsellAction.Retry) },
+            modifier = Modifier.fillMaxWidth().heightIn(min = FemtoDimens.MinTouchTarget),
+        ) {
+            Text(text = stringResource(R.string.upsell_retry))
+        }
+    }
+
+/** Map ISO 8601 duration codes to human-readable period labels. */
+@Composable
+private fun billingPeriodLabel(billingPeriod: String): String =
+    when (billingPeriod) {
+        "P1M" -> stringResource(R.string.upsell_period_month)
+        "P1Y" -> stringResource(R.string.upsell_period_year)
+        else -> billingPeriod
+    }
+
+@PreviewLightDark
+@Composable
+private fun UpsellScreenOffersPreview() {
+    FemtoTheme {
+        UpsellScreen(
+            uiState = UpsellUiState(
+                offers = listOf(
+                    SubscriptionOffer("monthly", "tok-monthly", "$3.99/mo", "P1M", isTrial = false),
+                    SubscriptionOffer("annual", "tok-annual", "$29.99/yr", "P1Y", isTrial = true),
+                ),
+                connected = true,
+                mapboxUnlocked = false,
+            ),
+            onAction = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun UpsellScreenUnavailablePreview() {
+    FemtoTheme {
+        UpsellScreen(
+            uiState = UpsellUiState.Initial,
+            onAction = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellSheet.kt
@@ -1,0 +1,48 @@
+package io.github.seijikohara.femto.ui.upsell
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.seijikohara.femto.ui.common.ImmersiveSheetEffect
+import io.github.seijikohara.femto.ui.common.rememberSheetHeight
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+
+/**
+ * The upsell paywall as a Material 3 [ModalBottomSheet].
+ * Mirrors [DiagnosticsSheet][io.github.seijikohara.femto.ui.diagnostics.DiagnosticsSheet]:
+ * same height fraction, same immersive-flag wiring, starts fully expanded.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun UpsellSheet(
+    onDismiss: () -> Unit,
+    fullscreen: Boolean,
+    onLaunchPurchase: (offerToken: String) -> Unit,
+    onPurchaseComplete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sheetHeight = rememberSheetHeight(FemtoDimens.DrawerSheetHeightFraction)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        ImmersiveSheetEffect(fullscreen)
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(sheetHeight),
+        ) {
+            UpsellRoute(
+                onPurchaseComplete = onPurchaseComplete,
+                onLaunchPurchase = onLaunchPurchase,
+            )
+        }
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellUiState.kt
@@ -1,0 +1,27 @@
+package io.github.seijikohara.femto.ui.upsell
+
+import io.github.seijikohara.femto.data.billing.SubscriptionOffer
+
+internal data class UpsellUiState(
+    val offers: List<SubscriptionOffer>,
+    val connected: Boolean,
+    val mapboxUnlocked: Boolean,
+) {
+    companion object {
+        val Initial: UpsellUiState = UpsellUiState(
+            offers = emptyList(),
+            connected = false,
+            mapboxUnlocked = false,
+        )
+    }
+}
+
+internal sealed interface UpsellAction {
+    // Routing marker: the Route dispatches this to onLaunchPurchase (which needs
+    // a live Activity) — the ViewModel never sees it.
+    data class Subscribe(
+        val offerToken: String,
+    ) : UpsellAction
+
+    data object Retry : UpsellAction
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellViewModel.kt
@@ -22,8 +22,10 @@ private const val TAG = "UpsellViewModel"
 
 /**
  * Merges the three billing flows into a single [UpsellUiState] projection.
- * Dependencies are plain seams so JVM tests drive every transition without
- * Android types or the Play Billing SDK.
+ * Holds no Play Billing SDK objects and no Activity reference — purchase
+ * launch is bridged through MainActivity via [UpsellAction.Subscribe].
+ * Dependencies are plain flows and lambdas, so JVM unit tests drive every
+ * transition without the Play Billing SDK or an Activity on the classpath.
  */
 internal class UpsellViewModel(
     offers: Flow<List<SubscriptionOffer>>,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/upsell/UpsellViewModel.kt
@@ -1,0 +1,82 @@
+package io.github.seijikohara.femto.ui.upsell
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.seijikohara.femto.data.billing.BillingRepository
+import io.github.seijikohara.femto.data.billing.ConnectionState
+import io.github.seijikohara.femto.data.billing.Entitlement
+import io.github.seijikohara.femto.data.billing.SubscriptionOffer
+import io.github.seijikohara.femto.data.common.WhileUiSubscribed
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+private const val TAG = "UpsellViewModel"
+
+/**
+ * Merges the three billing flows into a single [UpsellUiState] projection.
+ * Dependencies are plain seams so JVM tests drive every transition without
+ * Android types or the Play Billing SDK.
+ */
+internal class UpsellViewModel(
+    offers: Flow<List<SubscriptionOffer>>,
+    entitlement: Flow<Entitlement>,
+    connection: Flow<ConnectionState>,
+    // Injected so the ViewModel never directly references BillingRepository;
+    // the factory provides the real call, tests inject a lambda.
+    private val onRefresh: suspend () -> Unit,
+) : ViewModel() {
+    val uiState: StateFlow<UpsellUiState> =
+        combine(offers, connection, entitlement) { offerList, conn, ent ->
+            UpsellUiState(
+                offers = offerList,
+                connected = conn == ConnectionState.CONNECTED,
+                mapboxUnlocked = ent.mapboxUnlocked,
+            )
+        }.stateIn(viewModelScope, WhileUiSubscribed, UpsellUiState.Initial)
+
+    fun onAction(action: UpsellAction) =
+        when (action) {
+            is UpsellAction.Subscribe -> {
+                // Routing marker only — handled by the Route, which has access to
+                // onLaunchPurchase and therefore a live Activity reference.
+                Unit
+            }
+
+            UpsellAction.Retry -> {
+                viewModelScope.launch {
+                    // Mirror the runCatching pattern in DiagnosticsViewModel: a refresh
+                    // failure must degrade silently (logcat only) rather than propagate to
+                    // the coroutine supervisor and crash the ViewModel scope.
+                    runCatching { onRefresh() }
+                        .onFailure {
+                            if (it is CancellationException) throw it
+                            Log.e(TAG, "billing refresh failed", it)
+                        }
+                }
+                Unit
+            }
+        }
+}
+
+/** Wires the production BillingRepository without an UNCHECKED_CAST factory. */
+internal val UpsellViewModelFactory: ViewModelProvider.Factory =
+    viewModelFactory {
+        initializer {
+            val application = checkNotNull(this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
+            val repo = BillingRepository.get(application)
+            UpsellViewModel(
+                offers = repo.offers,
+                entitlement = repo.entitlement,
+                connection = repo.connection,
+                onRefresh = repo::refresh,
+            )
+        }
+    }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,6 +129,10 @@
     <string name="settings_section_map">Map</string>
     <string name="settings_section_location">Location</string>
     <string name="settings_section_panels">Panels</string>
+    <string name="settings_section_subscription">Subscription</string>
+    <string name="settings_upgrade_mapbox">Upgrade to Mapbox maps</string>
+    <string name="settings_manage_subscription">Manage subscription</string>
+    <string name="settings_restore_purchases">Restore purchases</string>
     <string name="settings_subheader_screen">Screen</string>
     <string name="settings_subheader_glass">Glass</string>
     <string name="settings_group_glass_blur">Blur radius</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -328,6 +328,16 @@
     <string name="licenses_map_data_note">Map data and tiles are provided under the Open Database License (ODbL) and CC BY 4.0. See each project for full terms.</string>
     <string name="licenses_fonts_note">Typography is provided on demand by Google Fonts, each family under its own SIL Open Font License (OFL) or Apache License 2.0. Fonts are downloaded and cached on the device; none are bundled in the app.</string>
 
+    <!-- Upsell paywall sheet -->
+    <string name="upsell_title">Unlock Mapbox maps</string>
+    <string name="upsell_subtitle">Satellite imagery, 3D, and live traffic.</string>
+    <string name="upsell_subscribe">Subscribe</string>
+    <string name="upsell_try_free">Try free</string>
+    <string name="upsell_unavailable">Subscriptions are unavailable right now.</string>
+    <string name="upsell_retry">Retry</string>
+    <string name="upsell_period_month">Monthly</string>
+    <string name="upsell_period_year">Yearly</string>
+
     <!-- Background-ranging foreground-service notification -->
     <string name="notification_trip_channel_name">Trip tracking</string>
     <string name="notification_trip_channel_desc">Ongoing notification shown while distance and average speed are measured in the background.</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/billing/MapAccessTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/billing/MapAccessTest.kt
@@ -1,8 +1,8 @@
 package io.github.seijikohara.femto.data.billing
 
 import io.github.seijikohara.femto.data.display.MapBackend
-import kotlin.test.assertEquals
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class MapAccessTest {
     @Test fun `mapbox stored and unlocked resolves to mapbox`() =

--- a/app/src/test/java/io/github/seijikohara/femto/data/billing/MapAccessTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/billing/MapAccessTest.kt
@@ -1,0 +1,18 @@
+package io.github.seijikohara.femto.data.billing
+
+import io.github.seijikohara.femto.data.display.MapBackend
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class MapAccessTest {
+    @Test fun `mapbox stored and unlocked resolves to mapbox`() =
+        assertEquals(MapBackend.MAPBOX, effectiveBackend(MapBackend.MAPBOX, mapboxUnlocked = true))
+
+    @Test fun `mapbox stored but locked falls back to osm`() =
+        assertEquals(MapBackend.OSM, effectiveBackend(MapBackend.MAPBOX, mapboxUnlocked = false))
+
+    @Test fun `osm stored stays osm regardless of entitlement`() {
+        assertEquals(MapBackend.OSM, effectiveBackend(MapBackend.OSM, mapboxUnlocked = true))
+        assertEquals(MapBackend.OSM, effectiveBackend(MapBackend.OSM, mapboxUnlocked = false))
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.ui.settings
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import io.github.seijikohara.femto.data.billing.Entitlement
 import io.github.seijikohara.femto.data.display.AccentColor
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.DisplaySettings
@@ -20,7 +21,9 @@ import io.github.seijikohara.femto.testfixtures.FakeFontSelectionStore
 import io.github.seijikohara.femto.testfixtures.FakeLocationSettingsStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -41,6 +44,7 @@ class SettingsViewModelTest {
     private val store = FakeDisplaySettingsStore()
     private val fontStore = FakeFontSelectionStore()
     private val locationStore = FakeLocationSettingsStore()
+    private val entitlementFlow = MutableStateFlow(Entitlement.Locked)
     private val dispatcher = StandardTestDispatcher()
 
     @Before
@@ -304,5 +308,22 @@ class SettingsViewModelTest {
             assertEquals(true, store.settings.first().mapboxTraffic)
         }
 
-    private fun viewModel() = SettingsViewModel(store, fontStore, locationStore)
+    @Test
+    fun `mapboxUnlocked reflects entitlement`() =
+        runTest(dispatcher) {
+            val entitlement = MutableStateFlow(Entitlement.Locked)
+            val vm = SettingsViewModel(store, fontStore, locationStore, entitlement)
+            // Collect uiState to satisfy WhileSubscribed so the combining flow stays alive
+            // across both phases of this test.
+            val collected = mutableListOf<Boolean>()
+            backgroundScope.launch { vm.uiState.collect { collected += it.mapboxUnlocked } }
+            advanceUntilIdle()
+            assertEquals(false, vm.uiState.value.mapboxUnlocked)
+
+            entitlement.value = Entitlement(mapboxUnlocked = true)
+            advanceUntilIdle()
+            assertEquals(true, vm.uiState.value.mapboxUnlocked)
+        }
+
+    private fun viewModel() = SettingsViewModel(store, fontStore, locationStore, entitlementFlow)
 }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/upsell/UpsellViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/upsell/UpsellViewModelTest.kt
@@ -1,0 +1,70 @@
+package io.github.seijikohara.femto.ui.upsell
+
+import app.cash.turbine.test
+import io.github.seijikohara.femto.data.billing.ConnectionState
+import io.github.seijikohara.femto.data.billing.Entitlement
+import io.github.seijikohara.femto.data.billing.SubscriptionOffer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpsellViewModelTest {
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun offer(id: String) = SubscriptionOffer(id, "tok-$id", "$3.99", "P1M", isTrial = false)
+
+    @Test
+    fun `state reflects offers connection and entitlement`() =
+        runTest {
+            val vm = UpsellViewModel(
+                offers = MutableStateFlow(listOf(offer("monthly"))),
+                entitlement = MutableStateFlow(Entitlement(mapboxUnlocked = false)),
+                connection = MutableStateFlow(ConnectionState.CONNECTED),
+                onRefresh = {},
+            )
+            vm.uiState.test {
+                val state = awaitItem()
+                assertEquals(1, state.offers.size)
+                assertTrue(state.connected)
+                assertFalse(state.mapboxUnlocked)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Retry invokes onRefresh`() =
+        runTest {
+            var refreshed = 0
+            val vm = UpsellViewModel(
+                offers = MutableStateFlow(emptyList()),
+                entitlement = MutableStateFlow(Entitlement.Locked),
+                connection = MutableStateFlow(ConnectionState.DISCONNECTED),
+                onRefresh = { refreshed++ },
+            )
+            vm.uiState.test {
+                awaitItem()
+                vm.onAction(UpsellAction.Retry)
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertEquals(1, refreshed)
+        }
+}


### PR DESCRIPTION
## Summary

Final sub-project of the paid Mapbox map plan (free = OpenFreeMap / paid = Mapbox).
C gates the Mapbox backend behind the Play Billing entitlement (sub-project B) and
adds the upsell (paywall) UX. Builds on A (#216, Mapbox backend) and B (#217,
entitlement). **No new billing infrastructure.**

## What changed

- **Effective-backend gate** (`data/billing/MapAccess.kt`): pure
  `effectiveBackend(stored, mapboxUnlocked)` renders OSM unless entitled.
  `MainActivity` collects `billingRepository.entitlement` and passes the effective
  backend to `MapConfig`. **The stored preference is preserved** — a lapsed
  subscription falls back to OSM and re-subscribing auto-restores Mapbox.
- **Upsell paywall** (`ui/upsell/`): a `ModalBottomSheet` (Diagnostics pattern)
  listing `BillingRepository.offers` (monthly/annual, price, trial); Subscribe
  bridges to `MainActivity.launchPurchase`; an "unavailable / Retry" state when
  offers aren't loaded.
- **Settings gate**: a lock affordance on the Mapbox provider option when locked;
  `SettingsRoute` intercepts `SetMapBackend(MAPBOX)` while not entitled → opens the
  upsell and does **not** store MAPBOX. A new **Subscription** section: Upgrade
  (opens upsell) / Manage subscription (Play deep link) / Restore purchases
  (`refresh()`).
- **Auto-switch**: when a purchase completes (entitlement → unlocked) the upsell
  sets `mapBackend = MAPBOX` and dismisses. Verified loop-free.
- `mapboxUnlocked` is sourced from `BillingRepository.entitlement` (combined into
  `SettingsViewModel`); no Activity enters any ViewModel.

## Verification

- Green: `spotlessCheck`, `assembleDebug`, `lint`, `testDebugUnitTest`
  (`MapAccess` truth table, `UpsellViewModel`, `SettingsViewModel` entitlement
  transition).
- On-device (emulator): the OSM fallback for a non-entitled user renders correctly.
- **Deferred:** the on-device purchase auto-switch needs a Play License Tester /
  test track (as in B). Unit tests + review cover the gate, intercept, and
  auto-switch logic.

## Out of scope

New billing infra (B). Plan upgrade/downgrade. A map-side lock overlay (silent OSM
fallback by design).

https://claude.ai/code/session_012MEBd6578FM3pzsNw3m94e
