### PR TITLE
fix(map): default the heavier terrain relief off

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
@@ -179,7 +179,7 @@ internal class DisplayPreferences(
                     mapNorthUp = prefs[MAP_NORTH_UP_KEY] ?: false,
                     mapMarkerPos = prefs[MAP_MARKER_POS_KEY] ?: DEFAULT_MAP_MARKER_POS,
                     map3dBuildings = prefs[MAP_3D_BUILDINGS_KEY] ?: true,
-                    mapTerrain = prefs[MAP_TERRAIN_KEY] ?: true,
+                    mapTerrain = prefs[MAP_TERRAIN_KEY] ?: false,
                     glassBlurRadius = prefs[GLASS_BLUR_KEY] ?: DEFAULT_GLASS_BLUR_DP,
                     glassTintScale = prefs[GLASS_TINT_KEY] ?: DEFAULT_GLASS_TINT_SCALE,
                     showCalendar = prefs[SHOW_CALENDAR_KEY] ?: true,

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplaySettings.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplaySettings.kt
@@ -189,8 +189,10 @@ internal data class DisplaySettings(
     // Location-marker vertical position (0..100): 0 = map centre, 100 = just above
     // the speed overlay. Applied to both backends.
     val mapMarkerPos: Int,
-    // OSM-map (WebGL) feature toggles. Both default off. 3D buildings extrude the
-    // OpenMapTiles building layer; terrain adds raster-DEM relief. Ignored when
+    // OSM-map (WebGL) feature toggles. 3D buildings extrude the OpenMapTiles building
+    // layer (default on); terrain adds raster-DEM relief and defaults OFF — it fetches
+    // a separate elevation-tile source and is the heavier of the two on the weakest
+    // head-unit GPUs, so a fresh install stays light and the user opts in. Ignored when
     // backend == MAPBOX (Mapbox GL JS manages its own layer stack).
     val map3dBuildings: Boolean,
     val mapTerrain: Boolean,
@@ -263,7 +265,7 @@ internal data class DisplaySettings(
                 mapNorthUp = false,
                 mapMarkerPos = DEFAULT_MAP_MARKER_POS,
                 map3dBuildings = true,
-                mapTerrain = true,
+                mapTerrain = false,
                 glassBlurRadius = DEFAULT_GLASS_BLUR_DP,
                 glassTintScale = DEFAULT_GLASS_TINT_SCALE,
                 showCalendar = true,

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -273,7 +273,7 @@ class SettingsViewModelTest {
             val defaults = DisplaySettings.Default
             assertEquals(FullscreenSetting.ON, defaults.fullscreen)
             assertEquals(true, defaults.map3dBuildings)
-            assertEquals(true, defaults.mapTerrain)
+            assertEquals(false, defaults.mapTerrain)
             assertEquals(false, defaults.showClockSeconds)
         }
 


### PR DESCRIPTION
Flip the OSM map's `mapTerrain` default to off (3D buildings stay on). Terrain adds a separate raster-DEM elevation-tile source + per-frame 3D relief — the heavier of the two WebGL features on the weakest head-unit GPUs — so a fresh install stays light and the user opts in from Map settings. Also fixes the stale `// Both default off` comment that contradicted the code (both were `true`). No visual golden change (the WebGL map is not rendered in the Robolectric goldens).