### PR TITLE
feat(settings): reorganize Settings around Appearance vs Map concerns

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -66,6 +66,7 @@ class SettingsScreenTest {
     private val googleMapsMapIdSaveLabel = context.getString(R.string.settings_google_maps_map_id_save)
     private val googleMapsMapIdClearLabel = context.getString(R.string.settings_google_maps_map_id_clear)
     private val accentOsmOnlyNoteLabel = context.getString(R.string.settings_map_accent_osm_only_note)
+    private val mapRenderingSubheaderLabel = context.getString(R.string.settings_subheader_map_rendering)
 
     @Test
     fun renders_fullscreen_row() {
@@ -365,6 +366,21 @@ class SettingsScreenTest {
                 ),
         )
         rule.onNodeWithText(accentOsmOnlyNoteLabel).performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun map_rendering_subheader_hidden_for_non_osm_backend() {
+        // The Rendering subheader (3D Buildings / Terrain) only applies to the OSM
+        // backend; Mapbox renders those effects natively, so neither the header nor
+        // its switches should appear once a non-OSM backend is selected.
+        setScreen(
+            uiState =
+                SettingsUiState.Initial.copy(
+                    mapBackend = MapBackend.MAPBOX,
+                    mapboxAccessToken = "pk.test",
+                ),
+        )
+        rule.onNodeWithText(mapRenderingSubheaderLabel).assertDoesNotExist()
     }
 
     @Test

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -27,6 +27,8 @@ class SettingsScreenTest {
     val rule = createComposeRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val appearanceSectionLabel = context.getString(R.string.settings_section_appearance)
+    private val screenSectionLabel = context.getString(R.string.settings_section_screen)
     private val fullscreenLabel = context.getString(R.string.settings_group_fullscreen)
     private val themeLabel = context.getString(R.string.settings_group_theme)
     private val darkLabel = context.getString(R.string.settings_theme_dark)
@@ -68,7 +70,22 @@ class SettingsScreenTest {
     @Test
     fun renders_fullscreen_row() {
         setScreen()
-        rule.onNodeWithText(fullscreenLabel).assertIsDisplayed()
+        // The Screen section now sits below the larger Appearance section (which
+        // absorbed the map-color rows), pushing Fullscreen below the fold on a
+        // short head unit; scroll it into view first.
+        rule.onNodeWithText(fullscreenLabel).performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun renders_appearance_section() {
+        setScreen()
+        rule.onNodeWithText(appearanceSectionLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun renders_screen_section() {
+        setScreen()
+        rule.onNodeWithText(screenSectionLabel).performScrollTo().assertIsDisplayed()
     }
 
     @Test
@@ -76,7 +93,8 @@ class SettingsScreenTest {
         val actions = mutableListOf<SettingsAction>()
         setScreen(onAction = { actions += it })
         // Initial.fullscreen is now ON (the revised default), so tapping flips it off.
-        rule.onNodeWithText(fullscreenLabel).performClick()
+        // Scroll first: see the comment on renders_fullscreen_row.
+        rule.onNodeWithText(fullscreenLabel).performScrollTo().performClick()
         assertEquals(listOf(SettingsAction.SetFullscreen(FullscreenSetting.OFF)), actions)
     }
 

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -32,6 +32,7 @@ class SettingsScreenTest {
     private val darkLabel = context.getString(R.string.settings_theme_dark)
     private val showSecondsLabel = context.getString(R.string.settings_group_clock_seconds)
     private val tealAccentLabel = context.getString(R.string.settings_accent_teal)
+    private val customPresetLabel = context.getString(R.string.settings_theme_preset_custom)
     private val resetLabel = context.getString(R.string.settings_reset_to_defaults)
     private val resetConfirmLabel = context.getString(R.string.settings_reset_confirm)
     private val keepScreenOnLabel = context.getString(R.string.settings_keep_screen_on)
@@ -95,6 +96,21 @@ class SettingsScreenTest {
         // then tapping it reports the matching AccentColor.
         rule.onNodeWithContentDescription(tealAccentLabel).performScrollTo().performClick()
         assertEquals(listOf(SettingsAction.SetAccentColor(AccentColor.TEAL)), actions)
+    }
+
+    @Test
+    fun theme_preset_row_shows_no_custom_chip_when_matching_dynamic_default() {
+        // SettingsUiState.Initial is DYNAMIC + ACCENT/ACCENT, which matches
+        // ThemePresets.Dynamic exactly, so no Custom chip should render.
+        setScreen()
+        rule.onNodeWithText(customPresetLabel).assertDoesNotExist()
+    }
+
+    @Test
+    fun theme_preset_row_shows_custom_chip_when_accent_diverges_from_every_preset() {
+        // PINK is not any preset's accent seed, so the bundle can't match.
+        setScreen(uiState = SettingsUiState.Initial.copy(accentColor = AccentColor.PINK))
+        rule.onNodeWithText(customPresetLabel).performScrollTo().assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -63,6 +63,7 @@ class SettingsScreenTest {
     private val googleMapsMapIdHintLabel = context.getString(R.string.settings_google_maps_map_id_hint)
     private val googleMapsMapIdSaveLabel = context.getString(R.string.settings_google_maps_map_id_save)
     private val googleMapsMapIdClearLabel = context.getString(R.string.settings_google_maps_map_id_clear)
+    private val accentOsmOnlyNoteLabel = context.getString(R.string.settings_map_accent_osm_only_note)
 
     @Test
     fun renders_fullscreen_row() {
@@ -319,6 +320,33 @@ class SettingsScreenTest {
         )
         rule.onNodeWithText(googleMapsTypeLabel).performScrollTo().assertIsDisplayed()
         rule.onNodeWithText(googleMapsTrafficLabel).performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun accent_osm_only_note_shown_for_mapbox_backend() {
+        setScreen(
+            uiState =
+                SettingsUiState.Initial.copy(
+                    mapBackend = MapBackend.MAPBOX,
+                    mapboxAccessToken = "pk.test",
+                ),
+        )
+        rule.onNodeWithText(accentOsmOnlyNoteLabel).performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun accent_osm_only_note_shown_for_google_maps_backend() {
+        // The note already shows for Mapbox (see the test above); Google Maps is
+        // equally non-recolorable and must show the same explanation, not leave
+        // the gap unexplained.
+        setScreen(
+            uiState =
+                SettingsUiState.Initial.copy(
+                    mapBackend = MapBackend.GOOGLEMAPS,
+                    googleMapsApiKey = "AIzaTestKey",
+                ),
+        )
+        rule.onNodeWithText(accentOsmOnlyNoteLabel).performScrollTo().assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -38,6 +38,8 @@ class SettingsScreenTest {
     private val keepScreenOnLabel = context.getString(R.string.settings_keep_screen_on)
     private val lightSchemeLabel = context.getString(R.string.settings_group_map_scheme_light)
     private val darkSchemeLabel = context.getString(R.string.settings_group_map_scheme_dark)
+    private val matchAppThemeLabel = context.getString(R.string.settings_map_match_theme)
+    private val mapStyleLabel = context.getString(R.string.settings_group_map_style)
     private val mapBackendLabel = context.getString(R.string.settings_map_backend)
     private val mapboxLabel = context.getString(R.string.settings_map_backend_mapbox)
     private val tokenLabel = context.getString(R.string.settings_mapbox_token)
@@ -175,6 +177,54 @@ class SettingsScreenTest {
         setScreen(uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.DARK))
         rule.onNodeWithText(darkSchemeLabel).performScrollTo().assertIsDisplayed()
         rule.onNodeWithText(lightSchemeLabel).assertDoesNotExist()
+    }
+
+    @Test
+    fun map_style_override_choice_hidden_when_matching_app_theme() {
+        // mapStyle == AUTO means "match app theme" is on, so the override
+        // Light/Dark choice row must not be present.
+        setScreen(uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.AUTO))
+        rule.onNodeWithText(mapStyleLabel).assertDoesNotExist()
+    }
+
+    @Test
+    fun map_style_override_choice_shown_and_dispatches_when_overridden() {
+        val actions = mutableListOf<SettingsAction>()
+        setScreen(
+            uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.LIGHT),
+            onAction = { actions += it },
+        )
+        rule.onNodeWithText(mapStyleLabel).performScrollTo().performClick()
+        rule.onNodeWithText(darkLabel).performClick()
+        assertEquals(listOf(SettingsAction.SetMapStyle(MapStyleSetting.DARK)), actions)
+    }
+
+    @Test
+    fun turning_off_match_app_theme_dispatches_set_map_style_dark_when_app_is_dark() {
+        val actions = mutableListOf<SettingsAction>()
+        setScreen(darkTheme = true, onAction = { actions += it })
+        // Initial.mapStyle is AUTO, so the toggle starts checked; tapping unchecks it.
+        rule.onNodeWithText(matchAppThemeLabel).performScrollTo().performClick()
+        assertEquals(listOf(SettingsAction.SetMapStyle(MapStyleSetting.DARK)), actions)
+    }
+
+    @Test
+    fun turning_off_match_app_theme_dispatches_set_map_style_light_when_app_is_light() {
+        val actions = mutableListOf<SettingsAction>()
+        setScreen(darkTheme = false, onAction = { actions += it })
+        rule.onNodeWithText(matchAppThemeLabel).performScrollTo().performClick()
+        assertEquals(listOf(SettingsAction.SetMapStyle(MapStyleSetting.LIGHT)), actions)
+    }
+
+    @Test
+    fun turning_on_match_app_theme_dispatches_set_map_style_auto() {
+        val actions = mutableListOf<SettingsAction>()
+        setScreen(
+            uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.DARK),
+            onAction = { actions += it },
+        )
+        rule.onNodeWithText(matchAppThemeLabel).performScrollTo().performClick()
+        assertEquals(listOf(SettingsAction.SetMapStyle(MapStyleSetting.AUTO)), actions)
     }
 
     @Test
@@ -474,9 +524,10 @@ class SettingsScreenTest {
     private fun setScreen(
         uiState: SettingsUiState = SettingsUiState.Initial,
         onAction: (SettingsAction) -> Unit = {},
+        darkTheme: Boolean = false,
     ) {
         rule.setContent {
-            FemtoTheme {
+            FemtoTheme(darkTheme = darkTheme) {
                 SettingsScreen(
                     uiState = uiState,
                     onAction = onAction,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -143,6 +143,7 @@ internal fun SettingsScreen(
                 onSelect = { onAction(SettingsAction.SetAccentColor(it)) },
             )
             ThemePresetRow(
+                accentColor = uiState.accentColor,
                 selectedPreset =
                     ThemePresets.matchingOrNull(
                         accentColor = uiState.accentColor,
@@ -875,9 +876,13 @@ private fun AccentSwatch(
 // The theme-preset picker: named bundles of accent + map colour schemes from the
 // ThemePresets registry. Tapping one applies the whole look at once; the accent
 // and map-scheme controls then reflect it. The data-driven "theme as data"
-// surface — mass-producing a theme is a registry entry, not new UI here.
+// surface — mass-producing a theme is a registry entry, not new UI here. When the
+// current accent/map-scheme combination matches no registered bundle, a
+// non-interactive "Custom" chip renders instead of leaving every chip unselected,
+// so a fine-tuned combination reads as a deliberate state rather than a stale one.
 @Composable
 private fun ThemePresetRow(
+    accentColor: AccentColor,
     selectedPreset: ThemePreset?,
     onSelect: (ThemePreset) -> Unit,
     modifier: Modifier = Modifier,
@@ -907,6 +912,46 @@ private fun ThemePresetRow(
                 onClick = { onSelect(preset) },
             )
         }
+        if (selectedPreset == null) {
+            CustomPresetChip(accentColor = accentColor)
+        }
+    }
+}
+
+// The "you are here" readout when no preset bundle matches: same visual weight as
+// a selected ThemePresetChip (secondaryContainer fill + primary border) but not
+// clickable — Custom is a status, not an action to invoke. The dot shows the
+// CURRENT accent live, since there is no single preset color to show.
+@Composable
+private fun CustomPresetChip(
+    accentColor: AccentColor,
+    modifier: Modifier = Modifier,
+) {
+    val seed = accentColor.accentSeedColor()
+    Row(
+        modifier =
+            modifier
+                .heightIn(min = FemtoDimens.MinTouchTarget)
+                .clip(MaterialTheme.shapes.large)
+                .background(MaterialTheme.colorScheme.secondaryContainer)
+                .border(width = 2.dp, color = MaterialTheme.colorScheme.primary, shape = MaterialTheme.shapes.large)
+                .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        val dot = if (seed !=
+            null
+        ) {
+            Modifier.background(seed)
+        } else {
+            Modifier.background(Brush.sweepGradient(DynamicAccentSweep))
+        }
+        Box(modifier = Modifier.size(20.dp).clip(CircleShape).then(dot))
+        Text(
+            text = stringResource(R.string.settings_theme_preset_custom),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
     }
 }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package io.github.seijikohara.femto.ui.settings
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -17,12 +16,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,17 +32,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.ChevronRight
-import com.composables.icons.lucide.Lucide
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.AccentColor
-import io.github.seijikohara.femto.data.display.GoogleMapType
-import io.github.seijikohara.femto.data.display.MAX_MAP_ZOOM
-import io.github.seijikohara.femto.data.display.MIN_MAP_ZOOM
-import io.github.seijikohara.femto.data.display.MapBackend
-import io.github.seijikohara.femto.data.display.MapColorScheme
-import io.github.seijikohara.femto.data.display.MapStyleSetting
-import io.github.seijikohara.femto.data.display.MapboxStyle
 import io.github.seijikohara.femto.data.display.ThemeMode
 import io.github.seijikohara.femto.data.display.ThemePreset
 import io.github.seijikohara.femto.data.display.ThemePresets
@@ -55,20 +42,18 @@ import io.github.seijikohara.femto.ui.settings.components.ChoiceRow
 import io.github.seijikohara.femto.ui.settings.components.FontRow
 import io.github.seijikohara.femto.ui.settings.components.Header
 import io.github.seijikohara.femto.ui.settings.components.LocationSection
+import io.github.seijikohara.femto.ui.settings.components.MapSection
 import io.github.seijikohara.femto.ui.settings.components.PanelsSection
 import io.github.seijikohara.femto.ui.settings.components.ScreenSection
-import io.github.seijikohara.femto.ui.settings.components.SettingRow
 import io.github.seijikohara.femto.ui.settings.components.SettingsSection
 import io.github.seijikohara.femto.ui.settings.components.SettingsSubheader
 import io.github.seijikohara.femto.ui.settings.components.SliderRow
 import io.github.seijikohara.femto.ui.settings.components.SwitchRow
 import io.github.seijikohara.femto.ui.settings.components.SystemSection
-import io.github.seijikohara.femto.ui.settings.components.TrailingIcon
 import io.github.seijikohara.femto.ui.settings.components.UnitsSection
 import io.github.seijikohara.femto.ui.theme.DynamicAccentSweep
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
-import io.github.seijikohara.femto.ui.theme.LocalFemtoDarkTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.accentSeedColor
 
@@ -101,9 +86,6 @@ internal fun SettingsScreen(
     // surface reads as the sheet rather than painting the opaque app background.
     color = MaterialTheme.colorScheme.surfaceContainerLow,
 ) {
-    var showTokenDialog by remember { mutableStateOf(false) }
-    var showGoogleKeyDialog by remember { mutableStateOf(false) }
-    var showGoogleMapIdDialog by remember { mutableStateOf(false) }
     Column(
         modifier =
             Modifier
@@ -172,200 +154,7 @@ internal fun SettingsScreen(
 
         UnitsSection(uiState = uiState, onAction = onAction)
 
-        SettingsSection(title = stringResource(R.string.settings_section_map)) {
-            // Selecting Mapbox without a token, or Google Maps without an API key, opens
-            // the respective entry dialog instead of persisting the backend switch — the
-            // Screen owns this interception because the dialogs live here.
-            ChoiceRow(
-                title = stringResource(R.string.settings_map_backend),
-                options =
-                    listOf(
-                        MapBackend.OSM to stringResource(R.string.settings_map_backend_osm),
-                        MapBackend.MAPBOX to stringResource(R.string.settings_map_backend_mapbox),
-                        MapBackend.GOOGLEMAPS to stringResource(R.string.settings_map_backend_googlemaps),
-                    ),
-                selected = uiState.mapBackend,
-                onSelect = { backend ->
-                    onAction(SettingsAction.SetMapBackend(backend))
-                    // Open the credential dialog as a convenience when the credential is
-                    // blank — the backend switch already happened above, so the map area
-                    // shows the "missing credential" notice if the dialog is dismissed.
-                    when {
-                        backend == MapBackend.MAPBOX && uiState.mapboxAccessToken.isBlank() -> {
-                            showTokenDialog = true
-                        }
-
-                        backend == MapBackend.GOOGLEMAPS && uiState.googleMapsApiKey.isBlank() -> {
-                            showGoogleKeyDialog = true
-                        }
-                    }
-                },
-            )
-            AnimatedVisibility(visible = uiState.mapBackend == MapBackend.MAPBOX) {
-                Column {
-                    ChoiceRow(
-                        title = stringResource(R.string.settings_mapbox_style),
-                        options =
-                            listOf(
-                                MapboxStyle.STANDARD to stringResource(R.string.settings_mapbox_style_standard),
-                                MapboxStyle.SATELLITE to stringResource(R.string.settings_mapbox_style_satellite),
-                                MapboxStyle.STREETS to stringResource(R.string.settings_mapbox_style_streets),
-                            ),
-                        selected = uiState.mapboxStyle,
-                        onSelect = { onAction(SettingsAction.SetMapboxStyle(it)) },
-                    )
-                    SwitchRow(
-                        title = stringResource(R.string.settings_mapbox_traffic),
-                        checked = uiState.mapboxTraffic,
-                        onCheckedChange = { onAction(SettingsAction.SetMapboxTraffic(it)) },
-                    )
-                    SettingRow(
-                        title = stringResource(R.string.settings_mapbox_token),
-                        summary = mapboxTokenSummary(uiState.mapboxAccessToken),
-                        modifier = Modifier.clickable { showTokenDialog = true },
-                    ) {
-                        TrailingIcon(Lucide.ChevronRight)
-                    }
-                    Text(
-                        text = stringResource(R.string.settings_map_accent_osm_only_note),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
-                    )
-                }
-            }
-            AnimatedVisibility(visible = uiState.mapBackend == MapBackend.GOOGLEMAPS) {
-                Column {
-                    ChoiceRow(
-                        title = stringResource(R.string.settings_google_maps_type),
-                        options =
-                            listOf(
-                                GoogleMapType.ROADMAP to stringResource(R.string.settings_google_maps_type_roadmap),
-                                GoogleMapType.SATELLITE to stringResource(R.string.settings_google_maps_type_satellite),
-                                GoogleMapType.HYBRID to stringResource(R.string.settings_google_maps_type_hybrid),
-                                GoogleMapType.TERRAIN to stringResource(R.string.settings_google_maps_type_terrain),
-                            ),
-                        selected = uiState.googleMapsMapType,
-                        onSelect = { onAction(SettingsAction.SetGoogleMapsMapType(it)) },
-                    )
-                    SwitchRow(
-                        title = stringResource(R.string.settings_google_maps_traffic),
-                        checked = uiState.googleMapsTraffic,
-                        onCheckedChange = { onAction(SettingsAction.SetGoogleMapsTraffic(it)) },
-                    )
-                    SettingRow(
-                        title = stringResource(R.string.settings_google_maps_key),
-                        summary = googleMapsKeySummary(uiState.googleMapsApiKey),
-                        modifier = Modifier.clickable { showGoogleKeyDialog = true },
-                    ) {
-                        TrailingIcon(Lucide.ChevronRight)
-                    }
-                    // Optional: a Map ID upgrades the raster map to a vector style
-                    // (heading-up/3D). It does not switch the backend — the key
-                    // already selected Google Maps — so the Map ID is not masked.
-                    SettingRow(
-                        title = stringResource(R.string.settings_google_maps_map_id),
-                        summary = googleMapsMapIdSummary(uiState.googleMapsMapId),
-                        modifier = Modifier.clickable { showGoogleMapIdDialog = true },
-                    ) {
-                        TrailingIcon(Lucide.ChevronRight)
-                    }
-                    Text(
-                        text = stringResource(R.string.settings_map_accent_osm_only_note),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
-                    )
-                }
-            }
-            // MapStyleSetting.AUTO also drives Mapbox Standard's lightPreset (day/night),
-            // so it belongs outside the OSM-only block. AUTO already resolves to
-            // LocalFemtoDarkTheme.current (WebMapView.kt), i.e. it follows the app's
-            // Theme setting above — MapThemeMatchRow makes that relationship visible
-            // instead of presenting a second, unrelated-looking AUTO/LIGHT/DARK picker.
-            MapThemeMatchRow(
-                mapStyle = uiState.mapStyle,
-                onSelect = { onAction(SettingsAction.SetMapStyle(it)) },
-            )
-            AnimatedVisibility(visible = uiState.mapBackend == MapBackend.OSM) {
-                Column {
-                    SettingsSubheader(stringResource(R.string.settings_subheader_map_rendering))
-                    SwitchRow(
-                        title = stringResource(R.string.settings_group_map_3d),
-                        checked = uiState.map3dBuildings,
-                        onCheckedChange = { onAction(SettingsAction.SetMap3dBuildings(it)) },
-                    )
-                    SwitchRow(
-                        title = stringResource(R.string.settings_group_map_terrain),
-                        checked = uiState.mapTerrain,
-                        onCheckedChange = { onAction(SettingsAction.SetMapTerrain(it)) },
-                        summary = stringResource(R.string.settings_map_terrain_desc),
-                    )
-                    SettingsSubheader(stringResource(R.string.settings_subheader_map_appearance))
-                    // Light scheme applies for AUTO + LIGHT, Dark scheme for AUTO + DARK. AUTO
-                    // can use either (the system theme decides), so AUTO shows both; a fixed
-                    // LIGHT / DARK hides the scheme it never uses. Independent colour schemes:
-                    // ACCENT is the adaptive accent-tinted default, the rest fixed OpenFreeMap.
-                    AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.DARK) {
-                        ChoiceRow(
-                            title = stringResource(R.string.settings_group_map_scheme_light),
-                            options =
-                                listOf(
-                                    MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
-                                    MapColorScheme.POSITRON to stringResource(R.string.settings_map_scheme_positron),
-                                    MapColorScheme.BRIGHT to stringResource(R.string.settings_map_scheme_bright),
-                                    MapColorScheme.LIBERTY to stringResource(R.string.settings_map_scheme_liberty),
-                                ),
-                            selected = uiState.mapSchemeLight,
-                            onSelect = { onAction(SettingsAction.SetMapSchemeLight(it)) },
-                        )
-                    }
-                    AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.LIGHT) {
-                        ChoiceRow(
-                            title = stringResource(R.string.settings_group_map_scheme_dark),
-                            options =
-                                listOf(
-                                    MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
-                                    MapColorScheme.DARK_MATTER to
-                                        stringResource(R.string.settings_map_scheme_dark_matter),
-                                    MapColorScheme.DARK to stringResource(R.string.settings_map_scheme_dark),
-                                    MapColorScheme.FIORD to stringResource(R.string.settings_map_scheme_fiord),
-                                ),
-                            selected = uiState.mapSchemeDark,
-                            onSelect = { onAction(SettingsAction.SetMapSchemeDark(it)) },
-                        )
-                    }
-                }
-            }
-            SettingsSubheader(stringResource(R.string.settings_subheader_map_camera))
-            SliderRow(
-                title = stringResource(R.string.settings_group_map_tilt),
-                valueLabel = stringResource(R.string.settings_map_tilt_value, uiState.mapTiltDeg),
-                value = uiState.mapTiltDeg,
-                range = MIN_MAP_TILT..MAX_MAP_TILT,
-                onValueChange = { onAction(SettingsAction.SetMapTilt(it)) },
-            )
-            SliderRow(
-                title = stringResource(R.string.settings_group_map_zoom),
-                valueLabel = stringResource(R.string.settings_map_zoom_value, uiState.mapZoom),
-                value = uiState.mapZoom,
-                range = MIN_MAP_ZOOM..MAX_MAP_ZOOM,
-                onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
-            )
-            SwitchRow(
-                title = stringResource(R.string.settings_group_map_north_up),
-                checked = uiState.mapNorthUp,
-                onCheckedChange = { onAction(SettingsAction.SetMapNorthUp(it)) },
-                summary = stringResource(R.string.settings_map_north_up_desc),
-            )
-            SliderRow(
-                title = stringResource(R.string.settings_group_map_marker_pos),
-                valueLabel = stringResource(R.string.settings_map_marker_pos_value, uiState.mapMarkerPos),
-                value = uiState.mapMarkerPos,
-                range = MIN_MAP_MARKER_POS..MAX_MAP_MARKER_POS,
-                onValueChange = { onAction(SettingsAction.SetMapMarkerPos(it)) },
-            )
-        }
+        MapSection(uiState = uiState, onAction = onAction)
 
         LocationSection(uiState = uiState, onAction = onAction)
 
@@ -378,149 +167,6 @@ internal fun SettingsScreen(
             onOpenDiagnostics = onOpenDiagnostics,
             onOpenLicenses = onOpenLicenses,
             onOpenPrivacyPolicy = onOpenPrivacyPolicy,
-        )
-    }
-    if (showTokenDialog) {
-        var draft by remember { mutableStateOf(uiState.mapboxAccessToken) }
-        AlertDialog(
-            onDismissRequest = { showTokenDialog = false },
-            title = { Text(stringResource(R.string.settings_mapbox_token)) },
-            text = {
-                Column {
-                    OutlinedTextField(
-                        value = draft,
-                        onValueChange = { draft = it },
-                        singleLine = true,
-                        label = { Text(stringResource(R.string.settings_mapbox_token_hint)) },
-                    )
-                }
-            },
-            confirmButton = {
-                TextButton(
-                    enabled = draft.isNotBlank(),
-                    onClick = {
-                        // One atomic action: persist the token and select Mapbox
-                        // together so the gate never sees a blank-token MAPBOX.
-                        onAction(SettingsAction.SaveMapboxToken(draft))
-                        showTokenDialog = false
-                    },
-                ) { Text(stringResource(R.string.settings_mapbox_token_save)) }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        onAction(SettingsAction.ClearMapboxToken)
-                        showTokenDialog = false
-                    },
-                ) { Text(stringResource(R.string.settings_mapbox_token_clear)) }
-            },
-        )
-    }
-    if (showGoogleKeyDialog) {
-        var draft by remember { mutableStateOf(uiState.googleMapsApiKey) }
-        AlertDialog(
-            onDismissRequest = { showGoogleKeyDialog = false },
-            title = { Text(stringResource(R.string.settings_google_maps_key)) },
-            text = {
-                Column(
-                    // The setup/ToS disclosure runs several lines on a car display;
-                    // without scrolling it pushes the input field past the dialog's
-                    // bounded content height and clips it. Scroll keeps the field at
-                    // full height and reachable.
-                    modifier = Modifier.verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    // The setup/ToS disclosure is the point of this feature, so it lives as a
-                    // full body paragraph above the field (bodyMedium >= 18sp, never bodySmall)
-                    // rather than a floating label that truncates on a car display — the
-                    // deliberate divergence from the Mapbox dialog, whose hint fits in a label.
-                    Text(
-                        text = stringResource(R.string.settings_google_maps_key_hint),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    OutlinedTextField(
-                        value = draft,
-                        onValueChange = { draft = it },
-                        singleLine = true,
-                        label = { Text(stringResource(R.string.settings_google_maps_key)) },
-                    )
-                }
-            },
-            confirmButton = {
-                TextButton(
-                    enabled = draft.isNotBlank(),
-                    onClick = {
-                        // One atomic action: persist the key and select Google Maps
-                        // together so the gate never sees a blank-key GOOGLEMAPS.
-                        onAction(SettingsAction.SaveGoogleMapsKey(draft))
-                        showGoogleKeyDialog = false
-                    },
-                    modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
-                ) { Text(stringResource(R.string.settings_google_maps_key_save)) }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        onAction(SettingsAction.ClearGoogleMapsKey)
-                        showGoogleKeyDialog = false
-                    },
-                    modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
-                ) { Text(stringResource(R.string.settings_google_maps_key_clear)) }
-            },
-        )
-    }
-    if (showGoogleMapIdDialog) {
-        var draft by remember { mutableStateOf(uiState.googleMapsMapId) }
-        AlertDialog(
-            onDismissRequest = { showGoogleMapIdDialog = false },
-            title = { Text(stringResource(R.string.settings_google_maps_map_id)) },
-            text = {
-                Column(
-                    // The setup/ToS disclosure runs several lines on a car display;
-                    // without scrolling it pushes the input field past the dialog's
-                    // bounded content height and clips it. Scroll keeps the field at
-                    // full height and reachable.
-                    modifier = Modifier.verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    // The vector-vs-raster guidance is the point of this optional field,
-                    // so it lives as a full body paragraph above the input (bodyMedium
-                    // >= 18sp, never bodySmall), mirroring the API-key dialog.
-                    Text(
-                        text = stringResource(R.string.settings_google_maps_map_id_hint),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    OutlinedTextField(
-                        value = draft,
-                        onValueChange = { draft = it },
-                        singleLine = true,
-                        label = { Text(stringResource(R.string.settings_google_maps_map_id)) },
-                    )
-                }
-            },
-            confirmButton = {
-                TextButton(
-                    // Blank is a valid Map ID (it reverts to the raster map), so the
-                    // confirm button is always enabled.
-                    enabled = true,
-                    onClick = {
-                        onAction(SettingsAction.SetGoogleMapsMapId(draft))
-                        showGoogleMapIdDialog = false
-                    },
-                    modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
-                ) { Text(stringResource(R.string.settings_google_maps_map_id_save)) }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        onAction(SettingsAction.ClearGoogleMapsMapId)
-                        showGoogleMapIdDialog = false
-                    },
-                    modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
-                ) { Text(stringResource(R.string.settings_google_maps_map_id_clear)) }
-            },
         )
     }
 }
@@ -735,56 +381,6 @@ private fun ThemePresetChip(
     }
 }
 
-// Theme stays the one primary light/dark control; this is the map's secondary,
-// clearly-subordinate override. Checked (the default) means mapStyle == AUTO,
-// which already follows the app's resolved theme (LocalFemtoDarkTheme). Turning
-// it off freezes the map at whatever the app currently renders (no visual jump at
-// the instant of toggling) and reveals a plain Light/Dark choice for further
-// manual override.
-@Composable
-private fun MapThemeMatchRow(
-    mapStyle: MapStyleSetting,
-    onSelect: (MapStyleSetting) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val appIsDark = LocalFemtoDarkTheme.current
-    SwitchRow(
-        title = stringResource(R.string.settings_map_match_theme),
-        summary = stringResource(R.string.settings_map_match_theme_desc),
-        checked = mapStyle == MapStyleSetting.AUTO,
-        onCheckedChange = { matchTheme ->
-            onSelect(
-                when {
-                    matchTheme -> MapStyleSetting.AUTO
-                    appIsDark -> MapStyleSetting.DARK
-                    else -> MapStyleSetting.LIGHT
-                },
-            )
-        },
-        modifier = modifier,
-    )
-    AnimatedVisibility(visible = mapStyle != MapStyleSetting.AUTO) {
-        ChoiceRow(
-            title = stringResource(R.string.settings_group_map_style),
-            options =
-                listOf(
-                    MapStyleSetting.LIGHT to stringResource(R.string.settings_theme_light),
-                    MapStyleSetting.DARK to stringResource(R.string.settings_theme_dark),
-                ),
-            selected = mapStyle,
-            onSelect = onSelect,
-        )
-    }
-}
-
-private const val MIN_MAP_TILT = 0
-private const val MAX_MAP_TILT = 60
-
-// Marker vertical-position band (percent): 0 centres the marker; 100 drops it to
-// just above the speed panel.
-private const val MIN_MAP_MARKER_POS = 0
-private const val MAX_MAP_MARKER_POS = 100
-
 // Glass-overlay blur radius (dp) and tint opacity (percent of the per-theme base
 // alpha; 100 = the default look, 0 = no tint).
 private const val MIN_GLASS_BLUR = 0
@@ -816,31 +412,6 @@ private fun ThemePreset.labelRes(): Int =
         "dusk" -> R.string.theme_preset_dusk
         else -> R.string.theme_preset_dynamic
     }
-
-// Masks all but the last four characters of the token so it is not fully visible
-// on a shared in-car screen, while still letting the user confirm which key is set.
-@Composable
-private fun mapboxTokenSummary(token: String): String =
-    if (token.isBlank()) {
-        stringResource(R.string.settings_mapbox_token_unset)
-    } else {
-        "••••" + token.takeLast(4)
-    }
-
-// Same masking pattern as mapboxTokenSummary, applied to the Google Maps API key.
-@Composable
-private fun googleMapsKeySummary(key: String): String =
-    if (key.isBlank()) {
-        stringResource(R.string.settings_google_maps_key_unset)
-    } else {
-        "••••" + key.takeLast(4)
-    }
-
-// The Map ID is not secret (it only names a console-defined style), so it is
-// shown verbatim — no masking, unlike the API key above.
-@Composable
-private fun googleMapsMapIdSummary(mapId: String): String =
-    mapId.ifBlank { stringResource(R.string.settings_google_maps_map_id_unset) }
 
 @PreviewLightDark
 @Composable

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -15,11 +15,9 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -34,19 +32,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ChevronRight
 import com.composables.icons.lucide.Lucide
 import io.github.seijikohara.femto.R
-import io.github.seijikohara.femto.data.calendar.CalendarInfo
 import io.github.seijikohara.femto.data.display.AccentColor
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
-import io.github.seijikohara.femto.data.display.ClockSetting
 import io.github.seijikohara.femto.data.display.DockPosition
 import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.GoogleMapType
@@ -57,25 +51,24 @@ import io.github.seijikohara.femto.data.display.MapColorScheme
 import io.github.seijikohara.femto.data.display.MapStyleSetting
 import io.github.seijikohara.femto.data.display.MapboxStyle
 import io.github.seijikohara.femto.data.display.OrientationSetting
-import io.github.seijikohara.femto.data.display.SpeedUnitSetting
-import io.github.seijikohara.femto.data.display.TemperatureUnitSetting
 import io.github.seijikohara.femto.data.display.ThemeMode
 import io.github.seijikohara.femto.data.display.ThemePreset
 import io.github.seijikohara.femto.data.display.ThemePresets
 import io.github.seijikohara.femto.data.display.UiScale
 import io.github.seijikohara.femto.data.fonts.FontSlot
-import io.github.seijikohara.femto.data.location.LocationQualitySetting
-import io.github.seijikohara.femto.ui.settings.components.ActionRow
 import io.github.seijikohara.femto.ui.settings.components.ChoiceRow
 import io.github.seijikohara.femto.ui.settings.components.FontRow
 import io.github.seijikohara.femto.ui.settings.components.Header
-import io.github.seijikohara.femto.ui.settings.components.ResetRow
+import io.github.seijikohara.femto.ui.settings.components.LocationSection
+import io.github.seijikohara.femto.ui.settings.components.PanelsSection
 import io.github.seijikohara.femto.ui.settings.components.SettingRow
 import io.github.seijikohara.femto.ui.settings.components.SettingsSection
 import io.github.seijikohara.femto.ui.settings.components.SettingsSubheader
 import io.github.seijikohara.femto.ui.settings.components.SliderRow
 import io.github.seijikohara.femto.ui.settings.components.SwitchRow
+import io.github.seijikohara.femto.ui.settings.components.SystemSection
 import io.github.seijikohara.femto.ui.settings.components.TrailingIcon
+import io.github.seijikohara.femto.ui.settings.components.UnitsSection
 import io.github.seijikohara.femto.ui.theme.DynamicAccentSweep
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -234,46 +227,7 @@ internal fun SettingsScreen(
             )
         }
 
-        SettingsSection(title = stringResource(R.string.settings_section_units)) {
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_speed),
-                options =
-                    listOf(
-                        SpeedUnitSetting.AUTO to stringResource(R.string.settings_option_auto),
-                        SpeedUnitSetting.KILOMETERS to stringResource(R.string.settings_speed_km),
-                        SpeedUnitSetting.MILES to stringResource(R.string.settings_speed_mi),
-                    ),
-                selected = uiState.speedUnit,
-                onSelect = { onAction(SettingsAction.SetSpeedUnit(it)) },
-            )
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_temperature),
-                options =
-                    listOf(
-                        TemperatureUnitSetting.AUTO to stringResource(R.string.settings_option_auto),
-                        TemperatureUnitSetting.CELSIUS to stringResource(R.string.settings_temp_celsius),
-                        TemperatureUnitSetting.FAHRENHEIT to stringResource(R.string.settings_temp_fahrenheit),
-                    ),
-                selected = uiState.temperatureUnit,
-                onSelect = { onAction(SettingsAction.SetTemperatureUnit(it)) },
-            )
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_clock),
-                options =
-                    listOf(
-                        ClockSetting.AUTO to stringResource(R.string.settings_option_auto),
-                        ClockSetting.TWELVE_HOUR to stringResource(R.string.settings_clock_12),
-                        ClockSetting.TWENTY_FOUR_HOUR to stringResource(R.string.settings_clock_24),
-                    ),
-                selected = uiState.clock,
-                onSelect = { onAction(SettingsAction.SetClock(it)) },
-            )
-            SwitchRow(
-                title = stringResource(R.string.settings_group_clock_seconds),
-                checked = uiState.showClockSeconds,
-                onCheckedChange = { onAction(SettingsAction.SetShowClockSeconds(it)) },
-            )
-        }
+        UnitsSection(uiState = uiState, onAction = onAction)
 
         SettingsSection(title = stringResource(R.string.settings_section_map)) {
             // Selecting Mapbox without a token, or Google Maps without an API key, opens
@@ -470,111 +424,18 @@ internal fun SettingsScreen(
             )
         }
 
-        SettingsSection(title = stringResource(R.string.settings_section_location)) {
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_location_quality),
-                options =
-                    listOf(
-                        LocationQualitySetting.HIGH_ACCURACY to
-                            stringResource(R.string.settings_location_quality_high),
-                        LocationQualitySetting.BALANCED to
-                            stringResource(R.string.settings_location_quality_balanced),
-                        LocationQualitySetting.LOW_POWER to
-                            stringResource(R.string.settings_location_quality_low),
-                    ),
-                selected = uiState.locationQuality,
-                onSelect = { onAction(SettingsAction.SetLocationQuality(it)) },
-            )
-            // The slider works in 250 ms steps so the knob lands on round values;
-            // the persisted value stays in milliseconds.
-            SliderRow(
-                title = stringResource(R.string.settings_group_location_interval),
-                valueLabel =
-                    stringResource(R.string.settings_location_interval_value, uiState.locationIntervalMillis),
-                value = (uiState.locationIntervalMillis / LOCATION_INTERVAL_STEP_MS).toInt(),
-                range = MIN_LOCATION_INTERVAL_STEPS..MAX_LOCATION_INTERVAL_STEPS,
-                onValueChange = { onAction(SettingsAction.SetLocationIntervalMillis(it * LOCATION_INTERVAL_STEP_MS)) },
-                description = stringResource(R.string.settings_location_interval_desc),
-            )
-            SliderRow(
-                title = stringResource(R.string.settings_group_location_min_distance),
-                valueLabel =
-                    stringResource(R.string.settings_location_min_distance_value, uiState.locationMinDistanceMeters),
-                value = uiState.locationMinDistanceMeters,
-                range = MIN_LOCATION_MIN_DISTANCE..MAX_LOCATION_MIN_DISTANCE,
-                onValueChange = { onAction(SettingsAction.SetLocationMinDistance(it)) },
-                description = stringResource(R.string.settings_location_min_distance_desc),
-            )
-            SwitchRow(
-                title = stringResource(R.string.settings_group_background_ranging),
-                checked = uiState.backgroundRangingEnabled,
-                onCheckedChange = { onAction(SettingsAction.SetBackgroundRanging(it)) },
-                summary = stringResource(R.string.settings_background_ranging_desc),
-            )
-        }
+        LocationSection(uiState = uiState, onAction = onAction)
 
-        SettingsSection(title = stringResource(R.string.settings_section_panels)) {
-            SwitchRow(
-                title = stringResource(R.string.settings_group_panel_calendar),
-                checked = uiState.showCalendar,
-                onCheckedChange = { onAction(SettingsAction.SetShowCalendar(it)) },
-            )
-            AnimatedVisibility(visible = uiState.showCalendar) {
-                MultiSelectRow(
-                    title = stringResource(R.string.settings_visible_calendars),
-                    summary = visibleCalendarsSummary(
-                        uiState.hasCalendarAccess,
-                        uiState.availableCalendars,
-                        uiState.hiddenCalendarIds,
-                    ),
-                    hasCalendarAccess = uiState.hasCalendarAccess,
-                    calendars = uiState.availableCalendars,
-                    hiddenIds = uiState.hiddenCalendarIds,
-                    onToggle = { id, hidden -> onAction(SettingsAction.SetCalendarHidden(id, hidden)) },
-                    onOpenAppSettings = onOpenSystemSettings,
-                )
-            }
-            SwitchRow(
-                title = stringResource(R.string.settings_group_panel_weather),
-                checked = uiState.showWeather,
-                onCheckedChange = { onAction(SettingsAction.SetShowWeather(it)) },
-            )
-            SwitchRow(
-                title = stringResource(R.string.settings_group_panel_music),
-                checked = uiState.showMusic,
-                onCheckedChange = { onAction(SettingsAction.SetShowMusic(it)) },
-            )
-            SwitchRow(
-                title = stringResource(R.string.settings_group_panel_music_spectrum),
-                checked = uiState.musicSpectrum,
-                onCheckedChange = { onAction(SettingsAction.SetMusicSpectrum(it)) },
-                summary = stringResource(R.string.settings_panel_music_spectrum_desc),
-            )
-        }
+        PanelsSection(uiState = uiState, onAction = onAction, onOpenSystemSettings = onOpenSystemSettings)
 
-        SettingsSection(title = stringResource(R.string.settings_group_system)) {
-            ActionRow(
-                title = stringResource(R.string.settings_open_notification_access),
-                onClick = onOpenNotificationAccess,
-            )
-            ActionRow(
-                title = stringResource(R.string.settings_open_system_settings),
-                onClick = onOpenSystemSettings,
-            )
-            ActionRow(
-                title = stringResource(R.string.settings_open_diagnostics),
-                onClick = onOpenDiagnostics,
-            )
-            ActionRow(
-                title = stringResource(R.string.settings_open_licenses),
-                onClick = onOpenLicenses,
-            )
-            ActionRow(
-                title = stringResource(R.string.settings_open_privacy),
-                onClick = onOpenPrivacyPolicy,
-            )
-            ResetRow(onConfirm = { onAction(SettingsAction.ResetToDefaults) })
-        }
+        SystemSection(
+            onAction = onAction,
+            onOpenNotificationAccess = onOpenNotificationAccess,
+            onOpenSystemSettings = onOpenSystemSettings,
+            onOpenDiagnostics = onOpenDiagnostics,
+            onOpenLicenses = onOpenLicenses,
+            onOpenPrivacyPolicy = onOpenPrivacyPolicy,
+        )
     }
     if (showTokenDialog) {
         var draft by remember { mutableStateOf(uiState.mapboxAccessToken) }
@@ -988,14 +849,6 @@ private const val MAX_GLASS_BLUR = 40
 private const val MIN_GLASS_OPACITY = 0
 private const val MAX_GLASS_OPACITY = 100
 
-// Location-request interval slider, in 250 ms steps (250 ms – 2 s); the persisted
-// value is milliseconds. Minimum-distance band in metres; 0 delivers every fix.
-private const val LOCATION_INTERVAL_STEP_MS = 250L
-private const val MIN_LOCATION_INTERVAL_STEPS = 1
-private const val MAX_LOCATION_INTERVAL_STEPS = 8
-private const val MIN_LOCATION_MIN_DISTANCE = 0
-private const val MAX_LOCATION_MIN_DISTANCE = 25
-
 private fun Boolean.toFullscreen(): FullscreenSetting = if (this) FullscreenSetting.ON else FullscreenSetting.OFF
 
 // The human-readable label for an accent, used as each swatch's content
@@ -1022,148 +875,6 @@ private fun ThemePreset.labelRes(): Int =
         "dusk" -> R.string.theme_preset_dusk
         else -> R.string.theme_preset_dynamic
     }
-
-// Summarises the current visible-calendar selection in one line for the row subtitle.
-// Three distinct states: permission denied, granted but no calendars, or a count of
-// visible vs total. An empty hidden-ids set means every calendar is shown.
-@Composable
-private fun visibleCalendarsSummary(
-    hasCalendarAccess: Boolean,
-    calendars: List<CalendarInfo>,
-    hiddenIds: Set<Long>,
-): String =
-    when {
-        !hasCalendarAccess -> {
-            stringResource(R.string.settings_visible_calendars_none)
-        }
-
-        calendars.isEmpty() -> {
-            stringResource(R.string.settings_visible_calendars_empty)
-        }
-
-        hiddenIds.isEmpty() -> {
-            stringResource(R.string.settings_visible_calendars_all)
-        }
-
-        else -> {
-            val shown = calendars.count { it.id !in hiddenIds }
-            stringResource(R.string.settings_visible_calendars_count, shown, calendars.size)
-        }
-    }
-
-// A choice row that opens a multi-select dialog — same open/dismiss pattern as
-// ChoiceRow, but the dialog hosts checkboxes instead of radio buttons so multiple
-// calendars can be independently toggled.
-@Composable
-private fun MultiSelectRow(
-    title: String,
-    summary: String,
-    hasCalendarAccess: Boolean,
-    calendars: List<CalendarInfo>,
-    hiddenIds: Set<Long>,
-    onToggle: (Long, Boolean) -> Unit,
-    onOpenAppSettings: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var open by remember { mutableStateOf(false) }
-    SettingRow(
-        modifier = modifier.clickable { open = true },
-        title = title,
-        summary = summary,
-    )
-    if (open) {
-        MultiSelectDialog(
-            title = title,
-            hasCalendarAccess = hasCalendarAccess,
-            calendars = calendars,
-            hiddenIds = hiddenIds,
-            onToggle = onToggle,
-            onOpenAppSettings = onOpenAppSettings,
-            onDismiss = { open = false },
-        )
-    }
-}
-
-// Multi-select dialog for the visible-calendars picker. Three states: permission
-// denied (shows a grant button linking to system settings), granted but no calendars
-// found, or the checkbox list. Each calendar row shows a colour dot (12 dp decorative
-// marker from CalendarInfo.color), display name, and account name. The whole row is
-// the toggle target (toggleable with Role.Checkbox); the Checkbox is visual-only
-// (onCheckedChange = null) so a single tap never double-fires. Touch targets meet
-// FemtoDimens.MinTouchTarget; text uses bodyLarge / bodyMedium.
-@Composable
-private fun MultiSelectDialog(
-    title: String,
-    hasCalendarAccess: Boolean,
-    calendars: List<CalendarInfo>,
-    hiddenIds: Set<Long>,
-    onToggle: (Long, Boolean) -> Unit,
-    onOpenAppSettings: () -> Unit,
-    onDismiss: () -> Unit,
-) = AlertDialog(
-    onDismissRequest = onDismiss,
-    title = { Text(title) },
-    text = {
-        when {
-            !hasCalendarAccess -> {
-                Column {
-                    Text(stringResource(R.string.settings_visible_calendars_none))
-                    TextButton(
-                        onClick = {
-                            onOpenAppSettings()
-                            onDismiss()
-                        },
-                        modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
-                    ) {
-                        Text(stringResource(R.string.settings_open_system_settings))
-                    }
-                }
-            }
-
-            calendars.isEmpty() -> {
-                Text(stringResource(R.string.settings_visible_calendars_empty))
-            }
-
-            else -> {
-                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                    calendars.forEach { calendar ->
-                        val shown = calendar.id !in hiddenIds
-                        Row(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .heightIn(min = FemtoDimens.MinTouchTarget)
-                                    // Hidden is the inverse of the new shown state.
-                                    .toggleable(
-                                        value = shown,
-                                        role = Role.Checkbox,
-                                        onValueChange = { newShown -> onToggle(calendar.id, !newShown) },
-                                    ),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        ) {
-                            Checkbox(checked = shown, onCheckedChange = null)
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .size(12.dp)
-                                        .clip(CircleShape)
-                                        .background(Color(calendar.color)),
-                            )
-                            Column {
-                                Text(calendar.displayName, style = MaterialTheme.typography.bodyLarge)
-                                Text(calendar.accountName, style = MaterialTheme.typography.bodyMedium)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    },
-    confirmButton = {
-        TextButton(onClick = onDismiss) { Text(stringResource(R.string.settings_dialog_close)) }
-    },
-)
 
 // Masks all but the last four characters of the token so it is not fully visible
 // on a shared in-car screen, while still letting the user confirm which key is set.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -375,6 +375,12 @@ internal fun SettingsScreen(
                     ) {
                         TrailingIcon(Lucide.ChevronRight)
                     }
+                    Text(
+                        text = stringResource(R.string.settings_map_accent_osm_only_note),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                    )
                 }
             }
             // MapStyleSetting.AUTO also drives Mapbox Standard's lightPreset (day/night),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -1,61 +1,28 @@
 package io.github.seijikohara.femto.ui.settings
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import io.github.seijikohara.femto.R
-import io.github.seijikohara.femto.data.display.AccentColor
-import io.github.seijikohara.femto.data.display.ThemeMode
-import io.github.seijikohara.femto.data.display.ThemePreset
-import io.github.seijikohara.femto.data.display.ThemePresets
 import io.github.seijikohara.femto.data.fonts.FontSlot
-import io.github.seijikohara.femto.ui.settings.components.ChoiceRow
-import io.github.seijikohara.femto.ui.settings.components.FontRow
+import io.github.seijikohara.femto.ui.settings.components.AppearanceSection
 import io.github.seijikohara.femto.ui.settings.components.Header
 import io.github.seijikohara.femto.ui.settings.components.LocationSection
 import io.github.seijikohara.femto.ui.settings.components.MapSection
 import io.github.seijikohara.femto.ui.settings.components.PanelsSection
 import io.github.seijikohara.femto.ui.settings.components.ScreenSection
-import io.github.seijikohara.femto.ui.settings.components.SettingsSection
-import io.github.seijikohara.femto.ui.settings.components.SettingsSubheader
-import io.github.seijikohara.femto.ui.settings.components.SliderRow
-import io.github.seijikohara.femto.ui.settings.components.SwitchRow
 import io.github.seijikohara.femto.ui.settings.components.SystemSection
 import io.github.seijikohara.femto.ui.settings.components.UnitsSection
-import io.github.seijikohara.femto.ui.theme.DynamicAccentSweep
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
-import io.github.seijikohara.femto.ui.theme.accentSeedColor
 
 /**
  * In-app settings, laid out like the Android system Settings app: category
@@ -96,59 +63,7 @@ internal fun SettingsScreen(
     ) {
         Header(onBack = onBack)
 
-        SettingsSection(title = stringResource(R.string.settings_section_display)) {
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_theme),
-                options =
-                    listOf(
-                        ThemeMode.SYSTEM to stringResource(R.string.settings_option_auto),
-                        ThemeMode.LIGHT to stringResource(R.string.settings_theme_light),
-                        ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
-                    ),
-                selected = uiState.themeMode,
-                onSelect = { onAction(SettingsAction.SetThemeMode(it)) },
-            )
-            AccentRow(
-                selected = uiState.accentColor,
-                onSelect = { onAction(SettingsAction.SetAccentColor(it)) },
-            )
-            ThemePresetRow(
-                accentColor = uiState.accentColor,
-                selectedPreset =
-                    ThemePresets.matchingOrNull(
-                        accentColor = uiState.accentColor,
-                        mapSchemeLight = uiState.mapSchemeLight,
-                        mapSchemeDark = uiState.mapSchemeDark,
-                    ),
-                onSelect = { onAction(SettingsAction.ApplyThemePreset(it)) },
-            )
-            SettingsSubheader(stringResource(R.string.settings_subheader_glass))
-            SliderRow(
-                title = stringResource(R.string.settings_group_glass_blur),
-                valueLabel = stringResource(R.string.settings_glass_blur_value, uiState.glassBlurRadius),
-                value = uiState.glassBlurRadius,
-                range = MIN_GLASS_BLUR..MAX_GLASS_BLUR,
-                onValueChange = { onAction(SettingsAction.SetGlassBlurRadius(it)) },
-            )
-            SliderRow(
-                title = stringResource(R.string.settings_group_glass_opacity),
-                valueLabel = stringResource(R.string.settings_glass_opacity_value, uiState.glassTintScale),
-                value = uiState.glassTintScale,
-                range = MIN_GLASS_OPACITY..MAX_GLASS_OPACITY,
-                onValueChange = { onAction(SettingsAction.SetGlassTintScale(it)) },
-            )
-            SettingsSubheader(stringResource(R.string.settings_subheader_fonts))
-            FontRow(
-                title = stringResource(R.string.settings_group_font_latin),
-                family = uiState.latinFont,
-                onClick = { onOpenFontPicker(FontSlot.LATIN) },
-            )
-            FontRow(
-                title = stringResource(R.string.settings_group_font_cjk),
-                family = uiState.cjkFont,
-                onClick = { onOpenFontPicker(FontSlot.CJK) },
-            )
-        }
+        AppearanceSection(uiState = uiState, onAction = onAction, onOpenFontPicker = onOpenFontPicker)
 
         ScreenSection(uiState = uiState, onAction = onAction)
 
@@ -170,248 +85,6 @@ internal fun SettingsScreen(
         )
     }
 }
-
-// The accent picker: a title over a horizontally-scrolling row of color swatches.
-// Selecting a swatch applies its seed immediately, so the picker (and the whole
-// app) recolors live. DYNAMIC keeps Material You wallpaper color.
-@Composable
-private fun AccentRow(
-    selected: AccentColor,
-    onSelect: (AccentColor) -> Unit,
-    modifier: Modifier = Modifier,
-) = Column(
-    modifier =
-        modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 12.dp),
-    verticalArrangement = Arrangement.spacedBy(10.dp),
-) {
-    Text(
-        text = stringResource(R.string.settings_group_accent),
-        style = MaterialTheme.typography.titleMedium,
-        color = MaterialTheme.colorScheme.onSurface,
-    )
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        AccentColor.entries.forEach { accent ->
-            AccentSwatch(
-                accent = accent,
-                selected = accent == selected,
-                onClick = { onSelect(accent) },
-            )
-        }
-    }
-}
-
-// One accent swatch: a >= MinTouchTarget tap target around a circular color chip.
-// A preset shows its seed; DYNAMIC shows a sweep gradient to read as "automatic".
-// The selected chip grows and gains an onSurface ring (color-agnostic, unlike a
-// tinted check that could vanish on a light seed).
-@Composable
-private fun AccentSwatch(
-    accent: AccentColor,
-    selected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val description = stringResource(accent.labelRes())
-    val seed = accent.accentSeedColor()
-    val ringColor =
-        if (selected) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outlineVariant
-    Box(
-        modifier =
-            modifier
-                .size(FemtoDimens.MinTouchTarget)
-                .clip(CircleShape)
-                .clickable(onClick = onClick)
-                .semantics { contentDescription = description },
-        contentAlignment = Alignment.Center,
-    ) {
-        val fill =
-            if (seed != null) {
-                Modifier.background(seed)
-            } else {
-                Modifier.background(Brush.sweepGradient(DynamicAccentSweep))
-            }
-        Box(
-            modifier =
-                Modifier
-                    .size(if (selected) 44.dp else 38.dp)
-                    .clip(CircleShape)
-                    .then(fill)
-                    .border(
-                        width = if (selected) 3.dp else 1.dp,
-                        color = ringColor,
-                        shape = CircleShape,
-                    ),
-        )
-    }
-}
-
-// The theme-preset picker: named bundles of accent + map colour schemes from the
-// ThemePresets registry. Tapping one applies the whole look at once; the accent
-// and map-scheme controls then reflect it. The data-driven "theme as data"
-// surface — mass-producing a theme is a registry entry, not new UI here. When the
-// current accent/map-scheme combination matches no registered bundle, a
-// non-interactive "Custom" chip renders instead of leaving every chip unselected,
-// so a fine-tuned combination reads as a deliberate state rather than a stale one.
-@Composable
-private fun ThemePresetRow(
-    accentColor: AccentColor,
-    selectedPreset: ThemePreset?,
-    onSelect: (ThemePreset) -> Unit,
-    modifier: Modifier = Modifier,
-) = Column(
-    modifier =
-        modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 12.dp),
-    verticalArrangement = Arrangement.spacedBy(10.dp),
-) {
-    Text(
-        text = stringResource(R.string.settings_group_theme_preset),
-        style = MaterialTheme.typography.titleMedium,
-        color = MaterialTheme.colorScheme.onSurface,
-    )
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        ThemePresets.all.forEach { preset ->
-            ThemePresetChip(
-                preset = preset,
-                selected = preset == selectedPreset,
-                onClick = { onSelect(preset) },
-            )
-        }
-        if (selectedPreset == null) {
-            CustomPresetChip(accentColor = accentColor)
-        }
-    }
-}
-
-// The "you are here" readout when no preset bundle matches: same visual weight as
-// a selected ThemePresetChip (secondaryContainer fill + primary border) but not
-// clickable — Custom is a status, not an action to invoke. The dot shows the
-// CURRENT accent live, since there is no single preset color to show.
-@Composable
-private fun CustomPresetChip(
-    accentColor: AccentColor,
-    modifier: Modifier = Modifier,
-) {
-    val seed = accentColor.accentSeedColor()
-    Row(
-        modifier =
-            modifier
-                .heightIn(min = FemtoDimens.MinTouchTarget)
-                .clip(MaterialTheme.shapes.large)
-                .background(MaterialTheme.colorScheme.secondaryContainer)
-                .border(width = 2.dp, color = MaterialTheme.colorScheme.primary, shape = MaterialTheme.shapes.large)
-                .padding(horizontal = 16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        val dot = if (seed !=
-            null
-        ) {
-            Modifier.background(seed)
-        } else {
-            Modifier.background(Brush.sweepGradient(DynamicAccentSweep))
-        }
-        Box(modifier = Modifier.size(20.dp).clip(CircleShape).then(dot))
-        Text(
-            text = stringResource(R.string.settings_theme_preset_custom),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
-        )
-    }
-}
-
-// One preset chip: the accent seed dot + the preset name, in a >= MinTouchTarget
-// tap target. Selected swaps to the secondaryContainer fill + a primary border
-// (the same color-agnostic emphasis the accent swatch uses).
-@Composable
-private fun ThemePresetChip(
-    preset: ThemePreset,
-    selected: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val seed = preset.accentColor.accentSeedColor()
-    val fill =
-        if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceContainerHigh
-    val border =
-        if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
-    val labelColor =
-        if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
-    Row(
-        modifier =
-            modifier
-                .heightIn(min = FemtoDimens.MinTouchTarget)
-                .clip(MaterialTheme.shapes.large)
-                .background(fill)
-                .border(width = if (selected) 2.dp else 1.dp, color = border, shape = MaterialTheme.shapes.large)
-                .clickable(onClick = onClick)
-                .padding(horizontal = 16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        val dot =
-            if (seed !=
-                null
-            ) {
-                Modifier.background(seed)
-            } else {
-                Modifier.background(Brush.sweepGradient(DynamicAccentSweep))
-            }
-        Box(modifier = Modifier.size(20.dp).clip(CircleShape).then(dot))
-        Text(
-            text = stringResource(preset.labelRes()),
-            style = MaterialTheme.typography.titleMedium,
-            color = labelColor,
-        )
-    }
-}
-
-// Glass-overlay blur radius (dp) and tint opacity (percent of the per-theme base
-// alpha; 100 = the default look, 0 = no tint).
-private const val MIN_GLASS_BLUR = 0
-private const val MAX_GLASS_BLUR = 40
-private const val MIN_GLASS_OPACITY = 0
-private const val MAX_GLASS_OPACITY = 100
-
-// The human-readable label for an accent, used as each swatch's content
-// description (the swatches are color-only, so they need an accessible name).
-private fun AccentColor.labelRes(): Int =
-    when (this) {
-        AccentColor.DYNAMIC -> R.string.settings_accent_dynamic
-        AccentColor.BLUE -> R.string.settings_accent_blue
-        AccentColor.TEAL -> R.string.settings_accent_teal
-        AccentColor.GREEN -> R.string.settings_accent_green
-        AccentColor.AMBER -> R.string.settings_accent_amber
-        AccentColor.ORANGE -> R.string.settings_accent_orange
-        AccentColor.RED -> R.string.settings_accent_red
-        AccentColor.VIOLET -> R.string.settings_accent_violet
-        AccentColor.PINK -> R.string.settings_accent_pink
-    }
-
-// The display name for a theme preset (keyed by ThemePreset.key, so the registry
-// stays free of any resource dependency).
-private fun ThemePreset.labelRes(): Int =
-    when (key) {
-        "ocean" -> R.string.theme_preset_ocean
-        "forest" -> R.string.theme_preset_forest
-        "dusk" -> R.string.theme_preset_dusk
-        else -> R.string.theme_preset_dynamic
-    }
 
 @PreviewLightDark
 @Composable

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -80,6 +80,7 @@ import io.github.seijikohara.femto.ui.theme.DynamicAccentSweep
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoIcon
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.LocalFemtoDarkTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.accentSeedColor
 import kotlin.math.roundToInt
@@ -376,17 +377,13 @@ internal fun SettingsScreen(
                     }
                 }
             }
-            // The AUTO/LIGHT/DARK map style also drives Mapbox Standard's lightPreset
-            // (day/night), so it belongs outside the OSM-only block.
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_map_style),
-                options =
-                    listOf(
-                        MapStyleSetting.AUTO to stringResource(R.string.settings_option_auto),
-                        MapStyleSetting.LIGHT to stringResource(R.string.settings_theme_light),
-                        MapStyleSetting.DARK to stringResource(R.string.settings_theme_dark),
-                    ),
-                selected = uiState.mapStyle,
+            // MapStyleSetting.AUTO also drives Mapbox Standard's lightPreset (day/night),
+            // so it belongs outside the OSM-only block. AUTO already resolves to
+            // LocalFemtoDarkTheme.current (WebMapView.kt), i.e. it follows the app's
+            // Theme setting above — MapThemeMatchRow makes that relationship visible
+            // instead of presenting a second, unrelated-looking AUTO/LIGHT/DARK picker.
+            MapThemeMatchRow(
+                mapStyle = uiState.mapStyle,
                 onSelect = { onAction(SettingsAction.SetMapStyle(it)) },
             )
             AnimatedVisibility(visible = uiState.mapBackend == MapBackend.OSM) {
@@ -997,6 +994,48 @@ private fun ThemePresetChip(
             text = stringResource(preset.labelRes()),
             style = MaterialTheme.typography.titleMedium,
             color = labelColor,
+        )
+    }
+}
+
+// Theme stays the one primary light/dark control; this is the map's secondary,
+// clearly-subordinate override. Checked (the default) means mapStyle == AUTO,
+// which already follows the app's resolved theme (LocalFemtoDarkTheme). Turning
+// it off freezes the map at whatever the app currently renders (no visual jump at
+// the instant of toggling) and reveals a plain Light/Dark choice for further
+// manual override.
+@Composable
+private fun MapThemeMatchRow(
+    mapStyle: MapStyleSetting,
+    onSelect: (MapStyleSetting) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val appIsDark = LocalFemtoDarkTheme.current
+    SwitchRow(
+        title = stringResource(R.string.settings_map_match_theme),
+        summary = stringResource(R.string.settings_map_match_theme_desc),
+        checked = mapStyle == MapStyleSetting.AUTO,
+        onCheckedChange = { matchTheme ->
+            onSelect(
+                when {
+                    matchTheme -> MapStyleSetting.AUTO
+                    appIsDark -> MapStyleSetting.DARK
+                    else -> MapStyleSetting.LIGHT
+                },
+            )
+        },
+        modifier = modifier,
+    )
+    AnimatedVisibility(visible = mapStyle != MapStyleSetting.AUTO) {
+        ChoiceRow(
+            title = stringResource(R.string.settings_group_map_style),
+            options =
+                listOf(
+                    MapStyleSetting.LIGHT to stringResource(R.string.settings_theme_light),
+                    MapStyleSetting.DARK to stringResource(R.string.settings_theme_dark),
+                ),
+            selected = mapStyle,
+            onSelect = onSelect,
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -40,9 +40,6 @@ import com.composables.icons.lucide.ChevronRight
 import com.composables.icons.lucide.Lucide
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.AccentColor
-import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
-import io.github.seijikohara.femto.data.display.DockPosition
-import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.GoogleMapType
 import io.github.seijikohara.femto.data.display.MAX_MAP_ZOOM
 import io.github.seijikohara.femto.data.display.MIN_MAP_ZOOM
@@ -50,17 +47,16 @@ import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.display.MapColorScheme
 import io.github.seijikohara.femto.data.display.MapStyleSetting
 import io.github.seijikohara.femto.data.display.MapboxStyle
-import io.github.seijikohara.femto.data.display.OrientationSetting
 import io.github.seijikohara.femto.data.display.ThemeMode
 import io.github.seijikohara.femto.data.display.ThemePreset
 import io.github.seijikohara.femto.data.display.ThemePresets
-import io.github.seijikohara.femto.data.display.UiScale
 import io.github.seijikohara.femto.data.fonts.FontSlot
 import io.github.seijikohara.femto.ui.settings.components.ChoiceRow
 import io.github.seijikohara.femto.ui.settings.components.FontRow
 import io.github.seijikohara.femto.ui.settings.components.Header
 import io.github.seijikohara.femto.ui.settings.components.LocationSection
 import io.github.seijikohara.femto.ui.settings.components.PanelsSection
+import io.github.seijikohara.femto.ui.settings.components.ScreenSection
 import io.github.seijikohara.femto.ui.settings.components.SettingRow
 import io.github.seijikohara.femto.ui.settings.components.SettingsSection
 import io.github.seijikohara.femto.ui.settings.components.SettingsSubheader
@@ -144,61 +140,6 @@ internal fun SettingsScreen(
                     ),
                 onSelect = { onAction(SettingsAction.ApplyThemePreset(it)) },
             )
-            SettingsSubheader(stringResource(R.string.settings_subheader_screen))
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_ui_scale),
-                options =
-                    listOf(
-                        UiScale.SMALL to stringResource(R.string.settings_ui_scale_small),
-                        UiScale.MEDIUM to stringResource(R.string.settings_ui_scale_medium),
-                        UiScale.LARGE to stringResource(R.string.settings_ui_scale_large),
-                    ),
-                selected = uiState.uiScale,
-                onSelect = { onAction(SettingsAction.SetUiScale(it)) },
-            )
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_orientation),
-                options =
-                    listOf(
-                        OrientationSetting.AUTO to stringResource(R.string.settings_option_auto),
-                        OrientationSetting.LANDSCAPE to stringResource(R.string.settings_orientation_landscape),
-                        OrientationSetting.PORTRAIT to stringResource(R.string.settings_orientation_portrait),
-                    ),
-                selected = uiState.orientation,
-                onSelect = { onAction(SettingsAction.SetOrientation(it)) },
-            )
-            SwitchRow(
-                title = stringResource(R.string.settings_group_fullscreen),
-                checked = uiState.fullscreen == FullscreenSetting.ON,
-                onCheckedChange = { onAction(SettingsAction.SetFullscreen(it.toFullscreen())) },
-            )
-            SwitchRow(
-                title = stringResource(R.string.settings_keep_screen_on),
-                checked = uiState.keepScreenOn,
-                onCheckedChange = { onAction(SettingsAction.SetKeepScreenOn(it)) },
-            )
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_dock_position),
-                options =
-                    listOf(
-                        DockPosition.BOTTOM to stringResource(R.string.settings_dock_bottom),
-                        DockPosition.TOP to stringResource(R.string.settings_dock_top),
-                        DockPosition.LEFT to stringResource(R.string.settings_dock_left),
-                        DockPosition.RIGHT to stringResource(R.string.settings_dock_right),
-                    ),
-                selected = uiState.dockPosition,
-                onSelect = { onAction(SettingsAction.SetDockPosition(it)) },
-            )
-            ChoiceRow(
-                title = stringResource(R.string.settings_group_assistant),
-                options =
-                    listOf(
-                        AssistantLaunchSetting.SYSTEM to stringResource(R.string.settings_assistant_system),
-                        AssistantLaunchSetting.IN_APP to stringResource(R.string.settings_assistant_in_app),
-                    ),
-                selected = uiState.assistantLaunch,
-                onSelect = { onAction(SettingsAction.SetAssistantLaunch(it)) },
-            )
             SettingsSubheader(stringResource(R.string.settings_subheader_glass))
             SliderRow(
                 title = stringResource(R.string.settings_group_glass_blur),
@@ -226,6 +167,8 @@ internal fun SettingsScreen(
                 onClick = { onOpenFontPicker(FontSlot.CJK) },
             )
         }
+
+        ScreenSection(uiState = uiState, onAction = onAction)
 
         UnitsSection(uiState = uiState, onAction = onAction)
 
@@ -848,8 +791,6 @@ private const val MIN_GLASS_BLUR = 0
 private const val MAX_GLASS_BLUR = 40
 private const val MIN_GLASS_OPACITY = 0
 private const val MAX_GLASS_OPACITY = 100
-
-private fun Boolean.toFullscreen(): FullscreenSetting = if (this) FullscreenSetting.ON else FullscreenSetting.OFF
 
 // The human-readable label for an accent, used as each swatch's content
 // description (the swatches are color-only, so they need an accessible name).

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,19 +15,14 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -41,18 +35,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.ArrowLeft
 import com.composables.icons.lucide.ChevronRight
-import com.composables.icons.lucide.ExternalLink
 import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.RotateCcw
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.calendar.CalendarInfo
 import io.github.seijikohara.femto.data.display.AccentColor
@@ -76,14 +65,23 @@ import io.github.seijikohara.femto.data.display.ThemePresets
 import io.github.seijikohara.femto.data.display.UiScale
 import io.github.seijikohara.femto.data.fonts.FontSlot
 import io.github.seijikohara.femto.data.location.LocationQualitySetting
+import io.github.seijikohara.femto.ui.settings.components.ActionRow
+import io.github.seijikohara.femto.ui.settings.components.ChoiceRow
+import io.github.seijikohara.femto.ui.settings.components.FontRow
+import io.github.seijikohara.femto.ui.settings.components.Header
+import io.github.seijikohara.femto.ui.settings.components.ResetRow
+import io.github.seijikohara.femto.ui.settings.components.SettingRow
+import io.github.seijikohara.femto.ui.settings.components.SettingsSection
+import io.github.seijikohara.femto.ui.settings.components.SettingsSubheader
+import io.github.seijikohara.femto.ui.settings.components.SliderRow
+import io.github.seijikohara.femto.ui.settings.components.SwitchRow
+import io.github.seijikohara.femto.ui.settings.components.TrailingIcon
 import io.github.seijikohara.femto.ui.theme.DynamicAccentSweep
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
-import io.github.seijikohara.femto.ui.theme.FemtoIcon
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.LocalFemtoDarkTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.accentSeedColor
-import kotlin.math.roundToInt
 
 /**
  * In-app settings, laid out like the Android system Settings app: category
@@ -723,77 +721,6 @@ internal fun SettingsScreen(
     }
 }
 
-@Composable
-private fun Header(
-    onBack: () -> Unit,
-    modifier: Modifier = Modifier,
-) = Row(
-    modifier = modifier.fillMaxWidth(),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(12.dp),
-) {
-    Box(
-        modifier =
-            Modifier
-                .size(FemtoDimens.MinTouchTarget)
-                .clipClickable(onBack),
-        contentAlignment = Alignment.Center,
-    ) {
-        FemtoIcon(
-            imageVector = Lucide.ArrowLeft,
-            contentDescription = stringResource(R.string.settings_back),
-            tint = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.size(28.dp),
-        )
-    }
-    Text(
-        text = stringResource(R.string.settings_title),
-        style = MaterialTheme.typography.headlineMedium,
-        color = MaterialTheme.colorScheme.onBackground,
-    )
-}
-
-// A category: a small colored header above a flat (0 dp) rounded card holding the
-// section's rows, echoing the Android Settings app's grouped layout.
-@Composable
-private fun SettingsSection(
-    title: String,
-    modifier: Modifier = Modifier,
-    content: @Composable ColumnScope.() -> Unit,
-) = Column(
-    modifier = modifier.fillMaxWidth(),
-    verticalArrangement = Arrangement.spacedBy(8.dp),
-) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(start = 12.dp),
-    )
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceContainer,
-    ) {
-        Column(content = content)
-    }
-}
-
-// A sub-group label inside a section card, separating related rows under a
-// section heading. Same 18sp as the section heading but muted (onSurfaceVariant
-// vs the section's primary) and indented to align with row content, so it reads
-// as a child cluster rather than a new section.
-@Composable
-private fun SettingsSubheader(
-    title: String,
-    modifier: Modifier = Modifier,
-) = Text(
-    text = title,
-    style = MaterialTheme.typography.labelLarge,
-    color = MaterialTheme.colorScheme.onSurfaceVariant,
-    modifier = modifier.padding(start = 20.dp, top = 14.dp, bottom = 2.dp),
-)
-
 // The accent picker: a title over a horizontally-scrolling row of color swatches.
 // Selecting a swatch applies its seed immediately, so the picker (and the whole
 // app) recolors live. DYNAMIC keeps Material You wallpaper color.
@@ -1046,261 +973,6 @@ private fun MapThemeMatchRow(
     }
 }
 
-// A single-choice row: shows the current value as its summary and opens a radio
-// dialog on tap (the Android ListPreference pattern).
-@Composable
-private fun <T> ChoiceRow(
-    title: String,
-    options: List<Pair<T, String>>,
-    selected: T,
-    onSelect: (T) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var dialogOpen by remember { mutableStateOf(false) }
-    SettingRow(
-        title = title,
-        modifier = modifier.clickable { dialogOpen = true },
-        summary = options.firstOrNull { it.first == selected }?.second,
-    ) {
-        TrailingIcon(Lucide.ChevronRight)
-    }
-    if (dialogOpen) {
-        ChoiceDialog(
-            title = title,
-            options = options,
-            selected = selected,
-            onSelect = {
-                onSelect(it)
-                dialogOpen = false
-            },
-            onDismiss = { dialogOpen = false },
-        )
-    }
-}
-
-@Composable
-private fun <T> ChoiceDialog(
-    title: String,
-    options: List<Pair<T, String>>,
-    selected: T,
-    onSelect: (T) -> Unit,
-    onDismiss: () -> Unit,
-) = AlertDialog(
-    onDismissRequest = onDismiss,
-    title = { Text(text = title) },
-    text = {
-        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-            options.forEach { (value, label) ->
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = FemtoDimens.MinTouchTarget)
-                            .selectable(
-                                selected = value == selected,
-                                role = Role.RadioButton,
-                                onClick = { onSelect(value) },
-                            ),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    RadioButton(selected = value == selected, onClick = null)
-                    Text(text = label, style = MaterialTheme.typography.bodyLarge)
-                }
-            }
-        }
-    },
-    // Tapping a radio option commits and dismisses (select-on-tap), so there is
-    // no confirm action — only Cancel.
-    confirmButton = {},
-    dismissButton = {
-        TextButton(onClick = onDismiss) {
-            Text(text = stringResource(R.string.settings_cancel))
-        }
-    },
-)
-
-// A boolean row: the whole row is the toggle (role = Switch), so the inline
-// Switch is presentation-only (onCheckedChange = null) and never double-fires. An
-// optional [summary] explains what the toggle does (e.g. attribution / cost notes).
-@Composable
-private fun SwitchRow(
-    title: String,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-    summary: String? = null,
-) = SettingRow(
-    title = title,
-    modifier = modifier.toggleable(value = checked, role = Role.Switch, onValueChange = onCheckedChange),
-    summary = summary,
-) {
-    Switch(checked = checked, onCheckedChange = null)
-}
-
-// A numeric row: an inline slider under the title / current-value line, with an
-// optional [description] caption beneath that explains what the value trades off.
-@Composable
-private fun SliderRow(
-    title: String,
-    valueLabel: String,
-    value: Int,
-    range: IntRange,
-    onValueChange: (Int) -> Unit,
-    modifier: Modifier = Modifier,
-    description: String? = null,
-) = Column(
-    modifier =
-        modifier
-            .fillMaxWidth()
-            .heightIn(min = FemtoDimens.MinTouchTarget)
-            .padding(horizontal = 20.dp, vertical = 10.dp),
-    verticalArrangement = Arrangement.spacedBy(4.dp),
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            // A long localized title shares the row with the value via SpaceBetween;
-            // weight(fill = false) keeps short titles in place but caps a long one so
-            // it ellipsizes instead of wrapping and shoving the value off the row.
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f, fill = false),
-        )
-        Text(
-            text = valueLabel,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-    if (description != null) {
-        Text(
-            text = description,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-    Slider(
-        value = value.coerceIn(range.first, range.last).toFloat(),
-        onValueChange = { onValueChange(it.roundToInt().coerceIn(range.first, range.last)) },
-        valueRange = range.first.toFloat()..range.last.toFloat(),
-    )
-}
-
-// A navigation row: links out to a system screen, marked with an external glyph.
-@Composable
-private fun ActionRow(
-    title: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) = SettingRow(
-    title = title,
-    modifier = modifier.clickable(onClick = onClick),
-) {
-    TrailingIcon(Lucide.ExternalLink)
-}
-
-// A destructive row: resetting every setting to its default. Tapping opens a
-// confirm dialog — the only destructive action in Settings — so a stray tap on
-// the head unit never wipes the user's configuration.
-@Composable
-private fun ResetRow(
-    onConfirm: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var dialogOpen by remember { mutableStateOf(false) }
-    SettingRow(
-        title = stringResource(R.string.settings_reset_to_defaults),
-        modifier = modifier.clickable { dialogOpen = true },
-    ) {
-        TrailingIcon(Lucide.RotateCcw)
-    }
-    if (dialogOpen) {
-        ResetConfirmDialog(
-            onConfirm = {
-                onConfirm()
-                dialogOpen = false
-            },
-            onDismiss = { dialogOpen = false },
-        )
-    }
-}
-
-@Composable
-private fun ResetConfirmDialog(
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit,
-) = AlertDialog(
-    onDismissRequest = onDismiss,
-    title = { Text(text = stringResource(R.string.settings_reset_confirm_title)) },
-    text = { Text(text = stringResource(R.string.settings_reset_confirm_message)) },
-    confirmButton = {
-        TextButton(onClick = onConfirm) {
-            Text(text = stringResource(R.string.settings_reset_confirm))
-        }
-    },
-    dismissButton = {
-        TextButton(onClick = onDismiss) {
-            Text(text = stringResource(R.string.settings_cancel))
-        }
-    },
-)
-
-// Shared row scaffold: a tap target ≥ MinTouchTarget with a title, optional
-// summary, and a trailing slot. The caller supplies the interaction (clickable /
-// toggleable) through [modifier] so each row keeps the right accessibility role.
-@Composable
-private fun SettingRow(
-    title: String,
-    modifier: Modifier = Modifier,
-    summary: String? = null,
-    trailing: @Composable () -> Unit = {},
-) = Row(
-    modifier =
-        modifier
-            .fillMaxWidth()
-            .heightIn(min = FemtoDimens.MinTouchTarget)
-            .padding(horizontal = 20.dp, vertical = 12.dp),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(16.dp),
-) {
-    Column(
-        modifier = Modifier.weight(1f),
-        verticalArrangement = Arrangement.spacedBy(2.dp),
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        if (summary != null) {
-            Text(
-                text = summary,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
-    trailing()
-}
-
-@Composable
-private fun TrailingIcon(
-    imageVector: ImageVector,
-    modifier: Modifier = Modifier,
-) = FemtoIcon(
-    imageVector = imageVector,
-    contentDescription = null,
-    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-    modifier = modifier.size(FemtoDimens.InlineIconSize),
-)
-
 private const val MIN_MAP_TILT = 0
 private const val MAX_MAP_TILT = 60
 
@@ -1350,28 +1022,6 @@ private fun ThemePreset.labelRes(): Int =
         "dusk" -> R.string.theme_preset_dusk
         else -> R.string.theme_preset_dynamic
     }
-
-// A font-slot row: the current family (or "System default") under the title,
-// opening the full Google Fonts picker on tap.
-@Composable
-private fun FontRow(
-    title: String,
-    family: String?,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) = SettingRow(
-    title = title,
-    modifier = modifier.clickable(onClick = onClick),
-    summary = family ?: stringResource(R.string.settings_font_system),
-) {
-    TrailingIcon(Lucide.ChevronRight)
-}
-
-// Small modifier helper: clip to a circle and make clickable, for the back box.
-private fun Modifier.clipClickable(onClick: () -> Unit): Modifier =
-    this
-        .clip(RoundedCornerShape(percent = 50))
-        .clickable(onClick = onClick)
 
 // Summarises the current visible-calendar selection in one line for the row subtitle.
 // Three distinct states: permission denied, granted but no calendars, or a count of

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/AppearanceSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/AppearanceSection.kt
@@ -1,0 +1,425 @@
+package io.github.seijikohara.femto.ui.settings.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.display.AccentColor
+import io.github.seijikohara.femto.data.display.MapBackend
+import io.github.seijikohara.femto.data.display.MapColorScheme
+import io.github.seijikohara.femto.data.display.MapStyleSetting
+import io.github.seijikohara.femto.data.display.ThemeMode
+import io.github.seijikohara.femto.data.display.ThemePreset
+import io.github.seijikohara.femto.data.display.ThemePresets
+import io.github.seijikohara.femto.data.fonts.FontSlot
+import io.github.seijikohara.femto.ui.settings.SettingsAction
+import io.github.seijikohara.femto.ui.settings.SettingsUiState
+import io.github.seijikohara.femto.ui.theme.DynamicAccentSweep
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.LocalFemtoDarkTheme
+import io.github.seijikohara.femto.ui.theme.accentSeedColor
+
+private const val MIN_GLASS_BLUR = 0
+private const val MAX_GLASS_BLUR = 40
+private const val MIN_GLASS_OPACITY = 0
+private const val MAX_GLASS_OPACITY = 100
+
+@Composable
+internal fun AppearanceSection(
+    uiState: SettingsUiState,
+    onAction: (SettingsAction) -> Unit,
+    onOpenFontPicker: (FontSlot) -> Unit,
+    modifier: Modifier = Modifier,
+) = SettingsSection(title = stringResource(R.string.settings_section_appearance), modifier = modifier) {
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_theme),
+        options =
+            listOf(
+                ThemeMode.SYSTEM to stringResource(R.string.settings_option_auto),
+                ThemeMode.LIGHT to stringResource(R.string.settings_theme_light),
+                ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
+            ),
+        selected = uiState.themeMode,
+        onSelect = { onAction(SettingsAction.SetThemeMode(it)) },
+    )
+    AccentRow(
+        selected = uiState.accentColor,
+        onSelect = { onAction(SettingsAction.SetAccentColor(it)) },
+    )
+    ThemePresetRow(
+        accentColor = uiState.accentColor,
+        selectedPreset =
+            ThemePresets.matchingOrNull(
+                accentColor = uiState.accentColor,
+                mapSchemeLight = uiState.mapSchemeLight,
+                mapSchemeDark = uiState.mapSchemeDark,
+            ),
+        onSelect = { onAction(SettingsAction.ApplyThemePreset(it)) },
+    )
+    SettingsSubheader(stringResource(R.string.settings_subheader_map_color))
+    MapThemeMatchRow(
+        mapStyle = uiState.mapStyle,
+        onSelect = { onAction(SettingsAction.SetMapStyle(it)) },
+    )
+    if (uiState.mapBackend == MapBackend.OSM) {
+        // Light scheme applies for AUTO + LIGHT, Dark scheme for AUTO + DARK. AUTO
+        // can use either (the system theme decides), so AUTO shows both; a fixed
+        // LIGHT / DARK hides the scheme it never uses. Independent colour schemes:
+        // ACCENT is the adaptive accent-tinted default, the rest fixed OpenFreeMap.
+        AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.DARK) {
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_map_scheme_light),
+                options =
+                    listOf(
+                        MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
+                        MapColorScheme.POSITRON to stringResource(R.string.settings_map_scheme_positron),
+                        MapColorScheme.BRIGHT to stringResource(R.string.settings_map_scheme_bright),
+                        MapColorScheme.LIBERTY to stringResource(R.string.settings_map_scheme_liberty),
+                    ),
+                selected = uiState.mapSchemeLight,
+                onSelect = { onAction(SettingsAction.SetMapSchemeLight(it)) },
+            )
+        }
+        AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.LIGHT) {
+            ChoiceRow(
+                title = stringResource(R.string.settings_group_map_scheme_dark),
+                options =
+                    listOf(
+                        MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
+                        MapColorScheme.DARK_MATTER to
+                            stringResource(R.string.settings_map_scheme_dark_matter),
+                        MapColorScheme.DARK to stringResource(R.string.settings_map_scheme_dark),
+                        MapColorScheme.FIORD to stringResource(R.string.settings_map_scheme_fiord),
+                    ),
+                selected = uiState.mapSchemeDark,
+                onSelect = { onAction(SettingsAction.SetMapSchemeDark(it)) },
+            )
+        }
+    }
+    SettingsSubheader(stringResource(R.string.settings_subheader_glass))
+    SliderRow(
+        title = stringResource(R.string.settings_group_glass_blur),
+        valueLabel = stringResource(R.string.settings_glass_blur_value, uiState.glassBlurRadius),
+        value = uiState.glassBlurRadius,
+        range = MIN_GLASS_BLUR..MAX_GLASS_BLUR,
+        onValueChange = { onAction(SettingsAction.SetGlassBlurRadius(it)) },
+    )
+    SliderRow(
+        title = stringResource(R.string.settings_group_glass_opacity),
+        valueLabel = stringResource(R.string.settings_glass_opacity_value, uiState.glassTintScale),
+        value = uiState.glassTintScale,
+        range = MIN_GLASS_OPACITY..MAX_GLASS_OPACITY,
+        onValueChange = { onAction(SettingsAction.SetGlassTintScale(it)) },
+    )
+    SettingsSubheader(stringResource(R.string.settings_subheader_fonts))
+    FontRow(
+        title = stringResource(R.string.settings_group_font_latin),
+        family = uiState.latinFont,
+        onClick = { onOpenFontPicker(FontSlot.LATIN) },
+    )
+    FontRow(
+        title = stringResource(R.string.settings_group_font_cjk),
+        family = uiState.cjkFont,
+        onClick = { onOpenFontPicker(FontSlot.CJK) },
+    )
+}
+
+// Theme stays the one primary light/dark control; this is the map's secondary,
+// clearly-subordinate override. Checked (the default) means mapStyle == AUTO,
+// which already follows the app's resolved theme (LocalFemtoDarkTheme). Turning
+// it off freezes the map at whatever the app currently renders (no visual jump at
+// the instant of toggling) and reveals a plain Light/Dark choice for further
+// manual override.
+@Composable
+private fun MapThemeMatchRow(
+    mapStyle: MapStyleSetting,
+    onSelect: (MapStyleSetting) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val appIsDark = LocalFemtoDarkTheme.current
+    SwitchRow(
+        title = stringResource(R.string.settings_map_match_theme),
+        summary = stringResource(R.string.settings_map_match_theme_desc),
+        checked = mapStyle == MapStyleSetting.AUTO,
+        onCheckedChange = { matchTheme ->
+            onSelect(
+                when {
+                    matchTheme -> MapStyleSetting.AUTO
+                    appIsDark -> MapStyleSetting.DARK
+                    else -> MapStyleSetting.LIGHT
+                },
+            )
+        },
+        modifier = modifier,
+    )
+    AnimatedVisibility(visible = mapStyle != MapStyleSetting.AUTO) {
+        ChoiceRow(
+            title = stringResource(R.string.settings_group_map_style),
+            options =
+                listOf(
+                    MapStyleSetting.LIGHT to stringResource(R.string.settings_theme_light),
+                    MapStyleSetting.DARK to stringResource(R.string.settings_theme_dark),
+                ),
+            selected = mapStyle,
+            onSelect = onSelect,
+        )
+    }
+}
+
+// The accent picker: a title over a horizontally-scrolling row of color swatches.
+// Selecting a swatch applies its seed immediately, so the picker (and the whole
+// app) recolors live. DYNAMIC keeps Material You wallpaper color.
+@Composable
+private fun AccentRow(
+    selected: AccentColor,
+    onSelect: (AccentColor) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier =
+        modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+) {
+    Text(
+        text = stringResource(R.string.settings_group_accent),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        AccentColor.entries.forEach { accent ->
+            AccentSwatch(
+                accent = accent,
+                selected = accent == selected,
+                onClick = { onSelect(accent) },
+            )
+        }
+    }
+}
+
+// One accent swatch: a >= MinTouchTarget tap target around a circular color chip.
+// A preset shows its seed; DYNAMIC shows a sweep gradient to read as "automatic".
+// The selected chip grows and gains an onSurface ring (color-agnostic, unlike a
+// tinted check that could vanish on a light seed).
+@Composable
+private fun AccentSwatch(
+    accent: AccentColor,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val description = stringResource(accent.labelRes())
+    val seed = accent.accentSeedColor()
+    val ringColor =
+        if (selected) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outlineVariant
+    Box(
+        modifier =
+            modifier
+                .size(FemtoDimens.MinTouchTarget)
+                .clip(CircleShape)
+                .clickable(onClick = onClick)
+                .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        val fill =
+            if (seed != null) {
+                Modifier.background(seed)
+            } else {
+                Modifier.background(Brush.sweepGradient(DynamicAccentSweep))
+            }
+        Box(
+            modifier =
+                Modifier
+                    .size(if (selected) 44.dp else 38.dp)
+                    .clip(CircleShape)
+                    .then(fill)
+                    .border(
+                        width = if (selected) 3.dp else 1.dp,
+                        color = ringColor,
+                        shape = CircleShape,
+                    ),
+        )
+    }
+}
+
+// The theme-preset picker: named bundles of accent + map colour schemes from the
+// ThemePresets registry. Tapping one applies the whole look at once; the accent
+// and map-scheme controls then reflect it. The data-driven "theme as data"
+// surface — mass-producing a theme is a registry entry, not new UI here. When the
+// current accent/map-scheme combination matches no registered bundle, a
+// non-interactive "Custom" chip renders instead of leaving every chip unselected,
+// so a fine-tuned combination reads as a deliberate state rather than a stale one.
+@Composable
+private fun ThemePresetRow(
+    accentColor: AccentColor,
+    selectedPreset: ThemePreset?,
+    onSelect: (ThemePreset) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier =
+        modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+) {
+    Text(
+        text = stringResource(R.string.settings_group_theme_preset),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ThemePresets.all.forEach { preset ->
+            ThemePresetChip(
+                preset = preset,
+                selected = preset == selectedPreset,
+                onClick = { onSelect(preset) },
+            )
+        }
+        if (selectedPreset == null) {
+            CustomPresetChip(accentColor = accentColor)
+        }
+    }
+}
+
+// One preset chip: the accent seed dot + the preset name, in a >= MinTouchTarget
+// tap target. Selected swaps to the secondaryContainer fill + a primary border
+// (the same color-agnostic emphasis the accent swatch uses).
+@Composable
+private fun ThemePresetChip(
+    preset: ThemePreset,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val seed = preset.accentColor.accentSeedColor()
+    val fill =
+        if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceContainerHigh
+    val border =
+        if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
+    val labelColor =
+        if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
+    Row(
+        modifier =
+            modifier
+                .heightIn(min = FemtoDimens.MinTouchTarget)
+                .clip(MaterialTheme.shapes.large)
+                .background(fill)
+                .border(width = if (selected) 2.dp else 1.dp, color = border, shape = MaterialTheme.shapes.large)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        val dot =
+            if (seed !=
+                null
+            ) {
+                Modifier.background(seed)
+            } else {
+                Modifier.background(Brush.sweepGradient(DynamicAccentSweep))
+            }
+        Box(modifier = Modifier.size(20.dp).clip(CircleShape).then(dot))
+        Text(
+            text = stringResource(preset.labelRes()),
+            style = MaterialTheme.typography.titleMedium,
+            color = labelColor,
+        )
+    }
+}
+
+// The "you are here" readout when no preset bundle matches: same visual weight as
+// a selected ThemePresetChip (secondaryContainer fill + primary border) but not
+// clickable — Custom is a status, not an action to invoke. The dot shows the
+// CURRENT accent live, since there is no single preset color to show.
+@Composable
+private fun CustomPresetChip(
+    accentColor: AccentColor,
+    modifier: Modifier = Modifier,
+) {
+    val seed = accentColor.accentSeedColor()
+    Row(
+        modifier =
+            modifier
+                .heightIn(min = FemtoDimens.MinTouchTarget)
+                .clip(MaterialTheme.shapes.large)
+                .background(MaterialTheme.colorScheme.secondaryContainer)
+                .border(width = 2.dp, color = MaterialTheme.colorScheme.primary, shape = MaterialTheme.shapes.large)
+                .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        val dot = if (seed !=
+            null
+        ) {
+            Modifier.background(seed)
+        } else {
+            Modifier.background(Brush.sweepGradient(DynamicAccentSweep))
+        }
+        Box(modifier = Modifier.size(20.dp).clip(CircleShape).then(dot))
+        Text(
+            text = stringResource(R.string.settings_theme_preset_custom),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+    }
+}
+
+// The human-readable label for an accent, used as each swatch's content
+// description (the swatches are color-only, so they need an accessible name).
+private fun AccentColor.labelRes(): Int =
+    when (this) {
+        AccentColor.DYNAMIC -> R.string.settings_accent_dynamic
+        AccentColor.BLUE -> R.string.settings_accent_blue
+        AccentColor.TEAL -> R.string.settings_accent_teal
+        AccentColor.GREEN -> R.string.settings_accent_green
+        AccentColor.AMBER -> R.string.settings_accent_amber
+        AccentColor.ORANGE -> R.string.settings_accent_orange
+        AccentColor.RED -> R.string.settings_accent_red
+        AccentColor.VIOLET -> R.string.settings_accent_violet
+        AccentColor.PINK -> R.string.settings_accent_pink
+    }
+
+// The display name for a theme preset (keyed by ThemePreset.key, so the registry
+// stays free of any resource dependency).
+private fun ThemePreset.labelRes(): Int =
+    when (key) {
+        "ocean" -> R.string.theme_preset_ocean
+        "forest" -> R.string.theme_preset_forest
+        "dusk" -> R.string.theme_preset_dusk
+        else -> R.string.theme_preset_dynamic
+    }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/LocationSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/LocationSection.kt
@@ -1,0 +1,63 @@
+package io.github.seijikohara.femto.ui.settings.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.location.LocationQualitySetting
+import io.github.seijikohara.femto.ui.settings.SettingsAction
+import io.github.seijikohara.femto.ui.settings.SettingsUiState
+
+private const val LOCATION_INTERVAL_STEP_MS = 250L
+private const val MIN_LOCATION_INTERVAL_STEPS = 1
+private const val MAX_LOCATION_INTERVAL_STEPS = 8
+private const val MIN_LOCATION_MIN_DISTANCE = 0
+private const val MAX_LOCATION_MIN_DISTANCE = 25
+
+@Composable
+internal fun LocationSection(
+    uiState: SettingsUiState,
+    onAction: (SettingsAction) -> Unit,
+    modifier: Modifier = Modifier,
+) = SettingsSection(title = stringResource(R.string.settings_section_location), modifier = modifier) {
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_location_quality),
+        options =
+            listOf(
+                LocationQualitySetting.HIGH_ACCURACY to
+                    stringResource(R.string.settings_location_quality_high),
+                LocationQualitySetting.BALANCED to
+                    stringResource(R.string.settings_location_quality_balanced),
+                LocationQualitySetting.LOW_POWER to
+                    stringResource(R.string.settings_location_quality_low),
+            ),
+        selected = uiState.locationQuality,
+        onSelect = { onAction(SettingsAction.SetLocationQuality(it)) },
+    )
+    // The slider works in 250 ms steps so the knob lands on round values;
+    // the persisted value stays in milliseconds.
+    SliderRow(
+        title = stringResource(R.string.settings_group_location_interval),
+        valueLabel =
+            stringResource(R.string.settings_location_interval_value, uiState.locationIntervalMillis),
+        value = (uiState.locationIntervalMillis / LOCATION_INTERVAL_STEP_MS).toInt(),
+        range = MIN_LOCATION_INTERVAL_STEPS..MAX_LOCATION_INTERVAL_STEPS,
+        onValueChange = { onAction(SettingsAction.SetLocationIntervalMillis(it * LOCATION_INTERVAL_STEP_MS)) },
+        description = stringResource(R.string.settings_location_interval_desc),
+    )
+    SliderRow(
+        title = stringResource(R.string.settings_group_location_min_distance),
+        valueLabel =
+            stringResource(R.string.settings_location_min_distance_value, uiState.locationMinDistanceMeters),
+        value = uiState.locationMinDistanceMeters,
+        range = MIN_LOCATION_MIN_DISTANCE..MAX_LOCATION_MIN_DISTANCE,
+        onValueChange = { onAction(SettingsAction.SetLocationMinDistance(it)) },
+        description = stringResource(R.string.settings_location_min_distance_desc),
+    )
+    SwitchRow(
+        title = stringResource(R.string.settings_group_background_ranging),
+        checked = uiState.backgroundRangingEnabled,
+        onCheckedChange = { onAction(SettingsAction.SetBackgroundRanging(it)) },
+        summary = stringResource(R.string.settings_background_ranging_desc),
+    )
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
@@ -147,9 +147,9 @@ internal fun MapSection(
                 )
             }
         }
-        SettingsSubheader(stringResource(R.string.settings_subheader_map_rendering))
         AnimatedVisibility(visible = uiState.mapBackend == MapBackend.OSM) {
             Column {
+                SettingsSubheader(stringResource(R.string.settings_subheader_map_rendering))
                 SwitchRow(
                     title = stringResource(R.string.settings_group_map_3d),
                     checked = uiState.map3dBuildings,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
@@ -1,0 +1,442 @@
+package io.github.seijikohara.femto.ui.settings.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.ChevronRight
+import com.composables.icons.lucide.Lucide
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.display.GoogleMapType
+import io.github.seijikohara.femto.data.display.MAX_MAP_ZOOM
+import io.github.seijikohara.femto.data.display.MIN_MAP_ZOOM
+import io.github.seijikohara.femto.data.display.MapBackend
+import io.github.seijikohara.femto.data.display.MapColorScheme
+import io.github.seijikohara.femto.data.display.MapStyleSetting
+import io.github.seijikohara.femto.data.display.MapboxStyle
+import io.github.seijikohara.femto.ui.settings.SettingsAction
+import io.github.seijikohara.femto.ui.settings.SettingsUiState
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.LocalFemtoDarkTheme
+
+private const val MIN_MAP_TILT = 0
+private const val MAX_MAP_TILT = 60
+private const val MIN_MAP_MARKER_POS = 0
+private const val MAX_MAP_MARKER_POS = 100
+
+@Composable
+internal fun MapSection(
+    uiState: SettingsUiState,
+    onAction: (SettingsAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showTokenDialog by remember { mutableStateOf(false) }
+    var showGoogleKeyDialog by remember { mutableStateOf(false) }
+    var showGoogleMapIdDialog by remember { mutableStateOf(false) }
+    SettingsSection(title = stringResource(R.string.settings_section_map), modifier = modifier) {
+        // Selecting Mapbox without a token, or Google Maps without an API key, opens
+        // the respective entry dialog instead of persisting the backend switch — the
+        // Screen owns this interception because the dialogs live here.
+        ChoiceRow(
+            title = stringResource(R.string.settings_map_backend),
+            options =
+                listOf(
+                    MapBackend.OSM to stringResource(R.string.settings_map_backend_osm),
+                    MapBackend.MAPBOX to stringResource(R.string.settings_map_backend_mapbox),
+                    MapBackend.GOOGLEMAPS to stringResource(R.string.settings_map_backend_googlemaps),
+                ),
+            selected = uiState.mapBackend,
+            onSelect = { backend ->
+                onAction(SettingsAction.SetMapBackend(backend))
+                when {
+                    backend == MapBackend.MAPBOX && uiState.mapboxAccessToken.isBlank() -> {
+                        showTokenDialog = true
+                    }
+
+                    backend == MapBackend.GOOGLEMAPS && uiState.googleMapsApiKey.isBlank() -> {
+                        showGoogleKeyDialog = true
+                    }
+                }
+            },
+        )
+        AnimatedVisibility(visible = uiState.mapBackend == MapBackend.MAPBOX) {
+            Column {
+                ChoiceRow(
+                    title = stringResource(R.string.settings_mapbox_style),
+                    options =
+                        listOf(
+                            MapboxStyle.STANDARD to stringResource(R.string.settings_mapbox_style_standard),
+                            MapboxStyle.SATELLITE to stringResource(R.string.settings_mapbox_style_satellite),
+                            MapboxStyle.STREETS to stringResource(R.string.settings_mapbox_style_streets),
+                        ),
+                    selected = uiState.mapboxStyle,
+                    onSelect = { onAction(SettingsAction.SetMapboxStyle(it)) },
+                )
+                SwitchRow(
+                    title = stringResource(R.string.settings_mapbox_traffic),
+                    checked = uiState.mapboxTraffic,
+                    onCheckedChange = { onAction(SettingsAction.SetMapboxTraffic(it)) },
+                )
+                SettingRow(
+                    title = stringResource(R.string.settings_mapbox_token),
+                    summary = mapboxTokenSummary(uiState.mapboxAccessToken),
+                    modifier = Modifier.clickable { showTokenDialog = true },
+                ) {
+                    TrailingIcon(Lucide.ChevronRight)
+                }
+                Text(
+                    text = stringResource(R.string.settings_map_accent_osm_only_note),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                )
+            }
+        }
+        AnimatedVisibility(visible = uiState.mapBackend == MapBackend.GOOGLEMAPS) {
+            Column {
+                ChoiceRow(
+                    title = stringResource(R.string.settings_google_maps_type),
+                    options =
+                        listOf(
+                            GoogleMapType.ROADMAP to stringResource(R.string.settings_google_maps_type_roadmap),
+                            GoogleMapType.SATELLITE to stringResource(R.string.settings_google_maps_type_satellite),
+                            GoogleMapType.HYBRID to stringResource(R.string.settings_google_maps_type_hybrid),
+                            GoogleMapType.TERRAIN to stringResource(R.string.settings_google_maps_type_terrain),
+                        ),
+                    selected = uiState.googleMapsMapType,
+                    onSelect = { onAction(SettingsAction.SetGoogleMapsMapType(it)) },
+                )
+                SwitchRow(
+                    title = stringResource(R.string.settings_google_maps_traffic),
+                    checked = uiState.googleMapsTraffic,
+                    onCheckedChange = { onAction(SettingsAction.SetGoogleMapsTraffic(it)) },
+                )
+                SettingRow(
+                    title = stringResource(R.string.settings_google_maps_key),
+                    summary = googleMapsKeySummary(uiState.googleMapsApiKey),
+                    modifier = Modifier.clickable { showGoogleKeyDialog = true },
+                ) {
+                    TrailingIcon(Lucide.ChevronRight)
+                }
+                SettingRow(
+                    title = stringResource(R.string.settings_google_maps_map_id),
+                    summary = googleMapsMapIdSummary(uiState.googleMapsMapId),
+                    modifier = Modifier.clickable { showGoogleMapIdDialog = true },
+                ) {
+                    TrailingIcon(Lucide.ChevronRight)
+                }
+                Text(
+                    text = stringResource(R.string.settings_map_accent_osm_only_note),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                )
+            }
+        }
+        // MapStyleSetting.AUTO also drives Mapbox Standard's lightPreset (day/night),
+        // so it belongs outside the OSM-only block. AUTO already resolves to
+        // LocalFemtoDarkTheme.current (WebMapView.kt), i.e. it follows the app's
+        // Theme setting above — MapThemeMatchRow makes that relationship visible
+        // instead of presenting a second, unrelated-looking AUTO/LIGHT/DARK picker.
+        // NOTE FOR TASK 8: this call + the MapThemeMatchRow composable definition
+        // below move OUT of this file and into AppearanceSection.kt in Task 8 — they
+        // land here in Task 7 only because they are still physically inside the same
+        // SettingsSection block as everything else this task extracts.
+        MapThemeMatchRow(
+            mapStyle = uiState.mapStyle,
+            onSelect = { onAction(SettingsAction.SetMapStyle(it)) },
+        )
+        SettingsSubheader(stringResource(R.string.settings_subheader_map_rendering))
+        AnimatedVisibility(visible = uiState.mapBackend == MapBackend.OSM) {
+            Column {
+                SwitchRow(
+                    title = stringResource(R.string.settings_group_map_3d),
+                    checked = uiState.map3dBuildings,
+                    onCheckedChange = { onAction(SettingsAction.SetMap3dBuildings(it)) },
+                )
+                SwitchRow(
+                    title = stringResource(R.string.settings_group_map_terrain),
+                    checked = uiState.mapTerrain,
+                    onCheckedChange = { onAction(SettingsAction.SetMapTerrain(it)) },
+                    summary = stringResource(R.string.settings_map_terrain_desc),
+                )
+                // NOTE FOR TASK 8: these two rows (and their "Map appearance" subheader)
+                // also move out of this file and into AppearanceSection.kt in Task 8, for
+                // the same reason as MapThemeMatchRow above.
+                SettingsSubheader(stringResource(R.string.settings_subheader_map_appearance))
+                // Light scheme applies for AUTO + LIGHT, Dark scheme for AUTO + DARK. AUTO
+                // can use either (the system theme decides), so AUTO shows both; a fixed
+                // LIGHT / DARK hides the scheme it never uses. Independent colour schemes:
+                // ACCENT is the adaptive accent-tinted default, the rest fixed OpenFreeMap.
+                AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.DARK) {
+                    ChoiceRow(
+                        title = stringResource(R.string.settings_group_map_scheme_light),
+                        options =
+                            listOf(
+                                MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
+                                MapColorScheme.POSITRON to stringResource(R.string.settings_map_scheme_positron),
+                                MapColorScheme.BRIGHT to stringResource(R.string.settings_map_scheme_bright),
+                                MapColorScheme.LIBERTY to stringResource(R.string.settings_map_scheme_liberty),
+                            ),
+                        selected = uiState.mapSchemeLight,
+                        onSelect = { onAction(SettingsAction.SetMapSchemeLight(it)) },
+                    )
+                }
+                AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.LIGHT) {
+                    ChoiceRow(
+                        title = stringResource(R.string.settings_group_map_scheme_dark),
+                        options =
+                            listOf(
+                                MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
+                                MapColorScheme.DARK_MATTER to
+                                    stringResource(R.string.settings_map_scheme_dark_matter),
+                                MapColorScheme.DARK to stringResource(R.string.settings_map_scheme_dark),
+                                MapColorScheme.FIORD to stringResource(R.string.settings_map_scheme_fiord),
+                            ),
+                        selected = uiState.mapSchemeDark,
+                        onSelect = { onAction(SettingsAction.SetMapSchemeDark(it)) },
+                    )
+                }
+            }
+        }
+        SettingsSubheader(stringResource(R.string.settings_subheader_map_camera))
+        SliderRow(
+            title = stringResource(R.string.settings_group_map_tilt),
+            valueLabel = stringResource(R.string.settings_map_tilt_value, uiState.mapTiltDeg),
+            value = uiState.mapTiltDeg,
+            range = MIN_MAP_TILT..MAX_MAP_TILT,
+            onValueChange = { onAction(SettingsAction.SetMapTilt(it)) },
+        )
+        SliderRow(
+            title = stringResource(R.string.settings_group_map_zoom),
+            valueLabel = stringResource(R.string.settings_map_zoom_value, uiState.mapZoom),
+            value = uiState.mapZoom,
+            range = MIN_MAP_ZOOM..MAX_MAP_ZOOM,
+            onValueChange = { onAction(SettingsAction.SetMapZoom(it)) },
+        )
+        SwitchRow(
+            title = stringResource(R.string.settings_group_map_north_up),
+            checked = uiState.mapNorthUp,
+            onCheckedChange = { onAction(SettingsAction.SetMapNorthUp(it)) },
+            summary = stringResource(R.string.settings_map_north_up_desc),
+        )
+        SliderRow(
+            title = stringResource(R.string.settings_group_map_marker_pos),
+            valueLabel = stringResource(R.string.settings_map_marker_pos_value, uiState.mapMarkerPos),
+            value = uiState.mapMarkerPos,
+            range = MIN_MAP_MARKER_POS..MAX_MAP_MARKER_POS,
+            onValueChange = { onAction(SettingsAction.SetMapMarkerPos(it)) },
+        )
+    }
+    if (showTokenDialog) {
+        var draft by remember { mutableStateOf(uiState.mapboxAccessToken) }
+        AlertDialog(
+            onDismissRequest = { showTokenDialog = false },
+            title = { Text(stringResource(R.string.settings_mapbox_token)) },
+            text = {
+                Column {
+                    OutlinedTextField(
+                        value = draft,
+                        onValueChange = { draft = it },
+                        singleLine = true,
+                        label = { Text(stringResource(R.string.settings_mapbox_token_hint)) },
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = draft.isNotBlank(),
+                    onClick = {
+                        onAction(SettingsAction.SaveMapboxToken(draft))
+                        showTokenDialog = false
+                    },
+                ) { Text(stringResource(R.string.settings_mapbox_token_save)) }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        onAction(SettingsAction.ClearMapboxToken)
+                        showTokenDialog = false
+                    },
+                ) { Text(stringResource(R.string.settings_mapbox_token_clear)) }
+            },
+        )
+    }
+    if (showGoogleKeyDialog) {
+        var draft by remember { mutableStateOf(uiState.googleMapsApiKey) }
+        AlertDialog(
+            onDismissRequest = { showGoogleKeyDialog = false },
+            title = { Text(stringResource(R.string.settings_google_maps_key)) },
+            text = {
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.settings_google_maps_key_hint),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    OutlinedTextField(
+                        value = draft,
+                        onValueChange = { draft = it },
+                        singleLine = true,
+                        label = { Text(stringResource(R.string.settings_google_maps_key)) },
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = draft.isNotBlank(),
+                    onClick = {
+                        onAction(SettingsAction.SaveGoogleMapsKey(draft))
+                        showGoogleKeyDialog = false
+                    },
+                    modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
+                ) { Text(stringResource(R.string.settings_google_maps_key_save)) }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        onAction(SettingsAction.ClearGoogleMapsKey)
+                        showGoogleKeyDialog = false
+                    },
+                    modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
+                ) { Text(stringResource(R.string.settings_google_maps_key_clear)) }
+            },
+        )
+    }
+    if (showGoogleMapIdDialog) {
+        var draft by remember { mutableStateOf(uiState.googleMapsMapId) }
+        AlertDialog(
+            onDismissRequest = { showGoogleMapIdDialog = false },
+            title = { Text(stringResource(R.string.settings_google_maps_map_id)) },
+            text = {
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.settings_google_maps_map_id_hint),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    OutlinedTextField(
+                        value = draft,
+                        onValueChange = { draft = it },
+                        singleLine = true,
+                        label = { Text(stringResource(R.string.settings_google_maps_map_id)) },
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = true,
+                    onClick = {
+                        onAction(SettingsAction.SetGoogleMapsMapId(draft))
+                        showGoogleMapIdDialog = false
+                    },
+                    modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
+                ) { Text(stringResource(R.string.settings_google_maps_map_id_save)) }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        onAction(SettingsAction.ClearGoogleMapsMapId)
+                        showGoogleMapIdDialog = false
+                    },
+                    modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
+                ) { Text(stringResource(R.string.settings_google_maps_map_id_clear)) }
+            },
+        )
+    }
+}
+
+// NOTE FOR TASK 8: this whole composable moves out of this file and into
+// AppearanceSection.kt in Task 8 — it lands here in Task 7 only because it is
+// still physically inside the same SettingsSection block as everything else
+// this task extracts (see the note at its call site above).
+//
+// Theme stays the one primary light/dark control; this is the map's secondary,
+// clearly-subordinate override. Checked (the default) means mapStyle == AUTO,
+// which already follows the app's resolved theme (LocalFemtoDarkTheme). Turning
+// it off freezes the map at whatever the app currently renders (no visual jump at
+// the instant of toggling) and reveals a plain Light/Dark choice for further
+// manual override.
+@Composable
+private fun MapThemeMatchRow(
+    mapStyle: MapStyleSetting,
+    onSelect: (MapStyleSetting) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val appIsDark = LocalFemtoDarkTheme.current
+    SwitchRow(
+        title = stringResource(R.string.settings_map_match_theme),
+        summary = stringResource(R.string.settings_map_match_theme_desc),
+        checked = mapStyle == MapStyleSetting.AUTO,
+        onCheckedChange = { matchTheme ->
+            onSelect(
+                when {
+                    matchTheme -> MapStyleSetting.AUTO
+                    appIsDark -> MapStyleSetting.DARK
+                    else -> MapStyleSetting.LIGHT
+                },
+            )
+        },
+        modifier = modifier,
+    )
+    AnimatedVisibility(visible = mapStyle != MapStyleSetting.AUTO) {
+        ChoiceRow(
+            title = stringResource(R.string.settings_group_map_style),
+            options =
+                listOf(
+                    MapStyleSetting.LIGHT to stringResource(R.string.settings_theme_light),
+                    MapStyleSetting.DARK to stringResource(R.string.settings_theme_dark),
+                ),
+            selected = mapStyle,
+            onSelect = onSelect,
+        )
+    }
+}
+
+// Masks all but the last four characters of the token so it is not fully visible
+// on a shared in-car screen, while still letting the user confirm which key is set.
+@Composable
+private fun mapboxTokenSummary(token: String): String =
+    if (token.isBlank()) {
+        stringResource(R.string.settings_mapbox_token_unset)
+    } else {
+        "••••" + token.takeLast(4)
+    }
+
+// Same masking pattern as mapboxTokenSummary, applied to the Google Maps API key.
+@Composable
+private fun googleMapsKeySummary(key: String): String =
+    if (key.isBlank()) {
+        stringResource(R.string.settings_google_maps_key_unset)
+    } else {
+        "••••" + key.takeLast(4)
+    }
+
+// The Map ID is not secret (it only names a console-defined style), so it is
+// shown verbatim — no masking, unlike the API key above.
+@Composable
+private fun googleMapsMapIdSummary(mapId: String): String =
+    mapId.ifBlank { stringResource(R.string.settings_google_maps_map_id_unset) }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
@@ -49,8 +49,8 @@ internal fun MapSection(
     var showGoogleMapIdDialog by remember { mutableStateOf(false) }
     SettingsSection(title = stringResource(R.string.settings_section_map), modifier = modifier) {
         // Selecting Mapbox without a token, or Google Maps without an API key, opens
-        // the respective entry dialog instead of persisting the backend switch — the
-        // Screen owns this interception because the dialogs live here.
+        // the respective entry dialog instead of persisting the backend switch —
+        // MapSection owns this interception because the dialogs live here.
         ChoiceRow(
             title = stringResource(R.string.settings_map_backend),
             options =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
@@ -28,13 +28,10 @@ import io.github.seijikohara.femto.data.display.GoogleMapType
 import io.github.seijikohara.femto.data.display.MAX_MAP_ZOOM
 import io.github.seijikohara.femto.data.display.MIN_MAP_ZOOM
 import io.github.seijikohara.femto.data.display.MapBackend
-import io.github.seijikohara.femto.data.display.MapColorScheme
-import io.github.seijikohara.femto.data.display.MapStyleSetting
 import io.github.seijikohara.femto.data.display.MapboxStyle
 import io.github.seijikohara.femto.ui.settings.SettingsAction
 import io.github.seijikohara.femto.ui.settings.SettingsUiState
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
-import io.github.seijikohara.femto.ui.theme.LocalFemtoDarkTheme
 
 private const val MIN_MAP_TILT = 0
 private const val MAX_MAP_TILT = 60
@@ -150,19 +147,6 @@ internal fun MapSection(
                 )
             }
         }
-        // MapStyleSetting.AUTO also drives Mapbox Standard's lightPreset (day/night),
-        // so it belongs outside the OSM-only block. AUTO already resolves to
-        // LocalFemtoDarkTheme.current (WebMapView.kt), i.e. it follows the app's
-        // Theme setting above — MapThemeMatchRow makes that relationship visible
-        // instead of presenting a second, unrelated-looking AUTO/LIGHT/DARK picker.
-        // NOTE FOR TASK 8: this call + the MapThemeMatchRow composable definition
-        // below move OUT of this file and into AppearanceSection.kt in Task 8 — they
-        // land here in Task 7 only because they are still physically inside the same
-        // SettingsSection block as everything else this task extracts.
-        MapThemeMatchRow(
-            mapStyle = uiState.mapStyle,
-            onSelect = { onAction(SettingsAction.SetMapStyle(it)) },
-        )
         SettingsSubheader(stringResource(R.string.settings_subheader_map_rendering))
         AnimatedVisibility(visible = uiState.mapBackend == MapBackend.OSM) {
             Column {
@@ -177,43 +161,6 @@ internal fun MapSection(
                     onCheckedChange = { onAction(SettingsAction.SetMapTerrain(it)) },
                     summary = stringResource(R.string.settings_map_terrain_desc),
                 )
-                // NOTE FOR TASK 8: these two rows (and their "Map appearance" subheader)
-                // also move out of this file and into AppearanceSection.kt in Task 8, for
-                // the same reason as MapThemeMatchRow above.
-                SettingsSubheader(stringResource(R.string.settings_subheader_map_appearance))
-                // Light scheme applies for AUTO + LIGHT, Dark scheme for AUTO + DARK. AUTO
-                // can use either (the system theme decides), so AUTO shows both; a fixed
-                // LIGHT / DARK hides the scheme it never uses. Independent colour schemes:
-                // ACCENT is the adaptive accent-tinted default, the rest fixed OpenFreeMap.
-                AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.DARK) {
-                    ChoiceRow(
-                        title = stringResource(R.string.settings_group_map_scheme_light),
-                        options =
-                            listOf(
-                                MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
-                                MapColorScheme.POSITRON to stringResource(R.string.settings_map_scheme_positron),
-                                MapColorScheme.BRIGHT to stringResource(R.string.settings_map_scheme_bright),
-                                MapColorScheme.LIBERTY to stringResource(R.string.settings_map_scheme_liberty),
-                            ),
-                        selected = uiState.mapSchemeLight,
-                        onSelect = { onAction(SettingsAction.SetMapSchemeLight(it)) },
-                    )
-                }
-                AnimatedVisibility(visible = uiState.mapStyle != MapStyleSetting.LIGHT) {
-                    ChoiceRow(
-                        title = stringResource(R.string.settings_group_map_scheme_dark),
-                        options =
-                            listOf(
-                                MapColorScheme.ACCENT to stringResource(R.string.settings_map_scheme_accent),
-                                MapColorScheme.DARK_MATTER to
-                                    stringResource(R.string.settings_map_scheme_dark_matter),
-                                MapColorScheme.DARK to stringResource(R.string.settings_map_scheme_dark),
-                                MapColorScheme.FIORD to stringResource(R.string.settings_map_scheme_fiord),
-                            ),
-                        selected = uiState.mapSchemeDark,
-                        onSelect = { onAction(SettingsAction.SetMapSchemeDark(it)) },
-                    )
-                }
             }
         }
         SettingsSubheader(stringResource(R.string.settings_subheader_map_camera))
@@ -365,53 +312,6 @@ internal fun MapSection(
                     modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
                 ) { Text(stringResource(R.string.settings_google_maps_map_id_clear)) }
             },
-        )
-    }
-}
-
-// NOTE FOR TASK 8: this whole composable moves out of this file and into
-// AppearanceSection.kt in Task 8 — it lands here in Task 7 only because it is
-// still physically inside the same SettingsSection block as everything else
-// this task extracts (see the note at its call site above).
-//
-// Theme stays the one primary light/dark control; this is the map's secondary,
-// clearly-subordinate override. Checked (the default) means mapStyle == AUTO,
-// which already follows the app's resolved theme (LocalFemtoDarkTheme). Turning
-// it off freezes the map at whatever the app currently renders (no visual jump at
-// the instant of toggling) and reveals a plain Light/Dark choice for further
-// manual override.
-@Composable
-private fun MapThemeMatchRow(
-    mapStyle: MapStyleSetting,
-    onSelect: (MapStyleSetting) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val appIsDark = LocalFemtoDarkTheme.current
-    SwitchRow(
-        title = stringResource(R.string.settings_map_match_theme),
-        summary = stringResource(R.string.settings_map_match_theme_desc),
-        checked = mapStyle == MapStyleSetting.AUTO,
-        onCheckedChange = { matchTheme ->
-            onSelect(
-                when {
-                    matchTheme -> MapStyleSetting.AUTO
-                    appIsDark -> MapStyleSetting.DARK
-                    else -> MapStyleSetting.LIGHT
-                },
-            )
-        },
-        modifier = modifier,
-    )
-    AnimatedVisibility(visible = mapStyle != MapStyleSetting.AUTO) {
-        ChoiceRow(
-            title = stringResource(R.string.settings_group_map_style),
-            options =
-                listOf(
-                    MapStyleSetting.LIGHT to stringResource(R.string.settings_theme_light),
-                    MapStyleSetting.DARK to stringResource(R.string.settings_theme_dark),
-                ),
-            selected = mapStyle,
-            onSelect = onSelect,
         )
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/PanelsSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/PanelsSection.kt
@@ -1,0 +1,225 @@
+package io.github.seijikohara.femto.ui.settings.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.calendar.CalendarInfo
+import io.github.seijikohara.femto.ui.settings.SettingsAction
+import io.github.seijikohara.femto.ui.settings.SettingsUiState
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+
+@Composable
+internal fun PanelsSection(
+    uiState: SettingsUiState,
+    onAction: (SettingsAction) -> Unit,
+    onOpenSystemSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) = SettingsSection(title = stringResource(R.string.settings_section_panels), modifier = modifier) {
+    SwitchRow(
+        title = stringResource(R.string.settings_group_panel_calendar),
+        checked = uiState.showCalendar,
+        onCheckedChange = { onAction(SettingsAction.SetShowCalendar(it)) },
+    )
+    AnimatedVisibility(visible = uiState.showCalendar) {
+        MultiSelectRow(
+            title = stringResource(R.string.settings_visible_calendars),
+            summary = visibleCalendarsSummary(
+                uiState.hasCalendarAccess,
+                uiState.availableCalendars,
+                uiState.hiddenCalendarIds,
+            ),
+            hasCalendarAccess = uiState.hasCalendarAccess,
+            calendars = uiState.availableCalendars,
+            hiddenIds = uiState.hiddenCalendarIds,
+            onToggle = { id, hidden -> onAction(SettingsAction.SetCalendarHidden(id, hidden)) },
+            onOpenAppSettings = onOpenSystemSettings,
+        )
+    }
+    SwitchRow(
+        title = stringResource(R.string.settings_group_panel_weather),
+        checked = uiState.showWeather,
+        onCheckedChange = { onAction(SettingsAction.SetShowWeather(it)) },
+    )
+    SwitchRow(
+        title = stringResource(R.string.settings_group_panel_music),
+        checked = uiState.showMusic,
+        onCheckedChange = { onAction(SettingsAction.SetShowMusic(it)) },
+    )
+    SwitchRow(
+        title = stringResource(R.string.settings_group_panel_music_spectrum),
+        checked = uiState.musicSpectrum,
+        onCheckedChange = { onAction(SettingsAction.SetMusicSpectrum(it)) },
+        summary = stringResource(R.string.settings_panel_music_spectrum_desc),
+    )
+}
+
+// Summarises the current visible-calendar selection in one line for the row subtitle.
+// Three distinct states: permission denied, granted but no calendars, or a count of
+// visible vs total. An empty hidden-ids set means every calendar is shown.
+@Composable
+private fun visibleCalendarsSummary(
+    hasCalendarAccess: Boolean,
+    calendars: List<CalendarInfo>,
+    hiddenIds: Set<Long>,
+): String =
+    when {
+        !hasCalendarAccess -> {
+            stringResource(R.string.settings_visible_calendars_none)
+        }
+
+        calendars.isEmpty() -> {
+            stringResource(R.string.settings_visible_calendars_empty)
+        }
+
+        hiddenIds.isEmpty() -> {
+            stringResource(R.string.settings_visible_calendars_all)
+        }
+
+        else -> {
+            val shown = calendars.count { it.id !in hiddenIds }
+            stringResource(R.string.settings_visible_calendars_count, shown, calendars.size)
+        }
+    }
+
+// A choice row that opens a multi-select dialog — same open/dismiss pattern as
+// ChoiceRow, but the dialog hosts checkboxes instead of radio buttons so multiple
+// calendars can be independently toggled.
+@Composable
+private fun MultiSelectRow(
+    title: String,
+    summary: String,
+    hasCalendarAccess: Boolean,
+    calendars: List<CalendarInfo>,
+    hiddenIds: Set<Long>,
+    onToggle: (Long, Boolean) -> Unit,
+    onOpenAppSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var open by remember { mutableStateOf(false) }
+    SettingRow(
+        modifier = modifier.clickable { open = true },
+        title = title,
+        summary = summary,
+    )
+    if (open) {
+        MultiSelectDialog(
+            title = title,
+            hasCalendarAccess = hasCalendarAccess,
+            calendars = calendars,
+            hiddenIds = hiddenIds,
+            onToggle = onToggle,
+            onOpenAppSettings = onOpenAppSettings,
+            onDismiss = { open = false },
+        )
+    }
+}
+
+// Multi-select dialog for the visible-calendars picker. Three states: permission
+// denied (shows a grant button linking to system settings), granted but no calendars
+// found, or the checkbox list. Each calendar row shows a colour dot (12 dp decorative
+// marker from CalendarInfo.color), display name, and account name. The whole row is
+// the toggle target (toggleable with Role.Checkbox); the Checkbox is visual-only
+// (onCheckedChange = null) so a single tap never double-fires. Touch targets meet
+// FemtoDimens.MinTouchTarget; text uses bodyLarge / bodyMedium.
+@Composable
+private fun MultiSelectDialog(
+    title: String,
+    hasCalendarAccess: Boolean,
+    calendars: List<CalendarInfo>,
+    hiddenIds: Set<Long>,
+    onToggle: (Long, Boolean) -> Unit,
+    onOpenAppSettings: () -> Unit,
+    onDismiss: () -> Unit,
+) = AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text(title) },
+    text = {
+        when {
+            !hasCalendarAccess -> {
+                Column {
+                    Text(stringResource(R.string.settings_visible_calendars_none))
+                    TextButton(
+                        onClick = {
+                            onOpenAppSettings()
+                            onDismiss()
+                        },
+                        modifier = Modifier.heightIn(min = FemtoDimens.MinTouchTarget),
+                    ) {
+                        Text(stringResource(R.string.settings_open_system_settings))
+                    }
+                }
+            }
+
+            calendars.isEmpty() -> {
+                Text(stringResource(R.string.settings_visible_calendars_empty))
+            }
+
+            else -> {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    calendars.forEach { calendar ->
+                        val shown = calendar.id !in hiddenIds
+                        Row(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .heightIn(min = FemtoDimens.MinTouchTarget)
+                                    // Hidden is the inverse of the new shown state.
+                                    .toggleable(
+                                        value = shown,
+                                        role = Role.Checkbox,
+                                        onValueChange = { newShown -> onToggle(calendar.id, !newShown) },
+                                    ),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Checkbox(checked = shown, onCheckedChange = null)
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(12.dp)
+                                        .clip(CircleShape)
+                                        .background(Color(calendar.color)),
+                            )
+                            Column {
+                                Text(calendar.displayName, style = MaterialTheme.typography.bodyLarge)
+                                Text(calendar.accountName, style = MaterialTheme.typography.bodyMedium)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    confirmButton = {
+        TextButton(onClick = onDismiss) { Text(stringResource(R.string.settings_dialog_close)) }
+    },
+)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/ScreenSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/ScreenSection.kt
@@ -1,0 +1,77 @@
+package io.github.seijikohara.femto.ui.settings.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
+import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.FullscreenSetting
+import io.github.seijikohara.femto.data.display.OrientationSetting
+import io.github.seijikohara.femto.data.display.UiScale
+import io.github.seijikohara.femto.ui.settings.SettingsAction
+import io.github.seijikohara.femto.ui.settings.SettingsUiState
+
+@Composable
+internal fun ScreenSection(
+    uiState: SettingsUiState,
+    onAction: (SettingsAction) -> Unit,
+    modifier: Modifier = Modifier,
+) = SettingsSection(title = stringResource(R.string.settings_section_screen), modifier = modifier) {
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_ui_scale),
+        options =
+            listOf(
+                UiScale.SMALL to stringResource(R.string.settings_ui_scale_small),
+                UiScale.MEDIUM to stringResource(R.string.settings_ui_scale_medium),
+                UiScale.LARGE to stringResource(R.string.settings_ui_scale_large),
+            ),
+        selected = uiState.uiScale,
+        onSelect = { onAction(SettingsAction.SetUiScale(it)) },
+    )
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_orientation),
+        options =
+            listOf(
+                OrientationSetting.AUTO to stringResource(R.string.settings_option_auto),
+                OrientationSetting.LANDSCAPE to stringResource(R.string.settings_orientation_landscape),
+                OrientationSetting.PORTRAIT to stringResource(R.string.settings_orientation_portrait),
+            ),
+        selected = uiState.orientation,
+        onSelect = { onAction(SettingsAction.SetOrientation(it)) },
+    )
+    SwitchRow(
+        title = stringResource(R.string.settings_group_fullscreen),
+        checked = uiState.fullscreen == FullscreenSetting.ON,
+        onCheckedChange = { onAction(SettingsAction.SetFullscreen(it.toFullscreen())) },
+    )
+    SwitchRow(
+        title = stringResource(R.string.settings_keep_screen_on),
+        checked = uiState.keepScreenOn,
+        onCheckedChange = { onAction(SettingsAction.SetKeepScreenOn(it)) },
+    )
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_dock_position),
+        options =
+            listOf(
+                DockPosition.BOTTOM to stringResource(R.string.settings_dock_bottom),
+                DockPosition.TOP to stringResource(R.string.settings_dock_top),
+                DockPosition.LEFT to stringResource(R.string.settings_dock_left),
+                DockPosition.RIGHT to stringResource(R.string.settings_dock_right),
+            ),
+        selected = uiState.dockPosition,
+        onSelect = { onAction(SettingsAction.SetDockPosition(it)) },
+    )
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_assistant),
+        options =
+            listOf(
+                AssistantLaunchSetting.SYSTEM to stringResource(R.string.settings_assistant_system),
+                AssistantLaunchSetting.IN_APP to stringResource(R.string.settings_assistant_in_app),
+            ),
+        selected = uiState.assistantLaunch,
+        onSelect = { onAction(SettingsAction.SetAssistantLaunch(it)) },
+    )
+}
+
+private fun Boolean.toFullscreen(): FullscreenSetting = if (this) FullscreenSetting.ON else FullscreenSetting.OFF

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SettingsPrimitives.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SettingsPrimitives.kt
@@ -1,0 +1,395 @@
+package io.github.seijikohara.femto.ui.settings.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.ChevronRight
+import com.composables.icons.lucide.ExternalLink
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.RotateCcw
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.FemtoIcon
+import kotlin.math.roundToInt
+
+@Composable
+internal fun Header(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) = Row(
+    modifier = modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+) {
+    Box(
+        modifier =
+            Modifier
+                .size(FemtoDimens.MinTouchTarget)
+                .clipClickable(onBack),
+        contentAlignment = Alignment.Center,
+    ) {
+        FemtoIcon(
+            imageVector = Lucide.ArrowLeft,
+            contentDescription = stringResource(R.string.settings_back),
+            tint = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.size(28.dp),
+        )
+    }
+    Text(
+        text = stringResource(R.string.settings_title),
+        style = MaterialTheme.typography.headlineMedium,
+        color = MaterialTheme.colorScheme.onBackground,
+    )
+}
+
+// A category: a small colored header above a flat (0 dp) rounded card holding the
+// section's rows, echoing the Android Settings app's grouped layout.
+@Composable
+internal fun SettingsSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) = Column(
+    modifier = modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(start = 12.dp),
+    )
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+    ) {
+        Column(content = content)
+    }
+}
+
+// A sub-group label inside a section card, separating related rows under a
+// section heading. Same 18sp as the section heading but muted (onSurfaceVariant
+// vs the section's primary) and indented to align with row content, so it reads
+// as a child cluster rather than a new section.
+@Composable
+internal fun SettingsSubheader(
+    title: String,
+    modifier: Modifier = Modifier,
+) = Text(
+    text = title,
+    style = MaterialTheme.typography.labelLarge,
+    color = MaterialTheme.colorScheme.onSurfaceVariant,
+    modifier = modifier.padding(start = 20.dp, top = 14.dp, bottom = 2.dp),
+)
+
+// A single-choice row: shows the current value as its summary and opens a radio
+// dialog on tap (the Android ListPreference pattern).
+@Composable
+internal fun <T> ChoiceRow(
+    title: String,
+    options: List<Pair<T, String>>,
+    selected: T,
+    onSelect: (T) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var dialogOpen by remember { mutableStateOf(false) }
+    SettingRow(
+        title = title,
+        modifier = modifier.clickable { dialogOpen = true },
+        summary = options.firstOrNull { it.first == selected }?.second,
+    ) {
+        TrailingIcon(Lucide.ChevronRight)
+    }
+    if (dialogOpen) {
+        ChoiceDialog(
+            title = title,
+            options = options,
+            selected = selected,
+            onSelect = {
+                onSelect(it)
+                dialogOpen = false
+            },
+            onDismiss = { dialogOpen = false },
+        )
+    }
+}
+
+@Composable
+private fun <T> ChoiceDialog(
+    title: String,
+    options: List<Pair<T, String>>,
+    selected: T,
+    onSelect: (T) -> Unit,
+    onDismiss: () -> Unit,
+) = AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text(text = title) },
+    text = {
+        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+            options.forEach { (value, label) ->
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = FemtoDimens.MinTouchTarget)
+                            .selectable(
+                                selected = value == selected,
+                                role = Role.RadioButton,
+                                onClick = { onSelect(value) },
+                            ),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    RadioButton(selected = value == selected, onClick = null)
+                    Text(text = label, style = MaterialTheme.typography.bodyLarge)
+                }
+            }
+        }
+    },
+    // Tapping a radio option commits and dismisses (select-on-tap), so there is
+    // no confirm action — only Cancel.
+    confirmButton = {},
+    dismissButton = {
+        TextButton(onClick = onDismiss) {
+            Text(text = stringResource(R.string.settings_cancel))
+        }
+    },
+)
+
+// A boolean row: the whole row is the toggle (role = Switch), so the inline
+// Switch is presentation-only (onCheckedChange = null) and never double-fires. An
+// optional [summary] explains what the toggle does (e.g. attribution / cost notes).
+@Composable
+internal fun SwitchRow(
+    title: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    summary: String? = null,
+) = SettingRow(
+    title = title,
+    modifier = modifier.toggleable(value = checked, role = Role.Switch, onValueChange = onCheckedChange),
+    summary = summary,
+) {
+    Switch(checked = checked, onCheckedChange = null)
+}
+
+// A numeric row: an inline slider under the title / current-value line, with an
+// optional [description] caption beneath that explains what the value trades off.
+@Composable
+internal fun SliderRow(
+    title: String,
+    valueLabel: String,
+    value: Int,
+    range: IntRange,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+) = Column(
+    modifier =
+        modifier
+            .fillMaxWidth()
+            .heightIn(min = FemtoDimens.MinTouchTarget)
+            .padding(horizontal = 20.dp, vertical = 10.dp),
+    verticalArrangement = Arrangement.spacedBy(4.dp),
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            // A long localized title shares the row with the value via SpaceBetween;
+            // weight(fill = false) keeps short titles in place but caps a long one so
+            // it ellipsizes instead of wrapping and shoving the value off the row.
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f, fill = false),
+        )
+        Text(
+            text = valueLabel,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    if (description != null) {
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    Slider(
+        value = value.coerceIn(range.first, range.last).toFloat(),
+        onValueChange = { onValueChange(it.roundToInt().coerceIn(range.first, range.last)) },
+        valueRange = range.first.toFloat()..range.last.toFloat(),
+    )
+}
+
+// A navigation row: links out to a system screen, marked with an external glyph.
+@Composable
+internal fun ActionRow(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) = SettingRow(
+    title = title,
+    modifier = modifier.clickable(onClick = onClick),
+) {
+    TrailingIcon(Lucide.ExternalLink)
+}
+
+// A destructive row: resetting every setting to its default. Tapping opens a
+// confirm dialog — the only destructive action in Settings — so a stray tap on
+// the head unit never wipes the user's configuration.
+@Composable
+internal fun ResetRow(
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var dialogOpen by remember { mutableStateOf(false) }
+    SettingRow(
+        title = stringResource(R.string.settings_reset_to_defaults),
+        modifier = modifier.clickable { dialogOpen = true },
+    ) {
+        TrailingIcon(Lucide.RotateCcw)
+    }
+    if (dialogOpen) {
+        ResetConfirmDialog(
+            onConfirm = {
+                onConfirm()
+                dialogOpen = false
+            },
+            onDismiss = { dialogOpen = false },
+        )
+    }
+}
+
+@Composable
+private fun ResetConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) = AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text(text = stringResource(R.string.settings_reset_confirm_title)) },
+    text = { Text(text = stringResource(R.string.settings_reset_confirm_message)) },
+    confirmButton = {
+        TextButton(onClick = onConfirm) {
+            Text(text = stringResource(R.string.settings_reset_confirm))
+        }
+    },
+    dismissButton = {
+        TextButton(onClick = onDismiss) {
+            Text(text = stringResource(R.string.settings_cancel))
+        }
+    },
+)
+
+// Shared row scaffold: a tap target ≥ MinTouchTarget with a title, optional
+// summary, and a trailing slot. The caller supplies the interaction (clickable /
+// toggleable) through [modifier] so each row keeps the right accessibility role.
+@Composable
+internal fun SettingRow(
+    title: String,
+    modifier: Modifier = Modifier,
+    summary: String? = null,
+    trailing: @Composable () -> Unit = {},
+) = Row(
+    modifier =
+        modifier
+            .fillMaxWidth()
+            .heightIn(min = FemtoDimens.MinTouchTarget)
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(16.dp),
+) {
+    Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        if (summary != null) {
+            Text(
+                text = summary,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+    trailing()
+}
+
+@Composable
+internal fun TrailingIcon(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+) = FemtoIcon(
+    imageVector = imageVector,
+    contentDescription = null,
+    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    modifier = modifier.size(FemtoDimens.InlineIconSize),
+)
+
+// A font-slot row: the current family (or "System default") under the title,
+// opening the full Google Fonts picker on tap.
+@Composable
+internal fun FontRow(
+    title: String,
+    family: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) = SettingRow(
+    title = title,
+    modifier = modifier.clickable(onClick = onClick),
+    summary = family ?: stringResource(R.string.settings_font_system),
+) {
+    TrailingIcon(Lucide.ChevronRight)
+}
+
+// Small modifier helper: clip to a circle and make clickable, for the back box.
+private fun Modifier.clipClickable(onClick: () -> Unit): Modifier =
+    this
+        .clip(RoundedCornerShape(percent = 50))
+        .clickable(onClick = onClick)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SystemSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SystemSection.kt
@@ -1,0 +1,40 @@
+package io.github.seijikohara.femto.ui.settings.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.ui.settings.SettingsAction
+
+@Composable
+internal fun SystemSection(
+    onAction: (SettingsAction) -> Unit,
+    onOpenNotificationAccess: () -> Unit,
+    onOpenSystemSettings: () -> Unit,
+    onOpenDiagnostics: () -> Unit,
+    onOpenLicenses: () -> Unit,
+    onOpenPrivacyPolicy: () -> Unit,
+    modifier: Modifier = Modifier,
+) = SettingsSection(title = stringResource(R.string.settings_group_system), modifier = modifier) {
+    ActionRow(
+        title = stringResource(R.string.settings_open_notification_access),
+        onClick = onOpenNotificationAccess,
+    )
+    ActionRow(
+        title = stringResource(R.string.settings_open_system_settings),
+        onClick = onOpenSystemSettings,
+    )
+    ActionRow(
+        title = stringResource(R.string.settings_open_diagnostics),
+        onClick = onOpenDiagnostics,
+    )
+    ActionRow(
+        title = stringResource(R.string.settings_open_licenses),
+        onClick = onOpenLicenses,
+    )
+    ActionRow(
+        title = stringResource(R.string.settings_open_privacy),
+        onClick = onOpenPrivacyPolicy,
+    )
+    ResetRow(onConfirm = { onAction(SettingsAction.ResetToDefaults) })
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/UnitsSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/UnitsSection.kt
@@ -1,0 +1,57 @@
+package io.github.seijikohara.femto.ui.settings.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.display.ClockSetting
+import io.github.seijikohara.femto.data.display.SpeedUnitSetting
+import io.github.seijikohara.femto.data.display.TemperatureUnitSetting
+import io.github.seijikohara.femto.ui.settings.SettingsAction
+import io.github.seijikohara.femto.ui.settings.SettingsUiState
+
+@Composable
+internal fun UnitsSection(
+    uiState: SettingsUiState,
+    onAction: (SettingsAction) -> Unit,
+    modifier: Modifier = Modifier,
+) = SettingsSection(title = stringResource(R.string.settings_section_units), modifier = modifier) {
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_speed),
+        options =
+            listOf(
+                SpeedUnitSetting.AUTO to stringResource(R.string.settings_option_auto),
+                SpeedUnitSetting.KILOMETERS to stringResource(R.string.settings_speed_km),
+                SpeedUnitSetting.MILES to stringResource(R.string.settings_speed_mi),
+            ),
+        selected = uiState.speedUnit,
+        onSelect = { onAction(SettingsAction.SetSpeedUnit(it)) },
+    )
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_temperature),
+        options =
+            listOf(
+                TemperatureUnitSetting.AUTO to stringResource(R.string.settings_option_auto),
+                TemperatureUnitSetting.CELSIUS to stringResource(R.string.settings_temp_celsius),
+                TemperatureUnitSetting.FAHRENHEIT to stringResource(R.string.settings_temp_fahrenheit),
+            ),
+        selected = uiState.temperatureUnit,
+        onSelect = { onAction(SettingsAction.SetTemperatureUnit(it)) },
+    )
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_clock),
+        options =
+            listOf(
+                ClockSetting.AUTO to stringResource(R.string.settings_option_auto),
+                ClockSetting.TWELVE_HOUR to stringResource(R.string.settings_clock_12),
+                ClockSetting.TWENTY_FOUR_HOUR to stringResource(R.string.settings_clock_24),
+            ),
+        selected = uiState.clock,
+        onSelect = { onAction(SettingsAction.SetClock(it)) },
+    )
+    SwitchRow(
+        title = stringResource(R.string.settings_group_clock_seconds),
+        checked = uiState.showClockSeconds,
+        onCheckedChange = { onAction(SettingsAction.SetShowClockSeconds(it)) },
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,7 @@
     <string name="settings_mapbox_token_hint">Paste your Mapbox public token (pk.…)</string>
     <string name="settings_mapbox_token_save">Save</string>
     <string name="settings_mapbox_token_clear">Clear</string>
-    <string name="settings_subheader_screen">Screen</string>
+    <string name="settings_section_screen">Screen</string>
     <string name="settings_subheader_glass">Glass</string>
     <string name="settings_group_glass_blur">Blur radius</string>
     <string name="settings_group_glass_opacity">Glass opacity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,6 +197,7 @@
     <string name="settings_accent_violet">Violet</string>
     <string name="settings_accent_pink">Pink</string>
     <string name="settings_group_theme_preset">Theme preset</string>
+    <string name="settings_theme_preset_custom">Custom</string>
     <string name="theme_preset_dynamic">Dynamic</string>
     <string name="theme_preset_ocean">Ocean</string>
     <string name="theme_preset_forest">Forest</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,9 +132,9 @@
     <string name="settings_title">Settings</string>
     <string name="settings_back">Back</string>
     <string name="settings_cancel">Cancel</string>
-    <string name="settings_section_display">Display</string>
     <string name="settings_section_units">Units</string>
     <string name="settings_section_map">Map</string>
+    <string name="settings_section_appearance">Appearance</string>
     <string name="settings_section_location">Location</string>
     <string name="settings_section_panels">Panels</string>
     <string name="settings_mapbox_token">Mapbox access token</string>
@@ -162,7 +162,6 @@
     <string name="settings_dock_right">Right</string>
     <string name="settings_subheader_fonts">Fonts</string>
     <string name="settings_subheader_map_rendering">Rendering</string>
-    <string name="settings_subheader_map_appearance">Appearance</string>
     <string name="settings_subheader_map_camera">Camera</string>
     <string name="settings_group_theme">Theme</string>
     <string name="settings_group_speed">Speed &amp; distance</string>
@@ -198,6 +197,7 @@
     <string name="settings_accent_pink">Pink</string>
     <string name="settings_group_theme_preset">Theme preset</string>
     <string name="settings_theme_preset_custom">Custom</string>
+    <string name="settings_subheader_map_color">Map color</string>
     <string name="theme_preset_dynamic">Dynamic</string>
     <string name="theme_preset_ocean">Ocean</string>
     <string name="theme_preset_forest">Forest</string>
@@ -219,7 +219,7 @@
     <string name="settings_map_match_theme_desc">Follows the Theme setting above. Turn off to set the map\'s light or dark mode independently.</string>
     <string name="settings_group_map_scheme_light">Light scheme</string>
     <string name="settings_group_map_scheme_dark">Dark scheme</string>
-    <string name="settings_map_scheme_accent">Accent</string>
+    <string name="settings_map_scheme_accent">Accent (app color)</string>
     <string name="settings_map_scheme_positron">Positron</string>
     <string name="settings_map_scheme_bright">Bright</string>
     <string name="settings_map_scheme_liberty">Liberty</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,6 +215,8 @@
     <string name="settings_assistant_system">System</string>
     <string name="settings_assistant_in_app">Built-in</string>
     <string name="settings_group_map_style">Map style</string>
+    <string name="settings_map_match_theme">Match app theme</string>
+    <string name="settings_map_match_theme_desc">Follows the Theme setting above. Turn off to set the map\'s light or dark mode independently.</string>
     <string name="settings_group_map_scheme_light">Light scheme</string>
     <string name="settings_group_map_scheme_dark">Dark scheme</string>
     <string name="settings_map_scheme_accent">Accent</string>


### PR DESCRIPTION
## Summary
- Splits the monolithic Display section into Appearance (theme, accent, map color) and Screen (UI scale, orientation, fullscreen, etc.), and slims Map down to backend/credentials/camera only. The app's color scheme and the map's rendering style were previously entangled across loosely-related settings groups, which made the relationship between them confusing.
- Theme Preset now shows a live "Custom" chip when the accent diverges from every named preset. The old, independently-controlled Map Style picker is replaced with a "Match app theme" toggle (with manual override) inside Appearance's Map Color subsection.
- Fixes an inconsistency where the "accent recolor applies to OpenStreetMap only" note only appeared for the Mapbox backend — it now shows for Google Maps too.
- Extracts the 1469-line `SettingsScreen.kt` into per-section files under `ui/settings/components/`, mirroring the existing `ui/home/components/` convention.
- No DataStore/schema changes — pure UI-layer restructuring reusing existing derivation logic (`ThemePresets.matchingOrNull`, `SettingsAction.SetMapStyle`).

## Test plan
- [x] `spotlessCheck` / `assembleDebug` / `lint` / `test` / `connectedAndroidTest` all green (122/122 instrumented tests, including 41/41 in `SettingsScreenTest`)
- [x] Manual verification on-device: final section order, Appearance contents + live Custom chip, unified non-OSM accent note across both Mapbox and Google Maps, and the "Match app theme" toggle's no-instant-flip behavior
- [x] Independent whole-branch code review; one regression found and fixed (an orphaned "Rendering" subheader shown for non-OSM map backends), with a new regression test added