### PR TITLE
fix(map): show the native tile attribution only for the OSM backend

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapPanel.kt
@@ -116,9 +116,12 @@ internal fun Attribution(
     modifier: Modifier = Modifier,
     showTerrainCredit: Boolean = false,
 ) {
-    // Append the terrain provider's required credit when that LIVE layer is active
-    // (its licence mandates attribution); the base OSM / OpenMapTiles / OpenFreeMap
-    // credit always shows.
+    // The OSM tile credit (OpenStreetMap / OpenMapTiles / OpenFreeMap). The host
+    // renders this overlay only for the OSM backend, whose web page hides its own
+    // attribution control (see showsNativeAttribution in WebMapView.kt); Mapbox and
+    // Google Maps carry their own in-WebView attribution instead. Append the terrain
+    // provider's required credit when that LIVE layer is active (its licence mandates
+    // attribution).
     val base = stringResource(R.string.map_attribution)
     val terrain = stringResource(R.string.map_attribution_terrain)
     val text = base + (if (showTerrainCredit) " · $terrain" else "")

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -524,10 +524,14 @@ internal fun WebMapView(
                 factory = { webView },
             )
         }
-        Attribution(
-            modifier = Modifier.align(Alignment.BottomStart),
-            showTerrainCredit = mapConfig.terrain,
-        )
+        // Native tile credit only for OSM; Mapbox and Google Maps render their own
+        // ToS-mandated attribution inside the WebView (see showsNativeAttribution).
+        if (showsNativeAttribution(mapConfig.backend)) {
+            Attribution(
+                modifier = Modifier.align(Alignment.BottomStart),
+                showTerrainCredit = mapConfig.terrain,
+            )
+        }
     }
 }
 
@@ -592,6 +596,16 @@ internal fun mapPageUrl(backend: MapBackend) =
         MapBackend.GOOGLEMAPS -> "googlemaps.html"
         MapBackend.OSM -> "map.html"
     }
+
+// Whether the host draws the native tile-credit overlay ([Attribution]) for this
+// backend. Only the OSM page hides its web-side attribution (map.html's CSS +
+// main.ts's `attributionControl: false`) and leans on the host for the
+// OpenStreetMap / OpenMapTiles / OpenFreeMap credit. Mapbox and Google Maps render
+// their own ToS-mandated attribution INSIDE the WebView (mapbox-main.ts keeps the
+// Mapbox AttributionControl + logo; googlemaps-main.ts keeps Google's logo +
+// credit), so a native overlay there would both duplicate that credit and — by
+// naming OpenMapTiles / OpenFreeMap — misattribute tiles those backends never serve.
+internal fun showsNativeAttribution(backend: MapBackend) = backend == MapBackend.OSM
 
 // Mapbox GL JS style identifier for the user-chosen style preset.
 internal fun mapboxStyleId(style: MapboxStyle) =

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/components/WebMapPageTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/components/WebMapPageTest.kt
@@ -4,6 +4,8 @@ import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.display.MapboxStyle
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class WebMapPageTest {
     @Test fun `osm backend loads map_html`() {
@@ -18,6 +20,22 @@ class WebMapPageTest {
             "https://appassets.androidplatform.net/assets/web/mapbox.html",
             mapPageUrl(MapBackend.MAPBOX),
         )
+    }
+
+    @Test fun `google maps backend loads googlemaps_html`() {
+        assertEquals(
+            "https://appassets.androidplatform.net/assets/web/googlemaps.html",
+            mapPageUrl(MapBackend.GOOGLEMAPS),
+        )
+    }
+
+    @Test fun `native attribution overlay shows only for osm backend`() {
+        // OSM hides its web-side attribution and relies on the native overlay; the
+        // paid backends carry their own ToS-mandated in-WebView attribution, so the
+        // host must not overlay the OSM/OpenMapTiles/OpenFreeMap credit on them.
+        assertTrue(showsNativeAttribution(MapBackend.OSM))
+        assertFalse(showsNativeAttribution(MapBackend.MAPBOX))
+        assertFalse(showsNativeAttribution(MapBackend.GOOGLEMAPS))
     }
 
     @Test fun `mapbox style ids match mapbox slugs`() {


### PR DESCRIPTION
## Summary

The native `Attribution` overlay in `WebMapView` rendered the
`© OpenStreetMap · OpenMapTiles · OpenFreeMap` credit **unconditionally**,
on top of every map backend. Verified that the map copyright did **not**
follow the active provider:

| Backend | Web-page attribution | Native overlay (before) | Correct? |
| --- | --- | --- | --- |
| **OSM** | hidden on purpose (`main.ts` `attributionControl: false` + `map.html` CSS) | OSM/OpenMapTiles/OpenFreeMap credit | ✅ by design |
| **Mapbox** | Mapbox `AttributionControl` + logo kept (ToS) | **same OSM credit too** | ❌ duplicate + misattributes tiles Mapbox never serves |
| **Google Maps** | Google logo + credit kept (ToS) | **same OSM credit too** | ❌ credits providers Google doesn't use; may obscure Google's own attribution |

## Fix

- Add a pure `showsNativeAttribution(backend)` helper (OSM only) and gate
  the `Attribution()` overlay on it. Mapbox and Google Maps now show only
  their own authoritative, ToS-mandated in-WebView attribution.
- The same gate confines the `Terrain © Mapterhorn` credit to OSM, where
  the terrain layer actually lives (it could otherwise persist onto a
  non-OSM map after the user toggled terrain on OSM then switched backend).
- Update the `Attribution` KDoc to reflect its OSM-only role.

## Test plan

- [x] Added `WebMapPageTest` cases: `showsNativeAttribution` is true only
  for OSM; also filled the missing `mapPageUrl(GOOGLEMAPS)` case.
- [x] `./gradlew spotlessCheck` — passed.
- [x] `./gradlew test` (`WebMapPageTest`) — passed.
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL.
- [x] `./gradlew lint` — 0 errors; the 3 warnings (OldTargetApi, GradleDependency, PluralsCandidate) are pre-existing and unrelated to this diff (no Gradle/manifest files touched).