### PR TITLE
fix(calendar): stretch the event color bar to the title's lines

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarCard.kt
@@ -5,9 +5,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -336,7 +339,7 @@ private fun EventRow(
     Text(
         text = time,
         // Indent past the bar gutter so the time shares the title's left edge;
-        // the bar leads the title row below, centered on the title line.
+        // the bar leads the title row below, spanning its rendered lines.
         modifier =
             if (showColorBar) {
                 Modifier.padding(start = FemtoDimens.CalendarBarGutter)
@@ -349,13 +352,15 @@ private fun EventRow(
         softWrap = false,
     )
     Row(
+        // IntrinsicSize.Min sizes this row to the title text, so the bar's
+        // fillMaxHeight spans exactly the rendered line(s) — one line for a
+        // short title, both when it wraps — instead of floating as a
+        // fixed-height stub beside wrapped text.
+        modifier = Modifier.height(IntrinsicSize.Min),
         horizontalArrangement = Arrangement.spacedBy(FemtoDimens.CalendarBarGap),
-        // Center the bar on the title line rather than the whole time+title
-        // stack, so it marks the event at its title.
-        verticalAlignment = Alignment.CenterVertically,
     ) {
         if (showColorBar) {
-            CalendarColorBar(color = color)
+            CalendarColorBar(color = color, modifier = Modifier.fillMaxHeight())
         }
         Text(
             text = title,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarColorBar.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarColorBar.kt
@@ -2,7 +2,7 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,9 +13,14 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
 /**
  * Thin rounded vertical bar painted in a calendar's own color, used on the
  * calendar card and panel to mark which calendar an event belongs to.
- * `CircleShape` over the narrow box renders as a capsule, so the bar keeps
- * fully round caps at any [FemtoDimens.CalendarBarWidth] /
- * [FemtoDimens.CalendarBarHeight].
+ * `CircleShape` over the narrow box renders as a capsule with fully round
+ * caps at any height.
+ *
+ * The bar owns only its [FemtoDimens.CalendarBarWidth]; the height comes from
+ * the call site — the event rows size themselves with
+ * `Modifier.height(IntrinsicSize.Min)` and pass `fillMaxHeight()`, so the
+ * capsule spans exactly the title's rendered lines (both lines when a long
+ * title wraps) instead of floating as a fixed-height stub beside them.
  *
  * The bar deliberately uses the raw provider color rather than a
  * `MaterialTheme` role: the whole point is to match the exact colors the user
@@ -30,7 +35,7 @@ internal fun CalendarColorBar(
     modifier: Modifier = Modifier,
 ) = Box(
     modifier
-        .size(width = FemtoDimens.CalendarBarWidth, height = FemtoDimens.CalendarBarHeight)
+        .width(FemtoDimens.CalendarBarWidth)
         .clip(CircleShape)
         .background(Color(color)),
 )

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarPanel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/CalendarPanel.kt
@@ -2,10 +2,12 @@ package io.github.seijikohara.femto.ui.home.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.HorizontalDivider
@@ -264,7 +266,7 @@ private fun AgendaEvent(
     verticalArrangement = Arrangement.spacedBy(2.dp),
 ) {
     // Indent the non-title lines past the bar gutter so every line shares the
-    // title's left edge; the bar leads the title row, centered on the title line.
+    // title's left edge; the bar leads the title row, spanning its rendered lines.
     val gutterIndent =
         if (showColorBars) {
             Modifier.padding(start = FemtoDimens.CalendarBarGutter)
@@ -279,13 +281,14 @@ private fun AgendaEvent(
         maxLines = 1,
     )
     Row(
+        // Match the card: IntrinsicSize.Min sizes this row to the title text,
+        // so the bar's fillMaxHeight spans exactly the rendered line(s) rather
+        // than floating as a fixed-height stub beside a wrapped title.
+        modifier = Modifier.height(IntrinsicSize.Min),
         horizontalArrangement = Arrangement.spacedBy(FemtoDimens.CalendarBarGap),
-        // Match the card: center the bar on the title line rather than the whole
-        // stacked lines, so it marks the event at its title.
-        verticalAlignment = Alignment.CenterVertically,
     ) {
         if (showColorBars) {
-            CalendarColorBar(color = event.color)
+            CalendarColorBar(color = event.color, modifier = Modifier.fillMaxHeight())
         }
         Text(
             text = event.title,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/theme/FemtoDimens.kt
@@ -83,24 +83,23 @@ object FemtoDimens {
     val InlineIconSize = 20.dp
 
     /**
-     * Width and height of the calendar event color bar — the thin rounded
-     * vertical line that marks which calendar an event belongs to on the
-     * calendar card and panel, shown only when the visible events span more
-     * than one calendar. A decorative indicator, not a tap target, so it is
-     * sized independently of [MinTouchTarget]; the height sits on the title
-     * line the bar centers on.
+     * Width of the calendar event color bar — the thin rounded vertical line
+     * that marks which calendar an event belongs to on the calendar card and
+     * panel, shown only when the visible events span more than one calendar.
+     * A decorative indicator, not a tap target. Width only: the bar stretches
+     * to the event title's rendered lines at its call sites (see
+     * `CalendarColorBar`).
      */
     val CalendarBarWidth = 3.dp
-    val CalendarBarHeight = 14.dp
 
     /** Gap between the calendar event color bar and the event's time / title text. */
     val CalendarBarGap = 4.dp
 
     /**
      * Start indent that clears the leading color-bar gutter: the bar's width
-     * plus its trailing gap. The bar leads the title row and centers on the title
-     * line, so an event's other lines (time, location) pad their start by this to
-     * share the title's left edge.
+     * plus its trailing gap. The bar leads the title row, spanning its rendered
+     * lines, so an event's other lines (time, location) pad their start by this
+     * to share the title's left edge.
      */
     val CalendarBarGutter = CalendarBarWidth + CalendarBarGap
 


### PR DESCRIPTION
## Summary

The event color bar was a fixed 3×14 dp capsule centered on the title block, so a wrapped two-line title left it floating as a short stub beside the text. The title row now sizes itself with `IntrinsicSize.Min` and the bar fills that height: the capsule spans exactly the title's rendered lines — one line for a short title, both lines when it wraps — on the compact card and the maximize panel alike. `FemtoDimens.CalendarBarHeight` is removed; the width token and gutter derivation stay.

## Verification

- `./gradlew spotlessCheck assembleDebug` + calendar unit tests — green locally.
- Verified live on the TBox-Mock-Play emulator with real wrapped events (two-line Japanese titles): the bar spans both lines; single-line events keep a single-line bar.
- No golden impact: the screenshot fixtures render no bars (multipleCalendarsVisible stays false there).