### PR TITLE
fix(trip): speed-overlay Since label and flyover data reload

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayTest.kt
@@ -29,6 +29,7 @@ class SpeedOverlayTest {
                     address = fakeAddress(),
                     tripState = fakeTripState(currentSpeedMs = 18.0),
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
                     onReset = {},
                 )
             }
@@ -47,6 +48,7 @@ class SpeedOverlayTest {
                     address = fakeAddress(),
                     tripState = fakeTripState(currentSpeedMs = 18.0),
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
                     onReset = {},
                 )
             }
@@ -69,6 +71,7 @@ class SpeedOverlayTest {
                     address = fakeAddress(),
                     tripState = fakeTripState(currentSpeedMs = 18.0),
                     speedUnit = SpeedUnit.MILES_PER_HOUR,
+                    is24Hour = true,
                     onReset = {},
                 )
             }

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlayTest.kt
@@ -94,6 +94,7 @@ class SpeedOverlayTest {
                     address = fakeAddress(),
                     tripState = fakeTripState(currentSpeedMs = 18.0),
                     speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                    is24Hour = true,
                     onReset = { resetCount++ },
                 )
             }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -545,6 +545,7 @@ private fun DashboardOverlays(
                 address = uiState.address,
                 tripState = uiState.tripState,
                 speedUnit = speedUnit,
+                is24Hour = is24Hour,
                 onReset = { onAction(HomeAction.ResetTrip) },
                 hazeState = hazeState,
                 glassConfig = glassConfig,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/SpeedOverlay.kt
@@ -121,6 +121,7 @@ internal fun SpeedOverlay(
     address: ShortAddress?,
     tripState: TripState,
     speedUnit: SpeedUnit,
+    is24Hour: Boolean,
     onReset: () -> Unit,
     modifier: Modifier = Modifier,
     hazeState: HazeState = rememberHazeState(),
@@ -217,7 +218,7 @@ internal fun SpeedOverlay(
             onReset = onReset,
         )
         TripSinceRow(
-            label = tripState.startedAtEpochMs?.let { tripStartLabel(it) },
+            label = tripState.startedAtEpochMs?.let { tripStartLabel(it, is24Hour) },
             tier = motionTier,
         )
         // Always render the address row (even with no fix / unresolved address) so
@@ -375,26 +376,33 @@ private fun SecondaryMetric(
 // Locale-aware "since" timestamp for the trip-start row: time only while the
 // trip started today, day + time once it crosses midnight (the parked-overnight
 // case, where a bare clock time would read as this morning). DateUtils follows
-// the system locale and the 12/24-hour setting. The "today" reference advances
-// on its own midnight ticker rather than relying on a location fix to recompose
-// (with a non-zero min-distance a parked car delivers none), so the label gains
-// the date at midnight even while stationary.
+// the system locale; the 12/24-hour choice comes from the app's clock setting
+// ([is24Hour]) via FORMAT_12HOUR/FORMAT_24HOUR — the same setting the calendar
+// and weather panels honour — rather than the device default. The "today"
+// reference advances on its own midnight ticker rather than relying on a
+// location fix to recompose (with a non-zero min-distance a parked car delivers
+// none), so the label gains the date at midnight even while stationary.
 @Composable
-private fun tripStartLabel(startedAtEpochMs: Long): String {
+private fun tripStartLabel(
+    startedAtEpochMs: Long,
+    is24Hour: Boolean,
+): String {
     val context = LocalContext.current
     val zone = ZoneId.systemDefault()
     val today = rememberToday(zone)
     val startedToday = Instant.ofEpochMilli(startedAtEpochMs).atZone(zone).toLocalDate() == today
+    val clockFlag = if (is24Hour) DateUtils.FORMAT_24HOUR else DateUtils.FORMAT_12HOUR
     val timestamp =
-        remember(startedAtEpochMs, startedToday) {
+        remember(startedAtEpochMs, startedToday, is24Hour) {
             DateUtils.formatDateTime(
                 context,
                 startedAtEpochMs,
-                if (startedToday) {
-                    DateUtils.FORMAT_SHOW_TIME
-                } else {
-                    DateUtils.FORMAT_SHOW_TIME or DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_ABBREV_MONTH
-                },
+                clockFlag or
+                    if (startedToday) {
+                        DateUtils.FORMAT_SHOW_TIME
+                    } else {
+                        DateUtils.FORMAT_SHOW_TIME or DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_ABBREV_MONTH
+                    },
             )
         }
     return stringResource(R.string.speed_trip_since, timestamp)
@@ -417,13 +425,15 @@ private fun rememberToday(zone: ZoneId): LocalDate {
     return today.value
 }
 
-// "Since 8:04" under the reset button (the metric row's trailing cell): when
+// "Since\n8:04" under the reset button (the metric row's trailing cell): when
 // the current reset-to-reset trip began — the wall-clock time of its first GPS
-// fix, which is also the track log's first point for the trip. The row always
-// occupies its line (blank until the first fix) so the overlay's height never
-// jumps when the label appears, and [ZeroIntrinsicWidth] keeps the varying
-// label text out of the overlay's intrinsic width vote — the same stability
-// contract as the address row.
+// fix, which is also the track log's first point for the trip. Rendered as a
+// two-line right-aligned caption ("Since" over the timestamp, see the newline in
+// R.string.speed_trip_since) so it stays tucked under the reset button instead of
+// spreading a wide localized timestamp across the whole metric row. The row is
+// blank (one reserved line) until the first fix, then grows to the two-line
+// caption; [ZeroIntrinsicWidth] keeps the varying label text out of the overlay's
+// intrinsic width vote — the same stability contract as the address row.
 @Composable
 private fun TripSinceRow(
     label: String?,
@@ -441,7 +451,8 @@ private fun TripSinceRow(
             // The dimmest tier (matches the metric keys): pure glance metadata,
             // never competing with the hero numeral.
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.62f),
-            maxLines = 1,
+            // Two lines for the "Since\n<time>" caption; blank stays one line.
+            maxLines = 2,
             minLines = 1,
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.End,
@@ -675,6 +686,7 @@ private fun SpeedOverlayPreview() {
                     startedAtEpochMs = System.currentTimeMillis(),
                 ),
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            is24Hour = true,
             onReset = {},
         )
     }
@@ -693,6 +705,7 @@ private fun SpeedOverlayWideValuesPreview() {
             address = ShortAddress(locality = "Minato-ku", region = "Tokyo"),
             tripState = TripState(distanceMeters = 188_400.0, avgSpeedMs = 30.5, currentSpeedMs = 30.5),
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            is24Hour = true,
             onReset = {},
         )
     }
@@ -710,6 +723,7 @@ private fun SpeedOverlayNoFixPreview() {
             address = ShortAddress(locality = "Minato-ku", region = "Tokyo"),
             tripState = TripState.Initial,
             speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+            is24Hour = true,
             onReset = {},
         )
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/TripVizViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/TripVizViewModel.kt
@@ -13,6 +13,7 @@ import io.github.seijikohara.femto.data.location.TripStatePreferences
 import io.github.seijikohara.femto.data.location.TripStats
 import io.github.seijikohara.femto.data.location.TripSummaryRow
 import io.github.seijikohara.femto.data.location.TripWireframe
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -78,6 +79,9 @@ internal class TripVizViewModel(
     private val tripSummaries: suspend () -> List<TripSummaryRow>,
     private val pointsForTrip: suspend (Long) -> List<TrackPointEntity>,
     private val currentTripId: suspend () -> Long,
+    // The projection + wireframe build run here (off the main thread in
+    // production); injected so tests can drive them on the test scheduler.
+    private val computeDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TripVizUiState())
     val uiState: StateFlow<TripVizUiState> = _uiState.asStateFlow()
@@ -117,16 +121,21 @@ internal class TripVizViewModel(
                         )
                     }
             _uiState.update { it.copy(loading = false, trips = trips) }
-            // Open on the most recent trip so the panel is never empty when data exists.
-            if (trips.isNotEmpty() && _uiState.value.selection == null) {
-                select(trips.first().tripId)
-            }
+            // Reload the trip's geometry on every refresh (the panel refreshes on
+            // each open), so reopening after more driving picks up the current
+            // trip's new points instead of showing the first-open snapshot. Keep
+            // the user's selection when it still exists; otherwise open on the most
+            // recent trip.
+            val target =
+                _uiState.value.selectedTripId?.takeIf { id -> trips.any { it.tripId == id } }
+                    ?: trips.firstOrNull()?.tripId
+            if (target != null) select(target)
         }
 
     private fun select(tripId: Long) =
         viewModelScope.launch {
             _uiState.update { it.copy(selectedTripId = tripId) }
-            val geometry = withContext(Dispatchers.Default) { TripGeometry.from(pointsForTrip(tripId)) }
+            val geometry = withContext(computeDispatcher) { TripGeometry.from(pointsForTrip(tripId)) }
             // Read the palette AFTER the load (back on main), so a palette change
             // during the load is honoured rather than a launch-time snapshot.
             val selection = geometry?.let { buildSelection(tripId, it, palette) }
@@ -159,7 +168,7 @@ internal class TripVizViewModel(
         geometry: TripGeometry,
         withPalette: TripScenePalette,
     ): TripSelection =
-        withContext(Dispatchers.Default) {
+        withContext(computeDispatcher) {
             TripSelection(tripId, TripWireframe.build(geometry, withPalette), geometry.stats, geometry)
         }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,9 @@
 
     <!-- Speed overlay -->
     <string name="speed_reset_trip">Reset trip</string>
-    <string name="speed_trip_since">Since %1$s</string>
+    <!-- Two lines: "Since" over the trip-start timestamp, so a wide localized
+         time stays tucked under the reset button (see TripSinceRow). -->
+    <string name="speed_trip_since">Since\n%1$s</string>
     <string name="speed_expand_trip">Open trip flyover</string>
     <string name="trip_viz_empty">No trips recorded yet</string>
     <string name="trip_viz_preparing">Preparing flyover…</string>

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/SpeedOverlayWidthTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/SpeedOverlayWidthTest.kt
@@ -80,6 +80,7 @@ class SpeedOverlayWidthTest {
                                 startedAtEpochMs = startedAtEpochMs,
                             ),
                         speedUnit = SpeedUnit.KILOMETERS_PER_HOUR,
+                        is24Hour = true,
                         onReset = {},
                     )
                 }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/components/TripVizViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/components/TripVizViewModelTest.kt
@@ -1,0 +1,94 @@
+package io.github.seijikohara.femto.ui.home.components
+
+import io.github.seijikohara.femto.data.location.TrackPointEntity
+import io.github.seijikohara.femto.data.location.TripSummaryRow
+import io.github.seijikohara.femto.testfixtures.fakeTrackPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class TripVizViewModelTest {
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // The flyover refreshes on every open, and the current trip keeps growing
+    // while it is closed. A refresh must reload the selected trip's now-larger
+    // point set instead of showing the first-open snapshot.
+    @Test
+    fun `refresh reloads the selected trip's new points`() =
+        runTest {
+            var points = straightTrack(count = 10)
+            val viewModel =
+                TripVizViewModel(
+                    tripSummaries = { listOf(summaryFor(TRIP_ID, points.size)) },
+                    pointsForTrip = { points },
+                    currentTripId = { TRIP_ID },
+                    computeDispatcher = StandardTestDispatcher(testScheduler),
+                )
+            advanceUntilIdle()
+
+            val firstOpen = viewModel.uiState.value.selection
+            assertNotNull(firstOpen)
+            val firstVertexCount = firstOpen.geometry.vertexCount
+
+            // Drive more while the panel is "closed", then reopen (Refresh).
+            points = straightTrack(count = 40)
+            viewModel.onAction(TripVizAction.Refresh)
+            advanceUntilIdle()
+
+            val reopened = viewModel.uiState.value.selection
+            assertNotNull(reopened)
+            assertTrue(
+                reopened.geometry.vertexCount > firstVertexCount,
+                "reopening should reload the trip's new points " +
+                    "(was $firstVertexCount, now ${reopened.geometry.vertexCount})",
+            )
+        }
+
+    private fun summaryFor(
+        tripId: Long,
+        pointCount: Int,
+    ) = TripSummaryRow(
+        tripId = tripId,
+        startMs = 0L,
+        endMs = pointCount * 1_000L,
+        pointCount = pointCount,
+        minLat = 35.0,
+        maxLat = 36.0,
+        minLon = 139.0,
+        maxLon = 140.0,
+        minAltitude = 20.0,
+        maxAltitude = 60.0,
+    )
+
+    private fun straightTrack(count: Int): List<TrackPointEntity> =
+        (0 until count).map { i ->
+            fakeTrackPoint(
+                tripId = TRIP_ID,
+                timeMs = i * 1_000L,
+                latitude = 35.6580 + i * 0.0005,
+                longitude = 139.7016 + i * 0.0003,
+                speedMps = 8f + (i % 5),
+                altitudeM = 20.0 + i,
+            )
+        }
+
+    private companion object {
+        const val TRIP_ID = 1L
+    }
+}


### PR DESCRIPTION
Three bugs reported on the shipped flyover build (Nightly 875).

## 1. "Since <time>" spread across the metric row
The trip-start label rendered as a full-width single line, so a wide localized timestamp (e.g. `Since 午後1:55`) spread across the metric row instead of tucking under the reset button. Now a **two-line right-aligned caption** — `Since` over the timestamp — that stays within the trailing cell. The row is blank (one line) until the first fix, so the fresh-dashboard height (and its goldens) are unchanged.

## 2. "Since" ignored the app's 12/24-hour setting
The label formatted its time with `DateUtils` FORMAT_SHOW_TIME, which follows the **device** setting, not the app's clock setting — so it diverged from the calendar/weather panels when the user overrode it. Threaded `is24Hour` into `SpeedOverlay` and pass `FORMAT_12HOUR`/`FORMAT_24HOUR`.

## 3. Reopening the flyover showed stale data
The flyover refreshes on every open, but the ViewModel re-selected a trip only when nothing was selected — so the current trip's new points recorded while the panel was closed were never reloaded. `refresh()` now re-selects the displayed (or most recent) trip on every open, reloading its geometry. The compute dispatcher is injected so the reload is unit-tested (`TripVizViewModelTest`).

## Verification
- `spotlessCheck`, `assembleDebug`, `test`, `lint` — all green.
- On the TBox-Mock-Play emulator (system 24h): the label now reads `Since` / `Jul 17, 22:09` as a two-line caption under the reset button, matching the app clock; the flyover opens without crash.
- `TripVizViewModelTest` pins that a refresh after the point set grows reloads the larger geometry.