### PR TITLE
feat(settings): collapsible sections + move driver-side into Driving

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -29,6 +29,8 @@ class SettingsScreenTest {
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val appearanceSectionLabel = context.getString(R.string.settings_section_appearance)
     private val screenSectionLabel = context.getString(R.string.settings_section_screen)
+    private val drivingSectionLabel = context.getString(R.string.settings_section_driving)
+    private val driverSideLabel = context.getString(R.string.settings_group_driver_side)
     private val fullscreenLabel = context.getString(R.string.settings_group_fullscreen)
     private val themeLabel = context.getString(R.string.settings_group_theme)
     private val darkLabel = context.getString(R.string.settings_theme_dark)
@@ -583,10 +585,26 @@ class SettingsScreenTest {
         assertEquals(listOf(SettingsAction.SetCalendarHidden(id = 1L, hidden = true)), actions)
     }
 
+    @Test
+    fun section_rows_are_absent_until_the_header_is_tapped() {
+        // Sections are collapsed by default, so the driver-side row (which now lives
+        // under Driving) is not composed until the Driving header is tapped.
+        setScreen(expandSections = false)
+        rule.onNodeWithText(driverSideLabel).assertDoesNotExist()
+        rule
+            .onNodeWithContentDescription(expandCd(R.string.settings_section_driving))
+            .performScrollTo()
+            .performClick()
+        rule.onNodeWithText(driverSideLabel).performScrollTo().assertIsDisplayed()
+    }
+
     private fun setScreen(
         uiState: SettingsUiState = SettingsUiState.Initial,
         onAction: (SettingsAction) -> Unit = {},
         darkTheme: Boolean = false,
+        // Sections collapse by default; most tests interact with rows, so expand
+        // every section after composing. The collapse-behavior test opts out.
+        expandSections: Boolean = true,
     ) {
         rule.setContent {
             FemtoTheme(darkTheme = darkTheme) {
@@ -603,5 +621,35 @@ class SettingsScreenTest {
                 )
             }
         }
+        if (expandSections) {
+            expandAllSections()
+        }
     }
+
+    // Expand every collapsible section so the existing row-level interactions find
+    // their targets, then scroll back to the top so no-scroll clicks and header
+    // assertions start from a fresh-screen position. Header taps toggle only local
+    // expand state — they dispatch no SettingsAction — so this never pollutes a
+    // captured-action assertion.
+    private fun expandAllSections() {
+        listOf(
+            R.string.settings_section_appearance,
+            R.string.settings_section_screen,
+            R.string.settings_section_driving,
+            R.string.settings_section_units,
+            R.string.settings_section_map,
+            R.string.settings_section_location,
+            R.string.settings_section_panels,
+            R.string.settings_group_system,
+        ).forEach { titleRes ->
+            rule.onNodeWithContentDescription(expandCd(titleRes)).performScrollTo().performClick()
+        }
+        rule.onNodeWithContentDescription(collapseCd(R.string.settings_section_appearance)).performScrollTo()
+    }
+
+    private fun expandCd(titleRes: Int) =
+        context.getString(R.string.settings_section_expand, context.getString(titleRes))
+
+    private fun collapseCd(titleRes: Int) =
+        context.getString(R.string.settings_section_collapse, context.getString(titleRes))
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/DrivingSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/DrivingSection.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.BriefingScope
+import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.data.display.PresetMode
 import io.github.seijikohara.femto.ui.settings.SettingsAction
@@ -29,6 +30,18 @@ internal fun DrivingSection(
             ),
         selected = uiState.presetMode,
         onSelect = { onAction(SettingsAction.SetPresetMode(it)) },
+    )
+    // Driver side is the most fundamental cockpit-layout choice, so it sits right
+    // under the auto-switch face at the top of the Driving section.
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_driver_side),
+        options =
+            listOf(
+                DriverSide.RIGHT to stringResource(R.string.settings_driver_side_right),
+                DriverSide.LEFT to stringResource(R.string.settings_driver_side_left),
+            ),
+        selected = uiState.driverSide,
+        onSelect = { onAction(SettingsAction.SetDriverSide(it)) },
     )
     SliderRow(
         title = stringResource(R.string.settings_group_driving_threshold),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/ScreenSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/ScreenSection.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.res.stringResource
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.DockPosition
-import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.OrientationSetting
 import io.github.seijikohara.femto.data.display.UiScale
@@ -62,16 +61,6 @@ internal fun ScreenSection(
             ),
         selected = uiState.dockPosition,
         onSelect = { onAction(SettingsAction.SetDockPosition(it)) },
-    )
-    ChoiceRow(
-        title = stringResource(R.string.settings_group_driver_side),
-        options =
-            listOf(
-                DriverSide.RIGHT to stringResource(R.string.settings_driver_side_right),
-                DriverSide.LEFT to stringResource(R.string.settings_driver_side_left),
-            ),
-        selected = uiState.driverSide,
-        onSelect = { onAction(SettingsAction.SetDriverSide(it)) },
     )
     ChoiceRow(
         title = stringResource(R.string.settings_group_assistant),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SettingsPrimitives.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SettingsPrimitives.kt
@@ -1,5 +1,7 @@
 package io.github.seijikohara.femto.ui.settings.components
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -27,16 +29,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ArrowLeft
+import com.composables.icons.lucide.ChevronDown
 import com.composables.icons.lucide.ChevronRight
 import com.composables.icons.lucide.ExternalLink
 import com.composables.icons.lucide.Lucide
@@ -76,29 +83,68 @@ internal fun Header(
     )
 }
 
-// A category: a small colored header above a flat (0 dp) rounded card holding the
-// section's rows, echoing the Android Settings app's grouped layout.
+// A collapsible category: a tap-to-toggle header row (colored title + rotating
+// chevron) over a flat (0 dp) rounded card holding the section's rows. Collapsed
+// by default so opening Settings shows a scannable list of category headers; the
+// rows compose only once the section is expanded. Mirrors the diagnostics section
+// idiom (DiagnosticsSectionCard). Each section is a distinct call site, so the
+// expand state is positionally scoped by rememberSaveable — one independent,
+// config-change-surviving flag per section, no explicit key needed.
 @Composable
 internal fun SettingsSection(
     title: String,
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit,
-) = Column(
-    modifier = modifier.fillMaxWidth(),
-    verticalArrangement = Arrangement.spacedBy(8.dp),
 ) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(start = 12.dp),
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        label = "sectionChevron",
     )
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceContainer,
+    val toggleDescription =
+        stringResource(
+            if (expanded) R.string.settings_section_collapse else R.string.settings_section_expand,
+            title,
+        )
+    Column(
+        modifier = modifier.fillMaxWidth().animateContentSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Column(content = content)
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = FemtoDimens.MinTouchTarget)
+                    .clickable { expanded = !expanded }
+                    .semantics { contentDescription = toggleDescription }
+                    .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.weight(1f),
+            )
+            FemtoIcon(
+                imageVector = Lucide.ChevronDown,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier =
+                    Modifier
+                        .size(FemtoDimens.InlineIconSize)
+                        .rotate(chevronRotation),
+            )
+        }
+        if (expanded) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.large,
+                color = MaterialTheme.colorScheme.surfaceContainer,
+            ) {
+                Column(content = content)
+            }
+        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,8 @@
     <string name="settings_section_location">Location</string>
     <string name="settings_section_panels">Panels</string>
     <string name="settings_section_driving">Driving</string>
+    <string name="settings_section_expand">Expand %1$s</string>
+    <string name="settings_section_collapse">Collapse %1$s</string>
     <string name="settings_mapbox_token">Mapbox access token</string>
     <string name="settings_mapbox_token_unset">Not set — tap to enter your token</string>
     <string name="settings_mapbox_token_hint">Paste your Mapbox public token (pk.…)</string>


### PR DESCRIPTION
## Settings refresh — Phase A: collapsible sections + consolidate driving

Fixes the "I can't find the setting" problem the owner hit on hardware (the LHD/RHD control lived in **Screen**, buried in a ~45-control single scroll).

- **Collapsible sections.** Every settings section now collapses to a tappable category header (title + rotating chevron), **collapsed by default** — opening Settings shows a clean, scannable list of ~8 categories (Appearance / Screen / Driving / Units / Map / Location / Panels / System) instead of a long scroll. Tap a category to expand it. Each section keeps its own independent expand state (positional `rememberSaveable`; the `key=` overload is deprecated and would bypass positional scoping). Header meets the 64dp tap floor.
- **Consolidate the driving experience.** The **Driver side (LHD/RHD)** control moves from Screen into **Driving**, next to preset auto-switch — so everything about the driving face (preset, threshold, motion, driver side, briefing) is in one place. (Only driver-side moved; the spectrum toggle stays with the music card, terrain with the map — those are correctly placed.)

`SettingsScreenTest` adapted: an `expandAllSections()` helper keeps the ~69 existing row interactions working, plus a new test asserting a section's rows are absent until its header is tapped.

Settings-only change (no cockpit/map/dashboard). Phase B (search) can follow if still wanted after this lands.
