### PR TITLE
chore(webmap)!: update maplibre-gl to v6

### DIFF
--- a/webmap/package.json
+++ b/webmap/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@googlemaps/js-api-loader": "^2.1.1",
     "mapbox-gl": "^3.25.0",
-    "maplibre-gl": "^5.24.0"
+    "maplibre-gl": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/webmap/pnpm-lock.yaml
+++ b/webmap/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^3.25.0
         version: 3.27.0
       maplibre-gl:
-        specifier: ^5.24.0
-        version: 5.24.0
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@types/node':
         specifier: ^26.1.1
@@ -73,24 +73,17 @@ packages:
   '@mapbox/tiny-sdf@2.2.0':
     resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
 
-  '@mapbox/unitbezier@0.0.1':
-    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
-
   '@mapbox/unitbezier@1.0.0':
     resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
 
-  '@mapbox/vector-tile@2.0.5':
-    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
-
-  '@mapbox/whoots-js@3.1.0':
-    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
-    engines: {node: '>=6.0.0'}
+  '@mapbox/vector-tile@3.0.0':
+    resolution: {integrity: sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==}
 
   '@maplibre/geojson-vt@6.1.1':
     resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
 
-  '@maplibre/maplibre-gl-style-spec@24.10.0':
-    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
     hasBin: true
 
   '@maplibre/mlt@1.1.12':
@@ -970,8 +963,8 @@ packages:
   mapbox-gl@3.27.0:
     resolution: {integrity: sha512-K8W9LTTjFEJsg9qsnJbKk+zbXrmSqa+nU1EiFXez5gQ0T0RMtylZUelgg1/RE6vCUMvHX0gaYfWU9g2mTWuA0g==}
 
-  maplibre-gl@5.24.0:
-    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+  maplibre-gl@6.0.0:
+    resolution: {integrity: sha512-1wBgEhzTZfA+cDpFdt0fM1mJA5mJ90fifORJ7D8JcKLJCvPT/iTx9bNxkP7DqEYde65DJd7gE7h83khwNRqdyg==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   minimist@1.2.8:
@@ -1025,10 +1018,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pbf@4.0.2:
-    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
-    hasBin: true
 
   pbf@5.1.2:
     resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
@@ -1222,23 +1211,19 @@ snapshots:
 
   '@mapbox/tiny-sdf@2.2.0': {}
 
-  '@mapbox/unitbezier@0.0.1': {}
-
   '@mapbox/unitbezier@1.0.0': {}
 
-  '@mapbox/vector-tile@2.0.5':
+  '@mapbox/vector-tile@3.0.0':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
-      pbf: 4.0.2
-
-  '@mapbox/whoots-js@3.1.0': {}
+      pbf: 5.1.2
 
   '@maplibre/geojson-vt@6.1.1':
     dependencies:
       kdbush: 4.1.0
 
-  '@maplibre/maplibre-gl-style-spec@24.10.0':
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/unitbezier': 1.0.0
@@ -1770,16 +1755,14 @@ snapshots:
 
   mapbox-gl@3.27.0: {}
 
-  maplibre-gl@5.24.0:
+  maplibre-gl@6.0.0:
     dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/point-geometry': 1.1.0
       '@mapbox/tiny-sdf': 2.2.0
-      '@mapbox/unitbezier': 0.0.1
-      '@mapbox/vector-tile': 2.0.5
-      '@mapbox/whoots-js': 3.1.0
+      '@mapbox/unitbezier': 1.0.0
+      '@mapbox/vector-tile': 3.0.0
       '@maplibre/geojson-vt': 6.1.1
-      '@maplibre/maplibre-gl-style-spec': 24.10.0
+      '@maplibre/maplibre-gl-style-spec': 26.2.1
       '@maplibre/mlt': 1.1.12
       '@maplibre/vt-pbf': 4.3.2
       '@types/geojson': 7946.0.16
@@ -1787,7 +1770,7 @@ snapshots:
       gl-matrix: 3.4.4
       kdbush: 4.1.0
       murmurhash-js: 1.0.0
-      pbf: 4.0.2
+      pbf: 5.1.2
       potpack: 2.1.0
       quickselect: 3.0.0
       tinyqueue: 3.0.0
@@ -1861,10 +1844,6 @@ snapshots:
       vite-plus: 0.2.6(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.6(@types/node@26.1.1)(typescript@7.0.2))(typescript@7.0.2)
 
   pathe@2.0.3: {}
-
-  pbf@4.0.2:
-    dependencies:
-      resolve-protobuf-schema: 2.1.0
 
   pbf@5.1.2:
     dependencies:

--- a/webmap/src/backends/osm.ts
+++ b/webmap/src/backends/osm.ts
@@ -3,13 +3,26 @@
 // OSM-only style bridge (setStyleUrl / setFeatures with the ACCENT recolour
 // palette and the 3D-buildings / terrain injection); the follow camera and
 // chevron come from the shared follow-camera engine.
-import maplibregl from "maplibre-gl";
+// MapLibre 6 is ESM-only and publishes no default export, so the classes come in
+// by name. `MapLibreMap` is the library's own alias for its `Map` export, which
+// would otherwise shadow the global `Map`.
+import { MapLibreMap, Marker, setWorkerUrl } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
+// MapLibre 6 resolves its worker through `import.meta.url`, which a bundler
+// cannot honour, so every bundled consumer must hand it the URL. `?worker&url`
+// (not a plain `?url`) is required: the published worker imports a sibling
+// chunk, and only the worker transform bundles that sibling in. Without this
+// call the build still succeeds and the page still loads — but the worker URL
+// points at a file Vite never emits, so no tile is ever parsed and the map
+// stays blank. Neither tsc nor the lint/test pass can catch it.
+import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
 import type { PageReporter, PendingBridgeCalls } from "../bridge";
 import { webglSupport } from "../bridge";
 import { chevronHandles } from "../chevron";
 import { createFollowEngine } from "../follow-camera";
 import { type AccentColors, injectFeatures } from "../style";
+
+setWorkerUrl(maplibreWorkerUrl);
 
 const INITIAL_STYLE_URL = "https://tiles.openfreemap.org/styles/positron";
 
@@ -26,12 +39,12 @@ const STYLE_LOAD_FATAL_GRACE_MS = 10_000;
 export function init(reporter: PageReporter, pending: PendingBridgeCalls): void {
     const { log, report, reportErrorThrottled } = reporter;
 
-    // MapLibre renders WebGL 2 or falls back to WebGL 1; neither available is
-    // a definitive never-going-to-render fact — report it and stop.
-    // Constructing the map anyway would only throw a second, noisier fatal
-    // from a page the host is about to tear down.
-    const gl = webglSupport();
-    if (!gl.webgl2 && !gl.webgl1) {
+    // MapLibre 6 dropped the WebGL 1 fallback and only ever acquires a webgl2
+    // context, so a missing one is a definitive never-going-to-render fact —
+    // report it and stop, matching the mapbox backend's gate. Constructing the
+    // map anyway would only throw a second, noisier fatal (a
+    // GPUInitializationError) from a page the host is about to tear down.
+    if (!webglSupport().webgl2) {
         log("no-webgl-context");
         report("fatal", "no-webgl-context");
         return;
@@ -59,7 +72,7 @@ export function init(reporter: PageReporter, pending: PendingBridgeCalls): void 
     };
 
     try {
-        const liveMap = new maplibregl.Map({
+        const liveMap = new MapLibreMap({
             container: "map",
             style: INITIAL_STYLE_URL,
             center: [0, 0],
@@ -217,7 +230,7 @@ export function init(reporter: PageReporter, pending: PendingBridgeCalls): void 
             chevron: chevronHandles(),
             map: liveMap,
             createGeoMarker: (el, lngLat) =>
-                new maplibregl.Marker({
+                new Marker({
                     element: el,
                     rotationAlignment: "map",
                     pitchAlignment: "map",

--- a/webmap/src/bridge.ts
+++ b/webmap/src/bridge.ts
@@ -190,11 +190,12 @@ export function installPendingStubs(): PendingBridgeCalls {
     return pending;
 }
 
-// WebGL availability probe. Each backend applies its own policy: MapLibre
-// accepts webgl2 or webgl, mapbox-gl v3 hard-requires webgl2, and a Google
-// raster map needs neither. One canvas per probe: a canvas locks to its first
-// context mode, so asking one canvas for webgl2 then webgl would report a
-// false webgl1=false on every WebGL2-capable device.
+// WebGL availability probe. Each backend applies its own policy: maplibre-gl 6
+// and mapbox-gl 3 both hard-require webgl2 (MapLibre dropped its WebGL 1
+// fallback in 6), while a Google raster map needs neither — only its vector
+// mode does. One canvas per probe: a canvas locks to its first context mode, so
+// asking one canvas for webgl2 then webgl would report a false webgl1=false on
+// every WebGL2-capable device.
 export function webglSupport(): { webgl2: boolean; webgl1: boolean } {
     return {
         webgl2: document.createElement("canvas").getContext("webgl2") != null,


### PR DESCRIPTION
Supersedes #321 (the Renovate bump), which changes only `package.json` and the
lockfile — v6 needs source changes to render at all.

## What v6 changes for us

MapLibre GL JS 6 is ESM-only, drops the default export, removes the WebGL 1
fallback, and requires bundled consumers to supply the worker URL themselves.

| Change | Action |
| --- | --- |
| No default export | `import { MapLibreMap, Marker, setWorkerUrl }` — `MapLibreMap` is the library's own alias for its `Map` export, which would otherwise shadow the global `Map` |
| Worker resolved via `import.meta.url` | **`setWorkerUrl` with a `?worker&url` import** (see below) |
| WebGL 1 fallback removed | OSM's pre-flight gate narrowed to `webgl2`, matching the mapbox backend |
| style-spec 25 warns on legacy expressions | Upstream style only — see below |
| `styleimagemissing`, `map.transform`, `GeoJSONSource.setData`, `Hash`, event classes, `zoomLevelsToOverscale`, `#pragma mapbox` | Not used here |

## The worker call is load-bearing and invisible to CI

MapLibre 6 resolves its worker through `import.meta.url`, which a bundler cannot
honour, so every bundled consumer must hand it the URL. Without the call:

- `vp check` (oxlint + `tsc --noEmit` + 79 unit tests) passes
- `vp build` succeeds
- the page loads and the map object constructs
- …and the emitted bundle points at `maplibre-gl-worker.mjs`, **a file Vite never
  emits**, so no tile is ever parsed and the map stays blank

I confirmed this on the first build of this branch: no worker asset in
`dist/web/assets/`, and a bare `maplibre-gl-worker.mjs` string inside the backend
chunk. `?worker&url` rather than a plain `?url` because the published worker
imports a sibling chunk that only the worker transform bundles in. The build now
emits `maplibre-gl-worker-*.js` (467 kB) beside the backend chunk.

This is exactly the failure mode the `update-gradle-dependency` skill warns about
for `maplibre-gl` majors — no automated signal, so it has to be caught on device.

## ⚠️ WebGL 2 is now required for the OSM backend

v6 only ever acquires a `webgl2` context. The Android 13 CDD §7.1.4.1 mandates
only **OpenGL ES 2.0** (`[C-1-1]`); ES 3.1 is `[C-SR-1]` — *strongly
recommended*, not required — and ES 3.0, which WebGL 2 maps onto, is not named
at all. A CDD-compliant Android 13 device may therefore have no WebGL 2, and
uncertified AI boxes are not bound by the CDD in the first place. This mirrors
the Vulkan finding already on record for this project.

Consequence: a device that rendered the map under v5's WebGL 1 fallback now gets
the existing `no-webgl-context` notice instead. The pre-flight gate is what keeps
it a clean notice rather than a `GPUInitializationError` fired synchronously
inside the `Map` constructor (which a listener attached after construction can
never observe). Every other backend already required WebGL 2 (mapbox-gl 3) or
nothing (Google raster), so the OSM backend was the last WebGL 1 path.

ES2022, the other flagged item, is a non-issue: maplibre's highest requirement is
Chrome 94 and our `build.target` floor is `chrome109`. `build.target` is
unchanged.

## Verification

- `spotlessCheck`, `lint`, `test`, `assembleDebug` — all pass. `:app:buildWebMap`
  runs oxfmt + oxlint + `tsc --noEmit` + 79 webmap unit tests.
- **On the TBox-Mock-Play emulator with the OSM backend selected**: real
  OpenFreeMap tiles, 3D buildings, labels, the follow chevron and reverse
  geocoding all render; the page logs `[osm] rendered` / `[osm] load`, and tile
  parsing is served by `assets/maplibre-gl-worker-*.js` — direct evidence the
  worker wiring works end to end.
- License unchanged: maplibre-gl 6 is still BSD-3-Clause and its `LICENSE.txt` is
  byte-identical to the bundled `app/src/main/assets/licenses/maplibre-gl-js-LICENSE.txt`.

New console warnings under style-spec 25 come from the **upstream** Positron
style's US road-shield filters (`["<=", ["get", "ref_length"], 6]` against a null
`ref_length`). They fall back to `false` exactly as they silently did under v5,
affect US-only shield layers, and are not ours to fix.