### PR TITLE
feat(dashboard): cross-fade content on switch (clock, speed, dock status, calendar head)

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -38,6 +38,7 @@ import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.FitText
+import io.github.seijikohara.femto.ui.theme.Motion
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.PreviewTextStress
 import io.github.seijikohara.femto.ui.theme.bigNumber
@@ -75,10 +76,9 @@ internal fun CalendarCard(
     modifier: Modifier = Modifier,
     hazeState: HazeState = rememberHazeState(),
     glassConfig: GlassConfig = GlassConfig(),
-    // Retained for the uniform card-family signature (the dashboard passes the
-    // same motionTier to every card). The agenda now scrolls rather than
-    // crossfading on refresh, so the calendar card itself no longer tiers on it;
-    // the weather card still does for its fixed hero.
+    // Fades the head only (the big day number + weekday + month) on a date change.
+    // The agenda below scrolls rather than crossfading, so a data refresh keeps the
+    // user's scroll position instead of resetting it to today (see CalendarContent).
     motionTier: MotionTier = MotionTier.STANDARD,
 ) = Surface(
     modifier = modifier.glassChrome(MaterialTheme.shapes.large, hazeState, glassConfig),
@@ -100,7 +100,7 @@ internal fun CalendarCard(
             // a read failure, not a free month, so say so rather than fake it.
             snapshot.queryFailed -> CenteredHint(stringResource(R.string.calendar_query_failed))
 
-            else -> CalendarContent(snapshot, is24Hour, onExpand)
+            else -> CalendarContent(snapshot, is24Hour, motionTier, onExpand)
         }
     }
 }
@@ -109,6 +109,7 @@ internal fun CalendarCard(
 private fun CalendarContent(
     snapshot: CalendarSnapshot,
     is24Hour: Boolean,
+    motionTier: MotionTier,
     onExpand: () -> Unit,
 ) {
     // clickable + an explicit contentDescription (the AlbumArt idiom in
@@ -135,7 +136,17 @@ private fun CalendarContent(
                 .padding(FemtoDimens.CardPaddingCompact),
         verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGapCompact),
     ) {
-        Head(snapshot)
+        // Fade only the head on a date change, keyed on its own displayed identity so
+        // an agenda-only refresh (same day number / weekday / month) never re-fires it.
+        // The scrollable agenda below is deliberately NOT wrapped — a Crossfade there
+        // would reset the user's scroll on every refresh.
+        Motion.ContentCrossfade(
+            targetState = CalendarHead(snapshot.today.dayOfMonth, snapshot.weekday, snapshot.monthLabel),
+            tier = motionTier,
+            label = "calendarHead",
+        ) { head ->
+            Head(head)
+        }
         // Free days are dropped rather than rendered as placeholder rows: the glance
         // question is "what is coming up". Today is the one exception — it stays
         // visible even when free.
@@ -166,15 +177,25 @@ private fun CalendarContent(
     }
 }
 
+// The head's displayed identity: the big day number, weekday, and month label —
+// the fields [Head] renders. Carries all three (rather than the bare date) so the
+// crossfade's outgoing frame renders a fully-consistent old head while the incoming
+// one renders the new; equality on this drives the head fade.
+private data class CalendarHead(
+    val day: Int,
+    val weekday: String,
+    val month: String,
+)
+
 @Composable
-private fun Head(snapshot: CalendarSnapshot) =
+private fun Head(head: CalendarHead) =
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Text(
-            text = "${snapshot.today.dayOfMonth}",
+            text = "${head.day}",
             style = MaterialTheme.typography.bigNumber(
                 size = FemtoDimens.Text4Xl,
                 weight = MaterialTheme.typography.normalWeight,
@@ -184,7 +205,7 @@ private fun Head(snapshot: CalendarSnapshot) =
         )
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             FitText(
-                text = snapshot.weekday,
+                text = head.weekday,
                 style = MaterialTheme.typography.calendarWeekday(),
                 color = MaterialTheme.colorScheme.onSurface,
                 // The weekday is glance metadata beside the big day number, so it may
@@ -194,7 +215,7 @@ private fun Head(snapshot: CalendarSnapshot) =
                 minFontSize = FemtoDimens.GlanceTextSize,
             )
             Text(
-                text = snapshot.monthLabel.uppercase(),
+                text = head.month.uppercase(),
                 style = MaterialTheme.typography.eyebrow(),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/ClockOverlay.kt
@@ -10,8 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.rememberHazeState
+import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.Motion
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.heroNumeral
 import io.github.seijikohara.femto.ui.theme.normalWeight
@@ -50,6 +52,7 @@ internal fun ClockOverlay(
     showSeconds: Boolean = true,
     hazeState: HazeState = rememberHazeState(),
     glassConfig: GlassConfig = GlassConfig(),
+    motionTier: MotionTier = MotionTier.STANDARD,
     clock: Clock = Clock.systemDefaultZone(),
 ) {
     val now by produceState(initialValue = LocalTime.now(clock), showSeconds) {
@@ -69,15 +72,16 @@ internal fun ClockOverlay(
             showSeconds -> ClockFormatter12
             else -> ClockFormatter12NoSeconds
         }
-    Text(
-        text = now.format(formatter),
-        // Normal tier: the clock is ambient (not the safety glance), so it shares
-        // the dashboard's unified 40sp normal-tier hero-numeral look with the
-        // calendar day and weather temperature, tracking the user's weight setting.
-        // The speed value, by contrast, uses the heavier strong tier as the
-        // safety-critical readout.
-        style = MaterialTheme.typography.heroNumeral(weight = MaterialTheme.typography.normalWeight),
-        color = MaterialTheme.colorScheme.onSurface,
+    // Key the fade on the DISPLAYED string, not the raw LocalTime: it changes once
+    // per second (or per minute when seconds are hidden), so the glass frame stays
+    // put while only the time text dissolves on each tick — never a per-frame thrash.
+    val timeText = now.format(formatter)
+    Motion.ContentCrossfade(
+        targetState = timeText,
+        tier = motionTier,
+        label = "clock",
+        // Glass chrome + padding stay on the stable outer frame so only the time
+        // text crossfades inside it, rather than dissolving the whole glass card.
         modifier =
             modifier
                 .glassChrome(MaterialTheme.shapes.large, hazeState, glassConfig)
@@ -85,7 +89,18 @@ internal fun ClockOverlay(
                     horizontal = FemtoDimens.OverlayPaddingHorizontal,
                     vertical = FemtoDimens.OverlayPaddingVertical,
                 ),
-    )
+    ) { text ->
+        Text(
+            text = text,
+            // Normal tier: the clock is ambient (not the safety glance), so it shares
+            // the dashboard's unified 40sp normal-tier hero-numeral look with the
+            // calendar day and weather temperature, tracking the user's weight setting.
+            // The speed value, by contrast, uses the heavier strong tier as the
+            // safety-critical readout.
+            style = MaterialTheme.typography.heroNumeral(weight = MaterialTheme.typography.normalWeight),
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
 }
 
 @PreviewLightDark

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
@@ -49,6 +49,7 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.rememberHazeState
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.data.dock.DockNavId
 import io.github.seijikohara.femto.data.dock.DockStatusId
 import io.github.seijikohara.femto.data.system.SystemStatus
@@ -181,6 +182,7 @@ internal fun DashboardDock(
     hazeState: HazeState = rememberHazeState(),
     glassConfig: GlassConfig = GlassConfig(),
     dockConfig: DockConfig = DockConfig(),
+    motionTier: MotionTier = MotionTier.STANDARD,
 ) = when (position) {
     DockPosition.BOTTOM, DockPosition.TOP -> {
         HorizontalDock(
@@ -190,6 +192,7 @@ internal fun DashboardDock(
             glassConfig = glassConfig,
             modifier = modifier,
             dockConfig = dockConfig,
+            motionTier = motionTier,
         )
     }
 
@@ -201,6 +204,7 @@ internal fun DashboardDock(
             glassConfig = glassConfig,
             modifier = modifier,
             dockConfig = dockConfig,
+            motionTier = motionTier,
         )
     }
 }
@@ -213,6 +217,7 @@ private fun HorizontalDock(
     glassConfig: GlassConfig,
     modifier: Modifier = Modifier,
     dockConfig: DockConfig = DockConfig(),
+    motionTier: MotionTier = MotionTier.STANDARD,
 ) {
     val visibleNav = dockConfig.visibleNav
     // Read the available width before committing to a layout. The fixed-margin
@@ -273,6 +278,7 @@ private fun HorizontalDock(
                             vertical = false,
                             order = dockConfig.visibleStatus,
                             onAction = onAction,
+                            motionTier = motionTier,
                             modifier = Modifier.padding(horizontal = FemtoDimens.DockButtonMargin),
                         )
                     }
@@ -329,6 +335,7 @@ private fun HorizontalDock(
                             vertical = false,
                             order = dockConfig.visibleStatus,
                             onAction = onAction,
+                            motionTier = motionTier,
                             modifier = Modifier.padding(start = 20.dp),
                         )
                     }
@@ -348,6 +355,7 @@ private fun VerticalDock(
     glassConfig: GlassConfig,
     modifier: Modifier = Modifier,
     dockConfig: DockConfig = DockConfig(),
+    motionTier: MotionTier = MotionTier.STANDARD,
 ) = Surface(
     // Floating rounded glass rail, mirroring HorizontalDock on the width; on the
     // Live backend the blur falls back to the tint.
@@ -414,6 +422,7 @@ private fun VerticalDock(
                         vertical = true,
                         order = dockConfig.visibleStatus,
                         onAction = onAction,
+                        motionTier = motionTier,
                         modifier = Modifier.padding(top = 20.dp),
                     )
                 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -332,6 +332,7 @@ private fun DashboardContent(
         hazeState = hazeState,
         glassConfig = glassConfig,
         dockConfig = dockConfig,
+        motionTier = motionTier,
         modifier =
             when (dockPosition) {
                 DockPosition.BOTTOM, DockPosition.TOP -> {
@@ -478,6 +479,7 @@ private fun DashboardOverlays(
             showSeconds = showClockSeconds,
             hazeState = hazeState,
             glassConfig = glassConfig,
+            motionTier = motionTier,
             clock = clock,
             modifier =
                 Modifier
@@ -531,6 +533,7 @@ private fun DashboardOverlays(
                 onReset = { onAction(HomeAction.ResetTrip) },
                 hazeState = hazeState,
                 glassConfig = glassConfig,
+                motionTier = motionTier,
                 modifier = Modifier.onSizeChanged { onOverlayHeightChange(it.height) },
             )
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DockStatusCluster.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DockStatusCluster.kt
@@ -43,10 +43,12 @@ import com.composables.icons.lucide.WifiHigh
 import com.composables.icons.lucide.WifiLow
 import com.composables.icons.lucide.WifiZero
 import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.data.dock.DockStatusId
 import io.github.seijikohara.femto.data.system.SystemStatus
 import io.github.seijikohara.femto.ui.home.HomeAction
 import io.github.seijikohara.femto.ui.theme.FemtoIcon
+import io.github.seijikohara.femto.ui.theme.Motion
 import io.github.seijikohara.femto.ui.theme.glanceCaption
 
 @Composable
@@ -58,6 +60,7 @@ internal fun StatusCluster(
     // its declared order (today's factory cluster) so an omitted argument
     // renders byte-identical to before this parameter existed.
     order: List<DockStatusId> = DockStatusId.entries,
+    motionTier: MotionTier = MotionTier.STANDARD,
     // Dispatches the long-press edit menu's Move/Hide/Reset actions; the
     // default no-op keeps every caller that has nothing to wire (there is
     // none left in production, but a stray preview or test) compiling.
@@ -75,6 +78,7 @@ internal fun StatusCluster(
                     canMoveLeft = index > 0,
                     canMoveRight = index < order.lastIndex,
                     canHide = order.size > 1,
+                    tier = motionTier,
                     onAction = onAction,
                 )
             }
@@ -127,6 +131,7 @@ private fun EditableStatusIndicator(
     canMoveLeft: Boolean,
     canMoveRight: Boolean,
     canHide: Boolean,
+    tier: MotionTier,
     onAction: (HomeAction) -> Unit,
 ) {
     var menuOpen by remember { mutableStateOf(false) }
@@ -143,7 +148,7 @@ private fun EditableStatusIndicator(
                     detectTapGestures(onLongPress = { menuOpen = true })
                 },
     ) {
-        StatusIndicator(id, status)
+        StatusIndicator(id, status, tier)
         DockEditMenu(
             expanded = menuOpen,
             onDismiss = { menuOpen = false },
@@ -168,6 +173,7 @@ private fun EditableStatusIndicator(
 private fun StatusIndicator(
     id: DockStatusId,
     status: SystemStatus,
+    tier: MotionTier,
 ) {
     when (id) {
         DockStatusId.CELLULAR -> {
@@ -189,6 +195,7 @@ private fun StatusIndicator(
                         stringResource(
                             if (active) R.string.status_cellular_connected else R.string.status_cellular_disconnected,
                         ),
+                    tier = tier,
                 )
             }
         }
@@ -203,6 +210,7 @@ private fun StatusIndicator(
                     stringResource(
                         if (status.wifiConnected) R.string.status_wifi_connected else R.string.status_wifi_disconnected,
                     ),
+                tier = tier,
             )
         }
 
@@ -221,15 +229,16 @@ private fun StatusIndicator(
                             else -> R.string.status_bluetooth_off
                         },
                     ),
+                tier = tier,
             )
         }
 
         DockStatusId.GPS -> {
-            GpsIndicator(fixed = status.gpsFixed, satelliteCount = status.gpsSatelliteCount)
+            GpsIndicator(fixed = status.gpsFixed, satelliteCount = status.gpsSatelliteCount, tier = tier)
         }
 
         DockStatusId.BATTERY -> {
-            BatteryIndicator(percent = status.batteryPercent, charging = status.charging)
+            BatteryIndicator(percent = status.batteryPercent, charging = status.charging, tier = tier)
         }
     }
 }
@@ -292,15 +301,23 @@ private fun StatusIcon(
     icon: ImageVector,
     active: Boolean,
     description: String,
+    tier: MotionTier,
     modifier: Modifier = Modifier,
-) {
-    val tint =
-        if (active) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outline
+) = Motion.ContentCrossfade(
+    // Key on the (glyph, lit-state) pair so a signal-ramp glyph swap or a
+    // connect/disconnect tint flip dissolves; the fixed 20 dp icon slot keeps the
+    // cluster from reflowing. Both values ride the target so the outgoing layer
+    // fades the old glyph out rather than snapping straight to the new one.
+    targetState = Pair(icon, active),
+    tier = tier,
+    label = "statusIcon",
+    modifier = modifier,
+) { (glyph, lit) ->
     FemtoIcon(
-        imageVector = icon,
+        imageVector = glyph,
         contentDescription = description,
-        tint = tint,
-        modifier = modifier.size(20.dp),
+        tint = if (lit) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outline,
+        modifier = Modifier.size(20.dp),
     )
 }
 
@@ -311,28 +328,37 @@ private fun StatusIcon(
 private fun GpsIndicator(
     fixed: Boolean,
     satelliteCount: Int,
+    tier: MotionTier,
     modifier: Modifier = Modifier,
-) = Column(
+) = Motion.ContentCrossfade(
+    // The whole indicator (satellite glyph + count) dissolves together on a
+    // fix/lost flip or a satellite-count change, keyed on that discrete pair.
+    targetState = Pair(fixed, satelliteCount),
+    tier = tier,
+    label = "gps",
     modifier = modifier,
-    horizontalAlignment = Alignment.CenterHorizontally,
-    verticalArrangement = Arrangement.spacedBy(1.dp),
-) {
-    val tint = if (fixed) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outline
-    FemtoIcon(
-        imageVector = Lucide.Satellite,
-        contentDescription =
-            stringResource(
-                if (fixed) R.string.status_gps_fixed else R.string.status_gps_searching,
-            ),
-        tint = tint,
-        modifier = Modifier.size(20.dp),
-    )
-    Text(
-        text = stringResource(R.string.status_gps_satellites, satelliteCount),
-        style = MaterialTheme.typography.glanceCaption(),
-        color = tint,
-        maxLines = 1,
-    )
+) { (isFixed, count) ->
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(1.dp),
+    ) {
+        val tint = if (isFixed) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.outline
+        FemtoIcon(
+            imageVector = Lucide.Satellite,
+            contentDescription =
+                stringResource(
+                    if (isFixed) R.string.status_gps_fixed else R.string.status_gps_searching,
+                ),
+            tint = tint,
+            modifier = Modifier.size(20.dp),
+        )
+        Text(
+            text = stringResource(R.string.status_gps_satellites, count),
+            style = MaterialTheme.typography.glanceCaption(),
+            color = tint,
+            maxLines = 1,
+        )
+    }
 }
 
 // Battery icon stacked over its percent. Charging is conveyed by the bolt glyph
@@ -341,24 +367,33 @@ private fun GpsIndicator(
 private fun BatteryIndicator(
     percent: Int?,
     charging: Boolean,
+    tier: MotionTier,
     modifier: Modifier = Modifier,
-) = Column(
+) = Motion.ContentCrossfade(
+    // The whole indicator (battery glyph + percent) dissolves together on a
+    // level-bucket, charging, or percent change, keyed on that discrete pair.
+    targetState = Pair(percent, charging),
+    tier = tier,
+    label = "battery",
     modifier = modifier,
-    horizontalAlignment = Alignment.CenterHorizontally,
-    verticalArrangement = Arrangement.spacedBy(1.dp),
-) {
-    FemtoIcon(
-        imageVector = batteryIconForLevel(percent = percent, charging = charging),
-        contentDescription = stringResource(R.string.status_battery),
-        tint = if (charging) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.size(20.dp),
-    )
-    Text(
-        // Render an em-dash while the percent is unknown (cold start / battery-less
-        // unit) so the cluster never reads as a dead 0% battery.
-        text = if (percent == null) "—" else stringResource(R.string.battery_percent, percent),
-        style = MaterialTheme.typography.glanceCaption(),
-        color = MaterialTheme.colorScheme.onSurface,
-        maxLines = 1,
-    )
+) { (pct, isCharging) ->
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(1.dp),
+    ) {
+        FemtoIcon(
+            imageVector = batteryIconForLevel(percent = pct, charging = isCharging),
+            contentDescription = stringResource(R.string.status_battery),
+            tint = if (isCharging) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp),
+        )
+        Text(
+            // Render an em-dash while the percent is unknown (cold start / battery-less
+            // unit) so the cluster never reads as a dead 0% battery.
+            text = if (pct == null) "—" else stringResource(R.string.battery_percent, pct),
+            style = MaterialTheme.typography.glanceCaption(),
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+        )
+    }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -36,6 +36,7 @@ import com.composables.icons.lucide.RotateCcw
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.rememberHazeState
 import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.data.geocoding.ShortAddress
 import io.github.seijikohara.femto.data.location.MIN_MOVING_SPEED_MS
 import io.github.seijikohara.femto.data.location.TripState
@@ -47,6 +48,7 @@ import io.github.seijikohara.femto.ui.locale.tripDistanceFromMeters
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoIcon
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.Motion
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.PreviewTextStress
 import io.github.seijikohara.femto.ui.theme.glanceCaption
@@ -97,6 +99,7 @@ internal fun SpeedOverlay(
     modifier: Modifier = Modifier,
     hazeState: HazeState = rememberHazeState(),
     glassConfig: GlassConfig = GlassConfig(),
+    motionTier: MotionTier = MotionTier.STANDARD,
 ) {
     // Source the hero numeral from the trip's effective speed, not
     // location.speed: cheap GPS chips leave Location.speed at 0.0
@@ -166,6 +169,7 @@ internal fun SpeedOverlay(
             distance = distance,
             distanceUnitLabel = speedUnit.distanceLabel(),
             avgSpeed = avgSpeed,
+            tier = motionTier,
             onReset = onReset,
         )
         // Always render the address row (even with no fix / unresolved address) so
@@ -186,17 +190,19 @@ private fun MetricRow(
     distance: Double,
     distanceUnitLabel: String,
     avgSpeed: Int,
+    tier: MotionTier,
     onReset: () -> Unit,
 ) = Row(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(12.dp),
 ) {
-    NowMetric(value = currentSpeed, unit = speedUnitLabel)
+    NowMetric(value = currentSpeed, unit = speedUnitLabel, tier = tier)
     Separator()
     SecondaryMetric(
         key = stringResource(R.string.speed_metric_distance),
         value = "%.1f".format(distance),
         unit = distanceUnitLabel,
+        tier = tier,
         modifier = Modifier.widthIn(min = FemtoDimens.SpeedMetricMinWidth),
     )
     Separator()
@@ -204,6 +210,7 @@ private fun MetricRow(
         key = stringResource(R.string.speed_metric_avg),
         value = "$avgSpeed",
         unit = speedUnitLabel,
+        tier = tier,
         modifier = Modifier.widthIn(min = FemtoDimens.SpeedMetricMinWidth),
     )
     Separator()
@@ -214,24 +221,36 @@ private fun MetricRow(
 private fun NowMetric(
     value: String,
     unit: String,
+    tier: MotionTier,
 ) = Row(
     horizontalArrangement = Arrangement.spacedBy(4.dp),
 ) {
-    Text(
-        text = value,
-        // Strong-tier hero numeral: heavier than the ambient clock's normal tier
-        // since the speed is the safety-critical glance that must stay legible on a
-        // dim head unit. Tracks the user's weight setting while keeping that
-        // relative emphasis across the range.
-        style = MaterialTheme.typography.heroNumeral(weight = MaterialTheme.typography.strongWeight),
-        color = MaterialTheme.colorScheme.onSurface,
-        maxLines = 1,
-        // Reserve a stable width sized for the clamped 3-digit range and
-        // right-align within it, so the hero numeral does not reflow the
-        // overlay as the speed's digit count changes.
-        textAlign = TextAlign.End,
-        modifier = Modifier.widthIn(min = FemtoDimens.SpeedHeroValueMinWidth).alignByBaseline(),
-    )
+    // The numeral dissolves on a change of the DISPLAYED, EMA-rounded string (not
+    // the raw smoothed float), so it fades once per real digit change. The reserved
+    // 3-digit width stays on the inner Text, so both the reserve and the baseline
+    // the crossfade box propagates keep the overlay from reflowing as the value ticks.
+    Motion.ContentCrossfade(
+        targetState = value,
+        tier = tier,
+        label = "speedHero",
+        modifier = Modifier.alignByBaseline(),
+    ) { numeral ->
+        Text(
+            text = numeral,
+            // Strong-tier hero numeral: heavier than the ambient clock's normal tier
+            // since the speed is the safety-critical glance that must stay legible on a
+            // dim head unit. Tracks the user's weight setting while keeping that
+            // relative emphasis across the range.
+            style = MaterialTheme.typography.heroNumeral(weight = MaterialTheme.typography.strongWeight),
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            // Reserve a stable width sized for the clamped 3-digit range and
+            // right-align within it, so the hero numeral does not reflow the
+            // overlay as the speed's digit count changes.
+            textAlign = TextAlign.End,
+            modifier = Modifier.widthIn(min = FemtoDimens.SpeedHeroValueMinWidth),
+        )
+    }
     // Dimmed unit trailing the numeral on its baseline (the shared dashboard unit
     // treatment) — a step below the value it annotates.
     UnitSuffix(unit, modifier = Modifier.alignByBaseline())
@@ -252,6 +271,7 @@ private fun SecondaryMetric(
     key: String,
     value: String,
     unit: String,
+    tier: MotionTier,
     modifier: Modifier = Modifier,
 ) = Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
     Text(
@@ -265,15 +285,22 @@ private fun SecondaryMetric(
     )
     // Numeric value + dimmed trailing unit on the value's baseline, matching the
     // hero speed's value/unit treatment; the caller's min-width cell keeps a
-    // digit change from reflowing the row.
+    // digit change from reflowing the row. The value dissolves on a change of its
+    // DISPLAYED string (keyed on the formatted value, not the raw trip total).
     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text(
-            text = value,
-            style = MaterialTheme.typography.glanceMetric(),
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
+        Motion.ContentCrossfade(
+            targetState = value,
+            tier = tier,
+            label = "speedMetric",
             modifier = Modifier.alignByBaseline(),
-        )
+        ) { metric ->
+            Text(
+                text = metric,
+                style = MaterialTheme.typography.glanceMetric(),
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+            )
+        }
         UnitSuffix(unit, modifier = Modifier.alignByBaseline())
     }
 }


### PR DESCRIPTION
Extends the app's cross-fade — the shared, tier-aware `Motion.ContentCrossfade` (STANDARD ~220 ms, REDUCED ~120 ms, OFF snaps) — to the dashboard surfaces that previously **snapped** when their content changed, so text / icons / images fade in on a switch app-wide. The music card, weather, and expanded player already used this helper.

## Surfaces now fading

- **Clock** (`ClockOverlay`) — the time readout fades on each displayed change (per-second when seconds show, else per-minute).
- **Speed overlay** (`SpeedOverlay`) — the hero speed value and the distance / average metrics fade on each displayed (rounded) change; the fixed-width reserves keep the row from reflowing.
- **Dock status cluster** (`DashboardDock`) — each status indicator (wifi / bluetooth / cellular / GPS / battery) fades on a state change.
- **Calendar head** (`CalendarCard`) — the big day number + weekday + month fade on a date rollover. The scrollable agenda is intentionally left un-faded so a refresh keeps the user's scroll position.

## How

- Reuses `Motion.ContentCrossfade`; no new animation primitive. Each wrapper keys on a **discrete displayed identity** (a formatted string / date tuple / status pair), never a per-frame value, so the fade never thrashes.
- Respects `MotionTier`; `motionTier` is now threaded to the clock, speed overlay, and dock (the calendar already received it).
- **Golden-safe**: `ContentCrossfade` settles at the target on first composition, so the screenshot goldens render the same settled frame — unchanged, not re-recorded.

## Verification

- `spotlessCheck`, `assembleDebug`, `lint`, and the touched-class unit tests pass.
- Reviewed against the project's Compose / Material 3 / automotive conventions.
