### PR TITLE
feat(drawer): recently-used apps + A-Z fast-scroll index

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -34,6 +34,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import io.github.seijikohara.femto.data.apps.AppsRepository
+import io.github.seijikohara.femto.data.apps.RecentAppsPreferences
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.ClockSetting
 import io.github.seijikohara.femto.data.display.DisplayPreferences
@@ -73,6 +74,7 @@ import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     private val appsRepository by lazy { AppsRepository(this) }
+    private val recentAppsPreferences by lazy { RecentAppsPreferences(this) }
     private val displayPreferences by lazy { DisplayPreferences(this) }
     private val fontRepository by lazy { FontRepository.get(this) }
 
@@ -224,7 +226,16 @@ class MainActivity : ComponentActivity() {
                 if (showDrawer) {
                     AppDrawerSheet(
                         onLaunch = { component ->
-                            appsRepository.launch(component)
+                            // Only a resolved launch feeds the Recent row — a stale
+                            // tile (ActivityNotFoundException / SecurityException)
+                            // never actually opened anything worth surfacing again.
+                            if (appsRepository.launch(component)) {
+                                lifecycleScope.launch {
+                                    recentAppsPreferences.recordLaunch(
+                                        component.flattenToString(),
+                                    )
+                                }
+                            }
                             showDrawer = false
                         },
                         onDismiss = { showDrawer = false },

--- a/app/src/main/java/io/github/seijikohara/femto/data/apps/RecentAppsPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/apps/RecentAppsPreferences.kt
@@ -1,0 +1,120 @@
+package io.github.seijikohara.femto.data.apps
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import io.github.seijikohara.femto.data.common.catchIoAsDefaults
+import io.github.seijikohara.femto.data.common.editOrLog
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Top-N cap for the drawer's "Recent" row (a short, glanceable strip, not a
+ * second full app list). Also caps the persisted history itself: nothing past
+ * the display cap is ever read back out, so keeping more on disk would only
+ * be wasted writes.
+ */
+internal const val RECENT_APPS_MAX_COUNT = 8
+
+/**
+ * One tracked app launch. [component] is a flattened [android.content.ComponentName]
+ * (matches the encoding [DrawerPreferences] already uses for pins).
+ * [launchCount] costs nothing extra to carry alongside the timestamp and is
+ * the natural input for a future "most used" view; today only
+ * [lastLaunchAtMillis] drives the Recent row's ordering.
+ */
+internal data class RecentLaunch(
+    val component: String,
+    val lastLaunchAtMillis: Long,
+    val launchCount: Int,
+)
+
+// A flattened ComponentName can never contain a newline or this field
+// separator, so both are safe delimiters (mirrors DrawerPreferences.PIN_SEPARATOR).
+private const val RECORD_SEPARATOR = "\n"
+private const val FIELD_SEPARATOR = ""
+
+/** Decode the persisted history string, dropping any record that fails to parse. */
+internal fun parseRecentLaunches(raw: String?): List<RecentLaunch> =
+    raw
+        ?.split(RECORD_SEPARATOR)
+        ?.filter { it.isNotEmpty() }
+        ?.mapNotNull { it.toRecentLaunchOrNull() }
+        .orEmpty()
+
+private fun String.toRecentLaunchOrNull(): RecentLaunch? {
+    val fields = split(FIELD_SEPARATOR)
+    if (fields.size != 3) return null
+    val timestamp = fields[1].toLongOrNull() ?: return null
+    val count = fields[2].toIntOrNull() ?: return null
+    return RecentLaunch(component = fields[0], lastLaunchAtMillis = timestamp, launchCount = count)
+}
+
+/** Encode the history back to the persisted string form [parseRecentLaunches] reads. */
+internal fun List<RecentLaunch>.encode(): String =
+    joinToString(RECORD_SEPARATOR) {
+        "${it.component}$FIELD_SEPARATOR${it.lastLaunchAtMillis}$FIELD_SEPARATOR${it.launchCount}"
+    }
+
+/**
+ * Return the history with a launch of [component] at [atMillis] applied: bump
+ * the existing entry's timestamp and count, or append a new entry. The result
+ * is sorted most-recent-first and trimmed to [RECENT_APPS_MAX_COUNT], so it is
+ * always ready to persist or read back as-is.
+ */
+internal fun List<RecentLaunch>.withRecordedLaunch(
+    component: String,
+    atMillis: Long,
+): List<RecentLaunch> {
+    val previousCount = find { it.component == component }?.launchCount ?: 0
+    val updated = RecentLaunch(component = component, lastLaunchAtMillis = atMillis, launchCount = previousCount + 1)
+    return (filterNot { it.component == component } + updated)
+        .sortedByDescending { it.lastLaunchAtMillis }
+        .take(RECENT_APPS_MAX_COUNT)
+}
+
+/**
+ * Persisted launch-history store backing the drawer's "Recent" row: which
+ * component was launched, and when.
+ */
+internal interface RecentAppsStore {
+    /** Most-recently-launched components first, capped to [RECENT_APPS_MAX_COUNT]. */
+    val recentComponents: Flow<List<String>>
+
+    /** Record a launch of [component], bumping it to the front of [recentComponents]. */
+    suspend fun recordLaunch(
+        component: String,
+        atMillis: Long = System.currentTimeMillis(),
+    )
+}
+
+private val Context.recentAppsDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "recent_apps_preferences",
+)
+
+private const val TAG = "RecentAppsPreferences"
+
+internal class RecentAppsPreferences(
+    private val context: Context,
+) : RecentAppsStore {
+    override val recentComponents: Flow<List<String>> =
+        context.recentAppsDataStore.data
+            .catchIoAsDefaults(TAG)
+            .map { prefs -> parseRecentLaunches(prefs[HISTORY_KEY]).map { it.component } }
+
+    override suspend fun recordLaunch(
+        component: String,
+        atMillis: Long,
+    ) {
+        context.recentAppsDataStore.editOrLog(TAG) { prefs ->
+            prefs[HISTORY_KEY] =
+                parseRecentLaunches(prefs[HISTORY_KEY]).withRecordedLaunch(component, atMillis).encode()
+        }
+    }
+
+    private companion object {
+        val HISTORY_KEY = stringPreferencesKey("recent_app_launches")
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerIndex.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerIndex.kt
@@ -1,22 +1,5 @@
 package io.github.seijikohara.femto.ui.drawer
 
-/**
- * One entry in the drawer's alphabetically-sectioned app list: either a
- * full-span section [Header] (its bucket key, e.g. "A", or [NON_LETTER_SECTION_KEY]
- * for a label with no leading letter) or a launchable [App]. Shared by the
- * grid and list layouts so both render the same header + fast-scroll
- * structure over the same item list.
- */
-internal sealed interface DrawerListEntry<out T> {
-    data class Header(
-        val key: String,
-    ) : DrawerListEntry<Nothing>
-
-    data class App<T>(
-        val item: T,
-    ) : DrawerListEntry<T>
-}
-
 /** Bucket for a label with no leading letter (digits, symbols, emoji). */
 internal const val NON_LETTER_SECTION_KEY = "#"
 
@@ -34,46 +17,26 @@ internal fun sectionKeyOf(label: String): String =
         ?.toString() ?: NON_LETTER_SECTION_KEY
 
 /**
- * Interleave alphabetical section headers into [items] (assumed pre-sorted by
- * [labelOf]): one [DrawerListEntry.Header] per run of a shared [sectionKeyOf]
- * bucket, immediately before that bucket's first item. A bucket with no items
- * never appears — the index only ever shows letters the list actually has.
+ * The flat-list index of the first item in each alphabetical bucket present in
+ * [items] (assumed pre-sorted by [labelOf]), keyed by [sectionKeyOf] and
+ * ordered by first appearance. The app grid/list flows continuously with no
+ * section-header items breaking it up (a header-per-letter forced a new row
+ * at every letter, leaving a car launcher's typically 1-2-app-per-letter list
+ * mostly empty space), so a rail letter jumps straight to its first app's own
+ * index rather than to a header above it. This one map feeds both the A-Z
+ * rail's letter set ([Map.keys]) and its `animateScrollToItem` target
+ * ([Map.values]).
  */
-internal fun <T> withSectionHeaders(
+internal fun <T> sectionStartIndices(
     items: List<T>,
     labelOf: (T) -> String,
-): List<DrawerListEntry<T>> {
-    val entries = mutableListOf<DrawerListEntry<T>>()
-    var currentKey: String? = null
-    for (item in items) {
-        val key = sectionKeyOf(labelOf(item))
-        if (key != currentKey) {
-            entries += DrawerListEntry.Header(key)
-            currentKey = key
-        }
-        entries += DrawerListEntry.App(item)
+): Map<String, Int> {
+    val indices = LinkedHashMap<String, Int>()
+    items.forEachIndexed { index, item ->
+        indices.getOrPut(sectionKeyOf(labelOf(item))) { index }
     }
-    return entries
+    return indices
 }
-
-/**
- * The section keys present in [items], in the order [withSectionHeaders]
- * would emit their headers — the letters the fast-scroll rail renders.
- */
-internal fun <T> availableSectionKeys(
-    items: List<T>,
-    labelOf: (T) -> String,
-): List<String> = items.map { sectionKeyOf(labelOf(it)) }.distinct()
-
-/**
- * The flattened-list index of [targetKey]'s header, or null when that section
- * is not present. Feeds the fast-scroll rail's `LazyGridState` /
- * `LazyListState` `.animateScrollToItem(...)` target.
- */
-internal fun <T> headerIndexOf(
-    entries: List<DrawerListEntry<T>>,
-    targetKey: String,
-): Int? = entries.indexOfFirst { it is DrawerListEntry.Header && it.key == targetKey }.takeIf { it >= 0 }
 
 // A drag that has not yet moved past the rail's bottom edge should still
 // resolve to the last letter, not roll over past it.

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerIndex.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerIndex.kt
@@ -1,0 +1,98 @@
+package io.github.seijikohara.femto.ui.drawer
+
+/**
+ * One entry in the drawer's alphabetically-sectioned app list: either a
+ * full-span section [Header] (its bucket key, e.g. "A", or [NON_LETTER_SECTION_KEY]
+ * for a label with no leading letter) or a launchable [App]. Shared by the
+ * grid and list layouts so both render the same header + fast-scroll
+ * structure over the same item list.
+ */
+internal sealed interface DrawerListEntry<out T> {
+    data class Header(
+        val key: String,
+    ) : DrawerListEntry<Nothing>
+
+    data class App<T>(
+        val item: T,
+    ) : DrawerListEntry<T>
+}
+
+/** Bucket for a label with no leading letter (digits, symbols, emoji). */
+internal const val NON_LETTER_SECTION_KEY = "#"
+
+/**
+ * The alphabetical bucket [label] belongs in: its uppercased first letter, or
+ * [NON_LETTER_SECTION_KEY]. Mirrors the standard Android launcher fast-scroll
+ * index (bucket by leading letter; everything else shares one bucket).
+ */
+internal fun sectionKeyOf(label: String): String =
+    label
+        .trim()
+        .firstOrNull()
+        ?.takeIf { it.isLetter() }
+        ?.uppercaseChar()
+        ?.toString() ?: NON_LETTER_SECTION_KEY
+
+/**
+ * Interleave alphabetical section headers into [items] (assumed pre-sorted by
+ * [labelOf]): one [DrawerListEntry.Header] per run of a shared [sectionKeyOf]
+ * bucket, immediately before that bucket's first item. A bucket with no items
+ * never appears — the index only ever shows letters the list actually has.
+ */
+internal fun <T> withSectionHeaders(
+    items: List<T>,
+    labelOf: (T) -> String,
+): List<DrawerListEntry<T>> {
+    val entries = mutableListOf<DrawerListEntry<T>>()
+    var currentKey: String? = null
+    for (item in items) {
+        val key = sectionKeyOf(labelOf(item))
+        if (key != currentKey) {
+            entries += DrawerListEntry.Header(key)
+            currentKey = key
+        }
+        entries += DrawerListEntry.App(item)
+    }
+    return entries
+}
+
+/**
+ * The section keys present in [items], in the order [withSectionHeaders]
+ * would emit their headers — the letters the fast-scroll rail renders.
+ */
+internal fun <T> availableSectionKeys(
+    items: List<T>,
+    labelOf: (T) -> String,
+): List<String> = items.map { sectionKeyOf(labelOf(it)) }.distinct()
+
+/**
+ * The flattened-list index of [targetKey]'s header, or null when that section
+ * is not present. Feeds the fast-scroll rail's `LazyGridState` /
+ * `LazyListState` `.animateScrollToItem(...)` target.
+ */
+internal fun <T> headerIndexOf(
+    entries: List<DrawerListEntry<T>>,
+    targetKey: String,
+): Int? = entries.indexOfFirst { it is DrawerListEntry.Header && it.key == targetKey }.takeIf { it >= 0 }
+
+// A drag that has not yet moved past the rail's bottom edge should still
+// resolve to the last letter, not roll over past it.
+private const val ALMOST_ONE = 0.999999f
+
+/**
+ * Map a touch/drag offset along the fast-scroll rail to a letter index: the
+ * rail scrubs proportionally across its full height rather than requiring the
+ * finger to land inside one specific (necessarily small, per
+ * CLAUDE.md#automotive-overrides) letter row — the standard launcher
+ * fast-scroll interaction. Degrades to index 0 for a not-yet-measured
+ * (zero-height) rail or an empty letter set.
+ */
+internal fun letterIndexForOffset(
+    offsetY: Float,
+    heightPx: Float,
+    letterCount: Int,
+): Int {
+    if (letterCount <= 0 || heightPx <= 0f) return 0
+    val fraction = (offsetY / heightPx).coerceIn(0f, ALMOST_ONE)
+    return (fraction * letterCount).toInt().coerceIn(0, letterCount - 1)
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -16,10 +16,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -34,6 +39,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -57,6 +63,7 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.apps.AppEntry
 import io.github.seijikohara.femto.data.apps.DrawerIconSize
 import io.github.seijikohara.femto.data.apps.DrawerLayout
+import io.github.seijikohara.femto.ui.drawer.components.AlphabetIndexRail
 import io.github.seijikohara.femto.ui.drawer.components.AppListRow
 import io.github.seijikohara.femto.ui.drawer.components.AppTile
 import io.github.seijikohara.femto.ui.drawer.components.PinnedDock
@@ -65,6 +72,7 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoIcon
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+import kotlinx.coroutines.launch
 
 // Per-preset drawer dimensions. MEDIUM matches the pre-preset values: a 120 dp
 // minimum tile yields ~5 columns on the 853 dp-wide reference head unit, giving
@@ -282,9 +290,12 @@ private fun ContentState(
     val pinnedSet = remember(pinned) { pinned.toSet() }
     // Prefix matches rank before substring matches; an empty query shows everything.
     val matched = remember(apps, query) { filterAndRank(apps, query) { it.label } }
-    // The Recent row is a browsing aid; it steps aside the moment a query is
-    // active, when the filtered flat list is the primary signal.
-    if (query.isBlank() && recentApps.isNotEmpty()) {
+    // Both the Recent row and the A-Z index are browsing aids; they step
+    // aside the moment a query is active, when the filtered flat list is the
+    // primary signal (and headers over a filtered subset would be confusing:
+    // the ranking is relevance, not alphabetical).
+    val isSearching = query.isNotBlank()
+    if (!isSearching && recentApps.isNotEmpty()) {
         RecentAppsRow(apps = recentApps, iconSize = iconSize, onLaunch = onLaunch)
     }
     Box(modifier = Modifier.weight(1f)) {
@@ -292,10 +303,50 @@ private fun ContentState(
             CenteredMessage(text = stringResource(R.string.drawer_no_matches))
         } else {
             val dimensions = iconSize.dimensions()
+            val entries: List<DrawerListEntry<AppEntry>> =
+                remember(matched, isSearching) {
+                    if (isSearching) {
+                        matched.map { DrawerListEntry.App(it) }
+                    } else {
+                        withSectionHeaders(matched) { it.label }
+                    }
+                }
+            val sectionKeys =
+                remember(matched, isSearching) {
+                    if (isSearching) emptyList() else availableSectionKeys(matched) { it.label }
+                }
             // A query forces the list layout so labels stay readable while searching.
-            when (effectiveLayout(layout, query)) {
-                DrawerLayout.GRID -> GridApps(matched, pinnedSet, dimensions, onLaunch, onTogglePin)
-                DrawerLayout.LIST -> ListApps(matched, pinnedSet, dimensions, onLaunch, onTogglePin)
+            val effective = effectiveLayout(layout, query)
+            val gridState = rememberLazyGridState()
+            val listState = rememberLazyListState()
+            val scope = rememberCoroutineScope()
+            Row(modifier = Modifier.fillMaxSize()) {
+                Box(modifier = Modifier.weight(1f)) {
+                    when (effective) {
+                        DrawerLayout.GRID -> {
+                            GridApps(entries, pinnedSet, dimensions, onLaunch, onTogglePin, state = gridState)
+                        }
+
+                        DrawerLayout.LIST -> {
+                            ListApps(entries, pinnedSet, dimensions, onLaunch, onTogglePin, state = listState)
+                        }
+                    }
+                }
+                // Only one bucket present (or none) means nothing to jump between.
+                if (sectionKeys.size > 1) {
+                    AlphabetIndexRail(
+                        letters = sectionKeys,
+                        onSelectLetter = { letter ->
+                            val index = headerIndexOf(entries, letter) ?: return@AlphabetIndexRail
+                            scope.launch {
+                                when (effective) {
+                                    DrawerLayout.GRID -> gridState.animateScrollToItem(index)
+                                    DrawerLayout.LIST -> listState.animateScrollToItem(index)
+                                }
+                            }
+                        },
+                    )
+                }
             }
         }
     }
@@ -406,53 +457,97 @@ private val IconSizeOptions =
         DrawerIconSize.LARGE to R.string.drawer_icon_size_large,
     )
 
+// Stable key for a mixed header/app entry: headers are keyed by their bucket
+// (prefixed so an app can never collide with one), apps by their component.
+private fun drawerEntryKey(entry: DrawerListEntry<AppEntry>): Any =
+    when (entry) {
+        is DrawerListEntry.Header -> "header:${entry.key}"
+        is DrawerListEntry.App -> entry.item.componentName.flattenToString()
+    }
+
 @Composable
 private fun GridApps(
-    apps: List<AppEntry>,
+    entries: List<DrawerListEntry<AppEntry>>,
     pinnedSet: Set<String>,
     dimensions: DrawerDimensions,
     onLaunch: (ComponentName) -> Unit,
     onTogglePin: (ComponentName) -> Unit,
     modifier: Modifier = Modifier,
+    state: LazyGridState = rememberLazyGridState(),
 ) = LazyVerticalGrid(
     modifier = modifier,
+    state = state,
     columns = GridCells.Adaptive(minSize = dimensions.minTileWidth),
     contentPadding = PaddingValues(FemtoDimens.ScreenPadding),
     horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
     verticalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
 ) {
-    items(items = apps, key = { it.componentName.flattenToString() }) { entry ->
-        DrawerAppItem(
-            entry = entry,
-            layout = DrawerLayout.GRID,
-            dimensions = dimensions,
-            isPinned = entry.componentName.flattenToString() in pinnedSet,
-            onLaunch = onLaunch,
-            onTogglePin = onTogglePin,
-        )
+    items(
+        items = entries,
+        key = ::drawerEntryKey,
+        // A header spans the full grid width; an app keeps the default 1x1 cell.
+        span = { entry -> if (entry is DrawerListEntry.Header) GridItemSpan(maxLineSpan) else GridItemSpan(1) },
+    ) { entry ->
+        when (entry) {
+            is DrawerListEntry.Header -> {
+                SectionHeader(letter = entry.key)
+            }
+
+            is DrawerListEntry.App -> {
+                DrawerAppItem(
+                    entry = entry.item,
+                    layout = DrawerLayout.GRID,
+                    dimensions = dimensions,
+                    isPinned = entry.item.componentName.flattenToString() in pinnedSet,
+                    onLaunch = onLaunch,
+                    onTogglePin = onTogglePin,
+                )
+            }
+        }
     }
 }
 
 @Composable
 private fun ListApps(
-    apps: List<AppEntry>,
+    entries: List<DrawerListEntry<AppEntry>>,
     pinnedSet: Set<String>,
     dimensions: DrawerDimensions,
     onLaunch: (ComponentName) -> Unit,
     onTogglePin: (ComponentName) -> Unit,
     modifier: Modifier = Modifier,
-) = LazyColumn(modifier = modifier, contentPadding = PaddingValues(vertical = FemtoDimens.GridGutter)) {
-    items(items = apps, key = { it.componentName.flattenToString() }) { entry ->
-        DrawerAppItem(
-            entry = entry,
-            layout = DrawerLayout.LIST,
-            dimensions = dimensions,
-            isPinned = entry.componentName.flattenToString() in pinnedSet,
-            onLaunch = onLaunch,
-            onTogglePin = onTogglePin,
-        )
+    state: LazyListState = rememberLazyListState(),
+) = LazyColumn(modifier = modifier, state = state, contentPadding = PaddingValues(vertical = FemtoDimens.GridGutter)) {
+    items(items = entries, key = ::drawerEntryKey) { entry ->
+        when (entry) {
+            is DrawerListEntry.Header -> {
+                SectionHeader(letter = entry.key)
+            }
+
+            is DrawerListEntry.App -> {
+                DrawerAppItem(
+                    entry = entry.item,
+                    layout = DrawerLayout.LIST,
+                    dimensions = dimensions,
+                    isPinned = entry.item.componentName.flattenToString() in pinnedSet,
+                    onLaunch = onLaunch,
+                    onTogglePin = onTogglePin,
+                )
+            }
+        }
     }
 }
+
+// Full-span alphabetical section marker ("A", "B", ..., or NON_LETTER_SECTION_KEY).
+@Composable
+private fun SectionHeader(
+    letter: String,
+    modifier: Modifier = Modifier,
+) = Text(
+    text = letter,
+    style = MaterialTheme.typography.titleSmall,
+    color = MaterialTheme.colorScheme.primary,
+    modifier = modifier.fillMaxWidth().padding(horizontal = FemtoDimens.ScreenPadding, vertical = 4.dp),
+)
 
 // One app entry (grid tile or list row) wrapping a long-press pin / unpin menu.
 @Composable

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -18,12 +18,11 @@ import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -66,6 +65,8 @@ import io.github.seijikohara.femto.data.apps.DrawerLayout
 import io.github.seijikohara.femto.ui.drawer.components.AlphabetIndexRail
 import io.github.seijikohara.femto.ui.drawer.components.AppListRow
 import io.github.seijikohara.femto.ui.drawer.components.AppTile
+import io.github.seijikohara.femto.ui.drawer.components.FloatingLetterIndicator
+import io.github.seijikohara.femto.ui.drawer.components.IndexRailWidth
 import io.github.seijikohara.femto.ui.drawer.components.PinnedDock
 import io.github.seijikohara.femto.ui.drawer.components.RecentAppsRow
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
@@ -292,60 +293,90 @@ private fun ContentState(
     val matched = remember(apps, query) { filterAndRank(apps, query) { it.label } }
     // Both the Recent row and the A-Z index are browsing aids; they step
     // aside the moment a query is active, when the filtered flat list is the
-    // primary signal (and headers over a filtered subset would be confusing:
-    // the ranking is relevance, not alphabetical).
+    // primary signal (and a jump-to-letter rail over a relevance-ranked
+    // subset would be confusing: the ranking is relevance, not alphabetical).
     val isSearching = query.isNotBlank()
+    // Letter -> first-matching-app flat index (see sectionStartIndices):
+    // computed once here so the Recent row above and the grid/list + rail
+    // below agree on whether the rail is showing, and inset by the same
+    // width when it is — see IndexRailWidth.
+    val sectionIndex: Map<String, Int> =
+        remember(matched, isSearching) {
+            if (isSearching) emptyMap() else sectionStartIndices(matched) { it.label }
+        }
+    // A single bucket (or none) means nothing to jump between.
+    val showRail = sectionIndex.size > 1
+    val railInset = if (showRail) IndexRailWidth else 0.dp
     if (!isSearching && recentApps.isNotEmpty()) {
-        RecentAppsRow(apps = recentApps, iconSize = iconSize, onLaunch = onLaunch)
+        RecentAppsRow(
+            apps = recentApps,
+            iconSize = iconSize,
+            onLaunch = onLaunch,
+            modifier = Modifier.padding(end = railInset),
+        )
     }
     Box(modifier = Modifier.weight(1f)) {
         if (matched.isEmpty()) {
             CenteredMessage(text = stringResource(R.string.drawer_no_matches))
         } else {
             val dimensions = iconSize.dimensions()
-            val entries: List<DrawerListEntry<AppEntry>> =
-                remember(matched, isSearching) {
-                    if (isSearching) {
-                        matched.map { DrawerListEntry.App(it) }
-                    } else {
-                        withSectionHeaders(matched) { it.label }
-                    }
-                }
-            val sectionKeys =
-                remember(matched, isSearching) {
-                    if (isSearching) emptyList() else availableSectionKeys(matched) { it.label }
-                }
+            val letters = remember(sectionIndex) { sectionIndex.keys.toList() }
+            val sectionStarts = remember(sectionIndex) { sectionIndex.values.toSet() }
             // A query forces the list layout so labels stay readable while searching.
             val effective = effectiveLayout(layout, query)
             val gridState = rememberLazyGridState()
             val listState = rememberLazyListState()
             val scope = rememberCoroutineScope()
-            Row(modifier = Modifier.fillMaxSize()) {
-                Box(modifier = Modifier.weight(1f)) {
-                    when (effective) {
-                        DrawerLayout.GRID -> {
-                            GridApps(entries, pinnedSet, dimensions, onLaunch, onTogglePin, state = gridState)
-                        }
-
-                        DrawerLayout.LIST -> {
-                            ListApps(entries, pinnedSet, dimensions, onLaunch, onTogglePin, state = listState)
-                        }
-                    }
-                }
-                // Only one bucket present (or none) means nothing to jump between.
-                if (sectionKeys.size > 1) {
-                    AlphabetIndexRail(
-                        letters = sectionKeys,
-                        onSelectLetter = { letter ->
-                            val index = headerIndexOf(entries, letter) ?: return@AlphabetIndexRail
-                            scope.launch {
-                                when (effective) {
-                                    DrawerLayout.GRID -> gridState.animateScrollToItem(index)
-                                    DrawerLayout.LIST -> listState.animateScrollToItem(index)
-                                }
-                            }
-                        },
+            // The app list/grid flows continuously (no per-letter header breaking a
+            // row), inset from the rail's width so nothing scrolls under it.
+            val contentModifier = Modifier.fillMaxSize().padding(end = railInset)
+            when (effective) {
+                DrawerLayout.GRID -> {
+                    GridApps(
+                        matched,
+                        pinnedSet,
+                        dimensions,
+                        onLaunch,
+                        onTogglePin,
+                        modifier = contentModifier,
+                        state = gridState,
                     )
+                }
+
+                DrawerLayout.LIST -> {
+                    ListApps(
+                        matched,
+                        pinnedSet,
+                        dimensions,
+                        sectionStarts,
+                        onLaunch,
+                        onTogglePin,
+                        modifier = contentModifier,
+                        state = listState,
+                    )
+                }
+            }
+            if (showRail) {
+                var activeLetter by remember { mutableStateOf<String?>(null) }
+                AlphabetIndexRail(
+                    letters = letters,
+                    onSelectLetter = { letter ->
+                        val index = sectionIndex[letter] ?: return@AlphabetIndexRail
+                        scope.launch {
+                            when (effective) {
+                                DrawerLayout.GRID -> gridState.animateScrollToItem(index)
+                                DrawerLayout.LIST -> listState.animateScrollToItem(index)
+                            }
+                        }
+                    },
+                    onActiveLetterChange = { activeLetter = it },
+                    modifier = Modifier.align(Alignment.CenterEnd),
+                )
+                // Visible only while the rail is actively pressed/dragged (see
+                // onActiveLetterChange): the "where am I" feedback a fast-scroll
+                // rail needs since it is too narrow to show the letter itself.
+                activeLetter?.let { letter ->
+                    FloatingLetterIndicator(letter = letter, modifier = Modifier.align(Alignment.Center))
                 }
             }
         }
@@ -457,17 +488,14 @@ private val IconSizeOptions =
         DrawerIconSize.LARGE to R.string.drawer_icon_size_large,
     )
 
-// Stable key for a mixed header/app entry: headers are keyed by their bucket
-// (prefixed so an app can never collide with one), apps by their component.
-private fun drawerEntryKey(entry: DrawerListEntry<AppEntry>): Any =
-    when (entry) {
-        is DrawerListEntry.Header -> "header:${entry.key}"
-        is DrawerListEntry.App -> entry.item.componentName.flattenToString()
-    }
-
+// Continuous, densely-packed grid: apps flow multiple-per-row with no
+// per-letter header breaking a row (the sparse-grid fix — a header-per-letter
+// forced a new row at every letter, and most letters in a realistic app list
+// hold only 1-2 apps). AlphabetIndexRail still lets the user jump straight to
+// a letter's first app via sectionStartIndices.
 @Composable
 private fun GridApps(
-    entries: List<DrawerListEntry<AppEntry>>,
+    apps: List<AppEntry>,
     pinnedSet: Set<String>,
     dimensions: DrawerDimensions,
     onLaunch: (ComponentName) -> Unit,
@@ -482,64 +510,55 @@ private fun GridApps(
     horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
     verticalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
 ) {
-    items(
-        items = entries,
-        key = ::drawerEntryKey,
-        // A header spans the full grid width; an app keeps the default 1x1 cell.
-        span = { entry -> if (entry is DrawerListEntry.Header) GridItemSpan(maxLineSpan) else GridItemSpan(1) },
-    ) { entry ->
-        when (entry) {
-            is DrawerListEntry.Header -> {
-                SectionHeader(letter = entry.key)
-            }
-
-            is DrawerListEntry.App -> {
-                DrawerAppItem(
-                    entry = entry.item,
-                    layout = DrawerLayout.GRID,
-                    dimensions = dimensions,
-                    isPinned = entry.item.componentName.flattenToString() in pinnedSet,
-                    onLaunch = onLaunch,
-                    onTogglePin = onTogglePin,
-                )
-            }
-        }
+    items(items = apps, key = { it.componentName.flattenToString() }) { entry ->
+        DrawerAppItem(
+            entry = entry,
+            layout = DrawerLayout.GRID,
+            dimensions = dimensions,
+            isPinned = entry.componentName.flattenToString() in pinnedSet,
+            onLaunch = onLaunch,
+            onTogglePin = onTogglePin,
+        )
     }
 }
 
+// Dense single-column list: unlike the grid, a letter change costs no extra
+// row here (a list is already one item per row), so [InlineLetterMarker]
+// decorates the first row of each bucket in [sectionStarts] rather than
+// inserting a separate header item.
 @Composable
 private fun ListApps(
-    entries: List<DrawerListEntry<AppEntry>>,
+    apps: List<AppEntry>,
     pinnedSet: Set<String>,
     dimensions: DrawerDimensions,
+    sectionStarts: Set<Int>,
     onLaunch: (ComponentName) -> Unit,
     onTogglePin: (ComponentName) -> Unit,
     modifier: Modifier = Modifier,
     state: LazyListState = rememberLazyListState(),
 ) = LazyColumn(modifier = modifier, state = state, contentPadding = PaddingValues(vertical = FemtoDimens.GridGutter)) {
-    items(items = entries, key = ::drawerEntryKey) { entry ->
-        when (entry) {
-            is DrawerListEntry.Header -> {
-                SectionHeader(letter = entry.key)
+    itemsIndexed(items = apps, key = { _, entry -> entry.componentName.flattenToString() }) { index, entry ->
+        Column {
+            if (index in sectionStarts) {
+                InlineLetterMarker(letter = sectionKeyOf(entry.label))
             }
-
-            is DrawerListEntry.App -> {
-                DrawerAppItem(
-                    entry = entry.item,
-                    layout = DrawerLayout.LIST,
-                    dimensions = dimensions,
-                    isPinned = entry.item.componentName.flattenToString() in pinnedSet,
-                    onLaunch = onLaunch,
-                    onTogglePin = onTogglePin,
-                )
-            }
+            DrawerAppItem(
+                entry = entry,
+                layout = DrawerLayout.LIST,
+                dimensions = dimensions,
+                isPinned = entry.componentName.flattenToString() in pinnedSet,
+                onLaunch = onLaunch,
+                onTogglePin = onTogglePin,
+            )
         }
     }
 }
 
-// Full-span alphabetical section marker ("A", "B", ..., or NON_LETTER_SECTION_KEY).
+// Compact alphabetical marker ("A", "B", ..., or NON_LETTER_SECTION_KEY) shown
+// above the LIST layout's first row of a bucket. Decorates that row rather
+// than inserting a separate full-width item — see ListApps.
 @Composable
-private fun SectionHeader(
+private fun InlineLetterMarker(
     letter: String,
     modifier: Modifier = Modifier,
 ) = Text(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerScreen.kt
@@ -60,6 +60,7 @@ import io.github.seijikohara.femto.data.apps.DrawerLayout
 import io.github.seijikohara.femto.ui.drawer.components.AppListRow
 import io.github.seijikohara.femto.ui.drawer.components.AppTile
 import io.github.seijikohara.femto.ui.drawer.components.PinnedDock
+import io.github.seijikohara.femto.ui.drawer.components.RecentAppsRow
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoIcon
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
@@ -130,6 +131,7 @@ internal fun AppDrawerScreen(
                 layout = layout,
                 iconSize = iconSize,
                 pinned = pinned,
+                recentApps = uiState.recentApps,
                 onLaunch = onLaunch,
                 onTogglePin = onTogglePin,
                 onToggleLayout = onToggleLayout,
@@ -149,9 +151,10 @@ internal fun AppDrawerScreen(
 }
 
 /**
- * The quick pinned view the dock's apps button opens: just the pinned dock plus
- * an All-apps row that expands to the full drawer. Loading / error fall back to
- * a fixed-height placeholder so the wrap-content sheet never collapses to zero.
+ * The quick pinned view the dock's apps button opens: the Recent row (when
+ * there is any launch history) above the pinned dock, plus an All-apps row
+ * that expands to the full drawer. Loading / error fall back to a
+ * fixed-height placeholder so the wrap-content sheet never collapses to zero.
  */
 @Composable
 private fun CompactContent(
@@ -171,6 +174,9 @@ private fun CompactContent(
             // quick view is useless, so fall through to the full drawer.
             val currentOnExpand by rememberUpdatedState(onExpand)
             LaunchedEffect(dockApps.isEmpty()) { if (dockApps.isEmpty()) currentOnExpand() }
+            if (uiState.recentApps.isNotEmpty()) {
+                RecentAppsRow(apps = uiState.recentApps, iconSize = iconSize, onLaunch = onLaunch)
+            }
             PinnedDock(
                 apps = dockApps,
                 iconSize = iconSize,
@@ -238,11 +244,7 @@ private fun AllAppsRow(
 private fun rememberDockApps(
     apps: List<AppEntry>,
     pinned: List<String>,
-): List<AppEntry> =
-    remember(apps, pinned) {
-        val byComponent = apps.associateBy { it.componentName.flattenToString() }
-        pinned.mapNotNull { byComponent[it] }
-    }
+): List<AppEntry> = remember(apps, pinned) { resolveByOrder(apps, pinned) { it.componentName.flattenToString() } }
 
 @Composable
 private fun LoadingState(modifier: Modifier = Modifier) =
@@ -256,6 +258,7 @@ private fun ContentState(
     layout: DrawerLayout,
     iconSize: DrawerIconSize,
     pinned: List<String>,
+    recentApps: List<AppEntry>,
     onLaunch: (ComponentName) -> Unit,
     onTogglePin: (ComponentName) -> Unit,
     onToggleLayout: () -> Unit,
@@ -279,6 +282,11 @@ private fun ContentState(
     val pinnedSet = remember(pinned) { pinned.toSet() }
     // Prefix matches rank before substring matches; an empty query shows everything.
     val matched = remember(apps, query) { filterAndRank(apps, query) { it.label } }
+    // The Recent row is a browsing aid; it steps aside the moment a query is
+    // active, when the filtered flat list is the primary signal.
+    if (query.isBlank() && recentApps.isNotEmpty()) {
+        RecentAppsRow(apps = recentApps, iconSize = iconSize, onLaunch = onLaunch)
+    }
     Box(modifier = Modifier.weight(1f)) {
         if (matched.isEmpty()) {
             CenteredMessage(text = stringResource(R.string.drawer_no_matches))

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSearch.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSearch.kt
@@ -31,3 +31,18 @@ internal fun effectiveLayout(
     persisted: DrawerLayout,
     query: String,
 ): DrawerLayout = if (query.isBlank()) persisted else DrawerLayout.LIST
+
+/**
+ * Resolve [order] (component/package keys) against [items] via [keyOf],
+ * preserving [order]'s sequence and silently dropping a key with no matching
+ * item. Shared by the Pinned dock and the Recent row — both can reference an
+ * app uninstalled since it was pinned / launched.
+ */
+internal fun <T> resolveByOrder(
+    items: List<T>,
+    order: List<String>,
+    keyOf: (T) -> String,
+): List<T> {
+    val byKey = items.associateBy(keyOf)
+    return order.mapNotNull { byKey[it] }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerUiState.kt
@@ -17,6 +17,13 @@ internal sealed interface AppDrawerUiState {
 
     data class Content(
         val apps: List<AppEntry>,
+        /**
+         * Top-N most-recently-launched apps, most-recent-first (see
+         * `RecentAppsPreferences.RECENT_APPS_MAX_COUNT`). Empty on a fresh
+         * install / before the first drawer launch — the Recent row hides
+         * itself entirely in that case rather than rendering blank.
+         */
+        val recentApps: List<AppEntry> = emptyList(),
     ) : AppDrawerUiState
 
     data object Error : AppDrawerUiState

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/AppDrawerViewModel.kt
@@ -8,9 +8,13 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import io.github.seijikohara.femto.data.apps.AppEntry
 import io.github.seijikohara.femto.data.apps.AppsRepository
+import io.github.seijikohara.femto.data.apps.RecentAppsPreferences
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -22,12 +26,45 @@ private const val TAG = "AppDrawerViewModel"
  * [queryApps] is injected as a plain suspend seam so JVM tests exercise the
  * Loading/Content/Error transitions without Android types; production wires
  * [AppsRepository.queryApps] via [AppDrawerViewModelFactory].
+ *
+ * [recentComponents] is the launch-history store's ordered component list
+ * (most-recent-first). Unlike [queryApps] it is collected continuously, not
+ * just on [AppDrawerAction.Refresh]: a launch from the very sheet currently
+ * open should bump the Recent row immediately, without waiting for the next
+ * full app re-query.
  */
 internal class AppDrawerViewModel(
     private val queryApps: suspend () -> List<AppEntry>,
+    recentComponents: Flow<List<String>> = emptyFlow(),
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<AppDrawerUiState>(AppDrawerUiState.Loading)
     val uiState: StateFlow<AppDrawerUiState> = _uiState.asStateFlow()
+
+    // Snapshot of the latest launch-history read: resolved into Content the
+    // next time refresh() succeeds, and re-resolved in place below whenever
+    // it changes while Content is already showing.
+    private var latestRecentComponents: List<String> = emptyList()
+
+    init {
+        viewModelScope.launch {
+            recentComponents.collect { recent ->
+                latestRecentComponents = recent
+                _uiState.update { state ->
+                    when (state) {
+                        is AppDrawerUiState.Content -> {
+                            state.copy(
+                                recentApps = resolveByOrder(state.apps, recent) { it.componentName.flattenToString() },
+                            )
+                        }
+
+                        else -> {
+                            state
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     fun onAction(action: AppDrawerAction) =
         when (action) {
@@ -40,8 +77,14 @@ internal class AppDrawerViewModel(
         _uiState.value = AppDrawerUiState.Loading
         viewModelScope.launch {
             runCatching { queryApps() }
-                .onSuccess { apps -> _uiState.value = AppDrawerUiState.Content(apps) }
-                .onFailure {
+                .onSuccess { apps ->
+                    _uiState.value =
+                        AppDrawerUiState.Content(
+                            apps = apps,
+                            recentApps =
+                                resolveByOrder(apps, latestRecentComponents) { it.componentName.flattenToString() },
+                        )
+                }.onFailure {
                     // runCatching also traps cancellation; rethrow so it never
                     // renders as the Error state.
                     if (it is CancellationException) throw it
@@ -52,11 +95,14 @@ internal class AppDrawerViewModel(
     }
 }
 
-/** Wires the production [AppsRepository] without an UNCHECKED_CAST factory. */
+/** Wires the production [AppsRepository] and [RecentAppsPreferences] without an UNCHECKED_CAST factory. */
 internal val AppDrawerViewModelFactory: ViewModelProvider.Factory =
     viewModelFactory {
         initializer {
             val application = checkNotNull(this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
-            AppDrawerViewModel(queryApps = AppsRepository(application)::queryApps)
+            AppDrawerViewModel(
+                queryApps = AppsRepository(application)::queryApps,
+                recentComponents = RecentAppsPreferences(application).recentComponents,
+            )
         }
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/AlphabetIndexRail.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/AlphabetIndexRail.kt
@@ -3,23 +3,29 @@ package io.github.seijikohara.femto.ui.drawer.components
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.github.seijikohara.femto.ui.drawer.letterIndexForOffset
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 
@@ -30,8 +36,10 @@ import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 // rather than requiring the finger to land inside one specific letter row —
 // the standard launcher fast-scroll interaction, and the same kind of narrow,
 // low-precision control the map zoom / follow pill is sanctioned as
-// (CLAUDE.md#automotive-overrides).
-private val IndexRailWidth = 28.dp
+// (CLAUDE.md#automotive-overrides). Internal (not private): the drawer screen
+// insets the app grid/list and the Recent row by this same width so nothing
+// scrolls under the rail.
+internal val IndexRailWidth = 28.dp
 
 /**
  * Vertical A-Z fast-scroll rail. A tap or drag over it resolves the touch
@@ -39,12 +47,17 @@ private val IndexRailWidth = 28.dp
  * and invokes [onSelectLetter] — continuously while dragging, so a single
  * top-to-bottom drag scrubs through the whole alphabet. [letters] holds only
  * the buckets the current list actually has (never a blank A-Z scaffold).
+ * [onActiveLetterChange] reports the letter under the finger while pressed
+ * and `null` on release, driving a caller-owned floating letter indicator
+ * (see [FloatingLetterIndicator]) — the rail itself is too narrow to show the
+ * letter at a legible size.
  */
 @Composable
 internal fun AlphabetIndexRail(
     letters: List<String>,
     onSelectLetter: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onActiveLetterChange: (String?) -> Unit = {},
 ) {
     var heightPx by remember { mutableFloatStateOf(0f) }
     Column(
@@ -57,7 +70,7 @@ internal fun AlphabetIndexRail(
                     awaitEachGesture {
                         val down = awaitFirstDown()
                         down.consume()
-                        selectLetterAt(down.position.y, heightPx, letters, onSelectLetter)
+                        selectLetterAt(down.position.y, heightPx, letters, onSelectLetter, onActiveLetterChange)
                         var pressed = true
                         while (pressed) {
                             val event = awaitPointerEvent()
@@ -66,10 +79,17 @@ internal fun AlphabetIndexRail(
                                 pressed = false
                             } else {
                                 change.consume()
-                                selectLetterAt(change.position.y, heightPx, letters, onSelectLetter)
+                                selectLetterAt(
+                                    change.position.y,
+                                    heightPx,
+                                    letters,
+                                    onSelectLetter,
+                                    onActiveLetterChange,
+                                )
                                 pressed = change.pressed
                             }
                         }
+                        onActiveLetterChange(null)
                     }
                 },
         verticalArrangement = Arrangement.Center,
@@ -91,9 +111,36 @@ private fun selectLetterAt(
     heightPx: Float,
     letters: List<String>,
     onSelectLetter: (String) -> Unit,
+    onActiveLetterChange: (String?) -> Unit,
 ) {
     if (letters.isEmpty()) return
-    onSelectLetter(letters[letterIndexForOffset(offsetY, heightPx, letters.size)])
+    val letter = letters[letterIndexForOffset(offsetY, heightPx, letters.size)]
+    onSelectLetter(letter)
+    onActiveLetterChange(letter)
+}
+
+/**
+ * Floating "where am I" bubble shown over the app list while [AlphabetIndexRail]
+ * is being dragged — standard fast-scroll launcher feedback, and necessary here
+ * since the rail itself (narrow by necessity, see [IndexRailWidth]) has no room
+ * to show the current letter at a legible size.
+ */
+@Composable
+internal fun FloatingLetterIndicator(
+    letter: String,
+    modifier: Modifier = Modifier,
+) = Surface(
+    modifier = modifier.size(FemtoDimens.IndexBubbleSize),
+    shape = CircleShape,
+    color = MaterialTheme.colorScheme.primaryContainer,
+) {
+    Box(contentAlignment = Alignment.Center) {
+        Text(
+            text = letter,
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+    }
 }
 
 @PreviewLightDark
@@ -104,5 +151,13 @@ private fun AlphabetIndexRailPreview() {
             letters = listOf("A", "B", "C", "D", "M", "S", "Z", "#"),
             onSelectLetter = {},
         )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun FloatingLetterIndicatorPreview() {
+    FemtoTheme {
+        FloatingLetterIndicator(letter = "M")
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/AlphabetIndexRail.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/AlphabetIndexRail.kt
@@ -1,0 +1,108 @@
+package io.github.seijikohara.femto.ui.drawer.components
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.ui.drawer.letterIndexForOffset
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+
+// Narrow by necessity: a 26+ letter A-Z strip could not otherwise fit beside
+// the app grid at any reasonable width. The rail compensates for its
+// necessarily sub-floor per-letter target by resolving a tap or drag
+// proportionally across the whole rail height (see letterIndexForOffset)
+// rather than requiring the finger to land inside one specific letter row —
+// the standard launcher fast-scroll interaction, and the same kind of narrow,
+// low-precision control the map zoom / follow pill is sanctioned as
+// (CLAUDE.md#automotive-overrides).
+private val IndexRailWidth = 28.dp
+
+/**
+ * Vertical A-Z fast-scroll rail. A tap or drag over it resolves the touch
+ * position to one of [letters] (proportionally, via [letterIndexForOffset])
+ * and invokes [onSelectLetter] — continuously while dragging, so a single
+ * top-to-bottom drag scrubs through the whole alphabet. [letters] holds only
+ * the buckets the current list actually has (never a blank A-Z scaffold).
+ */
+@Composable
+internal fun AlphabetIndexRail(
+    letters: List<String>,
+    onSelectLetter: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var heightPx by remember { mutableFloatStateOf(0f) }
+    Column(
+        modifier =
+            modifier
+                .width(IndexRailWidth)
+                .fillMaxHeight()
+                .onSizeChanged { heightPx = it.height.toFloat() }
+                .pointerInput(letters) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown()
+                        down.consume()
+                        selectLetterAt(down.position.y, heightPx, letters, onSelectLetter)
+                        var pressed = true
+                        while (pressed) {
+                            val event = awaitPointerEvent()
+                            val change = event.changes.firstOrNull { it.id == down.id }
+                            if (change == null) {
+                                pressed = false
+                            } else {
+                                change.consume()
+                                selectLetterAt(change.position.y, heightPx, letters, onSelectLetter)
+                                pressed = change.pressed
+                            }
+                        }
+                    }
+                },
+        verticalArrangement = Arrangement.Center,
+    ) {
+        letters.forEach { letter ->
+            Text(
+                text = letter,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
+        }
+    }
+}
+
+private fun selectLetterAt(
+    offsetY: Float,
+    heightPx: Float,
+    letters: List<String>,
+    onSelectLetter: (String) -> Unit,
+) {
+    if (letters.isEmpty()) return
+    onSelectLetter(letters[letterIndexForOffset(offsetY, heightPx, letters.size)])
+}
+
+@PreviewLightDark
+@Composable
+private fun AlphabetIndexRailPreview() {
+    FemtoTheme {
+        AlphabetIndexRail(
+            letters = listOf("A", "B", "C", "D", "M", "S", "Z", "#"),
+            onSelectLetter = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/AlphabetIndexRail.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/AlphabetIndexRail.kt
@@ -97,7 +97,10 @@ internal fun AlphabetIndexRail(
         letters.forEach { letter ->
             Text(
                 text = letter,
-                style = MaterialTheme.typography.labelSmall,
+                // titleSmall (18sp) keeps the rail's letters on the automotive body-text
+                // floor (CLAUDE.md#automotive-overrides) — this drawer is not one of the
+                // sanctioned relaxation surfaces. The letters distribute via weight(1f).
+                style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f).fillMaxWidth(),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/PinnedDock.kt
@@ -65,13 +65,15 @@ private val DockVerticalPadding = 8.dp
 // Per-preset dock tile dimensions, scaled in step with the drawer grid's
 // presets (the dock previously hardcoded the MEDIUM values and ignored the
 // user's icon-size choice). Tile widths keep a readable one-line label and
-// stay above the touch-target floor via the tile's min height.
-private data class DockDimensions(
+// stay above the touch-target floor via the tile's min height. Internal (not
+// private): the Recent row wants tiles that look identical to the Pinned
+// dock's, so it reuses this same size mapping rather than duplicating it.
+internal data class DockDimensions(
     val tileWidth: Dp,
     val iconSize: Dp,
 )
 
-private fun DrawerIconSize.dockDimensions(): DockDimensions =
+internal fun DrawerIconSize.dockDimensions(): DockDimensions =
     when (this) {
         DrawerIconSize.SMALL -> DockDimensions(tileWidth = 80.dp, iconSize = 48.dp)
         DrawerIconSize.MEDIUM -> DockDimensions(tileWidth = 96.dp, iconSize = 64.dp)

--- a/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/RecentAppsRow.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/drawer/components/RecentAppsRow.kt
@@ -1,0 +1,134 @@
+package io.github.seijikohara.femto.ui.drawer.components
+
+import android.content.ComponentName
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.createBitmap
+import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.apps.AppEntry
+import io.github.seijikohara.femto.data.apps.DrawerIconSize
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.PreviewLightDark
+import io.github.seijikohara.femto.ui.theme.tileLabel
+
+private val RowVerticalPadding = 8.dp
+private val IconLabelGap = 4.dp
+private val LabelBottomPadding = 4.dp
+
+/**
+ * "Recent" section: a horizontal row of the most-recently-launched apps
+ * (backed by the drawer's launch-history store), tap to relaunch. Mirrors
+ * [PinnedDock]'s tile idiom (icon + single-line label, sized via
+ * [DrawerIconSize.dockDimensions]) but without its drag-reorder / unpin
+ * affordances — history order is derived, not user-curated. Callers skip
+ * composing the row when [apps] is empty (a fresh install, or nothing
+ * launched from the drawer yet).
+ */
+@Composable
+internal fun RecentAppsRow(
+    apps: List<AppEntry>,
+    iconSize: DrawerIconSize,
+    onLaunch: (ComponentName) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(modifier = modifier.fillMaxWidth()) {
+    Text(
+        text = stringResource(R.string.drawer_recent_apps),
+        // Cleared at exactly the automotive body-text floor: the drawer is
+        // not one of the sanctioned card-relaxation areas in
+        // CLAUDE.md#automotive-overrides, so this label may not go smaller.
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier =
+            Modifier.padding(
+                horizontal = FemtoDimens.ScreenPadding,
+                vertical = LabelBottomPadding,
+            ),
+    )
+    val dimensions = iconSize.dockDimensions()
+    LazyRow(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = FemtoDimens.ScreenPadding, vertical = RowVerticalPadding),
+        horizontalArrangement = Arrangement.spacedBy(FemtoDimens.GridGutter),
+    ) {
+        items(items = apps, key = { it.componentName.flattenToString() }) { entry ->
+            RecentTile(entry = entry, dimensions = dimensions, onLaunch = onLaunch)
+        }
+    }
+}
+
+@Composable
+private fun RecentTile(
+    entry: AppEntry,
+    dimensions: DockDimensions,
+    onLaunch: (ComponentName) -> Unit,
+    modifier: Modifier = Modifier,
+) = Column(
+    modifier =
+        modifier
+            .width(dimensions.tileWidth)
+            .defaultMinSize(minHeight = FemtoDimens.MinTouchTarget)
+            .clickable(onClick = { onLaunch(entry.componentName) }),
+    horizontalAlignment = Alignment.CenterHorizontally,
+) {
+    Icon(
+        painter = BitmapPainter(entry.icon.asImageBitmap()),
+        contentDescription = entry.label,
+        tint = Color.Unspecified,
+        modifier = Modifier.size(dimensions.iconSize),
+    )
+    Spacer(Modifier.height(IconLabelGap))
+    // Same deterministic line box as the grid / dock tiles (see tileLabel), so
+    // every tile row measures identically across scripts and fallbacks.
+    Text(
+        text = entry.label,
+        style = MaterialTheme.typography.tileLabel(),
+        color = MaterialTheme.colorScheme.onSurface,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun RecentAppsRowPreview() {
+    val icon = createBitmap(1, 1)
+    FemtoTheme {
+        RecentAppsRow(
+            apps =
+                listOf(
+                    AppEntry(ComponentName("com.maps", ".Main"), "Maps", icon),
+                    AppEntry(ComponentName("com.music", ".Main"), "Music", icon),
+                    AppEntry(ComponentName("com.phone", ".Main"), "Phone", icon),
+                ),
+            iconSize = DrawerIconSize.MEDIUM,
+            onLaunch = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -29,6 +29,14 @@ object FemtoDimens {
     /** Spacing between tiles in a launcher grid. */
     val GridGutter = 16.dp
 
+    /**
+     * Diameter of the app drawer's floating letter-indicator bubble, shown
+     * over the app list while the A-Z rail is being dragged. Decorative only
+     * (not itself a tap target), so it is sized independently of
+     * [MinTouchTarget].
+     */
+    val IndexBubbleSize = 72.dp
+
     /** Hero-block icon size for dashboard cards (e.g., the weather summary). */
     val HeroIconSize = 36.dp
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="drawer_icon_size_medium">Medium</string>
     <string name="drawer_icon_size_large">Large</string>
     <string name="drawer_all_apps">All apps</string>
+    <string name="drawer_recent_apps">Recent</string>
 
     <!-- Assistant sheet -->
     <string name="assistant_sheet_title">Voice assistant</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/apps/RecentAppsPreferencesTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/apps/RecentAppsPreferencesTest.kt
@@ -1,0 +1,47 @@
+package io.github.seijikohara.femto.data.apps
+
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class RecentAppsPreferencesTest {
+    // The `preferencesDataStore` delegate behind RecentAppsPreferences is a
+    // process-wide singleton bound to the first Application's filesDir, while
+    // Robolectric hands each test method a fresh Application and temp dir. All
+    // round-trip steps therefore live in one test method, so the persisted
+    // file and the singleton never disagree across tests (same caveat as
+    // DrawerPreferencesTest).
+    @Test
+    fun `recordLaunch round-trips ordering and caps history at RECENT_APPS_MAX_COUNT`() =
+        runTest {
+            val store = RecentAppsPreferences(ApplicationProvider.getApplicationContext())
+
+            store.recordLaunch(MAPS, atMillis = 100L)
+            store.recordLaunch(MUSIC, atMillis = 200L)
+            assertEquals(listOf(MUSIC, MAPS), store.recentComponents.first())
+
+            // Re-launching an older entry bumps it back to the front.
+            store.recordLaunch(MAPS, atMillis = 300L)
+            assertEquals(listOf(MAPS, MUSIC), store.recentComponents.first())
+
+            (0 until RECENT_APPS_MAX_COUNT + 2).forEach { i ->
+                store.recordLaunch("com.example.app$i/.Main", atMillis = 1_000L + i)
+            }
+            val recent = store.recentComponents.first()
+            assertEquals(RECENT_APPS_MAX_COUNT, recent.size)
+            // The most recently launched components survive; the oldest are trimmed.
+            assertEquals("com.example.app${RECENT_APPS_MAX_COUNT + 1}/.Main", recent.first())
+        }
+
+    private companion object {
+        const val MAPS = "com.example.maps/.MapsActivity"
+        const val MUSIC = "com.example.music/.MainActivity"
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/apps/RecentLaunchOrderingTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/apps/RecentLaunchOrderingTest.kt
@@ -1,0 +1,71 @@
+package io.github.seijikohara.femto.data.apps
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pure ordering / (de)serialization logic behind [RecentAppsPreferences],
+ * exercised without Android or DataStore (no [android.graphics.Bitmap], no
+ * Robolectric) — the round-trip through the real DataStore is covered
+ * separately by [RecentAppsPreferencesTest].
+ */
+class RecentLaunchOrderingTest {
+    @Test
+    fun `withRecordedLaunch appends a new component at the front`() =
+        assertEquals(
+            listOf(RecentLaunch("maps", 100L, 1)),
+            emptyList<RecentLaunch>().withRecordedLaunch("maps", 100L),
+        )
+
+    @Test
+    fun `withRecordedLaunch moves an existing component to the front and increments its count`() {
+        val history = listOf(RecentLaunch("maps", 100L, 3), RecentLaunch("music", 200L, 1))
+
+        val updated = history.withRecordedLaunch("maps", 300L)
+
+        assertEquals(listOf(RecentLaunch("maps", 300L, 4), RecentLaunch("music", 200L, 1)), updated)
+    }
+
+    @Test
+    fun `withRecordedLaunch orders most-recent-first`() {
+        val history =
+            listOf(RecentLaunch("maps", 100L, 1))
+                .withRecordedLaunch("music", 200L)
+                .withRecordedLaunch("phone", 300L)
+
+        assertEquals(listOf("phone", "music", "maps"), history.map { it.component })
+    }
+
+    @Test
+    fun `withRecordedLaunch trims history past RECENT_APPS_MAX_COUNT`() {
+        val history =
+            (0 until RECENT_APPS_MAX_COUNT + 3).fold(emptyList<RecentLaunch>()) { acc, i ->
+                acc.withRecordedLaunch("app$i", i.toLong())
+            }
+
+        assertEquals(RECENT_APPS_MAX_COUNT, history.size)
+        // The most recently launched survive; the oldest ones are dropped.
+        assertEquals("app${RECENT_APPS_MAX_COUNT + 2}", history.first().component)
+    }
+
+    @Test
+    fun `encode then parseRecentLaunches round-trips the history`() {
+        val history = listOf(RecentLaunch("com.example.maps/.Main", 1_700_000_000_000L, 5), RecentLaunch("b/.B", 1L, 0))
+
+        assertEquals(history, parseRecentLaunches(history.encode()))
+    }
+
+    @Test
+    fun `parseRecentLaunches returns empty for a null or blank raw value`() {
+        assertEquals(emptyList(), parseRecentLaunches(null))
+        assertEquals(emptyList(), parseRecentLaunches(""))
+    }
+
+    @Test
+    fun `parseRecentLaunches drops a record that fails to parse and keeps the rest`() {
+        val good = RecentLaunch("maps", 100L, 1)
+        val raw = "${listOf(good).encode()}\nnot-a-valid-record"
+
+        assertEquals(listOf(good), parseRecentLaunches(raw))
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerIndexTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerIndexTest.kt
@@ -2,7 +2,6 @@ package io.github.seijikohara.femto.ui.drawer
 
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class AppDrawerIndexTest {
     @Test
@@ -22,65 +21,36 @@ class AppDrawerIndexTest {
     fun `sectionKeyOf trims leading whitespace before bucketing`() = assertEquals("M", sectionKeyOf("  Maps"))
 
     @Test
-    fun `withSectionHeaders inserts one header per run of a shared bucket`() {
-        val entries = withSectionHeaders(listOf("alpha", "Amazon", "Bravo", "Charlie")) { it }
+    fun `sectionStartIndices maps each bucket to its first item's flat index`() {
+        val indices = sectionStartIndices(listOf("alpha", "Amazon", "Bravo", "Charlie")) { it }
 
+        assertEquals(mapOf("A" to 0, "B" to 2, "C" to 3), indices)
+    }
+
+    @Test
+    fun `sectionStartIndices orders keys by first appearance, not alphabetically`() {
+        val indices = sectionStartIndices(listOf("Zebra", "Alpha", "Amazon")) { it }
+
+        assertEquals(listOf("Z", "A"), indices.keys.toList())
+    }
+
+    @Test
+    fun `sectionStartIndices never emits a bucket with no items`() {
+        val indices = sectionStartIndices(listOf("Alpha", "Zebra")) { it }
+
+        assertEquals(mapOf("A" to 0, "Z" to 1), indices)
+    }
+
+    @Test
+    fun `sectionStartIndices returns an empty map for an empty input`() =
+        assertEquals(emptyMap(), sectionStartIndices(emptyList<String>()) { it })
+
+    @Test
+    fun `sectionStartIndices buckets a label with no leading letter under the shared key`() =
         assertEquals(
-            listOf(
-                DrawerListEntry.Header("A"),
-                DrawerListEntry.App("alpha"),
-                DrawerListEntry.App("Amazon"),
-                DrawerListEntry.Header("B"),
-                DrawerListEntry.App("Bravo"),
-                DrawerListEntry.Header("C"),
-                DrawerListEntry.App("Charlie"),
-            ),
-            entries,
+            mapOf("A" to 0, NON_LETTER_SECTION_KEY to 1, "Z" to 2),
+            sectionStartIndices(listOf("Alpha", "1Password", "Zebra")) { it },
         )
-    }
-
-    @Test
-    fun `withSectionHeaders never emits a header for a bucket with no items`() {
-        val entries = withSectionHeaders(listOf("Alpha", "Zebra")) { it }
-
-        assertEquals(
-            listOf(
-                DrawerListEntry.Header("A"),
-                DrawerListEntry.App("Alpha"),
-                DrawerListEntry.Header("Z"),
-                DrawerListEntry.App("Zebra"),
-            ),
-            entries,
-        )
-    }
-
-    @Test
-    fun `withSectionHeaders returns an empty list for an empty input`() =
-        assertEquals(emptyList(), withSectionHeaders(emptyList<String>()) { it })
-
-    @Test
-    fun `availableSectionKeys lists only the buckets present, in first-appearance order`() =
-        assertEquals(
-            listOf("A", NON_LETTER_SECTION_KEY, "Z"),
-            availableSectionKeys(listOf("Alpha", "Amazon", "1Password", "Zebra")) { it },
-        )
-
-    @Test
-    fun `headerIndexOf finds the flattened index of a bucket's header`() {
-        val entries = withSectionHeaders(listOf("Alpha", "Bravo", "Charlie")) { it }
-
-        // Header(A)=0, App(Alpha)=1, Header(B)=2, App(Bravo)=3, Header(C)=4, App(Charlie)=5.
-        assertEquals(0, headerIndexOf(entries, "A"))
-        assertEquals(2, headerIndexOf(entries, "B"))
-        assertEquals(4, headerIndexOf(entries, "C"))
-    }
-
-    @Test
-    fun `headerIndexOf returns null for an absent bucket`() {
-        val entries = withSectionHeaders(listOf("Alpha")) { it }
-
-        assertNull(headerIndexOf(entries, "Z"))
-    }
 
     @Test
     fun `letterIndexForOffset maps a proportional position to a letter index`() {

--- a/app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerIndexTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerIndexTest.kt
@@ -1,0 +1,110 @@
+package io.github.seijikohara.femto.ui.drawer
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AppDrawerIndexTest {
+    @Test
+    fun `sectionKeyOf uppercases the leading letter`() {
+        assertEquals("M", sectionKeyOf("maps"))
+        assertEquals("M", sectionKeyOf("Music"))
+    }
+
+    @Test
+    fun `sectionKeyOf buckets a label with no leading letter under the shared key`() {
+        assertEquals(NON_LETTER_SECTION_KEY, sectionKeyOf("1Password"))
+        assertEquals(NON_LETTER_SECTION_KEY, sectionKeyOf("#Hashtag"))
+        assertEquals(NON_LETTER_SECTION_KEY, sectionKeyOf(""))
+    }
+
+    @Test
+    fun `sectionKeyOf trims leading whitespace before bucketing`() = assertEquals("M", sectionKeyOf("  Maps"))
+
+    @Test
+    fun `withSectionHeaders inserts one header per run of a shared bucket`() {
+        val entries = withSectionHeaders(listOf("alpha", "Amazon", "Bravo", "Charlie")) { it }
+
+        assertEquals(
+            listOf(
+                DrawerListEntry.Header("A"),
+                DrawerListEntry.App("alpha"),
+                DrawerListEntry.App("Amazon"),
+                DrawerListEntry.Header("B"),
+                DrawerListEntry.App("Bravo"),
+                DrawerListEntry.Header("C"),
+                DrawerListEntry.App("Charlie"),
+            ),
+            entries,
+        )
+    }
+
+    @Test
+    fun `withSectionHeaders never emits a header for a bucket with no items`() {
+        val entries = withSectionHeaders(listOf("Alpha", "Zebra")) { it }
+
+        assertEquals(
+            listOf(
+                DrawerListEntry.Header("A"),
+                DrawerListEntry.App("Alpha"),
+                DrawerListEntry.Header("Z"),
+                DrawerListEntry.App("Zebra"),
+            ),
+            entries,
+        )
+    }
+
+    @Test
+    fun `withSectionHeaders returns an empty list for an empty input`() =
+        assertEquals(emptyList(), withSectionHeaders(emptyList<String>()) { it })
+
+    @Test
+    fun `availableSectionKeys lists only the buckets present, in first-appearance order`() =
+        assertEquals(
+            listOf("A", NON_LETTER_SECTION_KEY, "Z"),
+            availableSectionKeys(listOf("Alpha", "Amazon", "1Password", "Zebra")) { it },
+        )
+
+    @Test
+    fun `headerIndexOf finds the flattened index of a bucket's header`() {
+        val entries = withSectionHeaders(listOf("Alpha", "Bravo", "Charlie")) { it }
+
+        // Header(A)=0, App(Alpha)=1, Header(B)=2, App(Bravo)=3, Header(C)=4, App(Charlie)=5.
+        assertEquals(0, headerIndexOf(entries, "A"))
+        assertEquals(2, headerIndexOf(entries, "B"))
+        assertEquals(4, headerIndexOf(entries, "C"))
+    }
+
+    @Test
+    fun `headerIndexOf returns null for an absent bucket`() {
+        val entries = withSectionHeaders(listOf("Alpha")) { it }
+
+        assertNull(headerIndexOf(entries, "Z"))
+    }
+
+    @Test
+    fun `letterIndexForOffset maps a proportional position to a letter index`() {
+        val letters = 4
+        val heightPx = 400f
+
+        assertEquals(0, letterIndexForOffset(offsetY = 0f, heightPx = heightPx, letterCount = letters))
+        assertEquals(0, letterIndexForOffset(offsetY = 50f, heightPx = heightPx, letterCount = letters))
+        assertEquals(1, letterIndexForOffset(offsetY = 150f, heightPx = heightPx, letterCount = letters))
+        assertEquals(2, letterIndexForOffset(offsetY = 250f, heightPx = heightPx, letterCount = letters))
+        assertEquals(3, letterIndexForOffset(offsetY = 350f, heightPx = heightPx, letterCount = letters))
+    }
+
+    @Test
+    fun `letterIndexForOffset clamps an offset past either end of the rail`() {
+        assertEquals(0, letterIndexForOffset(offsetY = -20f, heightPx = 400f, letterCount = 4))
+        assertEquals(3, letterIndexForOffset(offsetY = 4000f, heightPx = 400f, letterCount = 4))
+        // Exactly the bottom edge must still resolve to the last letter, not roll over.
+        assertEquals(3, letterIndexForOffset(offsetY = 400f, heightPx = 400f, letterCount = 4))
+    }
+
+    @Test
+    fun `letterIndexForOffset degrades to 0 for a not-yet-measured rail or no letters`() {
+        assertEquals(0, letterIndexForOffset(offsetY = 100f, heightPx = 0f, letterCount = 4))
+        assertEquals(0, letterIndexForOffset(offsetY = 100f, heightPx = 400f, letterCount = 0))
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSearchTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerSearchTest.kt
@@ -42,4 +42,22 @@ class AppDrawerSearchTest {
         assertEquals(DrawerLayout.GRID, effectiveLayout(DrawerLayout.GRID, "   "))
         assertEquals(DrawerLayout.LIST, effectiveLayout(DrawerLayout.LIST, ""))
     }
+
+    @Test
+    fun `resolveByOrder preserves the order argument, not the items argument`() =
+        assertEquals(
+            listOf("music", "maps"),
+            resolveByOrder(items = listOf("maps", "music"), order = listOf("music", "maps")) { it },
+        )
+
+    @Test
+    fun `resolveByOrder drops a key with no matching item`() =
+        assertEquals(
+            listOf("maps"),
+            resolveByOrder(items = listOf("maps"), order = listOf("uninstalled", "maps")) { it },
+        )
+
+    @Test
+    fun `resolveByOrder returns empty for an empty order`() =
+        assertEquals(emptyList(), resolveByOrder(items = listOf("maps"), order = emptyList()) { it })
 }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerViewModelRecentAppsTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/drawer/AppDrawerViewModelRecentAppsTest.kt
@@ -1,0 +1,108 @@
+package io.github.seijikohara.femto.ui.drawer
+
+import android.content.ComponentName
+import androidx.core.graphics.createBitmap
+import app.cash.turbine.test
+import io.github.seijikohara.femto.data.apps.AppEntry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Exercises [AppDrawerViewModel]'s recentApps resolution against real
+ * [AppEntry] objects (which need a real [android.graphics.Bitmap], hence
+ * Robolectric) — [AppDrawerViewModelTest] deliberately avoids that runtime
+ * cost and only covers the Loading/Content/Error apps-query transitions.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class AppDrawerViewModelRecentAppsTest {
+    private val icon = createBitmap(1, 1)
+    private val maps = AppEntry(ComponentName("com.maps", ".Main"), "Maps", icon)
+    private val music = AppEntry(ComponentName("com.music", ".Main"), "Music", icon)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `content resolves recentApps in recency order and drops an uninstalled entry`() =
+        runTest {
+            val recent = MutableStateFlow(listOf("com.music/.Main", "com.stale/.Gone", "com.maps/.Main"))
+            val viewModel = AppDrawerViewModel(queryApps = { listOf(maps, music) }, recentComponents = recent)
+
+            viewModel.uiState.test {
+                assertEquals(AppDrawerUiState.Loading, awaitItem())
+
+                viewModel.onAction(AppDrawerAction.Refresh)
+
+                val content = assertIs<AppDrawerUiState.Content>(awaitItem())
+                assertEquals(listOf(music, maps), content.recentApps)
+            }
+        }
+
+    @Test
+    fun `a later launch-history emission updates recentApps without a new apps query`() =
+        runTest {
+            var queryCount = 0
+            val recent = MutableStateFlow(listOf("com.maps/.Main"))
+            val viewModel =
+                AppDrawerViewModel(
+                    queryApps = {
+                        queryCount++
+                        listOf(maps, music)
+                    },
+                    recentComponents = recent,
+                )
+
+            viewModel.uiState.test {
+                assertEquals(AppDrawerUiState.Loading, awaitItem())
+
+                viewModel.onAction(AppDrawerAction.Refresh)
+                val firstContent = assertIs<AppDrawerUiState.Content>(awaitItem())
+                assertEquals(listOf(maps), firstContent.recentApps)
+
+                // Simulate a launch from the same open sheet: the store's flow
+                // emits a new order, and Content updates in place.
+                recent.value = listOf("com.music/.Main", "com.maps/.Main")
+                val secondContent = assertIs<AppDrawerUiState.Content>(awaitItem())
+                assertEquals(listOf(music, maps), secondContent.recentApps)
+                assertEquals(listOf(maps, music), secondContent.apps)
+            }
+            assertEquals(1, queryCount)
+        }
+
+    @Test
+    fun `content starts with no recent apps when the launch history is empty`() =
+        runTest {
+            val viewModel = AppDrawerViewModel(queryApps = { listOf(maps, music) })
+
+            viewModel.uiState.test {
+                assertEquals(AppDrawerUiState.Loading, awaitItem())
+
+                viewModel.onAction(AppDrawerAction.Refresh)
+
+                val content = assertIs<AppDrawerUiState.Content>(awaitItem())
+                assertEquals(emptyList(), content.recentApps)
+            }
+        }
+}


### PR DESCRIPTION
## App-drawer expansion — recents + A–Z fast-scroll (owner backlog — PR G of 8)

Fills out the drawer as a home launcher (on top of the existing search, pinned favorites with drag-reorder, grid/list, and icon-size controls).

- **Recently-used apps.** A launch-tracking store (own DataStore, package → timestamp + count, capped at 8, most-recent-first) increments at the single drawer launch path; a horizontal **Recent** row appears near the top of the drawer, hiding on a fresh install and while searching.
- **A–Z fast-scroll index.** The app grid now flows **continuously** (dense — multiple apps per row, no per-letter row breaks), with an A–Z **index rail** down the edge: tapping or dragging a letter scrolls to that letter's first app, and a floating letter bubble shows the active letter while dragging. Only letters that have apps appear; the rail and Recent row inset so nothing renders under the rail. Search hides the rail and shows the ranked results.

Verified by rendering at head-unit + portrait, grid + list, search-active, and a full-alphabet stress case. New unit tests cover the launch store, recency ordering, and the letter→scroll-target mapping. No golden change (the drawer isn't in the goldens).
