### PR TITLE
docs: fix stale references across README, CLAUDE.md, and rule files

### DIFF
--- a/.claude/rules/compose.md
+++ b/.claude/rules/compose.md
@@ -43,7 +43,9 @@ convention wins.
 - `stateIn` / `shareIn` use the shared `WhileUiSubscribed` policy
   from `data/common/FlowSharing.kt` — never an inline
   `WhileSubscribed(...)` literal.
-- Use the `add-viewmodel` skill to scaffold the VM + UiState.
+- Use the `add-compose-screen` skill to scaffold a new screen from
+  the canonical template, and the `add-viewmodel` skill to scaffold
+  the VM + UiState.
 
 ## Performance
 

--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -33,7 +33,10 @@ Dependency and build-file discipline for femto-car-launcher.
   skill for the procedure.
 
 Build-time endpoints: `GEOCODER_BASE_URL` / `GEOCODER_API_KEY`,
-`WEATHER_BASE_URL` / `WEATHER_API_KEY`, and `FONTS_METADATA_BASE_URL`
-are `BuildConfig` fields fed from the gitignored `local.properties`,
-falling back to the public hosts. The mechanism (and the per-field
-comments) in `app/build.gradle.kts` is the wiring SSOT.
+`WEATHER_BASE_URL`, and `FONTS_METADATA_BASE_URL` are `BuildConfig`
+fields fed from the gitignored `local.properties`. `WEATHER_BASE_URL`
+and `FONTS_METADATA_BASE_URL` fall back to public hosts;
+`GEOCODER_BASE_URL` / `GEOCODER_API_KEY` fall back to empty, which
+makes the launcher use the on-device platform geocoder instead of a
+network host. The mechanism (and the per-field comments) in
+`app/build.gradle.kts` is the wiring SSOT.

--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -42,8 +42,10 @@ with automotive overrides on top.
   ExtraBold/Bold, headline SemiBold, title Medium; body Normal, label
   Medium — `ui/theme/Type.kt` is the SSOT). Use
   `MaterialTheme.typography.*` styles or the named `Typography`
-  extensions in `Type.kt` (`bigNumber`, `sectionLabel`, `cardTitle`,
-  `cardMeta`, `cardCta`, `cardCtaHint`); never construct ad-hoc
+  extensions in `Type.kt` (`bigNumber`, `heroNumeral`, `sectionLabel`,
+  `eyebrow`, `calendarWeekday`, `glanceMetric`, `glanceBody`,
+  `progressCaption`, `monoReference`, `cardTitle`, `cardMeta`,
+  `cardCta`, `cardCtaHint`, `tileLabel`); never construct ad-hoc
   `TextStyle` literals — a recurring `.copy(fontSize = ...)` becomes a
   new named extension in `Type.kt`.
 - Sizing: read from `FemtoDimens` (e.g. `FemtoDimens.MinTouchTarget`).
@@ -53,3 +55,9 @@ with automotive overrides on top.
   ...)`) beside it are sanctioned responsive test cases: annotation
   classes cannot parameterise dimensions, and the geometries differ
   per component.
+- `ui/theme/FitText.kt` is the SSOT for a single-line label that
+  shrinks to fit its available width across locales and screen sizes
+  (weekday names, track titles, metric values).
+  `ui/theme/PreviewTextStress.kt` is a `@Preview` annotation bundling
+  pseudolocale (`en-XA`, `ar-XB`) and large-font-scale cases; apply it
+  alongside `@PreviewLightDark` on text-heavy components.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -11,7 +11,11 @@ reference: <https://developer.android.com/training/testing>.
 
 - JVM unit tests in `app/src/test/...`: JUnit 4 today (room to
   migrate to Kotest later). Async code uses `runTest` from
-  `kotlinx-coroutines-test` plus an injected `TestDispatcher`.
+  `kotlinx-coroutines-test`; dispatcher control varies by need — an
+  ambient `Dispatchers.setMain(StandardTestDispatcher())`, an
+  injected `TestScope` / `CoroutineScope`, or neither when Turbine
+  and the default `runTest` scheduler already serialise the
+  assertions.
 - Compose UI tests in `app/src/androidTest/...`: use
   `createComposeRule()`. Wrap content in `FemtoTheme { ... }` —
   never an ad-hoc `MaterialTheme`.
@@ -25,6 +29,7 @@ reference: <https://developer.android.com/training/testing>.
   as in production.
 - One assertion focus per test; descriptive names (`returns_x_when_y`).
 - Parameterised tests for repeated cases.
-- ViewModels expose `StateFlow`; tests collect with
-  `viewModel.uiState.test { ... }` (Turbine) or with explicit
-  `runCurrent()` calls.
+- ViewModels expose `StateFlow`; tests drive an action then either
+  collect with `viewModel.uiState.test { ... }` (Turbine) or call
+  `advanceUntilIdle()` and assert directly on the resulting state —
+  pick whichever reads more clearly for the assertion at hand.

--- a/.claude/rules/webmap.md
+++ b/.claude/rules/webmap.md
@@ -10,11 +10,14 @@ Rules for `webmap/`, the TypeScript source of the map WebView pages
 `mapbox.html` for Mapbox, `googlemaps.html` for Google Maps).
 Dependency versions live in `webmap/package.json` +
 `pnpm-lock.yaml` (the SSOT) — never restate version numbers here.
-`app/src/main/assets/licenses/` holds the licenses of the bundled
-map styles (Positron / Dark Matter) and every JS map library bundled
-into a page — keep it in step with what each page bundles. A
-CDN-loaded library (e.g. the Google Maps JavaScript API) needs no
-local license file.
+`app/src/main/assets/licenses/` holds the license texts for the
+bundled OSS map styles (Positron / Dark Matter) and MapLibre GL JS
+(BSD-3-Clause) — keep it in step with what each page bundles under
+an OSS license. Mapbox GL JS ships under Mapbox's own proprietary
+Terms of Service rather than a redistributable OSS license (the end
+user's own Mapbox account and token govern its use), so it has no
+bundled license file here; a CDN-loaded library (e.g. the Google
+Maps JavaScript API) likewise needs none.
 
 ## Toolchain split
 

--- a/.claude/rules/webmap.md
+++ b/.claude/rules/webmap.md
@@ -5,12 +5,16 @@ paths:
 
 # Webmap
 
-Rules for `webmap/`, the TypeScript source of the LIVE map WebView
-page. Dependency versions live in `webmap/package.json` +
+Rules for `webmap/`, the TypeScript source of the map WebView pages
+(one HTML entry point per backend — `map.html` for OSM/MapLibre,
+`mapbox.html` for Mapbox, `googlemaps.html` for Google Maps).
+Dependency versions live in `webmap/package.json` +
 `pnpm-lock.yaml` (the SSOT) — never restate version numbers here.
 `app/src/main/assets/licenses/` holds the licenses of the bundled
-map styles (Positron / Dark Matter) and MapLibre GL JS — keep it in
-step with what the page bundles.
+map styles (Positron / Dark Matter) and every JS map library bundled
+into a page — keep it in step with what each page bundles. A
+CDN-loaded library (e.g. the Google Maps JavaScript API) needs no
+local license file.
 
 ## Toolchain split
 

--- a/.claude/skills/add-launcher-permission/SKILL.md
+++ b/.claude/skills/add-launcher-permission/SKILL.md
@@ -80,8 +80,6 @@ and degradation behaviour live in the audit log at
 | --- | --- | --- |
 | `QUERY_ALL_PACKAGES` | Show installed apps in the launcher's app list | Play Store policy: requires justification at submission. Prefer `<queries>` with specific intents when feasible. |
 | `SYSTEM_ALERT_WINDOW` | Map / music PiP overlays | User-grantable but visually scary; explain in onboarding. |
-| `POST_NOTIFICATIONS` | User-facing alerts raised by a launcher feature | API 33+; runtime grant required. |
-| `BIND_NOTIFICATION_LISTENER_SERVICE` | Read music MediaSession metadata | User must enable via Settings → Notifications → Notification access. |
 
 ## Skill-specific anti-patterns
 

--- a/.claude/skills/update-gradle-dependency/SKILL.md
+++ b/.claude/skills/update-gradle-dependency/SKILL.md
@@ -113,11 +113,15 @@ need the per-bump justification rule from
   Kotlin and the `kotlin-compose` / `kotlin-serialization` plugin
   aliases move in lock-step automatically (shared `version.ref =
   "kotlin"` in the catalog).
-- **MapLibre renders but cannot be seen on the emulator** (the emulator
-  GLES translator never presents the live map surface). After any
-  MapLibre bump, run `MapSnapshotRenderTest` (`./gradlew
-  connectedAndroidTest`) — its off-screen `MapSnapshotter` is the guard
-  that the map still rasterises real tiles; a grey screenshot is not.
+- **A `maplibre-gl` bump can silently break tile rendering with no
+  automated signal.** There is no automated tile-rendering test —
+  `pnpm run check` (type-check + the `webmap/` unit tests) only
+  covers pure logic (camera math, style JSON), not what actually
+  paints. After any `maplibre-gl` (or `mapbox-gl`) major bump,
+  manually verify the map still renders real tiles, ideally on a
+  physical device — the `verify-on-emulator` skill's own "Known
+  limitation" section explains why the emulator's GLES translator
+  makes the emulator an unreliable check for this specific case.
 
 ## Skill-specific anti-patterns
 

--- a/.claude/skills/verify-android-build/SKILL.md
+++ b/.claude/skills/verify-android-build/SKILL.md
@@ -85,9 +85,13 @@ task. Default is `assembleDebug`.
    do not skip hooks. If a Compose API is experimental, opt in at
    file level — never at module level.
 
-CI parity: `.github/workflows/ci.yml` runs the same set
-(`spotlessCheck test lint assembleDebug`). If this step list
-changes, change `ci.yml` in the same commit.
+CI parity: `.github/workflows/ci.yml` runs the same four tasks
+(`spotlessCheck`, `lint`, `test`, `assembleDebug`), split across
+three parallel jobs (`static-checks`, `unit-tests`, `assemble`) for
+wall-clock speed, plus `verifyRoborazziDebug` alongside `test` in
+CI only (screenshot verification against goldens recorded on the
+CI runner OS). If this step list changes, change `ci.yml` in the
+same commit.
 
 ## Common failure modes and fixes
 

--- a/.claude/skills/verify-on-emulator/SKILL.md
+++ b/.claude/skills/verify-on-emulator/SKILL.md
@@ -85,10 +85,10 @@ the home dashboard.
 ## Known limitation
 
 The emulator cannot present the map WebView's GL surface for any
-backend (OSM/MapLibre, Mapbox, or Google Maps) — see the map memory
-note (`memory/map_maplibre_openfreemap.md` under the project memory
-directory) for the details; do not treat a blank map on the emulator
-as a regression.
+backend (OSM/MapLibre, Mapbox, or Google Maps) — this is a known
+GLES-translator limitation, not a regression; do not treat a blank
+map on the emulator as one. See the project's Claude Code memory
+(CLAUDE.md's Memory section) for the detailed history if needed.
 
 ## Report
 

--- a/.claude/skills/verify-on-emulator/SKILL.md
+++ b/.claude/skills/verify-on-emulator/SKILL.md
@@ -68,7 +68,8 @@ the home dashboard.
    then `am force-stop` + restart.
 
 5. **Drive the UI**: `uiautomator dump /sdcard/ui.xml` + `adb pull`,
-   grep `content-desc="Settings"` for the footer button bounds, then
+   grep `content-desc="Settings"` for the dock button bounds (the
+   `DashboardDock` component, formerly called the footer), then
    `input tap`. The settings ModalBottomSheet opens **partially
    expanded** — `input swipe` up to fully expand, then swipe to
    scroll.
@@ -83,10 +84,11 @@ the home dashboard.
 
 ## Known limitation
 
-The emulator cannot present the native LIVE map GL — see the map
-memory note (`memory/map_maplibre_openfreemap.md` under the project
-memory directory) for the details and the SNAPSHOT floor; do not
-treat a blank LIVE map on the emulator as a regression.
+The emulator cannot present the map WebView's GL surface for any
+backend (OSM/MapLibre, Mapbox, or Google Maps) — see the map memory
+note (`memory/map_maplibre_openfreemap.md` under the project memory
+directory) for the details; do not treat a blank map on the emulator
+as a regression.
 
 ## Report
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ applicable rule wins when markets diverge.
 
 - Kotlin (auto-applied by AGP), Jetpack Compose (via the BOM),
   Material 3; JDK 21 toolchain, Java 11 source/target. Versions:
-  `gradle/libs.versions.toml` + `gradle/wrapper/gradle-wrapper.properties`.
+  `gradle/libs.versions.toml` + `gradle/wrapper/gradle-wrapper.properties`
+  (the JDK toolchain version itself is pinned in
+  `gradle/gradle-daemon-jvm.properties`).
 - `minSdk = 33`, `targetSdk = 36` with `compileSdk { release(37) }`
   (compile against API 37 as `androidx.core` 1.19+ requires; the
   supported-device floor stays Android 13 / API 33).
@@ -75,7 +77,7 @@ Trivial stateless screens need only `<Area>Screen.kt` — see
 | Concern | M3 default | Femto rule | Symbol |
 | --- | --- | --- | --- |
 | Tap target | 48 dp | **≥ 64 dp** | `FemtoDimens.MinTouchTarget` |
-| Body text on the head-unit dashboard | flexible | **≥ 18 sp**, never `bodySmall` / `labelSmall`. Cards may deliberately relax this for glance metadata, metrics, and progress captions — never as a literal in component code: the size lives in `FemtoDimens.GlanceTextSize` (13 sp) or inside a named `Type.kt` extension (e.g. `cardMeta`). The shipped card components under `ui/home/components/` are the reference for where the relaxation applies (inherited from the retired dashboard-v2 mockup, whose KDoc notes mark each spot) | `FemtoDimens.MinBodyTextSize` / `FemtoDimens.GlanceTextSize` |
+| Body text on the head-unit dashboard | flexible | **≥ 18 sp**, never `bodySmall` / `labelSmall`. Cards may deliberately relax this for glance metadata, metrics, progress captions, and dense reference text (e.g. license/log listings) — never as a literal in component code: the size lives in `FemtoDimens.GlanceTextSize` (13 sp) or inside a named `Type.kt` extension (e.g. `cardMeta`, `monoReference`). `ui/home/components/`, `ui/licenses/`, and `ui/diagnostics/` are the reference for where the relaxation applies (inherited from the retired dashboard-v2 mockup, whose KDoc notes mark each spot) | `FemtoDimens.MinBodyTextSize` / `FemtoDimens.GlanceTextSize` |
 
 When the value lives in code, the symbol on the right is the SSOT —
 not a magic number in another file.
@@ -164,7 +166,7 @@ scope column abbreviates it. When in doubt, read them all.
 | `.claude/rules/permissions.md` | `AndroidManifest.xml` | Permission procedure + the audit-log table |
 | `.claude/rules/dependencies.md` | Gradle catalog + wrapper, `**/build.gradle.kts`, `settings.gradle.kts`, `webmap/package.json` + lockfile | Version-catalog discipline, Compose BOM, lock-step rule, build-time endpoints |
 | `.claude/rules/kotlin-style.md` | `app/src/**/*.kt` | Expression chains, naming, sanctioned language features, ktlint / Spotless wiring |
-| `.claude/rules/compose.md` | `app/src/main/java/**/*.kt` | UDF architecture, layering, `WhileUiSubscribed`, Compose performance |
+| `.claude/rules/compose.md` | `app/src/main/java/io/github/seijikohara/femto/**/*.kt` | UDF architecture, layering, `WhileUiSubscribed`, Compose performance |
 | `.claude/rules/testing.md` | `app/src/test/**`, `app/src/androidTest/**` | JUnit 4 + `runTest`, Compose UI tests, `testfixtures/` |
 | `.claude/rules/webmap.md` | `webmap/**` | TS toolchain split, `build.target` floor, TS7 readiness, pnpm pin |
 
@@ -182,6 +184,9 @@ scope column abbreviates it. When in doubt, read them all.
 
 The [`verify-android-build`](.claude/skills/verify-android-build/SKILL.md)
 skill is the canonical verification procedure for non-trivial changes.
+For UI changes, follow it with the
+[`verify-on-emulator`](.claude/skills/verify-on-emulator/SKILL.md)
+skill to check the result on the TBox-Mock AVD.
 
 ## Claude Code surface
 
@@ -199,6 +204,11 @@ SSOT. Manual-only entry points (`disable-model-invocation: true`):
 | `lint` | `/lint [task]` — Android Lint with parsed summary; the lint-report-interpretation SSOT. |
 | `format` | `/format` — runs `./gradlew spotlessApply` and reports the diff. |
 | `review` | `/review [git-range]` — forks the `compose-launcher-reviewer` agent on the resolved diff. |
+
+The [`update-launcher-icon`](.claude/skills/update-launcher-icon/SKILL.md)
+skill regenerates the adaptive launcher icon (background / foreground /
+monochrome) from the root `logo.svg` brand mark; it auto-invokes when
+either changes.
 
 Settings: `.claude/settings.json` (committed) holds the allow /
 deny permission lists; `settings.local.json` (gitignored) holds

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ The home screen is a fixed dashboard rather than a scrolling grid of apps.
   entering your own Google Maps Platform API key in the same screen. The
   view is heading-up (the map rotates so the travel
   direction points up) and offers an optional three-dimensional terrain
-  relief layer (Mapterhorn elevation tiles). Head units whose WebView
-  cannot sustain WebGL can switch to a Snapshot mode that rasterises the
-  same vector map off-screen.
+  relief layer (Mapterhorn elevation tiles).
 - **Trip overlay** — current speed, trip distance, and average speed
   derived from the Global Positioning System (GPS), plus the
   reverse-geocoded address of the current position.
@@ -54,7 +52,8 @@ The home screen is a fixed dashboard rather than a scrolling grid of apps.
   temperature, wind, humidity, and an hourly forecast from MET Norway
   (`api.met.no`).
 - **Calendar card** — a six-day strip and the upcoming events read from the
-  device calendar.
+  device calendar, with a Settings option to choose which of the
+  device's calendars are shown.
 - **Now-playing card** — the active media session (title, artist, source
   app, and transport controls), read through a notification-listener
   service.
@@ -76,18 +75,20 @@ The home screen is a fixed dashboard rather than a scrolling grid of apps.
   family chosen per slot (a Latin face plus a CJK — Chinese, Japanese,
   Korean — fallback face), downloaded on demand and cached on disk. No
   fonts are bundled in the APK and no Play Services are required.
-- **Settings** — in-app preferences for theme (follow-system / light /
-  dark), accent colour (Material You dynamic colour or a fixed seed
-  preset), screen orientation (auto / landscape / portrait), speed and
-  temperature units, clock format and seconds, a fullscreen toggle that
-  hides the system bars, dock edge, drawer icon size, glass-effect blur
-  and opacity for the dashboard overlays, map rendering (Live / Snapshot
-  mode, render quality, terrain, an optional Mapbox access token to
-  enable the Mapbox backend, an optional Google Maps Platform API key
-  to enable the Google Maps backend, and an optional Map ID for a vector
-  Google map), location-update tuning, and the font
-  pairing — plus shortcuts to the system notification-access and Android
-  settings screens, and a one-tap reset to defaults.
+- **Settings** — in-app preferences grouped into seven sections:
+  **Appearance** (theme, accent colour, a curated theme preset with a
+  live "Custom" indicator, map colour matching, glass-effect blur and
+  opacity, and font pairing), **Screen** (UI scale, screen orientation,
+  fullscreen, keep-screen-on, dock edge, and voice-assistant launch
+  behaviour), **Units** (speed and temperature units, clock format and
+  seconds), **Map** (backend choice, an optional Mapbox access token or
+  Google Maps Platform API key to enable the paid backends, 3D
+  buildings, terrain, and camera behaviour), **Location**
+  (location-update tuning), **Panels** (show or hide the calendar,
+  weather, and music cards, and which device calendars the calendar
+  card shows), and **System** (shortcuts to the system
+  notification-access and Android settings screens, and a one-tap
+  reset to defaults).
 
 Each panel degrades gracefully. A panel whose runtime permission is denied,
 or whose data source is unavailable, renders an empty or reduced state
@@ -152,7 +153,10 @@ app/src/main/
 │       ├── drawer/       # full app drawer with pinned dock
 │       ├── assistant/    # voice-assistant bottom sheet
 │       ├── settings/     # in-app settings
+│       ├── diagnostics/  # in-app diagnostics report
+│       ├── licenses/     # open-source licenses screen
 │       ├── fontpicker/   # per-slot Google Fonts picker
+│       ├── common/       # shared modal-sheet helpers
 │       ├── locale/       # unit and locale formatting
 │       └── theme/        # FemtoTheme, design tokens, previews
 └── res/                  # themes, strings (per-locale), launcher icon
@@ -220,11 +224,14 @@ set it to a self-hosted host to use network geocoding instead.
 The [`CI`](.github/workflows/ci.yml) workflow runs on every pull request
 and on pushes to `main`:
 
-- **Validate** (all triggers): runs
-  `./gradlew spotlessCheck test lint assembleDebug` on a Temurin JDK 21
-  runner.
-- **Publish nightly** (`main` pushes and manual `workflow_dispatch` only):
-  builds the release-signed APK behind the [Download](#download) badge.
+- **Checks** (all triggers): three parallel jobs on Temurin JDK 21
+  runners — `static-checks` (`spotlessCheck lint`), `unit-tests`
+  (`test verifyRoborazziDebug`), and `assemble` (`assembleDebug`).
+- **Validate** (all triggers): a lightweight gate that requires every
+  `Checks` job to succeed; this is the single required status check.
+- **Publish nightly** (`main` pushes and manual `workflow_dispatch`
+  only, after `Validate` passes): builds the release-signed APK and
+  AAB behind the [Download](#download) badge.
 
 The nightly APK is **release-signed**; local and contributor
 `./gradlew assembleRelease` builds stay **unsigned**, because the signing


### PR DESCRIPTION
## Summary

- Audited README.md, CLAUDE.md, and every `.claude/rules/*.md` /
  `.claude/skills/*/SKILL.md` file against the current codebase for
  staleness (prompted by recent map-backend and Settings-restructure
  work).
- Fixed discrepancies across 11 files, grouped by root cause:
  - Removed native-MapLibre **Snapshot render mode** (PR #216) is
    still described in README and referenced by a now-nonexistent
    test in `update-gradle-dependency` and a "SNAPSHOT floor" in
    `verify-on-emulator`.
  - **Settings restructure + multi-backend map expansion** (PRs
    #216/#230/#234) left README's Settings/Calendar bullets and
    project-layout tree out of sync, `webmap.md` still describing a
    single page (now 3: OSM/Mapbox/Google Maps), `design-system.md`'s
    `Type.kt` extension list undercounted (6 of 14), and CLAUDE.md's
    automotive-overrides reference missing the licenses/diagnostics
    screens.
  - **Weather/geocoding provider pivot** left a non-existent
    `WEATHER_API_KEY` field and an inaccurate fallback description in
    `dependencies.md`.
  - **CI parallelization** (PR #200) is still described as a single
    job in README and `verify-android-build`, instead of the actual
    3-way parallel matrix + gate.
  - Misc: an incomplete JDK-version citation in CLAUDE.md, a
    too-broad `compose.md` path-scope entry, a stale "footer button"
    reference (renamed to Dock), and 3 skills
    (`add-compose-screen`, `update-launcher-icon`,
    `verify-on-emulator`) that existed but were never cross-referenced
    from any rule file.
- No production code changed — this is a documentation/rule-file-only
  correction pass.

## Test plan

- [x] `./gradlew spotlessCheck` — passed (Markdown formatting).