### PR TITLE
feat(settings): 2-pane master-detail layout (category rail + detail)

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/settings/SettingsScreenTest.kt
@@ -27,10 +27,8 @@ class SettingsScreenTest {
     val rule = createComposeRule()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val appearanceSectionLabel = context.getString(R.string.settings_section_appearance)
-    private val screenSectionLabel = context.getString(R.string.settings_section_screen)
-    private val drivingSectionLabel = context.getString(R.string.settings_section_driving)
     private val driverSideLabel = context.getString(R.string.settings_group_driver_side)
+    private val dockPositionLabel = context.getString(R.string.settings_group_dock_position)
     private val fullscreenLabel = context.getString(R.string.settings_group_fullscreen)
     private val themeLabel = context.getString(R.string.settings_group_theme)
     private val darkLabel = context.getString(R.string.settings_theme_dark)
@@ -71,31 +69,30 @@ class SettingsScreenTest {
 
     @Test
     fun renders_fullscreen_row() {
-        setScreen()
-        // The Screen section now sits below the larger Appearance section (which
-        // absorbed the map-color rows), pushing Fullscreen below the fold on a
-        // short head unit; scroll it into view first.
+        setScreen(category = R.string.settings_section_screen)
         rule.onNodeWithText(fullscreenLabel).performScrollTo().assertIsDisplayed()
     }
 
     @Test
-    fun renders_appearance_section() {
+    fun appearance_category_is_selected_by_default() {
+        // Appearance is the master-detail layout's default category (both the
+        // wide rail and the narrow list start on it), so its rows show without
+        // any navigation — no `category` passed to setScreen here.
         setScreen()
-        rule.onNodeWithText(appearanceSectionLabel).assertIsDisplayed()
+        rule.onNodeWithText(themeLabel).assertIsDisplayed()
     }
 
     @Test
     fun renders_screen_section() {
-        setScreen()
-        rule.onNodeWithText(screenSectionLabel).performScrollTo().assertIsDisplayed()
+        setScreen(category = R.string.settings_section_screen)
+        rule.onNodeWithText(dockPositionLabel).performScrollTo().assertIsDisplayed()
     }
 
     @Test
     fun toggling_fullscreen_dispatches_set_fullscreen_off() {
         val actions = mutableListOf<SettingsAction>()
-        setScreen(onAction = { actions += it })
+        setScreen(onAction = { actions += it }, category = R.string.settings_section_screen)
         // Initial.fullscreen is now ON (the revised default), so tapping flips it off.
-        // Scroll first: see the comment on renders_fullscreen_row.
         rule.onNodeWithText(fullscreenLabel).performScrollTo().performClick()
         assertEquals(listOf(SettingsAction.SetFullscreen(FullscreenSetting.OFF)), actions)
     }
@@ -103,10 +100,9 @@ class SettingsScreenTest {
     @Test
     fun toggling_show_seconds_dispatches_set_show_clock_seconds_on() {
         val actions = mutableListOf<SettingsAction>()
-        setScreen(onAction = { actions += it })
-        // The row sits in the Units section, below the fold on a short head unit, so
-        // scroll it into view first. Initial.showClockSeconds is now false (the revised
-        // default), so tapping the row flips the switch on.
+        setScreen(onAction = { actions += it }, category = R.string.settings_section_units)
+        // Initial.showClockSeconds is now false (the revised default), so tapping
+        // the row flips the switch on.
         rule.onNodeWithText(showSecondsLabel).performScrollTo().performClick()
         assertEquals(listOf(SettingsAction.SetShowClockSeconds(true)), actions)
     }
@@ -114,7 +110,7 @@ class SettingsScreenTest {
     @Test
     fun tapping_an_accent_swatch_dispatches_set_accent_color() {
         val actions = mutableListOf<SettingsAction>()
-        setScreen(onAction = { actions += it })
+        setScreen(onAction = { actions += it }, category = R.string.settings_section_appearance)
         // The accent swatches scroll horizontally; bring the Teal chip into view,
         // then tapping it reports the matching AccentColor.
         rule.onNodeWithContentDescription(tealAccentLabel).performScrollTo().performClick()
@@ -124,7 +120,7 @@ class SettingsScreenTest {
     @Test
     fun choosing_theme_option_dispatches_set_theme_mode() {
         val actions = mutableListOf<SettingsAction>()
-        setScreen(onAction = { actions += it })
+        setScreen(onAction = { actions += it }, category = R.string.settings_section_appearance)
         // The Theme row opens a radio dialog; picking "Dark" reports the choice
         // and closes the dialog.
         rule.onNodeWithText(themeLabel).performClick()
@@ -135,9 +131,9 @@ class SettingsScreenTest {
     @Test
     fun confirming_reset_dispatches_reset_to_defaults() {
         val actions = mutableListOf<SettingsAction>()
-        setScreen(onAction = { actions += it })
-        // The reset row sits at the bottom (System section); scroll it in, tap to
-        // open the confirm dialog, then tap Reset to confirm.
+        setScreen(onAction = { actions += it }, category = R.string.settings_group_system)
+        // The reset row sits at the bottom of the System category; scroll it in,
+        // tap to open the confirm dialog, then tap Reset to confirm.
         rule.onNodeWithText(resetLabel).performScrollTo().performClick()
         rule.onNodeWithText(resetConfirmLabel).performClick()
         assertEquals(listOf(SettingsAction.ResetToDefaults), actions)
@@ -145,26 +141,29 @@ class SettingsScreenTest {
 
     @Test
     fun keep_screen_on_row_is_shown() {
-        setScreen()
+        setScreen(category = R.string.settings_section_screen)
         rule.onNodeWithText(keepScreenOnLabel).performScrollTo().assertIsDisplayed()
     }
 
     @Test
     fun glass_blur_row_is_shown() {
-        setScreen()
+        setScreen(category = R.string.settings_section_appearance)
         rule.onNodeWithText(glassBlurLabel).performScrollTo().assertIsDisplayed()
     }
 
     @Test
     fun location_interval_row_is_shown() {
-        setScreen()
+        setScreen(category = R.string.settings_section_location)
         rule.onNodeWithText(locationIntervalLabel).performScrollTo().assertIsDisplayed()
     }
 
     @Test
     fun auto_map_style_shows_both_scheme_rows() {
         // AUTO can use either scheme (the system theme decides), so both rows show.
-        setScreen(uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.AUTO))
+        setScreen(
+            uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.AUTO),
+            category = R.string.settings_section_appearance,
+        )
         rule.onNodeWithText(lightSchemeLabel).performScrollTo().assertIsDisplayed()
         rule.onNodeWithText(darkSchemeLabel).performScrollTo().assertIsDisplayed()
     }
@@ -172,7 +171,10 @@ class SettingsScreenTest {
     @Test
     fun light_map_style_hides_the_dark_scheme_row() {
         // A fixed LIGHT style never uses the dark scheme, so that row is hidden.
-        setScreen(uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.LIGHT))
+        setScreen(
+            uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.LIGHT),
+            category = R.string.settings_section_appearance,
+        )
         rule.onNodeWithText(lightSchemeLabel).performScrollTo().assertIsDisplayed()
         rule.onNodeWithText(darkSchemeLabel).assertDoesNotExist()
     }
@@ -180,7 +182,10 @@ class SettingsScreenTest {
     @Test
     fun dark_map_style_hides_the_light_scheme_row() {
         // A fixed DARK style never uses the light scheme, so that row is hidden.
-        setScreen(uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.DARK))
+        setScreen(
+            uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.DARK),
+            category = R.string.settings_section_appearance,
+        )
         rule.onNodeWithText(darkSchemeLabel).performScrollTo().assertIsDisplayed()
         rule.onNodeWithText(lightSchemeLabel).assertDoesNotExist()
     }
@@ -189,7 +194,10 @@ class SettingsScreenTest {
     fun map_style_override_choice_hidden_when_matching_app_theme() {
         // mapStyle == AUTO means "match app theme" is on, so the override
         // Light/Dark choice row must not be present.
-        setScreen(uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.AUTO))
+        setScreen(
+            uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.AUTO),
+            category = R.string.settings_section_appearance,
+        )
         rule.onNodeWithText(mapStyleLabel).assertDoesNotExist()
     }
 
@@ -199,6 +207,7 @@ class SettingsScreenTest {
         setScreen(
             uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.LIGHT),
             onAction = { actions += it },
+            category = R.string.settings_section_appearance,
         )
         rule.onNodeWithText(mapStyleLabel).performScrollTo().performClick()
         rule.onNodeWithText(darkLabel).performClick()
@@ -208,7 +217,7 @@ class SettingsScreenTest {
     @Test
     fun turning_off_match_app_theme_dispatches_set_map_style_dark_when_app_is_dark() {
         val actions = mutableListOf<SettingsAction>()
-        setScreen(darkTheme = true, onAction = { actions += it })
+        setScreen(darkTheme = true, onAction = { actions += it }, category = R.string.settings_section_appearance)
         // Initial.mapStyle is AUTO, so the toggle starts checked; tapping unchecks it.
         rule.onNodeWithText(matchAppThemeLabel).performScrollTo().performClick()
         assertEquals(listOf(SettingsAction.SetMapStyle(MapStyleSetting.DARK)), actions)
@@ -217,7 +226,7 @@ class SettingsScreenTest {
     @Test
     fun turning_off_match_app_theme_dispatches_set_map_style_light_when_app_is_light() {
         val actions = mutableListOf<SettingsAction>()
-        setScreen(darkTheme = false, onAction = { actions += it })
+        setScreen(darkTheme = false, onAction = { actions += it }, category = R.string.settings_section_appearance)
         rule.onNodeWithText(matchAppThemeLabel).performScrollTo().performClick()
         assertEquals(listOf(SettingsAction.SetMapStyle(MapStyleSetting.LIGHT)), actions)
     }
@@ -228,6 +237,7 @@ class SettingsScreenTest {
         setScreen(
             uiState = SettingsUiState.Initial.copy(mapStyle = MapStyleSetting.DARK),
             onAction = { actions += it },
+            category = R.string.settings_section_appearance,
         )
         rule.onNodeWithText(matchAppThemeLabel).performScrollTo().performClick()
         assertEquals(listOf(SettingsAction.SetMapStyle(MapStyleSetting.AUTO)), actions)
@@ -243,6 +253,7 @@ class SettingsScreenTest {
                     mapBackend = MapBackend.MAPBOX,
                     mapboxAccessToken = "pk.abc123",
                 ),
+            category = R.string.settings_section_map,
         )
         // "pk.abc123".takeLast(4) == "c123"
         rule.onNodeWithText("••••c123").performScrollTo().assertIsDisplayed()
@@ -256,6 +267,7 @@ class SettingsScreenTest {
                     mapBackend = MapBackend.MAPBOX,
                     mapboxAccessToken = "",
                 ),
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(tokenUnsetLabel).performScrollTo().assertIsDisplayed()
     }
@@ -268,6 +280,7 @@ class SettingsScreenTest {
         setScreen(
             uiState = SettingsUiState.Initial.copy(mapboxAccessToken = ""),
             onAction = { actions += it },
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(mapBackendLabel).performScrollTo().performClick()
         rule.onNodeWithText(mapboxLabel).performClick()
@@ -284,6 +297,7 @@ class SettingsScreenTest {
         setScreen(
             uiState = SettingsUiState.Initial.copy(mapboxAccessToken = ""),
             onAction = { actions += it },
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(mapBackendLabel).performScrollTo().performClick()
         rule.onNodeWithText(mapboxLabel).performClick()
@@ -306,6 +320,7 @@ class SettingsScreenTest {
                     mapboxAccessToken = "pk.old",
                 ),
             onAction = { actions += it },
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(tokenLabel).performScrollTo().performClick()
         rule.onNodeWithText(tokenClearLabel).performClick()
@@ -322,6 +337,7 @@ class SettingsScreenTest {
                     mapBackend = MapBackend.GOOGLEMAPS,
                     googleMapsApiKey = "AIzaTestKey",
                 ),
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(googleMapsTypeLabel).performScrollTo().assertIsDisplayed()
         rule.onNodeWithText(googleMapsTrafficLabel).performScrollTo().assertIsDisplayed()
@@ -335,6 +351,7 @@ class SettingsScreenTest {
                     mapBackend = MapBackend.MAPBOX,
                     mapboxAccessToken = "pk.test",
                 ),
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(accentOsmOnlyNoteLabel).performScrollTo().assertIsDisplayed()
     }
@@ -350,6 +367,7 @@ class SettingsScreenTest {
                     mapBackend = MapBackend.GOOGLEMAPS,
                     googleMapsApiKey = "AIzaTestKey",
                 ),
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(accentOsmOnlyNoteLabel).performScrollTo().assertIsDisplayed()
     }
@@ -365,6 +383,7 @@ class SettingsScreenTest {
                     mapBackend = MapBackend.MAPBOX,
                     mapboxAccessToken = "pk.test",
                 ),
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(mapRenderingSubheaderLabel).assertDoesNotExist()
     }
@@ -377,6 +396,7 @@ class SettingsScreenTest {
         setScreen(
             uiState = SettingsUiState.Initial.copy(googleMapsApiKey = ""),
             onAction = { actions += it },
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(mapBackendLabel).performScrollTo().performClick()
         rule.onNodeWithText(googleMapsLabel).performClick()
@@ -394,6 +414,7 @@ class SettingsScreenTest {
                     mapBackend = MapBackend.GOOGLEMAPS,
                     googleMapsApiKey = "AIzaTestKey",
                 ),
+            category = R.string.settings_section_map,
         )
         // "AIzaTestKey".takeLast(4) == "tKey"
         rule.onNodeWithText("••••tKey").performScrollTo().assertIsDisplayed()
@@ -407,6 +428,7 @@ class SettingsScreenTest {
                     mapBackend = MapBackend.GOOGLEMAPS,
                     googleMapsApiKey = "",
                 ),
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(googleMapsKeyUnsetLabel).performScrollTo().assertIsDisplayed()
     }
@@ -420,6 +442,7 @@ class SettingsScreenTest {
         setScreen(
             uiState = SettingsUiState.Initial.copy(googleMapsApiKey = ""),
             onAction = { actions += it },
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(mapBackendLabel).performScrollTo().performClick()
         rule.onNodeWithText(googleMapsLabel).performClick()
@@ -443,6 +466,7 @@ class SettingsScreenTest {
                     googleMapsApiKey = "AIzaOld",
                 ),
             onAction = { actions += it },
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(googleMapsKeyLabel).performScrollTo().performClick()
         rule.onNodeWithText(googleMapsKeyClearLabel).performClick()
@@ -459,6 +483,7 @@ class SettingsScreenTest {
                     googleMapsApiKey = "AIzaTestKey",
                 ),
             onAction = { actions += it },
+            category = R.string.settings_section_map,
         )
         val terrainLabel = context.getString(R.string.settings_google_maps_type_terrain)
         rule.onNodeWithText(googleMapsTypeLabel).performScrollTo().performClick()
@@ -476,6 +501,7 @@ class SettingsScreenTest {
                     mapBackend = MapBackend.GOOGLEMAPS,
                     googleMapsApiKey = "AIzaTestKey",
                 ),
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(googleMapsMapIdLabel).performScrollTo().assertIsDisplayed()
     }
@@ -491,6 +517,7 @@ class SettingsScreenTest {
                     googleMapsApiKey = "AIzaTestKey",
                     googleMapsMapId = "",
                 ),
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(googleMapsMapIdUnsetLabel).performScrollTo().assertIsDisplayed()
     }
@@ -505,6 +532,7 @@ class SettingsScreenTest {
                     googleMapsApiKey = "AIzaTestKey",
                     googleMapsMapId = "MAP_ID_42",
                 ),
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText("MAP_ID_42").performScrollTo().assertIsDisplayed()
     }
@@ -522,6 +550,7 @@ class SettingsScreenTest {
                     googleMapsMapId = "",
                 ),
             onAction = { actions += it },
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(googleMapsMapIdLabel).performScrollTo().performClick()
         // The hint marks the dialog as open; the field label duplicates the row title,
@@ -543,6 +572,7 @@ class SettingsScreenTest {
                     googleMapsMapId = "MAP_ID_OLD",
                 ),
             onAction = { actions += it },
+            category = R.string.settings_section_map,
         )
         rule.onNodeWithText(googleMapsMapIdLabel).performScrollTo().performClick()
         rule.onNodeWithText(googleMapsMapIdClearLabel).performClick()
@@ -561,6 +591,7 @@ class SettingsScreenTest {
                     hiddenCalendarIds = emptySet(),
                 ),
             onAction = { actions += it },
+            category = R.string.settings_section_panels,
         )
         // Scroll the "Visible calendars" row into view and tap to open the dialog.
         rule.onNodeWithText(visibleCalendarsLabel).performScrollTo().performClick()
@@ -570,15 +601,14 @@ class SettingsScreenTest {
     }
 
     @Test
-    fun section_rows_are_absent_until_the_header_is_tapped() {
-        // Sections are collapsed by default, so the driver-side row (which now lives
-        // under Driving) is not composed until the Driving header is tapped.
-        setScreen(expandSections = false)
+    fun driving_category_rows_are_absent_until_navigated_to() {
+        // Only the SELECTED category's rows are ever composed — Appearance is the
+        // default, not Driving, so the driver-side row starts absent. Navigating to
+        // Driving (via the rail in the wide layout, or the list in the narrow
+        // layout — navigateToCategory works either way) then shows it.
+        setScreen()
         rule.onNodeWithText(driverSideLabel).assertDoesNotExist()
-        rule
-            .onNodeWithContentDescription(expandCd(R.string.settings_section_driving))
-            .performScrollTo()
-            .performClick()
+        navigateToCategory(R.string.settings_section_driving)
         rule.onNodeWithText(driverSideLabel).performScrollTo().assertIsDisplayed()
     }
 
@@ -586,9 +616,10 @@ class SettingsScreenTest {
         uiState: SettingsUiState = SettingsUiState.Initial,
         onAction: (SettingsAction) -> Unit = {},
         darkTheme: Boolean = false,
-        // Sections collapse by default; most tests interact with rows, so expand
-        // every section after composing. The collapse-behavior test opts out.
-        expandSections: Boolean = true,
+        // The category to navigate to right after composing, or null to leave the
+        // screen on its initial state (the wide rail's default selection / the
+        // narrow layout's category list).
+        category: Int? = null,
     ) {
         rule.setContent {
             FemtoTheme(darkTheme = darkTheme) {
@@ -605,35 +636,21 @@ class SettingsScreenTest {
                 )
             }
         }
-        if (expandSections) {
-            expandAllSections()
+        if (category != null) {
+            navigateToCategory(category)
         }
     }
 
-    // Expand every collapsible section so the existing row-level interactions find
-    // their targets, then scroll back to the top so no-scroll clicks and header
-    // assertions start from a fresh-screen position. Header taps toggle only local
-    // expand state — they dispatch no SettingsAction — so this never pollutes a
-    // captured-action assertion.
-    private fun expandAllSections() {
-        listOf(
-            R.string.settings_section_appearance,
-            R.string.settings_section_screen,
-            R.string.settings_section_driving,
-            R.string.settings_section_units,
-            R.string.settings_section_map,
-            R.string.settings_section_location,
-            R.string.settings_section_panels,
-            R.string.settings_group_system,
-        ).forEach { titleRes ->
-            rule.onNodeWithContentDescription(expandCd(titleRes)).performScrollTo().performClick()
-        }
-        rule.onNodeWithContentDescription(collapseCd(R.string.settings_section_appearance)).performScrollTo()
+    // Selects [titleRes]'s category via its "Select <title>" click target
+    // (SettingsCategoryList). Works in both master-detail shapes: in the wide
+    // layout the rail is always visible, so this just changes the selection; in
+    // the narrow layout the category list is showing until this tap, which also
+    // navigates to the detail view — either way, the category's rows are
+    // composed and reachable afterward.
+    private fun navigateToCategory(titleRes: Int) {
+        rule.onNodeWithContentDescription(selectDescription(titleRes)).performScrollTo().performClick()
     }
 
-    private fun expandCd(titleRes: Int) =
-        context.getString(R.string.settings_section_expand, context.getString(titleRes))
-
-    private fun collapseCd(titleRes: Int) =
-        context.getString(R.string.settings_section_collapse, context.getString(titleRes))
+    private fun selectDescription(titleRes: Int) =
+        context.getString(R.string.settings_category_select, context.getString(titleRes))
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsCategoryId.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsCategoryId.kt
@@ -1,0 +1,31 @@
+package io.github.seijikohara.femto.ui.settings
+
+import androidx.annotation.StringRes
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.display.SettingsSectionId
+
+/**
+ * One entry per category in the Settings master-detail layout (the left rail
+ * in the wide layout, the list in the narrow list-detail layout): display
+ * order, title, and the [SettingsSectionId] whose keys the category's
+ * detail-pane reset affordance clears.
+ *
+ * [SYSTEM] has no [SettingsSectionId] counterpart — mirrors that enum's own
+ * KDoc: System holds only action links and the global "reset to defaults",
+ * no section-local settings of its own — so its [sectionId] is `null` and the
+ * detail pane omits the per-category reset icon for it (see
+ * `SettingsScreen`'s use of [sectionId] to build that icon's `onClick`).
+ */
+internal enum class SettingsCategoryId(
+    @StringRes val titleRes: Int,
+    val sectionId: SettingsSectionId?,
+) {
+    APPEARANCE(R.string.settings_section_appearance, SettingsSectionId.APPEARANCE),
+    SCREEN(R.string.settings_section_screen, SettingsSectionId.SCREEN),
+    DRIVING(R.string.settings_section_driving, SettingsSectionId.DRIVING),
+    UNITS(R.string.settings_section_units, SettingsSectionId.UNITS),
+    MAP(R.string.settings_section_map, SettingsSectionId.MAP),
+    LOCATION(R.string.settings_section_location, SettingsSectionId.LOCATION),
+    PANELS(R.string.settings_section_panels, SettingsSectionId.PANELS),
+    SYSTEM(R.string.settings_group_system, null),
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsScreen.kt
@@ -1,15 +1,25 @@
 package io.github.seijikohara.femto.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.data.fonts.FontSlot
 import io.github.seijikohara.femto.ui.settings.components.AppearanceSection
@@ -19,6 +29,8 @@ import io.github.seijikohara.femto.ui.settings.components.LocationSection
 import io.github.seijikohara.femto.ui.settings.components.MapSection
 import io.github.seijikohara.femto.ui.settings.components.PanelsSection
 import io.github.seijikohara.femto.ui.settings.components.ScreenSection
+import io.github.seijikohara.femto.ui.settings.components.SettingsCategoryDetail
+import io.github.seijikohara.femto.ui.settings.components.SettingsCategoryList
 import io.github.seijikohara.femto.ui.settings.components.SystemSection
 import io.github.seijikohara.femto.ui.settings.components.UnitsSection
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
@@ -26,11 +38,18 @@ import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 
 /**
- * In-app settings, laid out like the Android system Settings app: category
- * sections, each a flat rounded card of rows. A row carries a title plus the
- * current value as a summary; single-choice rows open a radio dialog, boolean
- * rows toggle an inline switch, numeric rows host an inline slider, and the
- * System rows link out.
+ * In-app settings, laid out as a master-detail pair: a category rail / list
+ * (see [SettingsCategoryList]) and a detail pane for the selected category's
+ * rows (see [SettingsCategoryDetail]). [BoxWithConstraints] reads the
+ * available width to pick the shape — never a specific device: **wide** shows
+ * the rail and the detail pane side by side; **narrow** shows the category
+ * list until one is tapped, then replaces it with the detail view (a back
+ * arrow returns to the list) — the two-pane-to-list-detail fallback Android's
+ * own Settings app uses between a tablet and a phone.
+ *
+ * A row carries a title plus the current value as a summary; single-choice
+ * rows open a radio dialog, boolean rows toggle an inline switch, numeric rows
+ * host an inline slider, and the System rows link out.
  *
  * Pure UI — persisted changes flow up via [onAction]; host-level navigation and
  * system intents flow up via the dedicated callbacks so the screen stays
@@ -58,36 +77,172 @@ internal fun SettingsScreen(
         modifier =
             Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
                 .padding(FemtoDimens.ScreenPadding),
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
         Header(onBack = onBack)
 
-        AppearanceSection(uiState = uiState, onAction = onAction, onOpenFontPicker = onOpenFontPicker)
+        val entries =
+            settingsCategoryEntries(
+                uiState = uiState,
+                onAction = onAction,
+                onOpenFontPicker = onOpenFontPicker,
+                onOpenSystemSettings = onOpenSystemSettings,
+                onOpenNotificationAccess = onOpenNotificationAccess,
+                onOpenDiagnostics = onOpenDiagnostics,
+                onOpenLicenses = onOpenLicenses,
+                onOpenPrivacyPolicy = onOpenPrivacyPolicy,
+            )
+        // Hoisted here (not the ViewModel): which category is showing is pure
+        // navigation state, not a persisted setting. rememberSaveable keeps it
+        // across rotation the same way the old per-section expand flags did.
+        var selectedId by rememberSaveable { mutableStateOf(SettingsCategoryId.entries.first()) }
+        // Narrow list-detail only — whether the detail view covers the list.
+        // Meaningless in the wide layout, where the rail and detail pane are
+        // always both visible side by side.
+        var showDetail by rememberSaveable { mutableStateOf(false) }
 
-        ScreenSection(uiState = uiState, onAction = onAction)
+        BoxWithConstraints(modifier = Modifier.fillMaxWidth().weight(1f)) {
+            if (maxWidth >= SettingsWidePaneBreakpoint) {
+                SettingsWidePane(
+                    entries = entries,
+                    selectedId = selectedId,
+                    onSelect = { selectedId = it },
+                    onAction = onAction,
+                )
+            } else {
+                SettingsNarrowPane(
+                    entries = entries,
+                    selectedId = selectedId,
+                    showDetail = showDetail,
+                    onSelect = {
+                        selectedId = it
+                        showDetail = true
+                    },
+                    onBack = { showDetail = false },
+                    onAction = onAction,
+                )
+            }
+        }
+    }
+}
 
-        DrivingSection(uiState = uiState, onAction = onAction)
+// The wide shape: a fixed-width category rail beside a detail pane filling
+// the rest of the row, both spanning the full available height so each
+// scrolls independently of the other (and of the rail's own scroll, if the
+// 8 categories ever outgrow it).
+@Composable
+private fun SettingsWidePane(
+    entries: List<SettingsCategoryEntry>,
+    selectedId: SettingsCategoryId,
+    onSelect: (SettingsCategoryId) -> Unit,
+    onAction: (SettingsAction) -> Unit,
+    modifier: Modifier = Modifier,
+) = Row(
+    modifier = modifier.fillMaxSize(),
+    horizontalArrangement = Arrangement.spacedBy(FemtoDimens.ScreenPadding),
+) {
+    SettingsCategoryList(
+        selectedId = selectedId,
+        onSelect = onSelect,
+        modifier = Modifier.width(SettingsRailWidth).fillMaxHeight(),
+    )
+    val selected = entries.first { it.id == selectedId }
+    SettingsCategoryDetail(
+        title = stringResource(selected.id.titleRes),
+        onReset = selected.id.sectionId?.let { sectionId -> { onAction(SettingsAction.ResetSection(sectionId)) } },
+        content = selected.content,
+        modifier = Modifier.weight(1f).fillMaxHeight(),
+    )
+}
 
-        UnitsSection(uiState = uiState, onAction = onAction)
-
-        MapSection(uiState = uiState, onAction = onAction)
-
-        LocationSection(uiState = uiState, onAction = onAction)
-
-        PanelsSection(uiState = uiState, onAction = onAction, onOpenSystemSettings = onOpenSystemSettings)
-
-        SystemSection(
-            onAction = onAction,
-            onOpenNotificationAccess = onOpenNotificationAccess,
-            onOpenSystemSettings = onOpenSystemSettings,
-            onOpenDiagnostics = onOpenDiagnostics,
-            onOpenLicenses = onOpenLicenses,
-            onOpenPrivacyPolicy = onOpenPrivacyPolicy,
+// The narrow list-detail shape: the category list fills the pane until a
+// category is selected, then the detail view (with a back arrow to return)
+// replaces it — only one of the two is ever composed at a time.
+@Composable
+private fun SettingsNarrowPane(
+    entries: List<SettingsCategoryEntry>,
+    selectedId: SettingsCategoryId,
+    showDetail: Boolean,
+    onSelect: (SettingsCategoryId) -> Unit,
+    onBack: () -> Unit,
+    onAction: (SettingsAction) -> Unit,
+    modifier: Modifier = Modifier,
+) = Box(modifier = modifier.fillMaxSize()) {
+    if (showDetail) {
+        val selected = entries.first { it.id == selectedId }
+        SettingsCategoryDetail(
+            title = stringResource(selected.id.titleRes),
+            onBack = onBack,
+            onReset = selected.id.sectionId?.let { sectionId -> { onAction(SettingsAction.ResetSection(sectionId)) } },
+            content = selected.content,
+            modifier = Modifier.fillMaxSize(),
+        )
+    } else {
+        SettingsCategoryList(
+            selectedId = selectedId,
+            onSelect = onSelect,
+            modifier = Modifier.fillMaxSize(),
         )
     }
 }
+
+// One entry per Settings category: pairs a [SettingsCategoryId] with the rows
+// composable it drives. Built once per SettingsScreen composition so the wide
+// and narrow shapes above look up the very same selected entry. The per-
+// category *Section composables (AppearanceSection, ScreenSection, ...) own
+// only their rows now — title and reset wiring live once here (via
+// SettingsCategoryId.titleRes / sectionId), not duplicated per section as
+// they were when each section wrapped itself in the old collapsible card.
+private data class SettingsCategoryEntry(
+    val id: SettingsCategoryId,
+    val content: @Composable () -> Unit,
+)
+
+@Composable
+private fun settingsCategoryEntries(
+    uiState: SettingsUiState,
+    onAction: (SettingsAction) -> Unit,
+    onOpenFontPicker: (FontSlot) -> Unit,
+    onOpenSystemSettings: () -> Unit,
+    onOpenNotificationAccess: () -> Unit,
+    onOpenDiagnostics: () -> Unit,
+    onOpenLicenses: () -> Unit,
+    onOpenPrivacyPolicy: () -> Unit,
+): List<SettingsCategoryEntry> =
+    listOf(
+        SettingsCategoryEntry(SettingsCategoryId.APPEARANCE) {
+            AppearanceSection(uiState = uiState, onAction = onAction, onOpenFontPicker = onOpenFontPicker)
+        },
+        SettingsCategoryEntry(SettingsCategoryId.SCREEN) {
+            ScreenSection(uiState = uiState, onAction = onAction)
+        },
+        SettingsCategoryEntry(SettingsCategoryId.DRIVING) {
+            DrivingSection(uiState = uiState, onAction = onAction)
+        },
+        SettingsCategoryEntry(SettingsCategoryId.UNITS) {
+            UnitsSection(uiState = uiState, onAction = onAction)
+        },
+        SettingsCategoryEntry(SettingsCategoryId.MAP) {
+            MapSection(uiState = uiState, onAction = onAction)
+        },
+        SettingsCategoryEntry(SettingsCategoryId.LOCATION) {
+            LocationSection(uiState = uiState, onAction = onAction)
+        },
+        SettingsCategoryEntry(SettingsCategoryId.PANELS) {
+            PanelsSection(uiState = uiState, onAction = onAction, onOpenSystemSettings = onOpenSystemSettings)
+        },
+        SettingsCategoryEntry(SettingsCategoryId.SYSTEM) {
+            SystemSection(
+                onAction = onAction,
+                onOpenNotificationAccess = onOpenNotificationAccess,
+                onOpenSystemSettings = onOpenSystemSettings,
+                onOpenDiagnostics = onOpenDiagnostics,
+                onOpenLicenses = onOpenLicenses,
+                onOpenPrivacyPolicy = onOpenPrivacyPolicy,
+            )
+        },
+    )
 
 @PreviewLightDark
 @Composable
@@ -106,3 +261,11 @@ private fun SettingsScreenPreview() {
         )
     }
 }
+
+// The width above which the rail + detail pane both fit comfortably: a
+// ~200 dp rail (SettingsRailWidth) plus a detail pane wide enough to host a
+// slider row's title/value pair without crowding.
+private val SettingsWidePaneBreakpoint: Dp = 640.dp
+
+// The category rail's fixed width in the wide layout.
+private val SettingsRailWidth: Dp = 200.dp

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsSheet.kt
@@ -18,9 +18,11 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
  * mirroring [io.github.seijikohara.femto.ui.drawer.AppDrawerSheet]: the dashboard
  * stays composed underneath, so settings read as an overlay the user dismisses by
  * swiping down, tapping the scrim, or the header back button — rather than a
- * full-screen swap. The sheet height is the same viewport fraction as the drawer so
- * the dashboard stays visible behind it. [SettingsRoute] supplies the content inside
- * the height-bounded [Box] so its sections scroll within the sheet.
+ * full-screen swap. The sheet is taller than the drawer's — see
+ * [FemtoDimens.SettingsSheetHeightFraction] — so the master-detail rail / list
+ * and detail pane both have room to breathe. [SettingsRoute] supplies the
+ * content inside the height-bounded [Box] so its category rail / list and
+ * detail pane scroll independently within the sheet.
  *
  * No standalone preview: a [ModalBottomSheet] renders in a popup window Compose
  * previews do not capture, so [SettingsScreen]'s own @PreviewLightDark covers the
@@ -39,7 +41,7 @@ internal fun SettingsSheet(
     fullscreen: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val sheetHeight = rememberSheetHeight(FemtoDimens.DrawerSheetHeightFraction)
+    val sheetHeight = rememberSheetHeight(FemtoDimens.SettingsSheetHeightFraction)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/AppearanceSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/AppearanceSection.kt
@@ -30,7 +30,6 @@ import io.github.seijikohara.femto.data.display.AccentColor
 import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.display.MapColorScheme
 import io.github.seijikohara.femto.data.display.MapStyleSetting
-import io.github.seijikohara.femto.data.display.SettingsSectionId
 import io.github.seijikohara.femto.data.display.ThemeMode
 import io.github.seijikohara.femto.data.fonts.FontSlot
 import io.github.seijikohara.femto.ui.settings.SettingsAction
@@ -45,17 +44,16 @@ private const val MAX_GLASS_BLUR = 40
 private const val MIN_GLASS_OPACITY = 0
 private const val MAX_GLASS_OPACITY = 100
 
+// The Appearance category's rows: the detail-pane title and reset affordance
+// are owned by the shared master-detail wrapper (see SettingsCategoryId,
+// SettingsScreen), not this composable.
 @Composable
 internal fun AppearanceSection(
     uiState: SettingsUiState,
     onAction: (SettingsAction) -> Unit,
     onOpenFontPicker: (FontSlot) -> Unit,
     modifier: Modifier = Modifier,
-) = SettingsSection(
-    title = stringResource(R.string.settings_section_appearance),
-    modifier = modifier,
-    onReset = { onAction(SettingsAction.ResetSection(SettingsSectionId.APPEARANCE)) },
-) {
+) = Column(modifier = modifier) {
     ChoiceRow(
         title = stringResource(R.string.settings_group_theme),
         options =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/DrivingSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/DrivingSection.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.ui.settings.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -7,23 +8,20 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.data.display.PresetMode
-import io.github.seijikohara.femto.data.display.SettingsSectionId
 import io.github.seijikohara.femto.ui.settings.SettingsAction
 import io.github.seijikohara.femto.ui.settings.SettingsUiState
 
 private const val MIN_DRIVING_THRESHOLD_KMH = 3
 private const val MAX_DRIVING_THRESHOLD_KMH = 40
 
+// The Driving category's rows; see AppearanceSection's header comment on why
+// there is no title / reset wiring here.
 @Composable
 internal fun DrivingSection(
     uiState: SettingsUiState,
     onAction: (SettingsAction) -> Unit,
     modifier: Modifier = Modifier,
-) = SettingsSection(
-    title = stringResource(R.string.settings_section_driving),
-    modifier = modifier,
-    onReset = { onAction(SettingsAction.ResetSection(SettingsSectionId.DRIVING)) },
-) {
+) = Column(modifier = modifier) {
     ChoiceRow(
         title = stringResource(R.string.settings_group_preset_mode),
         options =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/LocationSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/LocationSection.kt
@@ -1,10 +1,10 @@
 package io.github.seijikohara.femto.ui.settings.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import io.github.seijikohara.femto.R
-import io.github.seijikohara.femto.data.display.SettingsSectionId
 import io.github.seijikohara.femto.data.location.LocationQualitySetting
 import io.github.seijikohara.femto.ui.settings.SettingsAction
 import io.github.seijikohara.femto.ui.settings.SettingsUiState
@@ -15,16 +15,14 @@ private const val MAX_LOCATION_INTERVAL_STEPS = 8
 private const val MIN_LOCATION_MIN_DISTANCE = 0
 private const val MAX_LOCATION_MIN_DISTANCE = 25
 
+// The Location category's rows; see AppearanceSection's header comment on why
+// there is no title / reset wiring here.
 @Composable
 internal fun LocationSection(
     uiState: SettingsUiState,
     onAction: (SettingsAction) -> Unit,
     modifier: Modifier = Modifier,
-) = SettingsSection(
-    title = stringResource(R.string.settings_section_location),
-    modifier = modifier,
-    onReset = { onAction(SettingsAction.ResetSection(SettingsSectionId.LOCATION)) },
-) {
+) = Column(modifier = modifier) {
     ChoiceRow(
         title = stringResource(R.string.settings_group_location_quality),
         options =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
@@ -29,7 +29,6 @@ import io.github.seijikohara.femto.data.display.MAX_MAP_ZOOM
 import io.github.seijikohara.femto.data.display.MIN_MAP_ZOOM
 import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.display.MapboxStyle
-import io.github.seijikohara.femto.data.display.SettingsSectionId
 import io.github.seijikohara.femto.ui.settings.SettingsAction
 import io.github.seijikohara.femto.ui.settings.SettingsUiState
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
@@ -39,6 +38,11 @@ private const val MAX_MAP_TILT = 60
 private const val MIN_MAP_MARKER_POS = 0
 private const val MAX_MAP_MARKER_POS = 100
 
+// The Map category's rows; see AppearanceSection's header comment on why
+// there is no title / reset wiring here. The token / key / Map ID entry
+// dialogs sit as siblings of the row Column (below), not nested inside it —
+// they are plain AlertDialogs and render in their own window regardless of
+// where they are declared.
 @Composable
 internal fun MapSection(
     uiState: SettingsUiState,
@@ -48,11 +52,7 @@ internal fun MapSection(
     var showTokenDialog by remember { mutableStateOf(false) }
     var showGoogleKeyDialog by remember { mutableStateOf(false) }
     var showGoogleMapIdDialog by remember { mutableStateOf(false) }
-    SettingsSection(
-        title = stringResource(R.string.settings_section_map),
-        modifier = modifier,
-        onReset = { onAction(SettingsAction.ResetSection(SettingsSectionId.MAP)) },
-    ) {
+    Column(modifier = modifier) {
         // Selecting Mapbox without a token, or Google Maps without an API key, opens
         // the respective entry dialog instead of persisting the backend switch —
         // MapSection owns this interception because the dialogs live here.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/PanelsSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/PanelsSection.kt
@@ -33,22 +33,19 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.calendar.CalendarInfo
-import io.github.seijikohara.femto.data.display.SettingsSectionId
 import io.github.seijikohara.femto.ui.settings.SettingsAction
 import io.github.seijikohara.femto.ui.settings.SettingsUiState
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 
+// The Panels category's rows; see AppearanceSection's header comment on why
+// there is no title / reset wiring here.
 @Composable
 internal fun PanelsSection(
     uiState: SettingsUiState,
     onAction: (SettingsAction) -> Unit,
     onOpenSystemSettings: () -> Unit,
     modifier: Modifier = Modifier,
-) = SettingsSection(
-    title = stringResource(R.string.settings_section_panels),
-    modifier = modifier,
-    onReset = { onAction(SettingsAction.ResetSection(SettingsSectionId.PANELS)) },
-) {
+) = Column(modifier = modifier) {
     SwitchRow(
         title = stringResource(R.string.settings_group_panel_calendar),
         checked = uiState.showCalendar,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/ScreenSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/ScreenSection.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.ui.settings.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -8,21 +9,18 @@ import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.DockPosition
 import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.OrientationSetting
-import io.github.seijikohara.femto.data.display.SettingsSectionId
 import io.github.seijikohara.femto.data.display.UiScale
 import io.github.seijikohara.femto.ui.settings.SettingsAction
 import io.github.seijikohara.femto.ui.settings.SettingsUiState
 
+// The Screen category's rows; see AppearanceSection's header comment on why
+// there is no title / reset wiring here.
 @Composable
 internal fun ScreenSection(
     uiState: SettingsUiState,
     onAction: (SettingsAction) -> Unit,
     modifier: Modifier = Modifier,
-) = SettingsSection(
-    title = stringResource(R.string.settings_section_screen),
-    modifier = modifier,
-    onReset = { onAction(SettingsAction.ResetSection(SettingsSectionId.SCREEN)) },
-) {
+) = Column(modifier = modifier) {
     SliderRow(
         title = stringResource(R.string.settings_group_ui_scale),
         valueLabel = stringResource(uiState.uiScale.labelRes()),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SettingsCategoryList.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SettingsCategoryList.kt
@@ -1,0 +1,90 @@
+package io.github.seijikohara.femto.ui.settings.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.ui.settings.SettingsCategoryId
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+
+/**
+ * The master-detail layout's category navigator: the rail in the wide layout,
+ * the list in the narrow list-detail layout — one composable either way, only
+ * its width / placement differs at the call site (see `SettingsScreen`). Every
+ * [SettingsCategoryId] gets one row, in enum declaration order; the row
+ * matching [selectedId] is highlighted so the wide rail always shows which
+ * category the detail pane is showing.
+ */
+@Composable
+internal fun SettingsCategoryList(
+    selectedId: SettingsCategoryId,
+    onSelect: (SettingsCategoryId) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier = modifier.verticalScroll(rememberScrollState()),
+) {
+    SettingsCategoryId.entries.forEach { id ->
+        SettingsCategoryListItem(
+            title = stringResource(id.titleRes),
+            selected = id == selectedId,
+            onClick = { onSelect(id) },
+        )
+    }
+}
+
+// One rail / list row: a >= MinTouchTarget tap target, highlighted with the
+// secondary-container role color when selected. The click target's own
+// contentDescription ("Select X") is distinct from the title Text's plain
+// string so the two never collide in the wide layout, where the rail's row
+// and the detail pane's own header both show the same category title at once.
+@Composable
+private fun SettingsCategoryListItem(
+    title: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val containerColor =
+        if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceContainerLow
+    val contentColor =
+        if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
+    val selectDescription = stringResource(R.string.settings_category_select, title)
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .heightIn(min = FemtoDimens.MinTouchTarget)
+                .background(containerColor, MaterialTheme.shapes.large)
+                .selectable(selected = selected, role = Role.Tab, onClick = onClick)
+                .semantics { contentDescription = selectDescription }
+                .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = contentColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SettingsPrimitives.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SettingsPrimitives.kt
@@ -1,13 +1,11 @@
 package io.github.seijikohara.femto.ui.settings.components
 
-import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -29,12 +27,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -43,7 +39,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ArrowLeft
-import com.composables.icons.lucide.ChevronDown
 import com.composables.icons.lucide.ChevronRight
 import com.composables.icons.lucide.ExternalLink
 import com.composables.icons.lucide.Lucide
@@ -52,6 +47,12 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoIcon
 import kotlin.math.roundToInt
+
+// Shared back-arrow icon size: the screen-level Header (back to the
+// dashboard) and SettingsCategoryDetail's narrow-mode back arrow (back to the
+// category list) both use it, so the two back affordances read as the same
+// control at a glance.
+private val BackIconSize = 28.dp
 
 @Composable
 internal fun Header(
@@ -73,7 +74,7 @@ internal fun Header(
             imageVector = Lucide.ArrowLeft,
             contentDescription = stringResource(R.string.settings_back),
             tint = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.size(28.dp),
+            modifier = Modifier.size(BackIconSize),
         )
     }
     Text(
@@ -83,33 +84,25 @@ internal fun Header(
     )
 }
 
-// A collapsible category: a tap-to-toggle header row (colored title + rotating
-// chevron) over a flat (0 dp) rounded card holding the section's rows. Collapsed
-// by default so opening Settings shows a scannable list of category headers; the
-// rows compose only once the section is expanded. Mirrors the diagnostics section
-// idiom (DiagnosticsSectionCard). Each section is a distinct call site, so the
-// expand state is positionally scoped by rememberSaveable — one independent,
-// config-change-surviving flag per section, no explicit key needed.
+// The master-detail layout's right pane (wide) / detail view (narrow list-detail):
+// a header row (an optional back arrow for the narrow flow's return-to-list,
+// the category title, and an optional reset affordance) over a flat rounded
+// card holding the category's rows, scrolling independently of the rail /
+// list. Category SELECTION (the rail in wide, the list in narrow — see
+// SettingsCategoryList) is what used to be the collapsible per-section toggle;
+// this pane always shows its content, since only one category is ever mounted
+// at a time.
 @Composable
-internal fun SettingsSection(
+internal fun SettingsCategoryDetail(
     title: String,
     modifier: Modifier = Modifier,
+    onBack: (() -> Unit)? = null,
     onReset: (() -> Unit)? = null,
-    content: @Composable ColumnScope.() -> Unit,
+    content: @Composable () -> Unit,
 ) {
-    var expanded by rememberSaveable { mutableStateOf(false) }
     var resetDialogOpen by remember { mutableStateOf(false) }
-    val chevronRotation by animateFloatAsState(
-        targetValue = if (expanded) 180f else 0f,
-        label = "sectionChevron",
-    )
-    val toggleDescription =
-        stringResource(
-            if (expanded) R.string.settings_section_collapse else R.string.settings_section_expand,
-            title,
-        )
     Column(
-        modifier = modifier.fillMaxWidth().animateContentSize(),
+        modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Row(
@@ -117,39 +110,40 @@ internal fun SettingsSection(
                 Modifier
                     .fillMaxWidth()
                     .heightIn(min = FemtoDimens.MinTouchTarget)
-                    .clickable { expanded = !expanded }
-                    .semantics { contentDescription = toggleDescription }
                     .padding(horizontal = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
+            if (onBack != null) {
+                Box(
+                    modifier = Modifier.size(FemtoDimens.MinTouchTarget).clipClickable(onBack),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    FemtoIcon(
+                        imageVector = Lucide.ArrowLeft,
+                        contentDescription = stringResource(R.string.settings_category_back),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(BackIconSize),
+                    )
+                }
+            }
             Text(
                 text = title,
                 style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.weight(1f),
             )
-            // Only surfaced once expanded, alongside the rows it would reset — the
-            // collapsed header list stays a plain, scannable set of category names.
-            if (expanded && onReset != null) {
+            if (onReset != null) {
                 SectionResetButton(onClick = { resetDialogOpen = true })
             }
-            FemtoIcon(
-                imageVector = Lucide.ChevronDown,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier =
-                    Modifier
-                        .size(FemtoDimens.InlineIconSize)
-                        .rotate(chevronRotation),
-            )
         }
-        if (expanded) {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                shape = MaterialTheme.shapes.large,
-                color = MaterialTheme.colorScheme.surfaceContainer,
-            ) {
-                Column(content = content)
+        Surface(
+            modifier = Modifier.fillMaxWidth().weight(1f),
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.surfaceContainer,
+        ) {
+            Box(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                content()
             }
         }
     }
@@ -166,11 +160,8 @@ internal fun SettingsSection(
     }
 }
 
-// A compact >= MinTouchTarget tap target for the per-section reset affordance,
-// distinct from the header row's expand/collapse toggle. Nesting a separately
-// clickable region inside the (also clickable) header row is the same pattern
-// as a list row hosting a trailing icon button: the inner tap consumes the
-// gesture before it reaches the outer toggle.
+// A compact >= MinTouchTarget tap target for the per-category reset
+// affordance in SettingsCategoryDetail's header row.
 @Composable
 private fun SectionResetButton(
     onClick: () -> Unit,
@@ -399,8 +390,8 @@ internal fun ResetRow(
 }
 
 // Shared confirm dialog for both the global reset (ResetRow) and the
-// per-section reset (SettingsSection's SectionResetButton) — title and message
-// vary by caller, the Reset / Cancel actions do not.
+// per-category reset (SettingsCategoryDetail's SectionResetButton) — title and
+// message vary by caller, the Reset / Cancel actions do not.
 @Composable
 private fun ResetConfirmDialog(
     title: String,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SystemSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/SystemSection.kt
@@ -1,11 +1,16 @@
 package io.github.seijikohara.femto.ui.settings.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.ui.settings.SettingsAction
 
+// The System category's rows: action links plus the global reset. Unlike the
+// other 7 categories, System has no SettingsSectionId of its own (see
+// SettingsCategoryId), so the shared master-detail wrapper never gives it a
+// per-category reset icon — ResetRow below is its only reset affordance.
 @Composable
 internal fun SystemSection(
     onAction: (SettingsAction) -> Unit,
@@ -15,7 +20,7 @@ internal fun SystemSection(
     onOpenLicenses: () -> Unit,
     onOpenPrivacyPolicy: () -> Unit,
     modifier: Modifier = Modifier,
-) = SettingsSection(title = stringResource(R.string.settings_group_system), modifier = modifier) {
+) = Column(modifier = modifier) {
     ActionRow(
         title = stringResource(R.string.settings_open_notification_access),
         onClick = onOpenNotificationAccess,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/UnitsSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/UnitsSection.kt
@@ -1,26 +1,24 @@
 package io.github.seijikohara.femto.ui.settings.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.ClockSetting
-import io.github.seijikohara.femto.data.display.SettingsSectionId
 import io.github.seijikohara.femto.data.display.SpeedUnitSetting
 import io.github.seijikohara.femto.data.display.TemperatureUnitSetting
 import io.github.seijikohara.femto.ui.settings.SettingsAction
 import io.github.seijikohara.femto.ui.settings.SettingsUiState
 
+// The Units category's rows; see AppearanceSection's header comment on why
+// there is no title / reset wiring here.
 @Composable
 internal fun UnitsSection(
     uiState: SettingsUiState,
     onAction: (SettingsAction) -> Unit,
     modifier: Modifier = Modifier,
-) = SettingsSection(
-    title = stringResource(R.string.settings_section_units),
-    modifier = modifier,
-    onReset = { onAction(SettingsAction.ResetSection(SettingsSectionId.UNITS)) },
-) {
+) = Column(modifier = modifier) {
     ChoiceRow(
         title = stringResource(R.string.settings_group_speed),
         options =

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -209,10 +209,20 @@ object FemtoDimens {
 
     /**
      * Font-picker bottom-sheet height as a fraction of the viewport. Taller than
-     * the drawer / settings sheets because the picker is a long, scrollable list
-     * of every Google Fonts family and benefits from the extra rows.
+     * the drawer sheet because the picker is a long, scrollable list of every
+     * Google Fonts family and benefits from the extra rows.
      */
     val FontPickerSheetHeightFraction = 0.92f
+
+    /**
+     * Settings bottom-sheet height as a fraction of the viewport. Taller than
+     * the drawer sheet (and equal to the font picker's) because the
+     * master-detail layout needs the extra room on both sides: the rail /
+     * list wants to show as many of the 8 categories as possible without
+     * scrolling, and the detail pane wants to show more than a couple of rows
+     * before its own scroll kicks in.
+     */
+    val SettingsSheetHeightFraction = 0.92f
 
     /**
      * Fraction of the Now-Playing panel's height reserved for the upcoming-queue

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,8 +168,8 @@
     <string name="settings_section_location">Location</string>
     <string name="settings_section_panels">Panels</string>
     <string name="settings_section_driving">Driving</string>
-    <string name="settings_section_expand">Expand %1$s</string>
-    <string name="settings_section_collapse">Collapse %1$s</string>
+    <string name="settings_category_select">Select %1$s</string>
+    <string name="settings_category_back">Back to categories</string>
     <string name="settings_mapbox_token">Mapbox access token</string>
     <string name="settings_mapbox_token_unset">Not set — tap to enter your token</string>
     <string name="settings_mapbox_token_hint">Paste your Mapbox public token (pk.…)</string>


### PR DESCRIPTION
## Settings as a 2-pane master-detail (owner backlog — PR E of 8)

The single collapsible scroll became hard to operate; this replaces it with a master-detail layout.

- **Wide (head unit):** a vertical **category rail** on the left (Appearance / Screen / Driving / Units / Map / Location / Panels / System); selecting a category shows its settings in the right **detail pane** (each scrolls independently). The per-section reset lives in the detail-pane header.
- **Narrow (portrait phone):** the same categories as a full-width **list**; tapping one opens its detail with a Back arrow.
- Width-adaptive via a hand-rolled `BoxWithConstraints` split (640dp breakpoint) — no experimental `ListDetailPaneScaffold`, stable M3 only. Selection survives rotation.
- The 8 categories are one SSOT list `(id, title, content, reset)`; each old section's rows are reused unchanged (nothing dropped). The settings sheet is raised to 0.92 height so the two-pane isn't cramped.

541 unit tests pass; `SettingsScreenTest` reworked around category navigation. Settings isn't in the goldens (no golden change).
