### PR TITLE
ci: delete the rolling nightly release by id, not by tag lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,24 @@ jobs:
         run: |
           # `gh release edit --target` cannot move an existing tag (cli/cli#8669),
           # so delete the old rolling release and tag, then recreate against the
-          # exact built commit. `|| true` keeps the first-ever run idempotent.
-          gh release delete nightly --yes --cleanup-tag || true
+          # exact built commit.
+          #
+          # Delete by RELEASE ID from the list, never by tag lookup: a release
+          # whose server-side tag association is corrupted (seen 2026-07-16
+          # after a GitHub incident) is invisible to `gh release delete <tag>`
+          # ("release not found") yet still blocks the tag_name on create —
+          # a deadlock no rerun can clear. Listing sees every release, so this
+          # shape cannot wedge; an empty list (first-ever run) simply skips.
+          gh api "repos/$GITHUB_REPOSITORY/releases" \
+            --jq '.[] | select(.tag_name == "nightly") | .id' |
+            while read -r release_id; do
+              gh api -X DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id"
+            done
+          # Delete the tag ref explicitly (delete-by-id has no --cleanup-tag):
+          # `gh release create --target` is ignored when the tag already
+          # exists, so a stale ref would silently pin the new release to the
+          # OLD commit. A 404 here just means no tag yet.
+          gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly" || true
           gh release create nightly \
             "$RUNNER_TEMP/femto-car-launcher-nightly.apk" \
             "$RUNNER_TEMP/femto-car-launcher-nightly.aab" \


### PR DESCRIPTION
## Summary

Harden the nightly publish step against the "zombie release" deadlock that
broke the nightly on 2026-07-16.

**What happened.** A GitHub service disruption overlapped a nightly run and
left the rolling `nightly` release in a corrupted state: it appeared in
`GET /releases` and blocked the `nightly` tag_name on create
(`already exists`), but the tag lookup (`GET /releases/tags/nightly`)
returned 404. The publish step's `gh release delete nightly` (tag-lookup
based) therefore reported `release not found` — swallowed by `|| true` — and
`gh release create nightly` collided. Three consecutive attempts failed with
that exact signature while the signed release build itself was green every
time; no rerun could ever clear it. Manual remediation was DELETE-by-release-id
plus deleting the tag ref, after which the rerun published Nightly 842.

**Fix.** Replace delete-by-tag with delete-by-id:

- List the repo releases, filter `tag_name == "nightly"`, and `DELETE` each by
  id — the list sees every release, including a zombie, so this shape cannot
  wedge. An empty list (first-ever run) simply skips, preserving idempotency
  without a blanket `|| true` around the delete.
- Delete the tag ref explicitly afterwards (`delete-by-id` has no
  `--cleanup-tag`): `gh release create --target` is ignored when the tag
  already exists, so a stale ref would silently pin the new release to the OLD
  commit. A 404 (no tag yet) is fine.
- A transient API failure now fails the step loudly (retry-able) instead of
  deadlocking behind a swallowed lookup.

## Verification

- `ci.yml` validates as well-formed YAML; the step uses only runner-provided
  env (`GITHUB_REPOSITORY`, `GITHUB_SHA`) — no untrusted interpolation.
- The publish step only runs on main pushes, so PR CI cannot exercise it; the
  **post-merge nightly run on main is the live verification** and will be
  watched after merging.
