### PR TITLE
feat(calendar): let users choose which calendars the dashboard shows

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -224,6 +224,7 @@ class SettingsScreenTest {
             uiState =
                 SettingsUiState.Initial.copy(
                     showCalendar = true,
+                    hasCalendarAccess = true,
                     availableCalendars = listOf(fakeCalendarInfo(id = 1L, displayName = "Personal")),
                     hiddenCalendarIds = emptySet(),
                 ),

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -14,6 +14,7 @@ import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.display.MapStyleSetting
 import io.github.seijikohara.femto.data.display.ThemeMode
+import io.github.seijikohara.femto.testfixtures.fakeCalendarInfo
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -43,6 +44,7 @@ class SettingsScreenTest {
     private val tokenClearLabel = context.getString(R.string.settings_mapbox_token_clear)
     private val glassBlurLabel = context.getString(R.string.settings_group_glass_blur)
     private val locationIntervalLabel = context.getString(R.string.settings_group_location_interval)
+    private val visibleCalendarsLabel = context.getString(R.string.settings_visible_calendars)
 
     @Test
     fun renders_fullscreen_row() {
@@ -213,6 +215,25 @@ class SettingsScreenTest {
         rule.onNodeWithText(tokenLabel).performScrollTo().performClick()
         rule.onNodeWithText(tokenClearLabel).performClick()
         assertEquals(listOf(SettingsAction.ClearMapboxToken), actions)
+    }
+
+    @Test
+    fun toggling_a_calendar_dispatches_SetCalendarHidden() {
+        val actions = mutableListOf<SettingsAction>()
+        setScreen(
+            uiState =
+                SettingsUiState.Initial.copy(
+                    showCalendar = true,
+                    availableCalendars = listOf(fakeCalendarInfo(id = 1L, displayName = "Personal")),
+                    hiddenCalendarIds = emptySet(),
+                ),
+            onAction = { actions += it },
+        )
+        // Scroll the "Visible calendars" row into view and tap to open the dialog.
+        rule.onNodeWithText(visibleCalendarsLabel).performScrollTo().performClick()
+        // Tapping the "Personal" calendar row (currently shown) should hide it.
+        rule.onNodeWithText("Personal").performClick()
+        assertEquals(listOf(SettingsAction.SetCalendarHidden(id = 1L, hidden = true)), actions)
     }
 
     private fun setScreen(

--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarCatalog.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarCatalog.kt
@@ -1,0 +1,61 @@
+package io.github.seijikohara.femto.data.calendar
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.provider.CalendarContract
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+
+/** Reads the set of device calendars the user could choose to show or hide. */
+internal class CalendarCatalog(
+    private val context: Context,
+) {
+    fun availableCalendarsFlow(): Flow<List<CalendarInfo>> =
+        calendarChangeFlow(context)
+            .onStart { emit(Unit) }
+            .map { readCalendars() }
+            .distinctUntilChanged()
+            .flowOn(Dispatchers.IO)
+
+    private fun hasPermission(): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR) ==
+            PackageManager.PERMISSION_GRANTED
+
+    private fun readCalendars(): List<CalendarInfo> {
+        if (!hasPermission()) return emptyList()
+        val projection =
+            arrayOf(
+                CalendarContract.Calendars._ID,
+                CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+                CalendarContract.Calendars.ACCOUNT_NAME,
+                CalendarContract.Calendars.CALENDAR_COLOR,
+            )
+        return context.contentResolver
+            .query(
+                CalendarContract.Calendars.CONTENT_URI,
+                projection,
+                "${CalendarContract.Calendars.VISIBLE} = 1",
+                null,
+                "${CalendarContract.Calendars.CALENDAR_DISPLAY_NAME} ASC",
+            )?.use { c ->
+                buildList {
+                    while (c.moveToNext()) {
+                        add(
+                            CalendarInfo(
+                                id = c.getLong(0),
+                                displayName = c.getString(1).orEmpty(),
+                                accountName = c.getString(2).orEmpty(),
+                                color = c.getInt(3),
+                            ),
+                        )
+                    }
+                }
+            }.orEmpty()
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarCatalog.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarCatalog.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.provider.CalendarContract
+import androidx.compose.runtime.Immutable
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -12,15 +13,33 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 
+/**
+ * Snapshot emitted by [CalendarCatalog.availableCalendarsFlow].
+ *
+ * Carries both the permission flag and the resulting list so callers can
+ * distinguish "access denied" (hasAccess = false) from "granted but no
+ * visible calendars" (hasAccess = true, calendars = empty).
+ */
+@Immutable
+internal data class CalendarCatalogState(
+    val hasAccess: Boolean,
+    val calendars: List<CalendarInfo>,
+)
+
 /** Reads the set of device calendars the user could choose to show or hide. */
 internal class CalendarCatalog(
     private val context: Context,
 ) {
-    fun availableCalendarsFlow(): Flow<List<CalendarInfo>> =
+    fun availableCalendarsFlow(): Flow<CalendarCatalogState> =
         calendarChangeFlow(context)
             .onStart { emit(Unit) }
-            .map { readCalendars() }
-            .distinctUntilChanged()
+            .map {
+                val hasAccess = hasPermission()
+                CalendarCatalogState(
+                    hasAccess = hasAccess,
+                    calendars = if (hasAccess) readCalendars() else emptyList(),
+                )
+            }.distinctUntilChanged()
             .flowOn(Dispatchers.IO)
 
     private fun hasPermission(): Boolean =
@@ -28,7 +47,6 @@ internal class CalendarCatalog(
             PackageManager.PERMISSION_GRANTED
 
     private fun readCalendars(): List<CalendarInfo> {
-        if (!hasPermission()) return emptyList()
         val projection =
             arrayOf(
                 CalendarContract.Calendars._ID,

--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarChange.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarChange.kt
@@ -1,0 +1,59 @@
+@file:OptIn(kotlinx.coroutines.FlowPreview::class)
+
+package io.github.seijikohara.femto.data.calendar
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.database.ContentObserver
+import android.os.Handler
+import android.os.Looper
+import android.provider.CalendarContract
+import android.util.Log
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.debounce
+
+private const val TAG = "CalendarChange"
+private const val CHANGE_DEBOUNCE_MS = 500L
+
+/**
+ * Emit Unit whenever the calendar provider changes, so callers can re-query.
+ * Shared by CalendarRepository (events) and CalendarCatalog (calendar list).
+ *
+ * Registering an observer on the calendar provider requires `READ_CALENDAR`;
+ * without it `registerContentObserver` throws `SecurityException`. On a
+ * launcher that would crash the home screen on every cold start until the
+ * user grants the calendar, so a denied (or racing-revoked) grant skips
+ * registration rather than throwing.
+ */
+internal fun calendarChangeFlow(context: Context): Flow<Unit> =
+    callbackFlow {
+        val observer =
+            object : ContentObserver(Handler(Looper.getMainLooper())) {
+                override fun onChange(selfChange: Boolean) {
+                    trySend(Unit)
+                }
+            }
+        val registered =
+            ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR) ==
+                PackageManager.PERMISSION_GRANTED &&
+                runCatching {
+                    context.contentResolver.registerContentObserver(
+                        CalendarContract.Events.CONTENT_URI,
+                        // notifyForDescendants =
+                        true,
+                        observer,
+                    )
+                }.onFailure {
+                    // Mirror readWindow's split: the revoke race is expected and
+                    // silent, but any other fault leaves the card stale until the
+                    // next rebuild-key change — that needs a trail.
+                    if (it !is SecurityException) Log.e(TAG, "calendar observer registration failed", it)
+                }.isSuccess
+        awaitClose {
+            if (registered) context.contentResolver.unregisterContentObserver(observer)
+        }
+    }.debounce(CHANGE_DEBOUNCE_MS)

--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarChange.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarChange.kt
@@ -28,6 +28,12 @@ private const val CHANGE_DEBOUNCE_MS = 500L
  * launcher that would crash the home screen on every cold start until the
  * user grants the calendar, so a denied (or racing-revoked) grant skips
  * registration rather than throwing.
+ *
+ * Note: this flow observes [CalendarContract.Events.CONTENT_URI] only, not the
+ * Calendars table. CalendarCatalog liveness for calendar-list changes (e.g. a
+ * new calendar account added) relies on the Settings re-subscription cycle:
+ * [WhileUiSubscribed] cancels the upstream on Settings close and `onStart`
+ * re-queries when the screen re-opens.
  */
 internal fun calendarChangeFlow(context: Context): Flow<Unit> =
     callbackFlow {

--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarInfo.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarInfo.kt
@@ -1,0 +1,12 @@
+package io.github.seijikohara.femto.data.calendar
+
+import androidx.compose.runtime.Immutable
+
+/** A device calendar the user can choose to show or hide. `color` labels it in the selector only. */
+@Immutable
+internal data class CalendarInfo(
+    val id: Long,
+    val displayName: String,
+    val accountName: String,
+    val color: Int,
+)

--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarPreferences.kt
@@ -1,0 +1,54 @@
+package io.github.seijikohara.femto.data.calendar
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import io.github.seijikohara.femto.data.common.catchIoAsDefaults
+import io.github.seijikohara.femto.data.common.editOrLog
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private const val TAG = "CalendarPreferences"
+
+private val Context.calendarDataStore: DataStore<Preferences> by
+    preferencesDataStore(name = "calendar_preferences")
+
+/** Persists which calendars the user has hidden from the dashboard agenda. */
+internal interface CalendarPreferencesStore {
+    /** Calendar IDs the user has hidden; empty means every visible calendar shows. */
+    val hiddenCalendarIds: Flow<Set<Long>>
+
+    suspend fun setCalendarHidden(
+        id: Long,
+        hidden: Boolean,
+    )
+}
+
+internal class CalendarPreferences(
+    private val context: Context,
+) : CalendarPreferencesStore {
+    override val hiddenCalendarIds: Flow<Set<Long>> =
+        context.calendarDataStore.data
+            .catchIoAsDefaults(TAG)
+            .map { prefs ->
+                // Stored as strings; drop any malformed entry defensively.
+                prefs[HIDDEN_IDS_KEY].orEmpty().mapNotNull { it.toLongOrNull() }.toSet()
+            }
+
+    override suspend fun setCalendarHidden(
+        id: Long,
+        hidden: Boolean,
+    ) {
+        context.calendarDataStore.editOrLog(TAG) { prefs ->
+            val current = prefs[HIDDEN_IDS_KEY].orEmpty().toMutableSet()
+            if (hidden) current.add(id.toString()) else current.remove(id.toString())
+            prefs[HIDDEN_IDS_KEY] = current
+        }
+    }
+
+    private companion object {
+        val HIDDEN_IDS_KEY = stringSetPreferencesKey("hidden_calendar_ids")
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarRepository.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -51,7 +50,7 @@ private const val TAG = "CalendarRepository"
 internal class CalendarRepository(
     private val context: Context,
     private val clockFlow: Flow<ClockTick>,
-    private val hiddenCalendarIds: Flow<Set<Long>> = flowOf(emptySet()),
+    private val hiddenCalendarIds: Flow<Set<Long>>,
     // Read per rebuild rather than captured at construction: the repository
     // outlives timezone and locale changes (a phone mounted as car nav crosses
     // borders), and captured values would pin the agenda to the old zone /

--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarRepository.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -50,6 +51,7 @@ private const val TAG = "CalendarRepository"
 internal class CalendarRepository(
     private val context: Context,
     private val clockFlow: Flow<ClockTick>,
+    private val hiddenCalendarIds: Flow<Set<Long>> = flowOf(emptySet()),
     // Read per rebuild rather than captured at construction: the repository
     // outlives timezone and locale changes (a phone mounted as car nav crosses
     // borders), and captured values would pin the agenda to the old zone /
@@ -69,21 +71,23 @@ internal class CalendarRepository(
                 .map { Triple(it.date, hasPermission(), zoneProvider()) }
                 .distinctUntilChanged(),
             calendarChangeFlow(context).onStart { emit(Unit) },
-        ) { (date, granted, zone), _ ->
+            hiddenCalendarIds,
+        ) { (date, granted, zone), _, hidden ->
             // The build consumes the key's own values (not fresh provider
             // reads) so the snapshot always matches the key that produced it.
-            buildSnapshot(date, granted, zone)
+            buildSnapshot(date, granted, zone, hidden)
         }.distinctUntilChanged().flowOn(Dispatchers.IO)
 
     private fun buildSnapshot(
         today: LocalDate,
         granted: Boolean,
         zone: ZoneId,
+        hidden: Set<Long>,
     ): CalendarSnapshot {
         val locale = localeProvider()
         // null marks a provider fault (see readWindow); the days still build
         // from the clock alone so the strip never disappears.
-        val eventsByDay = if (granted) readWindow(today, zone) else emptyMap()
+        val eventsByDay = if (granted) readWindow(today, zone, hidden) else emptyMap()
         val days = (0 until WINDOW_DAYS).map { offset ->
             val date = today.plusDays(offset.toLong())
             DayCell(
@@ -164,9 +168,24 @@ internal class CalendarRepository(
     private fun readWindow(
         today: LocalDate,
         zone: ZoneId,
+        hidden: Set<Long>,
     ): Map<LocalDate, List<EventItem>>? =
         runCatching {
             val byDay = linkedMapOf<LocalDate, MutableList<EventItem>>()
+            // Respect the user's per-calendar visibility: events from a calendar
+            // hidden in the calendar app must not surface on the dashboard.
+            // Instances joins Calendars, so VISIBLE filters here. Additionally
+            // exclude any calendar the user has hidden via dashboard preferences.
+            // IDs are Longs (no injection risk); inline them as a NOT IN list.
+            val selection =
+                buildString {
+                    append("${CalendarContract.Calendars.VISIBLE} = 1")
+                    if (hidden.isNotEmpty()) {
+                        append(" AND ${CalendarContract.Instances.CALENDAR_ID} NOT IN (")
+                        append(hidden.joinToString(","))
+                        append(")")
+                    }
+                }
             context.contentResolver
                 .query(
                     windowUri(today, zone),
@@ -175,10 +194,7 @@ internal class CalendarRepository(
                         CalendarContract.Instances.TITLE,
                         CalendarContract.Instances.ALL_DAY,
                     ),
-                    // Respect the user's per-calendar visibility: events from a
-                    // calendar hidden in the calendar app must not surface on the
-                    // dashboard. Instances joins Calendars, so VISIBLE filters here.
-                    "${CalendarContract.Calendars.VISIBLE} = 1",
+                    selection,
                     null,
                     "${CalendarContract.Instances.BEGIN} ASC",
                 )?.use { cursor ->

--- a/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/calendar/CalendarRepository.kt
@@ -1,5 +1,3 @@
-@file:OptIn(kotlinx.coroutines.FlowPreview::class)
-
 package io.github.seijikohara.femto.data.calendar
 
 import android.Manifest
@@ -7,20 +5,14 @@ import android.annotation.SuppressLint
 import android.content.ContentUris
 import android.content.Context
 import android.content.pm.PackageManager
-import android.database.ContentObserver
-import android.os.Handler
-import android.os.Looper
 import android.provider.CalendarContract
 import android.text.format.DateFormat
 import android.util.Log
 import androidx.core.content.ContextCompat
 import io.github.seijikohara.femto.data.clock.ClockTick
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -76,7 +68,7 @@ internal class CalendarRepository(
             clockFlow
                 .map { Triple(it.date, hasPermission(), zoneProvider()) }
                 .distinctUntilChanged(),
-            calendarChangeFlow().onStart { emit(Unit) },
+            calendarChangeFlow(context).onStart { emit(Unit) },
         ) { (date, granted, zone), _ ->
             // The build consumes the key's own values (not fresh provider
             // reads) so the snapshot always matches the key that produced it.
@@ -235,52 +227,8 @@ internal class CalendarRepository(
             .atZone(if (allDay) ZoneOffset.UTC else zone)
             .toLocalDate()
 
-    /**
-     * Re-emit whenever the calendar provider notifies a change. Debounced
-     * because edit / delete operations on a single event can fire several
-     * notifications in quick succession.
-     *
-     * Registering an observer on the calendar provider requires `READ_CALENDAR`;
-     * without it `registerContentObserver` throws `SecurityException`. On a
-     * launcher that would crash the home screen on every cold start until the
-     * user grants the calendar, so a denied (or racing-revoked) grant skips
-     * registration rather than throwing. The card already renders the denial
-     * fallback from the clock alone (see [snapshotFlow]), and a grant that
-     * arrives later is picked up within a minute: each tick re-evaluates the
-     * permission state inside the rebuild key, so the grant flips the key and
-     * re-runs [buildSnapshot]. This mirrors [readWindow], whose `runCatching`
-     * already guards the query side against the same fault.
-     */
-    private fun calendarChangeFlow(): Flow<Unit> =
-        callbackFlow {
-            val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
-                override fun onChange(selfChange: Boolean) {
-                    trySend(Unit)
-                }
-            }
-            val registered =
-                hasPermission() &&
-                    runCatching {
-                        context.contentResolver.registerContentObserver(
-                            CalendarContract.Events.CONTENT_URI,
-                            // notifyForDescendants =
-                            true,
-                            observer,
-                        )
-                    }.onFailure {
-                        // Mirror readWindow's split: the revoke race is expected and
-                        // silent, but any other fault leaves the card stale until the
-                        // next rebuild-key change — that needs a trail.
-                        if (it !is SecurityException) Log.e(TAG, "calendar observer registration failed", it)
-                    }.isSuccess
-            awaitClose {
-                if (registered) context.contentResolver.unregisterContentObserver(observer)
-            }
-        }.debounce(CHANGE_DEBOUNCE_MS)
-
     private companion object {
         // Vertical day-list horizon (today .. today + WINDOW_DAYS).
         const val WINDOW_DAYS = 30
-        const val CHANGE_DEBOUNCE_MS = 500L
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import io.github.seijikohara.femto.BuildConfig
 import io.github.seijikohara.femto.data.apps.AppsRepository
+import io.github.seijikohara.femto.data.calendar.CalendarPreferences
 import io.github.seijikohara.femto.data.calendar.CalendarRepository
 import io.github.seijikohara.femto.data.calendar.CalendarSnapshot
 import io.github.seijikohara.femto.data.clock.ClockRepository
@@ -283,7 +284,8 @@ internal class HomeViewModelFactory(
         val weather = WeatherRepository(weatherApi, locationFlow, clockFlow)
         val music = MusicSessionRepository(application)
         val audioSpectrum = AudioSpectrumRepository(application)
-        val calendar = CalendarRepository(application, clockFlow)
+        val calendarPreferences = CalendarPreferences(application)
+        val calendar = CalendarRepository(application, clockFlow, calendarPreferences.hiddenCalendarIds)
         val systemStatus = SystemStatusRepository(application, locationFlow)
         val apps = AppsRepository(application)
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -1236,11 +1236,11 @@ private fun MultiSelectDialog(
                                 Modifier
                                     .fillMaxWidth()
                                     .heightIn(min = FemtoDimens.MinTouchTarget)
-                                    // Toggling hides when currently shown, shows when currently hidden.
+                                    // Hidden is the inverse of the new shown state.
                                     .toggleable(
                                         value = shown,
                                         role = Role.Checkbox,
-                                        onValueChange = { onToggle(calendar.id, shown) },
+                                        onValueChange = { newShown -> onToggle(calendar.id, !newShown) },
                                     ),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -1175,9 +1175,10 @@ private fun MultiSelectRow(
 
 // Multi-select dialog for the visible-calendars picker. Each row shows a checkbox,
 // a colour dot (12 dp decorative marker from CalendarInfo.color), and the calendar's
-// display name + account name. The whole row is clickable; the checkbox reflects the
-// checked state without a separate handler to avoid double-firing on row tap.
-// Touch targets meet FemtoDimens.MinTouchTarget; text uses bodyLarge / bodyMedium.
+// display name + account name. The whole row is the toggle target (toggleable with
+// Role.Checkbox); the Checkbox is visual-only (onCheckedChange = null) so a single
+// tap never double-fires. Touch targets meet FemtoDimens.MinTouchTarget; text uses
+// bodyLarge / bodyMedium.
 @Composable
 private fun MultiSelectDialog(
     title: String,
@@ -1201,11 +1202,15 @@ private fun MultiSelectDialog(
                                 .fillMaxWidth()
                                 .heightIn(min = FemtoDimens.MinTouchTarget)
                                 // Toggling hides when currently shown, shows when currently hidden.
-                                .clickable { onToggle(calendar.id, shown) },
+                                .toggleable(
+                                    value = shown,
+                                    role = Role.Checkbox,
+                                    onValueChange = { onToggle(calendar.id, shown) },
+                                ),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
-                        Checkbox(checked = shown, onCheckedChange = { onToggle(calendar.id, !it) })
+                        Checkbox(checked = shown, onCheckedChange = null)
                         Box(
                             modifier =
                                 Modifier

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -470,10 +470,16 @@ internal fun SettingsScreen(
             AnimatedVisibility(visible = uiState.showCalendar) {
                 MultiSelectRow(
                     title = stringResource(R.string.settings_visible_calendars),
-                    summary = visibleCalendarsSummary(uiState.availableCalendars, uiState.hiddenCalendarIds),
+                    summary = visibleCalendarsSummary(
+                        uiState.hasCalendarAccess,
+                        uiState.availableCalendars,
+                        uiState.hiddenCalendarIds,
+                    ),
+                    hasCalendarAccess = uiState.hasCalendarAccess,
                     calendars = uiState.availableCalendars,
                     hiddenIds = uiState.hiddenCalendarIds,
                     onToggle = { id, hidden -> onAction(SettingsAction.SetCalendarHidden(id, hidden)) },
+                    onOpenAppSettings = onOpenSystemSettings,
                 )
             }
             SwitchRow(
@@ -1121,17 +1127,21 @@ private fun Modifier.clipClickable(onClick: () -> Unit): Modifier =
         .clickable(onClick = onClick)
 
 // Summarises the current visible-calendar selection in one line for the row subtitle.
-// Empty calendar list means the READ_CALENDAR permission is not granted; an empty
-// hidden-ids set means every available calendar is shown; otherwise reports the
-// fraction of calendars the user has left visible.
+// Three distinct states: permission denied, granted but no calendars, or a count of
+// visible vs total. An empty hidden-ids set means every calendar is shown.
 @Composable
 private fun visibleCalendarsSummary(
+    hasCalendarAccess: Boolean,
     calendars: List<CalendarInfo>,
     hiddenIds: Set<Long>,
 ): String =
     when {
-        calendars.isEmpty() -> {
+        !hasCalendarAccess -> {
             stringResource(R.string.settings_visible_calendars_none)
+        }
+
+        calendars.isEmpty() -> {
+            stringResource(R.string.settings_visible_calendars_empty)
         }
 
         hiddenIds.isEmpty() -> {
@@ -1151,9 +1161,11 @@ private fun visibleCalendarsSummary(
 private fun MultiSelectRow(
     title: String,
     summary: String,
+    hasCalendarAccess: Boolean,
     calendars: List<CalendarInfo>,
     hiddenIds: Set<Long>,
     onToggle: (Long, Boolean) -> Unit,
+    onOpenAppSettings: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var open by remember { mutableStateOf(false) }
@@ -1165,62 +1177,85 @@ private fun MultiSelectRow(
     if (open) {
         MultiSelectDialog(
             title = title,
+            hasCalendarAccess = hasCalendarAccess,
             calendars = calendars,
             hiddenIds = hiddenIds,
             onToggle = onToggle,
+            onOpenAppSettings = onOpenAppSettings,
             onDismiss = { open = false },
         )
     }
 }
 
-// Multi-select dialog for the visible-calendars picker. Each row shows a checkbox,
-// a colour dot (12 dp decorative marker from CalendarInfo.color), and the calendar's
-// display name + account name. The whole row is the toggle target (toggleable with
-// Role.Checkbox); the Checkbox is visual-only (onCheckedChange = null) so a single
-// tap never double-fires. Touch targets meet FemtoDimens.MinTouchTarget; text uses
-// bodyLarge / bodyMedium.
+// Multi-select dialog for the visible-calendars picker. Three states: permission
+// denied (shows a grant button linking to system settings), granted but no calendars
+// found, or the checkbox list. Each calendar row shows a colour dot (12 dp decorative
+// marker from CalendarInfo.color), display name, and account name. The whole row is
+// the toggle target (toggleable with Role.Checkbox); the Checkbox is visual-only
+// (onCheckedChange = null) so a single tap never double-fires. Touch targets meet
+// FemtoDimens.MinTouchTarget; text uses bodyLarge / bodyMedium.
 @Composable
 private fun MultiSelectDialog(
     title: String,
+    hasCalendarAccess: Boolean,
     calendars: List<CalendarInfo>,
     hiddenIds: Set<Long>,
     onToggle: (Long, Boolean) -> Unit,
+    onOpenAppSettings: () -> Unit,
     onDismiss: () -> Unit,
 ) = AlertDialog(
     onDismissRequest = onDismiss,
     title = { Text(title) },
     text = {
-        if (calendars.isEmpty()) {
-            Text(stringResource(R.string.settings_visible_calendars_empty))
-        } else {
-            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                calendars.forEach { calendar ->
-                    val shown = calendar.id !in hiddenIds
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .heightIn(min = FemtoDimens.MinTouchTarget)
-                                // Toggling hides when currently shown, shows when currently hidden.
-                                .toggleable(
-                                    value = shown,
-                                    role = Role.Checkbox,
-                                    onValueChange = { onToggle(calendar.id, shown) },
-                                ),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        when {
+            !hasCalendarAccess -> {
+                Column {
+                    Text(stringResource(R.string.settings_visible_calendars_none))
+                    TextButton(
+                        onClick = {
+                            onOpenAppSettings()
+                            onDismiss()
+                        },
                     ) {
-                        Checkbox(checked = shown, onCheckedChange = null)
-                        Box(
+                        Text(stringResource(R.string.settings_open_system_settings))
+                    }
+                }
+            }
+
+            calendars.isEmpty() -> {
+                Text(stringResource(R.string.settings_visible_calendars_empty))
+            }
+
+            else -> {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    calendars.forEach { calendar ->
+                        val shown = calendar.id !in hiddenIds
+                        Row(
                             modifier =
                                 Modifier
-                                    .size(12.dp)
-                                    .clip(CircleShape)
-                                    .background(Color(calendar.color)),
-                        )
-                        Column {
-                            Text(calendar.displayName, style = MaterialTheme.typography.bodyLarge)
-                            Text(calendar.accountName, style = MaterialTheme.typography.bodyMedium)
+                                    .fillMaxWidth()
+                                    .heightIn(min = FemtoDimens.MinTouchTarget)
+                                    // Toggling hides when currently shown, shows when currently hidden.
+                                    .toggleable(
+                                        value = shown,
+                                        role = Role.Checkbox,
+                                        onValueChange = { onToggle(calendar.id, shown) },
+                                    ),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Checkbox(checked = shown, onCheckedChange = null)
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(12.dp)
+                                        .clip(CircleShape)
+                                        .background(Color(calendar.color)),
+                            )
+                            Column {
+                                Text(calendar.displayName, style = MaterialTheme.typography.bodyLarge)
+                                Text(calendar.accountName, style = MaterialTheme.typography.bodyMedium)
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
@@ -39,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -52,6 +54,7 @@ import com.composables.icons.lucide.ExternalLink
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.RotateCcw
 import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.calendar.CalendarInfo
 import io.github.seijikohara.femto.data.display.AccentColor
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.ClockSetting
@@ -464,6 +467,15 @@ internal fun SettingsScreen(
                 checked = uiState.showCalendar,
                 onCheckedChange = { onAction(SettingsAction.SetShowCalendar(it)) },
             )
+            AnimatedVisibility(visible = uiState.showCalendar) {
+                MultiSelectRow(
+                    title = stringResource(R.string.settings_visible_calendars),
+                    summary = visibleCalendarsSummary(uiState.availableCalendars, uiState.hiddenCalendarIds),
+                    calendars = uiState.availableCalendars,
+                    hiddenIds = uiState.hiddenCalendarIds,
+                    onToggle = { id, hidden -> onAction(SettingsAction.SetCalendarHidden(id, hidden)) },
+                )
+            }
             SwitchRow(
                 title = stringResource(R.string.settings_group_panel_weather),
                 checked = uiState.showWeather,
@@ -1107,6 +1119,113 @@ private fun Modifier.clipClickable(onClick: () -> Unit): Modifier =
     this
         .clip(RoundedCornerShape(percent = 50))
         .clickable(onClick = onClick)
+
+// Summarises the current visible-calendar selection in one line for the row subtitle.
+// Empty calendar list means the READ_CALENDAR permission is not granted; an empty
+// hidden-ids set means every available calendar is shown; otherwise reports the
+// fraction of calendars the user has left visible.
+@Composable
+private fun visibleCalendarsSummary(
+    calendars: List<CalendarInfo>,
+    hiddenIds: Set<Long>,
+): String =
+    when {
+        calendars.isEmpty() -> {
+            stringResource(R.string.settings_visible_calendars_none)
+        }
+
+        hiddenIds.isEmpty() -> {
+            stringResource(R.string.settings_visible_calendars_all)
+        }
+
+        else -> {
+            val shown = calendars.count { it.id !in hiddenIds }
+            stringResource(R.string.settings_visible_calendars_count, shown, calendars.size)
+        }
+    }
+
+// A choice row that opens a multi-select dialog — same open/dismiss pattern as
+// ChoiceRow, but the dialog hosts checkboxes instead of radio buttons so multiple
+// calendars can be independently toggled.
+@Composable
+private fun MultiSelectRow(
+    title: String,
+    summary: String,
+    calendars: List<CalendarInfo>,
+    hiddenIds: Set<Long>,
+    onToggle: (Long, Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var open by remember { mutableStateOf(false) }
+    SettingRow(
+        modifier = modifier.clickable { open = true },
+        title = title,
+        summary = summary,
+    )
+    if (open) {
+        MultiSelectDialog(
+            title = title,
+            calendars = calendars,
+            hiddenIds = hiddenIds,
+            onToggle = onToggle,
+            onDismiss = { open = false },
+        )
+    }
+}
+
+// Multi-select dialog for the visible-calendars picker. Each row shows a checkbox,
+// a colour dot (12 dp decorative marker from CalendarInfo.color), and the calendar's
+// display name + account name. The whole row is clickable; the checkbox reflects the
+// checked state without a separate handler to avoid double-firing on row tap.
+// Touch targets meet FemtoDimens.MinTouchTarget; text uses bodyLarge / bodyMedium.
+@Composable
+private fun MultiSelectDialog(
+    title: String,
+    calendars: List<CalendarInfo>,
+    hiddenIds: Set<Long>,
+    onToggle: (Long, Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) = AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text(title) },
+    text = {
+        if (calendars.isEmpty()) {
+            Text(stringResource(R.string.settings_visible_calendars_empty))
+        } else {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                calendars.forEach { calendar ->
+                    val shown = calendar.id !in hiddenIds
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = FemtoDimens.MinTouchTarget)
+                                // Toggling hides when currently shown, shows when currently hidden.
+                                .clickable { onToggle(calendar.id, shown) },
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Checkbox(checked = shown, onCheckedChange = { onToggle(calendar.id, !it) })
+                        Box(
+                            modifier =
+                                Modifier
+                                    .size(12.dp)
+                                    .clip(CircleShape)
+                                    .background(Color(calendar.color)),
+                        )
+                        Column {
+                            Text(calendar.displayName, style = MaterialTheme.typography.bodyLarge)
+                            Text(calendar.accountName, style = MaterialTheme.typography.bodyMedium)
+                        }
+                    }
+                }
+            }
+        }
+    },
+    confirmButton = {
+        TextButton(onClick = onDismiss) { Text(stringResource(R.string.settings_dialog_close)) }
+    },
+)
 
 // Masks all but the last four characters of the token so it is not fully visible
 // on a shared in-car screen, while still letting the user confirm which key is set.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -1216,6 +1216,7 @@ private fun MultiSelectDialog(
                             onOpenAppSettings()
                             onDismiss()
                         },
+                        modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
                     ) {
                         Text(stringResource(R.string.settings_open_system_settings))
                     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -62,6 +62,7 @@ internal data class SettingsUiState(
     val mapboxAccessToken: String = "",
     val availableCalendars: List<CalendarInfo> = emptyList(),
     val hiddenCalendarIds: Set<Long> = emptySet(),
+    val hasCalendarAccess: Boolean = true,
 ) {
     companion object {
         // Seeded from the persistence defaults so the default values live in one

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.ui.settings
 
+import io.github.seijikohara.femto.data.calendar.CalendarInfo
 import io.github.seijikohara.femto.data.display.AccentColor
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.ClockSetting
@@ -59,6 +60,8 @@ internal data class SettingsUiState(
     val mapboxStyle: MapboxStyle = DisplaySettings.Default.mapboxStyle,
     val mapboxTraffic: Boolean = DisplaySettings.Default.mapboxTraffic,
     val mapboxAccessToken: String = "",
+    val availableCalendars: List<CalendarInfo> = emptyList(),
+    val hiddenCalendarIds: Set<Long> = emptySet(),
 ) {
     companion object {
         // Seeded from the persistence defaults so the default values live in one
@@ -256,6 +259,11 @@ internal sealed interface SettingsAction {
     ) : SettingsAction
 
     data object ClearMapboxToken : SettingsAction
+
+    data class SetCalendarHidden(
+        val id: Long,
+        val hidden: Boolean,
+    ) : SettingsAction
 
     /** Restore every display + font + location setting to its default value. */
     data object ResetToDefaults : SettingsAction

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -62,7 +62,10 @@ internal data class SettingsUiState(
     val mapboxAccessToken: String = "",
     val availableCalendars: List<CalendarInfo> = emptyList(),
     val hiddenCalendarIds: Set<Long> = emptySet(),
-    val hasCalendarAccess: Boolean = true,
+    // Defaults false so a not-yet-loaded selector never falsely claims "no
+    // calendars found" (hiding the grant affordance) when access is actually
+    // denied; CalendarCatalog emits the real value on subscription.
+    val hasCalendarAccess: Boolean = false,
 ) {
     companion object {
         // Seeded from the persistence defaults so the default values live in one

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import io.github.seijikohara.femto.data.calendar.CalendarCatalog
-import io.github.seijikohara.femto.data.calendar.CalendarInfo
+import io.github.seijikohara.femto.data.calendar.CalendarCatalogState
 import io.github.seijikohara.femto.data.calendar.CalendarPreferences
 import io.github.seijikohara.femto.data.calendar.CalendarPreferencesStore
 import io.github.seijikohara.femto.data.common.WhileUiSubscribed
@@ -28,7 +28,7 @@ internal class SettingsViewModel(
     private val fontPreferences: FontSelectionStore,
     private val locationPreferences: LocationSettingsStore,
     private val calendarPreferences: CalendarPreferencesStore,
-    availableCalendars: Flow<List<CalendarInfo>>,
+    availableCalendars: Flow<CalendarCatalogState>,
 ) : ViewModel() {
     val uiState: StateFlow<SettingsUiState> =
         combine(
@@ -37,7 +37,7 @@ internal class SettingsViewModel(
             locationPreferences.settings,
             calendarPreferences.hiddenCalendarIds,
             availableCalendars,
-        ) { display, font, location, hiddenCalendars, calendars ->
+        ) { display, font, location, hiddenCalendars, catalog ->
             SettingsUiState(
                 themeMode = display.themeMode,
                 accentColor = display.accentColor,
@@ -76,8 +76,9 @@ internal class SettingsViewModel(
                 locationIntervalMillis = location.intervalMillis,
                 locationMinDistanceMeters = location.minUpdateDistanceMeters,
                 backgroundRangingEnabled = location.backgroundRangingEnabled,
-                availableCalendars = calendars,
+                availableCalendars = catalog.calendars,
                 hiddenCalendarIds = hiddenCalendars,
+                hasCalendarAccess = catalog.hasAccess,
             )
         }.stateIn(viewModelScope, WhileUiSubscribed, SettingsUiState.Initial)
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -5,6 +5,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import io.github.seijikohara.femto.data.calendar.CalendarCatalog
+import io.github.seijikohara.femto.data.calendar.CalendarInfo
+import io.github.seijikohara.femto.data.calendar.CalendarPreferences
+import io.github.seijikohara.femto.data.calendar.CalendarPreferencesStore
 import io.github.seijikohara.femto.data.common.WhileUiSubscribed
 import io.github.seijikohara.femto.data.display.DisplayPreferences
 import io.github.seijikohara.femto.data.display.DisplaySettingsStore
@@ -13,6 +17,7 @@ import io.github.seijikohara.femto.data.fonts.FontPreferences
 import io.github.seijikohara.femto.data.fonts.FontSelectionStore
 import io.github.seijikohara.femto.data.location.LocationPreferences
 import io.github.seijikohara.femto.data.location.LocationSettingsStore
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
@@ -22,13 +27,17 @@ internal class SettingsViewModel(
     private val displayPreferences: DisplaySettingsStore,
     private val fontPreferences: FontSelectionStore,
     private val locationPreferences: LocationSettingsStore,
+    private val calendarPreferences: CalendarPreferencesStore,
+    availableCalendars: Flow<List<CalendarInfo>>,
 ) : ViewModel() {
     val uiState: StateFlow<SettingsUiState> =
         combine(
             displayPreferences.settings,
             fontPreferences.selection,
             locationPreferences.settings,
-        ) { display, font, location ->
+            calendarPreferences.hiddenCalendarIds,
+            availableCalendars,
+        ) { display, font, location, hiddenCalendars, calendars ->
             SettingsUiState(
                 themeMode = display.themeMode,
                 accentColor = display.accentColor,
@@ -67,6 +76,8 @@ internal class SettingsViewModel(
                 locationIntervalMillis = location.intervalMillis,
                 locationMinDistanceMeters = location.minUpdateDistanceMeters,
                 backgroundRangingEnabled = location.backgroundRangingEnabled,
+                availableCalendars = calendars,
+                hiddenCalendarIds = hiddenCalendars,
             )
         }.stateIn(viewModelScope, WhileUiSubscribed, SettingsUiState.Initial)
 
@@ -225,6 +236,10 @@ internal class SettingsViewModel(
                     displayPreferences.setMapboxAccessToken("")
                 }
 
+                is SettingsAction.SetCalendarHidden -> {
+                    calendarPreferences.setCalendarHidden(action.id, action.hidden)
+                }
+
                 is SettingsAction.ResetToDefaults -> {
                     displayPreferences.resetToDefaults()
                     locationPreferences.resetToDefaults()
@@ -247,6 +262,8 @@ internal class SettingsViewModelFactory(
             displayPreferences = DisplayPreferences(application),
             fontPreferences = FontPreferences(application),
             locationPreferences = LocationPreferences(application),
+            calendarPreferences = CalendarPreferences(application),
+            availableCalendars = CalendarCatalog(application).availableCalendarsFlow(),
         ) as T
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,12 @@
     <string name="settings_group_panel_music">Music panel</string>
     <string name="settings_group_panel_music_spectrum">Music spectrum</string>
     <string name="settings_panel_music_spectrum_desc">Show a spectrum of the playing audio behind the playback controls; uses the audio-capture (microphone) permission.</string>
+    <string name="settings_visible_calendars">Visible calendars</string>
+    <string name="settings_visible_calendars_all">All calendars</string>
+    <string name="settings_visible_calendars_count">%1$d of %2$d shown</string>
+    <string name="settings_visible_calendars_none">Calendar access not granted</string>
+    <string name="settings_visible_calendars_empty">No calendars found</string>
+    <string name="settings_dialog_close">Close</string>
     <string name="settings_open_notification_access">Notification access</string>
     <string name="settings_open_system_settings">System settings</string>
     <string name="settings_open_diagnostics">Diagnostics</string>

--- a/app/src/sharedTest/java/io/github/seijikohara/femto/testfixtures/FakeCalendarInfo.kt
+++ b/app/src/sharedTest/java/io/github/seijikohara/femto/testfixtures/FakeCalendarInfo.kt
@@ -1,0 +1,10 @@
+package io.github.seijikohara.femto.testfixtures
+
+import io.github.seijikohara.femto.data.calendar.CalendarInfo
+
+internal fun fakeCalendarInfo(
+    id: Long = 1L,
+    displayName: String = "Personal",
+    accountName: String = "me@example.com",
+    color: Int = 0xFF4285F4.toInt(),
+): CalendarInfo = CalendarInfo(id, displayName, accountName, color)

--- a/app/src/test/java/io/github/seijikohara/femto/data/calendar/CalendarCatalogTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/calendar/CalendarCatalogTest.kt
@@ -1,0 +1,125 @@
+package io.github.seijikohara.femto.data.calendar
+
+import android.Manifest
+import android.app.Application
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.provider.CalendarContract
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class CalendarCatalogTest {
+    private val app: Application = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `lists visible calendars when permission granted`() =
+        runTest {
+            shadowOf(app).grantPermissions(Manifest.permission.READ_CALENDAR)
+            Robolectric
+                .buildContentProvider(VisibleCalendarsProvider::class.java)
+                .create(CalendarContract.AUTHORITY)
+
+            val catalog = CalendarCatalog(app)
+            val calendars = catalog.availableCalendarsFlow().first()
+
+            assertEquals(listOf(1L, 2L), calendars.map { it.id })
+            assertEquals("Personal", calendars.first().displayName)
+        }
+
+    @Test
+    fun `emits empty when permission denied`() =
+        runTest {
+            // READ_CALENDAR intentionally not granted: the list must be empty.
+            val catalog = CalendarCatalog(app)
+            assertEquals(emptyList(), catalog.availableCalendarsFlow().first())
+        }
+
+    /**
+     * Fake Calendars provider returning two visible rows (id 1 "Personal", id 2 "Work")
+     * ordered by CALENDAR_DISPLAY_NAME ASC, matching the query in [CalendarCatalog].
+     */
+    class VisibleCalendarsProvider : ContentProvider() {
+        override fun onCreate(): Boolean = true
+
+        override fun query(
+            uri: Uri,
+            projection: Array<out String>?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+            sortOrder: String?,
+        ): Cursor {
+            val columns =
+                projection ?: arrayOf(
+                    CalendarContract.Calendars._ID,
+                    CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+                    CalendarContract.Calendars.ACCOUNT_NAME,
+                    CalendarContract.Calendars.CALENDAR_COLOR,
+                )
+            val cursor = MatrixCursor(columns)
+            ROWS.forEach { (id, displayName, accountName, color) ->
+                cursor.addRow(
+                    columns.map { column ->
+                        when (column) {
+                            CalendarContract.Calendars._ID -> id
+                            CalendarContract.Calendars.CALENDAR_DISPLAY_NAME -> displayName
+                            CalendarContract.Calendars.ACCOUNT_NAME -> accountName
+                            CalendarContract.Calendars.CALENDAR_COLOR -> color
+                            else -> null
+                        }
+                    },
+                )
+            }
+            return cursor
+        }
+
+        override fun getType(uri: Uri): String? = null
+
+        override fun insert(
+            uri: Uri,
+            values: ContentValues?,
+        ): Uri? = null
+
+        override fun delete(
+            uri: Uri,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        override fun update(
+            uri: Uri,
+            values: ContentValues?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        companion object {
+            data class Row(
+                val id: Long,
+                val displayName: String,
+                val accountName: String,
+                val color: Int,
+            )
+
+            // Ordered by displayName ASC to mirror the sort the catalog applies, so the
+            // fake provider's insertion order matches what the catalog would return.
+            val ROWS =
+                listOf(
+                    Row(1L, "Personal", "user@example.com", 0xFF0000.toInt()),
+                    Row(2L, "Work", "work@example.com", 0x0000FF.toInt()),
+                )
+        }
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/calendar/CalendarCatalogTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/calendar/CalendarCatalogTest.kt
@@ -18,6 +18,8 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
@@ -33,18 +35,23 @@ class CalendarCatalogTest {
                 .create(CalendarContract.AUTHORITY)
 
             val catalog = CalendarCatalog(app)
-            val calendars = catalog.availableCalendarsFlow().first()
+            val state = catalog.availableCalendarsFlow().first()
 
-            assertEquals(listOf(1L, 2L), calendars.map { it.id })
-            assertEquals("Personal", calendars.first().displayName)
+            assertTrue(state.hasAccess)
+            assertEquals(listOf(1L, 2L), state.calendars.map { it.id })
+            assertEquals("Personal", state.calendars.first().displayName)
         }
 
     @Test
     fun `emits empty when permission denied`() =
         runTest {
-            // READ_CALENDAR intentionally not granted: the list must be empty.
+            // READ_CALENDAR intentionally not granted: hasAccess must be false
+            // and the calendar list must be empty.
             val catalog = CalendarCatalog(app)
-            assertEquals(emptyList(), catalog.availableCalendarsFlow().first())
+            val state = catalog.availableCalendarsFlow().first()
+
+            assertFalse(state.hasAccess)
+            assertTrue(state.calendars.isEmpty())
         }
 
     /**

--- a/app/src/test/java/io/github/seijikohara/femto/data/calendar/CalendarPreferencesTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/calendar/CalendarPreferencesTest.kt
@@ -1,0 +1,35 @@
+package io.github.seijikohara.femto.data.calendar
+
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+// The `preferencesDataStore` delegate behind CalendarPreferences is a
+// process-wide singleton bound to the first Application's filesDir, while
+// Robolectric hands each test method a fresh Application and temp dir. All
+// round-trip steps therefore live in one test method, so the persisted file
+// and the singleton never disagree across tests (mirrors DrawerPreferencesTest).
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class CalendarPreferencesTest {
+    private fun newStore() = CalendarPreferences(ApplicationProvider.getApplicationContext())
+
+    @Test
+    fun hidden_set_round_trips_add_and_remove() =
+        runTest {
+            val store = newStore()
+            assertEquals(emptySet(), store.hiddenCalendarIds.first())
+
+            store.setCalendarHidden(7L, hidden = true)
+            store.setCalendarHidden(9L, hidden = true)
+            assertEquals(setOf(7L, 9L), store.hiddenCalendarIds.first())
+
+            store.setCalendarHidden(7L, hidden = false)
+            assertEquals(setOf(9L), store.hiddenCalendarIds.first())
+        }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/calendar/CalendarRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/calendar/CalendarRepositoryTest.kt
@@ -47,6 +47,7 @@ class CalendarRepositoryTest {
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, LocalDate.of(2026, 6, 3))),
+                    hiddenCalendarIds = flowOf(emptySet()),
                 )
 
             val snapshot = repository.snapshotFlow().first()
@@ -78,6 +79,7 @@ class CalendarRepositoryTest {
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, LocalDate.of(2026, 6, 3))),
+                    hiddenCalendarIds = flowOf(emptySet()),
                 )
 
             val snapshot = repository.snapshotFlow().first()
@@ -105,6 +107,7 @@ class CalendarRepositoryTest {
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, LocalDate.of(2026, 6, 3))),
+                    hiddenCalendarIds = flowOf(emptySet()),
                 )
 
             val snapshot = repository.snapshotFlow().first()
@@ -134,6 +137,7 @@ class CalendarRepositoryTest {
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, AllDayCalendarProvider.TODAY)),
+                    hiddenCalendarIds = flowOf(emptySet()),
                     zoneProvider = { newYork },
                 )
 
@@ -179,6 +183,7 @@ class CalendarRepositoryTest {
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, MultiDayCalendarProvider.TODAY)),
+                    hiddenCalendarIds = flowOf(emptySet()),
                     zoneProvider = { ZoneOffset.UTC },
                 )
 
@@ -220,6 +225,7 @@ class CalendarRepositoryTest {
                             ClockTick(LocalTime.of(12, 1), date),
                             ClockTick(LocalTime.of(12, 2), date),
                         ),
+                    hiddenCalendarIds = flowOf(emptySet()),
                 )
 
             val snapshot = repository.snapshotFlow().first()
@@ -228,6 +234,40 @@ class CalendarRepositoryTest {
             // Same-date ticks collapse to one rebuild key, so the 30-day
             // Instances window is scanned once — not once per minute.
             assertEquals(1, CountingCalendarProvider.queryCount)
+        }
+
+    /**
+     * Calendar IDs hidden in the preferences must not appear in the agenda.
+     *
+     * The provider fake captures the selection string and also applies the
+     * NOT IN filter so the end-to-end title assertion is meaningful.
+     */
+    @Test
+    fun `hides events from hidden calendars`() =
+        runTest {
+            shadowOf(application).grantPermissions(Manifest.permission.READ_CALENDAR)
+            HiddenCalendarProvider.lastSelection = null
+            Robolectric
+                .buildContentProvider(HiddenCalendarProvider::class.java)
+                .create(CalendarContract.AUTHORITY)
+
+            val repo =
+                CalendarRepository(
+                    application,
+                    clockFlow = flowOf(ClockTick(LocalTime.NOON, HiddenCalendarProvider.TODAY)),
+                    hiddenCalendarIds = flowOf(setOf(2L)),
+                    zoneProvider = { ZoneOffset.UTC },
+                )
+            val snapshot = repo.snapshotFlow().first()
+
+            assertNotNull(snapshot)
+            // The repository must build a NOT IN clause so the resolver can filter.
+            val sel = HiddenCalendarProvider.lastSelection
+            assertNotNull(sel)
+            assertTrue(sel.contains("NOT IN (2)"), "expected NOT IN clause but got: $sel")
+            // The provider honours the NOT IN clause; only the Work event (cal 1) survives.
+            val titles = snapshot.days.flatMap { it.events }.map { it.title }
+            assertEquals(listOf("Work"), titles)
         }
 
     @Test
@@ -244,6 +284,7 @@ class CalendarRepositoryTest {
                     CalendarRepository(
                         application,
                         clockFlow = flowOf(ClockTick(LocalTime.NOON, today)),
+                        hiddenCalendarIds = flowOf(emptySet()),
                         localeProvider = { locale },
                     )
 
@@ -267,12 +308,14 @@ class CalendarRepositoryTest {
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, today)),
+                    hiddenCalendarIds = flowOf(emptySet()),
                     localeProvider = { Locale.ENGLISH },
                 ).snapshotFlow().first()!!.monthLabel
             val jaLabel =
                 CalendarRepository(
                     application,
                     clockFlow = flowOf(ClockTick(LocalTime.NOON, today)),
+                    hiddenCalendarIds = flowOf(emptySet()),
                     localeProvider = { Locale.JAPANESE },
                 ).snapshotFlow().first()!!.monthLabel
             assertTrue(enLabel != jaLabel)
@@ -458,6 +501,103 @@ class CalendarRepositoryTest {
 
         companion object {
             var queryCount: Int = 0
+        }
+    }
+
+    /**
+     * Stand-in calendar provider with two rows — calendar 1 ("Work") and calendar 2
+     * ("Private"). It captures the [selection] argument passed by the repository and
+     * also applies the NOT IN filter so the end-to-end title assertion is meaningful.
+     * [lastSelection] is reset by the test before registering the provider because
+     * Robolectric can share the companion across test methods.
+     */
+    class HiddenCalendarProvider : ContentProvider() {
+        override fun onCreate(): Boolean = true
+
+        override fun query(
+            uri: Uri,
+            projection: Array<out String>?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+            sortOrder: String?,
+        ): Cursor {
+            lastSelection = selection
+            val excludedIds = parseNotInIds(selection)
+            val columns: Array<out String> =
+                projection ?: arrayOf(CalendarContract.Instances.BEGIN)
+            val cursor = MatrixCursor(columns)
+            ROWS
+                .filter { row -> row.calId !in excludedIds }
+                .forEach { row ->
+                    cursor.addRow(
+                        columns.map { column ->
+                            when (column) {
+                                CalendarContract.Instances.BEGIN -> row.beginMs
+                                CalendarContract.Instances.ALL_DAY -> 0
+                                CalendarContract.Instances.TITLE -> row.title
+                                else -> null
+                            }
+                        },
+                    )
+                }
+            return cursor
+        }
+
+        override fun getType(uri: Uri): String? = null
+
+        override fun insert(
+            uri: Uri,
+            values: ContentValues?,
+        ): Uri? = null
+
+        override fun delete(
+            uri: Uri,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        override fun update(
+            uri: Uri,
+            values: ContentValues?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        data class Row(
+            val calId: Long,
+            val title: String,
+            val beginMs: Long,
+        )
+
+        companion object {
+            var lastSelection: String? = null
+            val TODAY: LocalDate = LocalDate.of(2099, 8, 1)
+
+            private fun at(hour: Int): Long =
+                TODAY
+                    .atTime(hour, 0)
+                    .atZone(ZoneOffset.UTC)
+                    .toInstant()
+                    .toEpochMilli()
+
+            val ROWS: List<Row> =
+                listOf(
+                    Row(1L, "Work", at(9)),
+                    Row(2L, "Private", at(10)),
+                )
+
+            // Extracts the IDs from a "NOT IN (1,2,3)" clause in the selection string.
+            // IDs are Longs without spaces, matching the joinToString(",") format the
+            // repository produces.
+            fun parseNotInIds(selection: String?): Set<Long> =
+                Regex("""NOT IN \(([0-9,]+)\)""")
+                    .find(selection.orEmpty())
+                    ?.groupValues
+                    ?.get(1)
+                    ?.split(",")
+                    ?.mapNotNull { it.toLongOrNull() }
+                    ?.toSet()
+                    .orEmpty()
         }
     }
 

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeCalendarPreferencesStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeCalendarPreferencesStore.kt
@@ -1,0 +1,23 @@
+package io.github.seijikohara.femto.testfixtures
+
+import io.github.seijikohara.femto.data.calendar.CalendarPreferencesStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * In-memory [CalendarPreferencesStore] for view-model tests: every setter mutates a
+ * [MutableStateFlow] synchronously, so a test sees the write with no DataStore IO
+ * and no cross-dispatcher timing.
+ */
+internal class FakeCalendarPreferencesStore(
+    initialHidden: Set<Long> = emptySet(),
+) : CalendarPreferencesStore {
+    private val state = MutableStateFlow(initialHidden)
+    override val hiddenCalendarIds: Flow<Set<Long>> = state
+
+    override suspend fun setCalendarHidden(
+        id: Long,
+        hidden: Boolean,
+    ) = state.update { if (hidden) it + id else it - id }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -12,12 +12,15 @@ import io.github.seijikohara.femto.data.display.OrientationSetting
 import io.github.seijikohara.femto.data.display.UiScale
 import io.github.seijikohara.femto.data.location.LocationQualitySetting
 import io.github.seijikohara.femto.data.location.LocationSettings
+import io.github.seijikohara.femto.testfixtures.FakeCalendarPreferencesStore
 import io.github.seijikohara.femto.testfixtures.FakeDisplaySettingsStore
 import io.github.seijikohara.femto.testfixtures.FakeFontSelectionStore
 import io.github.seijikohara.femto.testfixtures.FakeLocationSettingsStore
+import io.github.seijikohara.femto.testfixtures.fakeCalendarInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -317,5 +320,44 @@ class SettingsViewModelTest {
             assertEquals("", vm.uiState.value.mapboxAccessToken)
         }
 
-    private fun viewModel() = SettingsViewModel(store, fontStore, locationStore)
+    @Test
+    fun `available calendars and hidden set surface and SetCalendarHidden toggles`() =
+        runTest(dispatcher) {
+            val calendarPrefs = FakeCalendarPreferencesStore()
+            val vm =
+                SettingsViewModel(
+                    store,
+                    fontStore,
+                    locationStore,
+                    calendarPrefs,
+                    availableCalendars =
+                        flowOf(
+                            listOf(
+                                fakeCalendarInfo(id = 1L),
+                                fakeCalendarInfo(id = 2L, displayName = "Work"),
+                            ),
+                        ),
+                )
+            backgroundScope.launch { vm.uiState.collect { } }
+            advanceUntilIdle()
+            assertEquals(
+                listOf(1L, 2L),
+                vm.uiState.value.availableCalendars
+                    .map { it.id },
+            )
+            assertEquals(emptySet(), vm.uiState.value.hiddenCalendarIds)
+
+            vm.onAction(SettingsAction.SetCalendarHidden(id = 2L, hidden = true))
+            advanceUntilIdle()
+            assertEquals(setOf(2L), vm.uiState.value.hiddenCalendarIds)
+        }
+
+    private fun viewModel() =
+        SettingsViewModel(
+            store,
+            fontStore,
+            locationStore,
+            FakeCalendarPreferencesStore(),
+            availableCalendars = flowOf(emptyList()),
+        )
 }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.ui.settings
 
+import io.github.seijikohara.femto.data.calendar.CalendarCatalogState
 import io.github.seijikohara.femto.data.display.AccentColor
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.DisplaySettings
@@ -332,9 +333,13 @@ class SettingsViewModelTest {
                     calendarPrefs,
                     availableCalendars =
                         flowOf(
-                            listOf(
-                                fakeCalendarInfo(id = 1L),
-                                fakeCalendarInfo(id = 2L, displayName = "Work"),
+                            CalendarCatalogState(
+                                hasAccess = true,
+                                calendars =
+                                    listOf(
+                                        fakeCalendarInfo(id = 1L),
+                                        fakeCalendarInfo(id = 2L, displayName = "Work"),
+                                    ),
                             ),
                         ),
                 )
@@ -358,6 +363,6 @@ class SettingsViewModelTest {
             fontStore,
             locationStore,
             FakeCalendarPreferencesStore(),
-            availableCalendars = flowOf(emptyList()),
+            availableCalendars = flowOf(CalendarCatalogState(hasAccess = true, calendars = emptyList())),
         )
 }


### PR DESCRIPTION
## Why
The dashboard Calendar card showed every visible device calendar with no way to narrow it. This adds a per-calendar visibility selector in Settings.

## What changed
- **Exclusion model**: a set of hidden calendar IDs is persisted (`CalendarPreferences`, `data/calendar/`). Empty = all shown; new/unconfigured calendars show by default.
- **Available list**: `CalendarCatalog` lists the device's visible calendars (`CalendarInfo`: id/displayName/account/color), reusing a shared `calendarChangeFlow(context)` extracted from `CalendarRepository`. It also reports whether `READ_CALENDAR` is granted.
- **Dashboard filter**: `CalendarRepository` adds `CALENDAR_ID NOT IN (...)` to its `Instances` query (no clause when nothing is hidden) and re-emits when the selection changes.
- **Settings selector**: a "Visible calendars" row (shown when the card is on) opens a checkbox dialog. Toggling a calendar **persists immediately** (no Save). Three states: permission-denied (with a grant-access button), granted-but-empty, and the calendar list. Filter-only — event appearance is unchanged.

## Verification
`spotlessCheck → assembleDebug → lint → test` all green; androidTest compiles. Built via brainstorm → spec → plan → subagent-driven development (8 commits, per-task spec+quality reviews, a whole-branch review on the strongest model, all findings fixed: atomic toggle via `toggleable(role=Checkbox)`, permission/empty distinction, removed a trap default param, 64dp touch floor on the grant button).

https://claude.ai/code/session_012MEBd6578FM3pzsNw3m94e