### PR TITLE
fix(music): park the spectrum frame loop when it settles

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCardSpectrum.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MusicCardSpectrum.kt
@@ -28,6 +28,7 @@ import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.PreviewLightDark
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlin.math.abs
 import kotlin.math.exp
 import kotlin.math.sin
 
@@ -40,9 +41,11 @@ private const val TAU_DECAY_MS = 350f
 // dt for the first frame after (re)start, before a frame delta exists.
 private const val FALLBACK_FRAME_MS = 16L
 
-// Below this level a bar is invisible; once every band is under it (and the
-// spectrum is inactive) the frame loop parks instead of burning frames.
-private const val PARK_LEVEL = 0.005f
+// Convergence tolerance: once every band is within this of its target the
+// smoothing has visually settled (sub-pixel on the strip), so the loop snaps to
+// the target and parks instead of burning frames. It doubles as the decay-to-flat
+// floor when the spectrum is inactive (a null target has an all-zero goal).
+private const val CONVERGE_LEVEL = 0.005f
 
 // Bar gradient alphas. The cap keeps the strip a background: at 0.22 peak the
 // accent reads as texture behind the transport buttons, never as a competitor.
@@ -67,9 +70,11 @@ private const val MAX_BAR_HEIGHT_FRACTION = 0.9f
  *    [withFrameNanos] loop with asymmetric exponential smoothing, then are
  *    read ONLY inside the [Canvas] draw lambda — each frame invalidates the
  *    draw phase alone, never recomposing the card or its buttons.
- *  - When the spectrum goes null (visualization off, playback stopped,
- *    capture unavailable) the bars decay to flat and the loop parks until
- *    data returns, so an idle card costs zero frames.
+ *  - The loop parks whenever the bars have caught up to the target — a null
+ *    target (visualization off, playback stopped, capture unavailable) decays
+ *    to flat, a static one settles in place — and resumes on the next distinct
+ *    capture, so an idle or unchanging card costs zero frames and the
+ *    composition can reach idle.
  */
 @Composable
 internal fun SpectrumBackground(
@@ -99,9 +104,19 @@ internal fun SpectrumBackground(
                     previousFrameNanos = frameNanos
                     displayed = smoothedLevels(displayed, target, dtMillis)
                 }
-                if (target == null && displayed.all { it < PARK_LEVEL }) {
+                // Once the bars have caught up to the target there is nothing left
+                // to advance, so snap to the exact goal and park until the next
+                // distinct capture. A static signal — paused visualization, or a
+                // fixed test fixture — then costs zero frames and lets the
+                // composition reach idle; a live-but-unchanging FloatArray would
+                // otherwise re-invalidate the draw every frame forever, as arrays
+                // compare by reference.
+                val goal = target ?: FloatArray(displayed.size)
+                if (displayed.hasConverged(goal)) {
+                    displayed = goal
                     previousFrameNanos = 0L
-                    snapshotFlow { target }.first { it != null }
+                    val settled = target
+                    snapshotFlow { target }.first { it !== settled }
                 }
             }
         }
@@ -132,6 +147,11 @@ internal fun smoothedLevels(
         displayed[band] + (goal[band] - displayed[band]) * alpha
     }
 }
+
+// True once every band sits within the convergence tolerance of its goal, so
+// further smoothing frames would not change what is drawn and the loop can park.
+private fun FloatArray.hasConverged(goal: FloatArray): Boolean =
+    size == goal.size && indices.all { abs(this[it] - goal[it]) < CONVERGE_LEVEL }
 
 // One gradient shared by every bar (it spans the strip's draw bounds), in the
 // active scheme's accent so the strip tracks dynamic color and preset seeds.


### PR DESCRIPTION
## Summary

`SpectrumBackground`'s `withFrameNanos` loop only parked when the spectrum target
went null. A **static non-null** signal animated forever: `displayed` is
reassigned a fresh `FloatArray` each frame, and arrays compare by reference, so
the draw phase re-invalidated every frame even after the bars had visually
settled — the composition never reached idle.

Fix: park whenever the bars have **converged** to the current target (snap to the
exact goal, then suspend until the next distinct capture). A live, changing signal
is unaffected; a static one now costs zero frames — a small device-side win (no
wasted frames while audio is paused/static) and the real fix for a pathological CI
cost.

## The CI cost this fixes

Profiling the `unit-tests` leg (JUnit XML per-method timing, captured from a real
CI run) showed **96% of the ~13 min was two test methods** — the `*_spectrum`
NowPlaying screenshots — each ~5.5 min, because Roborazzi waits for compose idle
before capturing and the never-idle loop never got there.

| method | before | after (local) |
| --- | --- | --- |
| `nowplaying_head_unit_spectrum` | 330.7 s | 0.31 s |
| `nowplaying_phone_portrait_spectrum` | 336.7 s | 0.19 s |

Expected `unit-tests` leg: **~13 min → ~2 min**.

## Verification

- Local: the 8 `NowPlayingPanelScreenshotTest` methods run in ~16 s (was ~11 min);
  `:app:spotlessKotlinCheck` passes.
- `smoothedLevels` is unchanged, so `SpectrumSmoothingTest` is unaffected.
- CI runs `verifyRoborazziDebug`. The 2 spectrum goldens now capture the settled
  frame; if they drift beyond the 0.01 change threshold I will re-record them via
  the record-screenshots workflow (only those 2 can change — the fix touches only
  the non-null spectrum render path).
