### PR TITLE
feat(dashboard): cross-fade content in the maximize panels

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarPanel.kt
@@ -24,8 +24,10 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.calendar.CalendarSnapshot
 import io.github.seijikohara.femto.data.calendar.DayCell
 import io.github.seijikohara.femto.data.calendar.EventItem
+import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.Motion
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.PreviewTextStress
 import io.github.seijikohara.femto.ui.theme.calendarWeekday
@@ -61,6 +63,7 @@ internal fun CalendarPanel(
     onOpenExternal: () -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
+    motionTier: MotionTier = MotionTier.STANDARD,
     hazeState: HazeState = rememberHazeState(),
     glassConfig: GlassConfig = GlassConfig(),
 ) = MaximizePanel(
@@ -82,6 +85,7 @@ internal fun CalendarPanel(
             today = snapshot.today,
             is24Hour = is24Hour,
             showColorDots = snapshot.multipleCalendarsVisible,
+            motionTier = motionTier,
             modifier = Modifier.fillMaxSize(),
         )
     } else {
@@ -95,6 +99,7 @@ internal fun CalendarPanel(
                 snapshot.today,
                 is24Hour,
                 snapshot.multipleCalendarsVisible,
+                motionTier,
                 Modifier.weight(1f).fillMaxHeight(),
             )
             AgendaColumn(
@@ -102,6 +107,7 @@ internal fun CalendarPanel(
                 snapshot.today,
                 is24Hour,
                 snapshot.multipleCalendarsVisible,
+                motionTier,
                 Modifier.weight(1f).fillMaxHeight(),
             )
         }
@@ -146,6 +152,7 @@ private fun AgendaColumn(
     today: LocalDate,
     is24Hour: Boolean,
     showColorDots: Boolean,
+    motionTier: MotionTier,
     modifier: Modifier = Modifier,
 ) = FitWholeRows(
     modifier = modifier,
@@ -155,10 +162,11 @@ private fun AgendaColumn(
     days.forEachIndexed { index, day ->
         AgendaDay(
             day = day,
-            isToday = day.date == today,
+            today = today,
             isFirst = index == 0,
             is24Hour = is24Hour,
             showColorDots = showColorDots,
+            motionTier = motionTier,
         )
     }
 }
@@ -170,56 +178,73 @@ private fun AgendaColumn(
 @Composable
 private fun AgendaDay(
     day: DayCell,
-    isToday: Boolean,
+    today: LocalDate,
     isFirst: Boolean,
     is24Hour: Boolean,
     showColorDots: Boolean,
+    motionTier: MotionTier,
     modifier: Modifier = Modifier,
-) = Column(
-    modifier = modifier.fillMaxWidth(),
-    verticalArrangement = Arrangement.spacedBy(10.dp),
-) {
-    if (!isFirst) {
-        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = FemtoDimens.DividerAlpha))
-    }
-    Row(
+) = Motion.ContentCrossfade(
+    // A day's block dissolves when its events change on a refresh (DayCell
+    // equality is structural). isFirst is positional, so the leading divider
+    // stays consistent across the swap; isToday derives from the faded day so the
+    // outgoing frame stays internally consistent. FitWholeRows still measures one
+    // child per day (the Crossfade's single root), so its fit-to-height count is
+    // unaffected.
+    targetState = day,
+    tier = motionTier,
+    label = "agendaDay",
+    modifier = modifier,
+) { current ->
+    val isToday = current.date == today
+    Column(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
-        verticalAlignment = Alignment.Top,
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        val accent = if (isToday) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
-        Column(
-            modifier = Modifier.width(44.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text(
-                text = day.weekdayLetter.take(3).uppercase(),
-                style = MaterialTheme.typography.sectionLabel(12),
-                color = if (isToday) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                softWrap = false,
-            )
-            Text(
-                text = "${day.date.dayOfMonth}",
-                style = MaterialTheme.typography.calendarWeekday(),
-                color = accent,
-                maxLines = 1,
-            )
+        if (!isFirst) {
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = FemtoDimens.DividerAlpha))
         }
-        Column(
+        Row(
             modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            verticalAlignment = Alignment.Top,
         ) {
-            if (day.events.isEmpty()) {
+            val accent = if (isToday) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+            val weekdayColor =
+                if (isToday) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+            Column(
+                modifier = Modifier.width(44.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
                 Text(
-                    text = stringResource(R.string.calendar_no_events),
-                    style = MaterialTheme.typography.cardMeta(),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    text = current.weekdayLetter.take(3).uppercase(),
+                    style = MaterialTheme.typography.sectionLabel(12),
+                    color = weekdayColor,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+                Text(
+                    text = "${current.date.dayOfMonth}",
+                    style = MaterialTheme.typography.calendarWeekday(),
+                    color = accent,
                     maxLines = 1,
                 )
-            } else {
-                day.events.forEach { event ->
-                    AgendaEvent(event = event, is24Hour = is24Hour, showColorDots = showColorDots)
+            }
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (current.events.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.calendar_no_events),
+                        style = MaterialTheme.typography.cardMeta(),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                    )
+                } else {
+                    current.events.forEach { event ->
+                        AgendaEvent(event = event, is24Hour = is24Hour, showColorDots = showColorDots)
+                    }
                 }
             }
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -628,6 +628,7 @@ private fun DashboardOverlays(
                     onClose = { calendarExpanded = false },
                     hazeState = hazeState,
                     glassConfig = glassConfig,
+                    motionTier = motionTier,
                     modifier = Modifier.fillMaxSize(),
                 )
             }
@@ -649,6 +650,7 @@ private fun DashboardOverlays(
                     onClose = { weatherExpanded = false },
                     hazeState = hazeState,
                     glassConfig = glassConfig,
+                    motionTier = motionTier,
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WeatherPanel.kt
@@ -28,6 +28,7 @@ import com.composables.icons.lucide.Sunset
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.rememberHazeState
 import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.data.weather.DailyForecast
 import io.github.seijikohara.femto.data.weather.HourlyForecast
 import io.github.seijikohara.femto.data.weather.WeatherCode
@@ -40,6 +41,7 @@ import io.github.seijikohara.femto.ui.locale.windLabel
 import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoIcon
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import io.github.seijikohara.femto.ui.theme.Motion
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import io.github.seijikohara.femto.ui.theme.WeatherGlyphColors
 import io.github.seijikohara.femto.ui.theme.bigNumber
@@ -73,6 +75,7 @@ internal fun WeatherPanel(
     onOpenExternal: () -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
+    motionTier: MotionTier = MotionTier.STANDARD,
     hazeState: HazeState = rememberHazeState(),
     glassConfig: GlassConfig = GlassConfig(),
 ) = MaximizePanel(
@@ -92,20 +95,37 @@ internal fun WeatherPanel(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGap),
     ) {
-        Hero(snapshot, temperatureUnit, speedUnit)
-        if (snapshot.hourly.isNotEmpty()) HourlyStrip(snapshot, temperatureUnit, is24Hour, portrait)
+        // Each region dissolves on a data refresh — keyed on the whole snapshot,
+        // so a genuinely new fetch (not a per-frame value) drives the fade,
+        // mirroring the compact WeatherCard. The regions fade individually rather
+        // than wrapping the scrolling Column, so a refresh keeps the user's scroll
+        // position instead of snapping back to the top.
+        Motion.ContentCrossfade(targetState = snapshot, tier = motionTier, label = "weatherPanelHero") {
+            Hero(it, temperatureUnit, speedUnit)
+        }
+        if (snapshot.hourly.isNotEmpty()) {
+            Motion.ContentCrossfade(targetState = snapshot, tier = motionTier, label = "weatherPanelHourly") {
+                HourlyStrip(it, temperatureUnit, is24Hour, portrait)
+            }
+        }
         if (portrait) {
-            if (snapshot.daily.isNotEmpty()) DailyList(snapshot.daily, temperatureUnit)
-            Details(snapshot, is24Hour)
-        } else {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(FemtoDimens.ScreenPadding),
-            ) {
-                if (snapshot.daily.isNotEmpty()) {
-                    DailyList(snapshot.daily, temperatureUnit, modifier = Modifier.weight(1f))
+            Motion.ContentCrossfade(targetState = snapshot, tier = motionTier, label = "weatherPanelDetails") {
+                Column(verticalArrangement = Arrangement.spacedBy(FemtoDimens.CardSectionGap)) {
+                    if (it.daily.isNotEmpty()) DailyList(it.daily, temperatureUnit)
+                    Details(it, is24Hour)
                 }
-                Details(snapshot, is24Hour, modifier = Modifier.weight(1f))
+            }
+        } else {
+            Motion.ContentCrossfade(targetState = snapshot, tier = motionTier, label = "weatherPanelDetails") {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(FemtoDimens.ScreenPadding),
+                ) {
+                    if (it.daily.isNotEmpty()) {
+                        DailyList(it.daily, temperatureUnit, modifier = Modifier.weight(1f))
+                    }
+                    Details(it, is24Hour, modifier = Modifier.weight(1f))
+                }
             }
         }
     }


### PR DESCRIPTION
## What

Extends the app-wide content cross-fade (`Motion.ContentCrossfade`) into the **calendar** and **weather** maximize panels, so their content dissolves when it changes on a data refresh — matching the compact cards, the dashboard surfaces (#281), and the Now Playing panel.

Before this PR, only the music full-screen panel faded its content; the calendar and weather maximize panels **snapped** on refresh.

## Surfaces now fading

- **Weather panel** (`WeatherPanel`) — the hero (temperature / condition / feels-wind-humidity), the hourly strip, and the daily + details block each fade on a data refresh.
- **Calendar panel** (`CalendarPanel`) — each agenda day fades when its events change.

## How

- Reuses the shared, tier-aware `Motion.ContentCrossfade`; no new animation primitive.
- **Weather** keys each region on the whole `snapshot` (like the compact `WeatherCard`) and fades the regions **individually inside** the scrolling `Column` — never wrapping the scroll container — so a refresh keeps the user's scroll position.
- **Calendar** keys each `AgendaDay` on its `DayCell` (structural equality). The maximize agenda uses `FitWholeRows` (a fit-to-height layout, not a scroller), and the `Crossfade`'s single root keeps its fit-to-height child count intact — no scroll-position concern.
- `motionTier` is threaded into both panels, so `MotionTier.OFF` snaps like every other content fade.

## Verification

- `spotlessApply`, `assembleDebug`, `lint`, `testDebugUnitTest`, and **`verifyRoborazziDebug`** all pass locally.
- **Goldens unchanged** — `ContentCrossfade` settles at the target on the first composition, so the captured frame is identical (no PNG re-record).
