### PR TITLE
fix(webmap): glide the self-marker and camera in lockstep during a preset switch

### DIFF
--- a/webmap/src/camera.test.ts
+++ b/webmap/src/camera.test.ts
@@ -3,9 +3,11 @@ import {
 	appliedBearing,
 	BEARING_SNAP_DELTA_DEG,
 	easeDurationMs,
+	isPaddingOnlyReflow,
 	linearEase,
 	MAX_EASE_MS,
 	MIN_EASE_MS,
+	type ReflowFix,
 	shortestBearingDelta,
 	smoothedBearing,
 } from "./camera";
@@ -84,5 +86,55 @@ describe("appliedBearing", () => {
 
 	it("follows the travel heading when north-up is off", () => {
 		expect(appliedBearing(false, 137)).toBe(137);
+	});
+});
+
+describe("isPaddingOnlyReflow", () => {
+	const fix: ReflowFix = {
+		lon: 139.767,
+		lat: 35.681,
+		markerPos: 70,
+		bottomSafe: 0.1,
+		rightSafe: 0.4,
+		leftSafe: 0,
+	};
+
+	it("is false with no previous push", () => {
+		expect(isPaddingOnlyReflow(null, fix)).toBe(false);
+	});
+
+	it("is false when neither the center nor the padding changed", () => {
+		expect(isPaddingOnlyReflow(fix, { ...fix })).toBe(false);
+	});
+
+	it("is true when the center holds but a safe fraction changed (a preset switch)", () => {
+		expect(
+			isPaddingOnlyReflow(fix, { ...fix, rightSafe: 0, leftSafe: 0 }),
+		).toBe(true);
+	});
+
+	it("is true when only markerPos changed", () => {
+		expect(isPaddingOnlyReflow(fix, { ...fix, markerPos: 40 })).toBe(true);
+	});
+
+	it("is false when the center moved (a genuine GPS fix), even alongside a padding change", () => {
+		expect(
+			isPaddingOnlyReflow(fix, {
+				...fix,
+				lon: fix.lon + 0.001,
+				rightSafe: 0,
+				leftSafe: 0,
+			}),
+		).toBe(false);
+	});
+
+	it("tolerates float round-trip noise in the center without flagging a fix", () => {
+		expect(
+			isPaddingOnlyReflow(fix, {
+				...fix,
+				lat: fix.lat + 1e-9,
+				bottomSafe: 0,
+			}),
+		).toBe(true);
 	});
 });

--- a/webmap/src/camera.ts
+++ b/webmap/src/camera.ts
@@ -76,3 +76,65 @@ export const AUTO_REFOLLOW_MS = 15_000;
 export function appliedBearing(northUp: boolean, heading: number): number {
 	return northUp ? 0 : heading;
 }
+
+// --- Preset-reflow lockstep --------------------------------------------------
+// A Cockpit<->Driving preset switch (see DashboardScaffold.kt) changes which
+// overlay reserves screen space, so the host re-derives MapConfig's safe-area
+// fractions and re-pushes the SAME GPS fix through updateCamera with only the
+// padding changed — a "reflow", as opposed to a genuine fix where the center
+// itself moves. The screen-pinned marker is normally repositioned with an
+// instant style write while the camera eases toward the new padding over the
+// GPS-cadence duration (easeDurationMs); on a reflow that reads as the marker
+// snapping ahead of the map sliding underneath it. isPaddingOnlyReflow tells
+// the two apart so the caller can glide both together instead.
+
+// Tolerance for "same center", in degrees. Far tighter than any real
+// fix-to-fix GPS movement (even a parked vehicle's noise floor is orders of
+// magnitude above this) but loose enough to absorb the Kotlin-double ->
+// JS-string -> JS-double round-trip through evaluateJavascript.
+const REFLOW_CENTER_EPSILON_DEG = 1e-7;
+
+// The camera-relevant fields of one host push. lon/lat name the coordinate
+// pair generically — the Google Maps page's lat/lng fix maps onto the same
+// shape at its call site.
+export interface ReflowFix {
+	lon: number;
+	lat: number;
+	markerPos: number;
+	bottomSafe: number;
+	rightSafe: number;
+	leftSafe: number;
+}
+
+// True when [next] holds the same center as [previous] but a different
+// safe-area padding (a preset-switch reflow, not a new fix). A null
+// [previous] (no push yet) or a moved center (a genuine fix, coincidentally
+// alongside a padding change) both return false — see the call sites, which
+// additionally gate this on "not the first camera push" and "not a signal
+// gap" (those already force the existing snap path regardless).
+export function isPaddingOnlyReflow(
+	previous: ReflowFix | null,
+	next: ReflowFix,
+): boolean {
+	if (!previous) return false;
+	const sameCenter =
+		Math.abs(previous.lon - next.lon) < REFLOW_CENTER_EPSILON_DEG &&
+		Math.abs(previous.lat - next.lat) < REFLOW_CENTER_EPSILON_DEG;
+	if (!sameCenter) return false;
+	return (
+		previous.markerPos !== next.markerPos ||
+		previous.bottomSafe !== next.bottomSafe ||
+		previous.rightSafe !== next.rightSafe ||
+		previous.leftSafe !== next.leftSafe
+	);
+}
+
+// Fixed lockstep duration for a padding-only reflow, used by the OSM/Mapbox
+// pages: the marker's CSS transition and the camera's easeTo both run this
+// long, so they land together. (The Google Maps page needs no such constant —
+// its camera has no native easing to lock the marker against; see the note in
+// googlemaps-main.ts.) A reflow is driven by the preset Crossfade, not a new
+// GPS fix, so it uses a fixed duration matched to that Crossfade's pace
+// (Motion.kt's STANDARD tween is 220 ms) rather than easeDurationMs's
+// cadence-matched (and much wider, up to MAX_EASE_MS) range.
+export const PRESET_REFLOW_MS = 260;

--- a/webmap/src/googlemaps-main.ts
+++ b/webmap/src/googlemaps-main.ts
@@ -33,6 +33,10 @@
 // One divergence from the OSM/Mapbox pages remains: while detached (free pan) the
 // chevron is hidden rather than swapped to a geo-anchored clone — see setFollowing
 // for why (no mapId-free, non-deprecated geo-marker).
+//
+// A second, related divergence: this page has no preset-switch reflow lockstep
+// timing (contrast camera.ts isPaddingOnlyReflow + marker-motion.ts, used by the
+// OSM/Mapbox pages) because it needs none — see the moveCam doc below.
 import {
 	AUTO_REFOLLOW_MS,
 	appliedBearing,
@@ -412,6 +416,18 @@ async function initMap(): Promise<void> {
 	// A programmatic move opens the gesture-suppression window, then issues the
 	// immediate (un-animated) camera move. Camera-change events fired by this
 	// call land inside the window and are ignored by the gesture detacher.
+	//
+	// This is also why this page needs no preset-reflow lockstep timing (the
+	// mechanism the OSM/Mapbox pages add — see camera.ts isPaddingOnlyReflow
+	// and marker-motion.ts): moveCamera is documented as setting the camera
+	// "immediately... without animation" (there is no promise-based easeTo
+	// equivalent here; smooth motion at GPS cadence relies on frequent small
+	// jumps, not a single interpolated call — see the updateCamera doc below).
+	// So this call and the marker's left/top write in placeFollowCamera below
+	// already land in the same synchronous tick on EVERY push, a genuine fix
+	// or a preset-switch reflow alike: there is no separate "camera glide"
+	// phase for the marker to fall behind, so both already move in lockstep
+	// (a synchronized snap) by construction.
 	function moveCam(opts: GMCameraOptions): void {
 		state.programmaticUntil = Date.now() + GESTURE_SUPPRESS_MS;
 		liveMap.moveCamera(opts);

--- a/webmap/src/main.ts
+++ b/webmap/src/main.ts
@@ -8,10 +8,13 @@ import {
 	AUTO_REFOLLOW_MS,
 	appliedBearing,
 	easeDurationMs,
+	isPaddingOnlyReflow,
 	LOCATION_STALE_THRESHOLD_MS,
 	linearEase,
+	PRESET_REFLOW_MS,
 	smoothedBearing,
 } from "./camera";
+import { createMarkerTransition } from "./marker-motion";
 import {
 	type AccentColors,
 	injectFeatures,
@@ -316,6 +319,9 @@ try {
 	// travel bearing; rotateX lays it onto the tilted ground plane.
 	const markerEl = document.getElementById("self-marker") as HTMLElement;
 	const markerPath = markerEl.querySelector("path");
+	// Lockstep control for a preset-switch reflow — see isPaddingOnlyReflow
+	// and marker-motion.ts.
+	const markerTransition = createMarkerTransition(markerEl, PRESET_REFLOW_MS);
 
 	// Grey the chevron and stop its ripple once fixes stop arriving (signal lost
 	// in a tunnel): the host pushes a fix per update and goes quiet on loss, so
@@ -513,6 +519,11 @@ try {
 		leftSafe,
 		markerColor,
 	) => {
+		// Captured before state.lastFix below is overwritten with this push:
+		// compared against it to tell a genuine GPS fix (the center moves) from
+		// a preset-switch reflow (the center holds, only the safe-area padding
+		// changes) — see isPaddingOnlyReflow.
+		const previousFix = state.lastFix;
 		// Measure the inter-fix interval BEFORE refreshing lastFixMs: the ease
 		// duration matches it so each ease finishes as the next fix lands.
 		const now = Date.now();
@@ -557,6 +568,24 @@ try {
 			}
 			return;
 		}
+		// A preset switch re-pushes the SAME fix with only the padding changed;
+		// a signal gap always takes the jumpTo path below regardless, so it can
+		// never qualify as a reflow.
+		const isReflow =
+			!signalGap &&
+			isPaddingOnlyReflow(previousFix, {
+				lon,
+				lat,
+				markerPos: markerPos || 0,
+				bottomSafe: bottomSafe || 0,
+				rightSafe: rightSafe || 0,
+				leftSafe: leftSafe || 0,
+			});
+		// Lockstep: arm the marker's CSS transition on a reflow so its left/top
+		// write below glides instead of jumping; clear it otherwise so a real
+		// fix keeps snapping the screen-pinned marker while the camera eases
+		// the ground underneath it.
+		markerTransition.setActive(isReflow);
 		markerEl.style.left = `${(0.5 - markerXFraction(rightSafe) + markerXFraction(leftSafe)) * 100}%`;
 		markerEl.style.top = `${50 + markerDrop(markerPos, bottomSafe) * 100}%`;
 		syncChevronTransform(tilt || 0, heading);
@@ -583,6 +612,15 @@ try {
 		if (state.firstCamera || signalGap) {
 			state.firstCamera = false;
 			liveMap.jumpTo(opts);
+		} else if (isReflow) {
+			// Fixed lockstep duration (not the cadence-matched one below) so the
+			// camera lands exactly when the marker's CSS transition finishes.
+			liveMap.easeTo({
+				...opts,
+				duration: PRESET_REFLOW_MS,
+				easing: linearEase,
+				essential: true,
+			});
 		} else {
 			// Cadence-matched duration + linear easing: back-to-back segments
 			// compose into one continuous glide instead of the fixed-1000 ms

--- a/webmap/src/mapbox-main.ts
+++ b/webmap/src/mapbox-main.ts
@@ -21,8 +21,10 @@ import {
 	AUTO_REFOLLOW_MS,
 	appliedBearing,
 	easeDurationMs,
+	isPaddingOnlyReflow,
 	LOCATION_STALE_THRESHOLD_MS,
 	linearEase,
+	PRESET_REFLOW_MS,
 	smoothedBearing,
 } from "./camera";
 import {
@@ -32,6 +34,7 @@ import {
 	TRAFFIC_SOURCE_SPEC,
 	trafficLayerSpec,
 } from "./mapbox-style";
+import { createMarkerTransition } from "./marker-motion";
 import {
 	markerDrop,
 	markerPadLeft,
@@ -216,6 +219,9 @@ function getMapboxGL(): MapboxGLNamespace {
 
 const markerEl = document.getElementById("self-marker") as HTMLElement;
 const markerPath = markerEl.querySelector("path");
+// Lockstep control for a preset-switch reflow — see isPaddingOnlyReflow
+// and marker-motion.ts.
+const markerTransition = createMarkerTransition(markerEl, PRESET_REFLOW_MS);
 
 // The heading-up chevron stays fixed on screen; only the camera moves. North-up
 // mode keeps the map north-aligned and rotates the chevron to the travel bearing.
@@ -475,6 +481,11 @@ function initMap(): void {
 			leftSafe,
 			markerColor,
 		) => {
+			// Captured before state.lastFix below is overwritten with this push:
+			// compared against it to tell a genuine GPS fix (the center moves)
+			// from a preset-switch reflow (the center holds, only the safe-area
+			// padding changes) — see isPaddingOnlyReflow.
+			const previousFix = state.lastFix;
 			const now = Date.now();
 			const sinceLastFixMs = state.lastFixMs > 0 ? now - state.lastFixMs : 0;
 			const signalGap = sinceLastFixMs > LOCATION_STALE_THRESHOLD_MS;
@@ -517,6 +528,24 @@ function initMap(): void {
 				return;
 			}
 
+			// A preset switch re-pushes the SAME fix with only the padding
+			// changed; a signal gap always takes the jumpTo path below
+			// regardless, so it can never qualify as a reflow.
+			const isReflow =
+				!signalGap &&
+				isPaddingOnlyReflow(previousFix, {
+					lon,
+					lat,
+					markerPos: markerPos || 0,
+					bottomSafe: bottomSafe || 0,
+					rightSafe: rightSafe || 0,
+					leftSafe: leftSafe || 0,
+				});
+			// Lockstep: arm the marker's CSS transition on a reflow so its
+			// left/top write below glides instead of jumping; clear it otherwise
+			// so a real fix keeps snapping the screen-pinned marker while the
+			// camera eases the ground underneath it.
+			markerTransition.setActive(isReflow);
 			markerEl.style.left = `${(0.5 - markerXFraction(rightSafe) + markerXFraction(leftSafe)) * 100}%`;
 			markerEl.style.top = `${50 + markerDrop(markerPos, bottomSafe) * 100}%`;
 			syncChevronTransform(tilt || 0, heading);
@@ -547,6 +576,16 @@ function initMap(): void {
 			if (state.firstCamera || signalGap) {
 				state.firstCamera = false;
 				liveMap.jumpTo(opts);
+			} else if (isReflow) {
+				// Fixed lockstep duration (not the cadence-matched one below) so
+				// the camera lands exactly when the marker's CSS transition
+				// finishes.
+				liveMap.easeTo({
+					...opts,
+					duration: PRESET_REFLOW_MS,
+					easing: linearEase,
+					essential: true,
+				});
 			} else {
 				// Cadence-matched linear easing: back-to-back eases compose into one
 				// continuous glide rather than stuttering accelerate-decelerate arcs.

--- a/webmap/src/marker-motion.test.ts
+++ b/webmap/src/marker-motion.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PRESET_REFLOW_MS } from "./camera";
+import { createMarkerTransition } from "./marker-motion";
+
+// A plain style-bearing stub stands in for the marker element: the helper
+// only ever reads/writes el.style.transition, so a real HTMLElement (and the
+// jsdom environment it would require) adds nothing here.
+function markerStub(): HTMLElement {
+	return { style: { transition: "" } } as unknown as HTMLElement;
+}
+
+describe("createMarkerTransition", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("arms the left/top transition on setActive(true) and self-clears once the duration elapses", () => {
+		const marker = markerStub();
+		const transition = createMarkerTransition(marker, PRESET_REFLOW_MS);
+
+		transition.setActive(true);
+		expect(marker.style.transition).toBe(
+			`left ${PRESET_REFLOW_MS}ms linear, top ${PRESET_REFLOW_MS}ms linear`,
+		);
+
+		vi.advanceTimersByTime(PRESET_REFLOW_MS);
+		expect(marker.style.transition).toBe("");
+	});
+
+	it("clears the transition synchronously on setActive(false), with no lag for the next fix", () => {
+		const marker = markerStub();
+		const transition = createMarkerTransition(marker, PRESET_REFLOW_MS);
+
+		transition.setActive(true);
+		expect(marker.style.transition).not.toBe("");
+
+		transition.setActive(false);
+		expect(marker.style.transition).toBe("");
+	});
+
+	it("ignores a stale timeout from an interrupted arming and lets the later one clear at its own deadline", () => {
+		const marker = markerStub();
+		const transition = createMarkerTransition(marker, PRESET_REFLOW_MS);
+
+		transition.setActive(true); // first arming, generation N
+		vi.advanceTimersByTime(PRESET_REFLOW_MS / 2);
+		transition.setActive(true); // second arming (rapid preset toggle), generation N+1
+
+		// The first arming's timeout fires here; its generation check must fail
+		// and leave the second, still-active transition untouched.
+		vi.advanceTimersByTime(PRESET_REFLOW_MS / 2);
+		expect(marker.style.transition).not.toBe("");
+
+		// The second arming's own timeout fires here and clears it.
+		vi.advanceTimersByTime(PRESET_REFLOW_MS / 2);
+		expect(marker.style.transition).toBe("");
+	});
+
+	it("treats a setActive(false) before the timeout as final; the stale timeout later fires as a no-op", () => {
+		const marker = markerStub();
+		const transition = createMarkerTransition(marker, PRESET_REFLOW_MS);
+
+		transition.setActive(true);
+		transition.setActive(false);
+		expect(marker.style.transition).toBe("");
+
+		vi.advanceTimersByTime(PRESET_REFLOW_MS);
+		expect(marker.style.transition).toBe("");
+	});
+});

--- a/webmap/src/marker-motion.ts
+++ b/webmap/src/marker-motion.ts
@@ -1,0 +1,50 @@
+// Screen-pinned self-marker CSS-transition control, shared by the OSM and
+// Mapbox pages (main.ts / mapbox-main.ts render the same #self-marker element
+// positioned via left/top percentages — see style.ts for the percentage
+// math). The Google Maps page does not use this: its camera has no native
+// easing to lock the marker step against (see the note in
+// googlemaps-main.ts), so its marker and camera already update in the same
+// synchronous call.
+//
+// A preset-switch reflow (see camera.ts isPaddingOnlyReflow) needs the marker
+// to glide left/top over the SAME fixed duration the camera eases over,
+// instead of the marker's normal instant (screen-pinned) jump; a genuine GPS
+// fix needs that instant jump back, so the transition must be armed only for
+// the span of one reflow and cleared immediately for the next real fix. An
+// in-flight reflow interrupted by a real fix simply snaps to its
+// already-settled target, since a fix and a reflow write the same left/top
+// for an unchanged preset.
+export interface MarkerTransition {
+	// Arms (or clears) the CSS transition; call before writing the new
+	// left/top so the write itself is what animates (or jumps).
+	setActive(active: boolean): void;
+}
+
+export function createMarkerTransition(
+	el: HTMLElement,
+	durationMs: number,
+): MarkerTransition {
+	// Mutable state in one const holder (let/var are banned — see biome.json
+	// and no-let.grit). Guards the self-clearing timeout below against a stale
+	// clear: two reflows in quick succession (a rapid preset toggle) must not
+	// have the first reflow's timeout wipe out the second reflow's
+	// still-running transition.
+	const marker = { generation: 0 };
+	return {
+		setActive(active: boolean): void {
+			marker.generation += 1;
+			const thisGeneration = marker.generation;
+			if (!active) {
+				el.style.transition = "";
+				return;
+			}
+			el.style.transition = `left ${durationMs}ms linear, top ${durationMs}ms linear`;
+			// Self-clearing: a reflow with no follow-up push (GPS momentarily
+			// idle) must not leave the transition armed forever, where it would
+			// silently animate some unrelated later left/top write.
+			setTimeout(() => {
+				if (thisGeneration === marker.generation) el.style.transition = "";
+			}, durationMs);
+		},
+	};
+}


### PR DESCRIPTION
## Fix the preset-transition marker desync (owner backlog — PR C of 8)

On a cockpit⇄driving preset switch the safe-area changes, so the screen-pinned self-marker's CSS position **jumped** to its new slot instantly while the camera **eased** the ground back under it (~1s) — the marker floated over the wrong ground and read as spurious motion.

**Fix (webmap TypeScript, no Kotlin change):**
- `isPaddingOnlyReflow` detects a preset switch purely in JS — the geographic center is unchanged (within ~1cm) but the safe fractions / marker position differ.
- On such a reflow, the marker and the camera now glide in **lockstep** over the same fixed 260ms (a shared `marker-motion.ts` CSS-transition helper + a matched `easeTo`, same duration *and* linear easing). A genuine new GPS fix clears the transition and keeps the prior behavior (marker screen-pinned, camera eases over the GPS cadence).
- Applied to the OSM (MapLibre) and Mapbox pages; Google Maps is left unchanged because its `moveCamera` is synchronous (marker + camera already update in the same paint — no desync).

Tests: `isPaddingOnlyReflow` (6 cases) + the `marker-motion` generation-guard lifecycle (4 cases), 67/67 webmap tests green.

> **Visual smoothness can only be confirmed on real hardware** — the emulator can't present the live WebGL map and the goldens don't render it. No golden change.
