### PR TITLE
feat(diagnostics): add a MAP section reporting why the map is blank

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/DiagnosticsCollectors.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/DiagnosticsCollectors.kt
@@ -28,6 +28,7 @@ internal fun diagnosticsCollectors(context: Context): List<SectionCollector> {
     val performance = PerformanceFactsCollector(context)
     val storage = StorageFactsCollector(context)
     val webView = WebViewFactsCollector(context)
+    val map = MapFactsCollector(context)
     val settings = SettingsFactsCollector(context)
     val logs = LogTailCollector()
     val spectrumProbed = CompletableDeferred<Unit>()
@@ -52,6 +53,7 @@ internal fun diagnosticsCollectors(context: Context): List<SectionCollector> {
         SectionCollector(SectionId.STORAGE, storage::storageFacts),
         SectionCollector(SectionId.INPUT, environment::inputFacts),
         SectionCollector(SectionId.WEBVIEW, webView::webViewFacts),
+        SectionCollector(SectionId.MAP, map::mapFacts),
         SectionCollector(SectionId.SETTINGS, settings::settingsFacts),
         SectionCollector(SectionId.LOGS) {
             // Bounded: a wedged spectrum probe must not hold the log tail hostage.

--- a/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/DiagnosticsModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/DiagnosticsModel.kt
@@ -77,6 +77,7 @@ internal enum class SectionId {
     STORAGE,
     INPUT,
     WEBVIEW,
+    MAP,
     SETTINGS,
     LOGS,
 }

--- a/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/MapFactsCollector.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/MapFactsCollector.kt
@@ -4,8 +4,11 @@ import android.app.ActivityManager
 import android.content.Context
 import android.os.SystemClock
 import androidx.core.content.getSystemService
+import io.github.seijikohara.femto.data.display.DisplayPreferences
+import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.map.MapRuntimeSignals
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
 // WebGL 2 maps onto OpenGL ES 3.0, so that is the floor below which the map
@@ -15,22 +18,48 @@ import kotlinx.coroutines.withContext
 private const val WEBGL2_GL_ES_FLOOR = 0x30000
 
 /**
+ * What the active map configuration loses without WebGL 2. Verified against each
+ * vendor's own documentation rather than inferred:
+ *
+ *  - maplibre-gl 6 removed the WebGL 1 fallback, and mapbox-gl 3 made WebGL 2
+ *    mandatory in its 3.0.0 breaking changes — neither renders without it.
+ *  - A Google VECTOR map (a Cloud Map ID) treats WebGL 2 as its bar too, but
+ *    silently falls back to raster instead of failing: the map still draws, and
+ *    only the vector opt-in (heading-up, tilt, 3D) is lost.
+ *  - A Google RASTER map is server-rendered pixel tiles and needs no WebGL.
+ */
+private enum class WebGl2Need { TO_RENDER, FOR_VECTOR, NONE }
+
+private fun webGl2Need(
+    backend: MapBackend,
+    hasGoogleMapId: Boolean,
+): WebGl2Need =
+    when (backend) {
+        MapBackend.OSM, MapBackend.MAPBOX -> WebGl2Need.TO_RENDER
+        MapBackend.GOOGLEMAPS -> if (hasGoogleMapId) WebGl2Need.FOR_VECTOR else WebGl2Need.NONE
+    }
+
+/**
  * Builds the MAP section facts from already-resolved values. Pure so
  * [io.github.seijikohara.femto.data.diagnostics.MapFactsTest] can pin the floor
  * comparison and the failure formatting without a device.
  *
  * Reports what the map DID, not how it is configured: every map setting
  * (backend, style, credentials) is already a SETTINGS fact, and restating it
- * here would be a second home for the same value.
+ * here would be a second home for the same value. [backend] and [hasGoogleMapId]
+ * are read only to judge what a missing WebGL 2 actually costs — flagging it
+ * unconditionally would warn about a Google raster map that renders perfectly.
  */
 internal fun mapFactsFrom(
     glEsVersion: String?,
+    backend: MapBackend,
+    hasGoogleMapId: Boolean,
     lastFailure: MapRuntimeSignals.MapFailure?,
     failureCount: Int,
     nowElapsedRealtimeMs: Long,
 ): List<DiagnosticFact> =
     buildList {
-        add(webGl2Fact(glEsVersion))
+        add(webGl2Fact(glEsVersion, webGl2Need(backend, hasGoogleMapId)))
         add(lastFailureFact(lastFailure, nowElapsedRealtimeMs))
         if (failureCount > 1) {
             add(DiagnosticFact("Failures this session", FactValue.Text("$failureCount")))
@@ -41,22 +70,43 @@ internal fun mapFactsFrom(
 // direct probe of it: a driver the WebView blocklists can still deny a context
 // above the floor. Above the floor the fact therefore says "expected", and the
 // authoritative answer is the failure row below it.
-private fun webGl2Fact(glEsVersion: String?): DiagnosticFact {
+private fun webGl2Fact(
+    glEsVersion: String?,
+    need: WebGl2Need,
+): DiagnosticFact {
     val encoded = glEsVersionCode(glEsVersion)
     return when {
+        need == WebGl2Need.NONE -> {
+            DiagnosticFact("WebGL 2", FactValue.Text("not required (Google Maps raster)"))
+        }
+
         encoded == null -> {
             DiagnosticFact("WebGL 2", FactValue.Text("unknown (OpenGL ES unreported)"))
         }
 
-        encoded < WEBGL2_GL_ES_FLOOR -> {
+        encoded >= WEBGL2_GL_ES_FLOOR -> {
+            DiagnosticFact("WebGL 2", FactValue.Status("expected (OpenGL ES $glEsVersion)", FactHealth.OK))
+        }
+
+        // Below the floor: name the consequence, which differs by backend.
+        need == WebGl2Need.FOR_VECTOR -> {
             DiagnosticFact(
                 "WebGL 2",
-                FactValue.Status("unavailable (OpenGL ES $glEsVersion, needs 3.0)", FactHealth.WARNING),
+                FactValue.Status(
+                    "unavailable (OpenGL ES $glEsVersion, needs 3.0) — vector map falls back to raster",
+                    FactHealth.WARNING,
+                ),
             )
         }
 
         else -> {
-            DiagnosticFact("WebGL 2", FactValue.Status("expected (OpenGL ES $glEsVersion)", FactHealth.OK))
+            DiagnosticFact(
+                "WebGL 2",
+                FactValue.Status(
+                    "unavailable (OpenGL ES $glEsVersion, needs 3.0) — this backend cannot render",
+                    FactHealth.WARNING,
+                ),
+            )
         }
     }
 }
@@ -87,9 +137,12 @@ internal class MapFactsCollector(
 ) {
     suspend fun mapFacts(): SectionPayload.Facts =
         withContext(Dispatchers.IO) {
+            val display = DisplayPreferences(context).settings.first()
             SectionPayload.Facts(
                 mapFactsFrom(
                     glEsVersion = context.getSystemService<ActivityManager>()?.deviceConfigurationInfo?.glEsVersion,
+                    backend = display.mapBackend,
+                    hasGoogleMapId = display.googleMapsMapId.isNotBlank(),
                     lastFailure = MapRuntimeSignals.lastFailureOrNull(),
                     failureCount = MapRuntimeSignals.failureCount(),
                     nowElapsedRealtimeMs = SystemClock.elapsedRealtime(),

--- a/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/MapFactsCollector.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/MapFactsCollector.kt
@@ -1,0 +1,99 @@
+package io.github.seijikohara.femto.data.diagnostics
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.SystemClock
+import androidx.core.content.getSystemService
+import io.github.seijikohara.femto.data.map.MapRuntimeSignals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+// WebGL 2 maps onto OpenGL ES 3.0, so that is the floor below which the map
+// backends that need it cannot acquire a context. The Android 13 CDD mandates
+// only ES 2.0 ([C-1-1]) and merely strongly-recommends ES 3.1, so a compliant
+// device — and an uncertified one all the more — can legitimately sit below it.
+private const val WEBGL2_GL_ES_FLOOR = 0x30000
+
+/**
+ * Builds the MAP section facts from already-resolved values. Pure so
+ * [io.github.seijikohara.femto.data.diagnostics.MapFactsTest] can pin the floor
+ * comparison and the failure formatting without a device.
+ *
+ * Reports what the map DID, not how it is configured: every map setting
+ * (backend, style, credentials) is already a SETTINGS fact, and restating it
+ * here would be a second home for the same value.
+ */
+internal fun mapFactsFrom(
+    glEsVersion: String?,
+    lastFailure: MapRuntimeSignals.MapFailure?,
+    failureCount: Int,
+    nowElapsedRealtimeMs: Long,
+): List<DiagnosticFact> =
+    buildList {
+        add(webGl2Fact(glEsVersion))
+        add(lastFailureFact(lastFailure, nowElapsedRealtimeMs))
+        if (failureCount > 1) {
+            add(DiagnosticFact("Failures this session", FactValue.Text("$failureCount")))
+        }
+    }
+
+// The GLES version the platform reports is the capability behind WebGL 2, not a
+// direct probe of it: a driver the WebView blocklists can still deny a context
+// above the floor. Above the floor the fact therefore says "expected", and the
+// authoritative answer is the failure row below it.
+private fun webGl2Fact(glEsVersion: String?): DiagnosticFact {
+    val encoded = glEsVersionCode(glEsVersion)
+    return when {
+        encoded == null -> {
+            DiagnosticFact("WebGL 2", FactValue.Text("unknown (OpenGL ES unreported)"))
+        }
+
+        encoded < WEBGL2_GL_ES_FLOOR -> {
+            DiagnosticFact(
+                "WebGL 2",
+                FactValue.Status("unavailable (OpenGL ES $glEsVersion, needs 3.0)", FactHealth.WARNING),
+            )
+        }
+
+        else -> {
+            DiagnosticFact("WebGL 2", FactValue.Status("expected (OpenGL ES $glEsVersion)", FactHealth.OK))
+        }
+    }
+}
+
+// deviceConfigurationInfo reports the version as "major.minor"; compare on the
+// same packed 0xMMMMmmmm encoding the platform uses for reqGlEsVersion.
+private fun glEsVersionCode(glEsVersion: String?): Int? {
+    val major = glEsVersion?.substringBefore('.')?.toIntOrNull() ?: return null
+    val minor = glEsVersion.substringAfter('.', "0").toIntOrNull() ?: 0
+    return (major shl 16) or minor
+}
+
+private fun lastFailureFact(
+    lastFailure: MapRuntimeSignals.MapFailure?,
+    nowElapsedRealtimeMs: Long,
+): DiagnosticFact =
+    lastFailure?.let { failure ->
+        val agoSeconds = ((nowElapsedRealtimeMs - failure.elapsedRealtimeMs) / 1000L).coerceAtLeast(0L)
+        DiagnosticFact(
+            "Last failure",
+            FactValue.Status("${failure.detail} (${agoSeconds}s ago)", FactHealth.ERROR),
+        )
+    } ?: DiagnosticFact("Last failure", FactValue.Status("none this session", FactHealth.OK))
+
+/** Collects the MAP diagnostics section. */
+internal class MapFactsCollector(
+    private val context: Context,
+) {
+    suspend fun mapFacts(): SectionPayload.Facts =
+        withContext(Dispatchers.IO) {
+            SectionPayload.Facts(
+                mapFactsFrom(
+                    glEsVersion = context.getSystemService<ActivityManager>()?.deviceConfigurationInfo?.glEsVersion,
+                    lastFailure = MapRuntimeSignals.lastFailureOrNull(),
+                    failureCount = MapRuntimeSignals.failureCount(),
+                    nowElapsedRealtimeMs = SystemClock.elapsedRealtime(),
+                ),
+            )
+        }
+}

--- a/app/src/main/java/io/github/seijikohara/femto/data/map/MapRuntimeSignals.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/map/MapRuntimeSignals.kt
@@ -1,0 +1,52 @@
+package io.github.seijikohara.femto.data.map
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Process-wide record of what the live map page actually did this session.
+ *
+ * The map renders in a WebView, so its failures never surface as an Android
+ * exception: the page reports a `fatal` over the JS bridge, the host swaps in
+ * the failure notice, and the reason exists only as a logcat line. That leaves
+ * the in-app diagnostics unable to state whether the map rendered — the one
+ * question a "my map is blank" report turns on. This holder keeps the last
+ * reason (and how many arrived) so the MAP diagnostics section can report it as
+ * a fact rather than leaving it to be grepped out of the log tail, which is a
+ * bounded tail and drops the line once enough logging follows it.
+ *
+ * Written by the WebView host in `ui/`, read by the diagnostics collector in
+ * `data/`; it lives here because `data/` never imports `ui/`. Session-scoped by
+ * design: a failure the user has since navigated away from is still the fact
+ * worth reporting, but it must not outlive the process and mislead the next
+ * launch.
+ */
+internal object MapRuntimeSignals {
+    private val lastFailure = AtomicReference<MapFailure?>(null)
+    private val failureCount = AtomicInteger(0)
+
+    /** A `fatal` the page reported: [detail] is its reason string. */
+    data class MapFailure(
+        val detail: String,
+        val elapsedRealtimeMs: Long,
+    )
+
+    /** Record a page-reported fatal. Called from the JS bridge thread. */
+    fun recordFailure(
+        detail: String,
+        elapsedRealtimeMs: Long,
+    ) {
+        lastFailure.set(MapFailure(detail, elapsedRealtimeMs))
+        failureCount.incrementAndGet()
+    }
+
+    /** Clear the record once the map renders, so a recovered map reads clean. */
+    fun recordRendered() {
+        lastFailure.set(null)
+    }
+
+    fun lastFailureOrNull(): MapFailure? = lastFailure.get()
+
+    /** Total fatals this session, including ones a later recovery cleared. */
+    fun failureCount(): Int = failureCount.get()
+}

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReport.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReport.kt
@@ -37,6 +37,7 @@ internal fun SectionId.reportTitle(): String =
         SectionId.STORAGE -> "Storage"
         SectionId.INPUT -> "Input"
         SectionId.WEBVIEW -> "WebView"
+        SectionId.MAP -> "Map"
         SectionId.SETTINGS -> "Settings"
         SectionId.LOGS -> "Recent warnings"
     }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/components/DiagnosticsSectionCard.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/diagnostics/components/DiagnosticsSectionCard.kt
@@ -98,6 +98,8 @@ internal fun SectionId.title(): String =
 
         SectionId.WEBVIEW -> stringResource(R.string.diagnostics_section_webview)
 
+        SectionId.MAP -> stringResource(R.string.diagnostics_section_map)
+
         SectionId.SETTINGS -> stringResource(R.string.diagnostics_section_settings)
 
         // The tail length is unknowable from the id alone; SectionHeader

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -52,6 +52,7 @@ import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.display.MapStyleSetting
 import io.github.seijikohara.femto.data.display.MapboxStyle
+import io.github.seijikohara.femto.data.map.MapRuntimeSignals
 import io.github.seijikohara.femto.ui.theme.FemtoIcon
 import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import io.github.seijikohara.femto.ui.theme.LocalFemtoDarkTheme
@@ -83,7 +84,10 @@ import kotlinx.coroutines.delay
  * notice below rather than a silent blank map.
  *
  * The page reports into the host over a one-method [JavascriptInterface] bridge
- * (`window.femtoBridge.onMapEvent(kind, detail)`). Four kinds exist: `error`
+ * (`window.femtoBridge.onMapEvent(kind, detail)`). Five kinds exist: `ready` for
+ * the first frame the backend actually painted (recorded in
+ * [MapRuntimeSignals] for the MAP diagnostics section, which otherwise could not
+ * tell a working map from one that failed silently), `error`
  * for transient resource failures (tile / style / DEM fetch — logged, never UI,
  * because the removed auto-downgrade misfired on exactly such ambiguous signals),
  * `fatal` for definitive never-going-to-render facts (no WebGL context, a missing
@@ -402,6 +406,14 @@ internal fun WebMapView(
                             detail: String,
                         ) {
                             when (kind) {
+                                // The backend painted its first frame. Recorded for
+                                // the MAP diagnostics section, which otherwise cannot
+                                // tell a working map from one that failed silently —
+                                // onPageFinished only proves the script ran.
+                                "ready" -> {
+                                    MapRuntimeSignals.recordRendered()
+                                }
+
                                 // Transient by definition (tile / style / DEM
                                 // fetch): log only. The removed auto-downgrade
                                 // misfired on exactly such ambiguous signals —
@@ -412,6 +424,11 @@ internal fun WebMapView(
 
                                 "fatal" -> {
                                     Log.e(TAG, "LIVE map fatal: $detail")
+                                    // Kept beyond this composable's lifetime so the
+                                    // diagnostics report can state why the map is
+                                    // blank; the log tail alone is bounded and drops
+                                    // the line once enough logging follows it.
+                                    MapRuntimeSignals.recordFailure(detail, SystemClock.elapsedRealtime())
                                     // Bridge calls arrive on a background thread.
                                     mainHandler.post {
                                         lastFatalDetail = detail

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -446,6 +446,7 @@
     <string name="diagnostics_section_storage">Storage</string>
     <string name="diagnostics_section_input">Input</string>
     <string name="diagnostics_section_webview">WebView</string>
+    <string name="diagnostics_section_map">Map</string>
     <string name="diagnostics_section_settings">Settings</string>
     <string name="diagnostics_section_logs">Recent warnings (%1$d)</string>
     <string name="diagnostics_spectrum_hint">Probe the spectrum while music is playing: silence here with an active session means the player bypasses the audio mixer.</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/DiagnosticsModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/DiagnosticsModelTest.kt
@@ -87,6 +87,7 @@ class DiagnosticsModelTest {
                 SectionId.STORAGE,
                 SectionId.INPUT,
                 SectionId.WEBVIEW,
+                SectionId.MAP,
                 SectionId.SETTINGS,
                 SectionId.LOGS,
             ),

--- a/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/MapFactsTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/MapFactsTest.kt
@@ -1,0 +1,94 @@
+package io.github.seijikohara.femto.data.diagnostics
+
+import io.github.seijikohara.femto.data.map.MapRuntimeSignals
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class MapFactsTest {
+    @Test
+    fun `an OpenGL ES version below 3_0 warns that WebGL 2 is unavailable`() {
+        // The Android 13 CDD mandates only ES 2.0, so this device is compliant and
+        // still cannot host the WebGL 2 the OSM and Mapbox backends require.
+        val facts = mapFactsFrom(glEsVersion = "2.0", lastFailure = null, failureCount = 0, nowElapsedRealtimeMs = 0L)
+
+        assertEquals(
+            DiagnosticFact("WebGL 2", FactValue.Status("unavailable (OpenGL ES 2.0, needs 3.0)", FactHealth.WARNING)),
+            facts.first(),
+        )
+    }
+
+    @Test
+    fun `an OpenGL ES version at or above 3_0 reports WebGL 2 as expected`() {
+        val facts = mapFactsFrom(glEsVersion = "3.2", lastFailure = null, failureCount = 0, nowElapsedRealtimeMs = 0L)
+
+        assertEquals(
+            DiagnosticFact("WebGL 2", FactValue.Status("expected (OpenGL ES 3.2)", FactHealth.OK)),
+            facts.first(),
+        )
+    }
+
+    @Test
+    fun `a minor version alone never crosses the floor`() {
+        // "2.9" must stay below 3.0: comparing the strings, or the minor in
+        // isolation, would read it as sufficient.
+        val facts = mapFactsFrom(glEsVersion = "2.9", lastFailure = null, failureCount = 0, nowElapsedRealtimeMs = 0L)
+
+        assertEquals(FactHealth.WARNING, facts.first().health)
+    }
+
+    @Test
+    fun `an unreported OpenGL ES version says so rather than guessing`() {
+        val facts = mapFactsFrom(glEsVersion = null, lastFailure = null, failureCount = 0, nowElapsedRealtimeMs = 0L)
+
+        assertEquals(DiagnosticFact("WebGL 2", FactValue.Text("unknown (OpenGL ES unreported)")), facts.first())
+    }
+
+    @Test
+    fun `a clean session reports no failure`() {
+        val facts = mapFactsFrom(glEsVersion = "3.2", lastFailure = null, failureCount = 0, nowElapsedRealtimeMs = 0L)
+
+        assertEquals(DiagnosticFact("Last failure", FactValue.Status("none this session", FactHealth.OK)), facts[1])
+    }
+
+    @Test
+    fun `a recorded failure reports its reason and age`() {
+        val facts =
+            mapFactsFrom(
+                glEsVersion = "3.2",
+                lastFailure = MapRuntimeSignals.MapFailure("no-webgl-context", elapsedRealtimeMs = 1_000L),
+                failureCount = 1,
+                nowElapsedRealtimeMs = 91_000L,
+            )
+
+        assertEquals(
+            DiagnosticFact("Last failure", FactValue.Status("no-webgl-context (90s ago)", FactHealth.ERROR)),
+            facts[1],
+        )
+    }
+
+    @Test
+    fun `a single failure adds no count row`() {
+        val facts =
+            mapFactsFrom(
+                glEsVersion = "3.2",
+                lastFailure = MapRuntimeSignals.MapFailure("no-webgl-context", elapsedRealtimeMs = 0L),
+                failureCount = 1,
+                nowElapsedRealtimeMs = 0L,
+            )
+
+        assertEquals(2, facts.size)
+    }
+
+    @Test
+    fun `repeated failures surface the count so a flapping map is visible`() {
+        val facts =
+            mapFactsFrom(
+                glEsVersion = "3.2",
+                lastFailure = MapRuntimeSignals.MapFailure("style-load-failed", elapsedRealtimeMs = 0L),
+                failureCount = 4,
+                nowElapsedRealtimeMs = 0L,
+            )
+
+        assertEquals(DiagnosticFact("Failures this session", FactValue.Text("4")), facts[2])
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/MapFactsTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/MapFactsTest.kt
@@ -1,29 +1,72 @@
 package io.github.seijikohara.femto.data.diagnostics
 
+import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.map.MapRuntimeSignals
 import org.junit.Test
 import kotlin.test.assertEquals
 
 class MapFactsTest {
-    @Test
-    fun `an OpenGL ES version below 3_0 warns that WebGL 2 is unavailable`() {
-        // The Android 13 CDD mandates only ES 2.0, so this device is compliant and
-        // still cannot host the WebGL 2 the OSM and Mapbox backends require.
-        val facts = mapFactsFrom(glEsVersion = "2.0", lastFailure = null, failureCount = 0, nowElapsedRealtimeMs = 0L)
+    private fun facts(
+        glEsVersion: String? = "3.2",
+        backend: MapBackend = MapBackend.OSM,
+        hasGoogleMapId: Boolean = false,
+        lastFailure: MapRuntimeSignals.MapFailure? = null,
+        failureCount: Int = 0,
+        nowElapsedRealtimeMs: Long = 0L,
+    ) = mapFactsFrom(glEsVersion, backend, hasGoogleMapId, lastFailure, failureCount, nowElapsedRealtimeMs)
 
+    @Test
+    fun `a WebGL 2 backend below the OpenGL ES floor warns that it cannot render`() {
+        // The Android 13 CDD mandates only ES 2.0, so this device is compliant and
+        // still cannot host the WebGL 2 maplibre 6 and mapbox-gl 3 both require.
         assertEquals(
-            DiagnosticFact("WebGL 2", FactValue.Status("unavailable (OpenGL ES 2.0, needs 3.0)", FactHealth.WARNING)),
-            facts.first(),
+            DiagnosticFact(
+                "WebGL 2",
+                FactValue.Status(
+                    "unavailable (OpenGL ES 2.0, needs 3.0) — this backend cannot render",
+                    FactHealth.WARNING,
+                ),
+            ),
+            facts(glEsVersion = "2.0", backend = MapBackend.OSM).first(),
+        )
+    }
+
+    @Test
+    fun `mapbox is judged the same as OSM`() {
+        assertEquals(FactHealth.WARNING, facts(glEsVersion = "2.0", backend = MapBackend.MAPBOX).first().health)
+    }
+
+    @Test
+    fun `a Google raster map never warns, because it needs no WebGL at all`() {
+        // Raster tiles are rendered server-side, so flagging WebGL here would
+        // report a problem on a map that draws perfectly.
+        assertEquals(
+            DiagnosticFact("WebGL 2", FactValue.Text("not required (Google Maps raster)")),
+            facts(glEsVersion = "2.0", backend = MapBackend.GOOGLEMAPS, hasGoogleMapId = false).first(),
+        )
+    }
+
+    @Test
+    fun `a Google vector map warns that it silently degrades rather than fails`() {
+        // Google falls back to raster instead of failing, so the map still draws —
+        // what is lost is the vector opt-in the user configured a Map ID for.
+        assertEquals(
+            DiagnosticFact(
+                "WebGL 2",
+                FactValue.Status(
+                    "unavailable (OpenGL ES 2.0, needs 3.0) — vector map falls back to raster",
+                    FactHealth.WARNING,
+                ),
+            ),
+            facts(glEsVersion = "2.0", backend = MapBackend.GOOGLEMAPS, hasGoogleMapId = true).first(),
         )
     }
 
     @Test
     fun `an OpenGL ES version at or above 3_0 reports WebGL 2 as expected`() {
-        val facts = mapFactsFrom(glEsVersion = "3.2", lastFailure = null, failureCount = 0, nowElapsedRealtimeMs = 0L)
-
         assertEquals(
             DiagnosticFact("WebGL 2", FactValue.Status("expected (OpenGL ES 3.2)", FactHealth.OK)),
-            facts.first(),
+            facts(glEsVersion = "3.2").first(),
         )
     }
 
@@ -31,64 +74,53 @@ class MapFactsTest {
     fun `a minor version alone never crosses the floor`() {
         // "2.9" must stay below 3.0: comparing the strings, or the minor in
         // isolation, would read it as sufficient.
-        val facts = mapFactsFrom(glEsVersion = "2.9", lastFailure = null, failureCount = 0, nowElapsedRealtimeMs = 0L)
-
-        assertEquals(FactHealth.WARNING, facts.first().health)
+        assertEquals(FactHealth.WARNING, facts(glEsVersion = "2.9").first().health)
     }
 
     @Test
     fun `an unreported OpenGL ES version says so rather than guessing`() {
-        val facts = mapFactsFrom(glEsVersion = null, lastFailure = null, failureCount = 0, nowElapsedRealtimeMs = 0L)
-
-        assertEquals(DiagnosticFact("WebGL 2", FactValue.Text("unknown (OpenGL ES unreported)")), facts.first())
+        assertEquals(
+            DiagnosticFact("WebGL 2", FactValue.Text("unknown (OpenGL ES unreported)")),
+            facts(glEsVersion = null).first(),
+        )
     }
 
     @Test
     fun `a clean session reports no failure`() {
-        val facts = mapFactsFrom(glEsVersion = "3.2", lastFailure = null, failureCount = 0, nowElapsedRealtimeMs = 0L)
-
-        assertEquals(DiagnosticFact("Last failure", FactValue.Status("none this session", FactHealth.OK)), facts[1])
+        assertEquals(DiagnosticFact("Last failure", FactValue.Status("none this session", FactHealth.OK)), facts()[1])
     }
 
     @Test
     fun `a recorded failure reports its reason and age`() {
-        val facts =
-            mapFactsFrom(
-                glEsVersion = "3.2",
+        assertEquals(
+            DiagnosticFact("Last failure", FactValue.Status("no-webgl-context (90s ago)", FactHealth.ERROR)),
+            facts(
                 lastFailure = MapRuntimeSignals.MapFailure("no-webgl-context", elapsedRealtimeMs = 1_000L),
                 failureCount = 1,
                 nowElapsedRealtimeMs = 91_000L,
-            )
-
-        assertEquals(
-            DiagnosticFact("Last failure", FactValue.Status("no-webgl-context (90s ago)", FactHealth.ERROR)),
-            facts[1],
+            )[1],
         )
     }
 
     @Test
     fun `a single failure adds no count row`() {
-        val facts =
-            mapFactsFrom(
-                glEsVersion = "3.2",
+        assertEquals(
+            2,
+            facts(
                 lastFailure = MapRuntimeSignals.MapFailure("no-webgl-context", elapsedRealtimeMs = 0L),
                 failureCount = 1,
-                nowElapsedRealtimeMs = 0L,
-            )
-
-        assertEquals(2, facts.size)
+            ).size,
+        )
     }
 
     @Test
     fun `repeated failures surface the count so a flapping map is visible`() {
-        val facts =
-            mapFactsFrom(
-                glEsVersion = "3.2",
+        assertEquals(
+            DiagnosticFact("Failures this session", FactValue.Text("4")),
+            facts(
                 lastFailure = MapRuntimeSignals.MapFailure("style-load-failed", elapsedRealtimeMs = 0L),
                 failureCount = 4,
-                nowElapsedRealtimeMs = 0L,
-            )
-
-        assertEquals(DiagnosticFact("Failures this session", FactValue.Text("4")), facts[2])
+            )[2],
+        )
     }
 }

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDiagnosticSections.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDiagnosticSections.kt
@@ -101,6 +101,10 @@ private fun fakePayload(
             facts(fact("WebView", "com.google.android.webview 110.0.5481.154"))
         }
 
+        SectionId.MAP -> {
+            facts(fact("WebGL 2", "expected (OpenGL ES 3.2)"), fact("Last failure", "none this session"))
+        }
+
         SectionId.SETTINGS -> {
             facts(fact("Map backend", "OSM"), fact("UI scale", "MEDIUM"))
         }

--- a/app/src/test/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReportTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/diagnostics/DiagnosticsReportTest.kt
@@ -57,6 +57,38 @@ class DiagnosticsReportTest {
     }
 
     @Test
+    fun `a blank map surfaces its reason in the issues block and the Map section`() {
+        // The whole point of the MAP section: "my map is blank" has to be
+        // answerable from the pasted report alone, without reading the log tail.
+        val report =
+            diagnosticsReport(
+                sections(
+                    DiagnosticSection(
+                        SectionId.MAP,
+                        SectionPayload.Facts(
+                            listOf(
+                                DiagnosticFact(
+                                    "WebGL 2",
+                                    FactValue.Status("unavailable (OpenGL ES 2.0, needs 3.0)", FactHealth.WARNING),
+                                ),
+                                DiagnosticFact(
+                                    "Last failure",
+                                    FactValue.Status("no-webgl-context (12s ago)", FactHealth.ERROR),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                generatedAt,
+            )
+
+        assertTrue(report.contains("- Map: WebGL 2: unavailable (OpenGL ES 2.0, needs 3.0)"))
+        assertTrue(report.contains("- Map: Last failure: no-webgl-context (12s ago)"))
+        assertTrue(report.contains("## Map\n\n- WebGL 2: unavailable (OpenGL ES 2.0, needs 3.0)"))
+        assertTrue(report.indexOf("## WebView") < report.indexOf("## Map"))
+    }
+
+    @Test
     fun `permission table keeps the v1 shape with denied shouted`() {
         val report =
             diagnosticsReport(

--- a/webmap/package.json
+++ b/webmap/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@googlemaps/js-api-loader": "^2.1.1",
     "mapbox-gl": "^3.25.0",
-    "maplibre-gl": "^5.24.0"
+    "maplibre-gl": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/webmap/pnpm-lock.yaml
+++ b/webmap/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^3.25.0
         version: 3.27.0
       maplibre-gl:
-        specifier: ^5.24.0
-        version: 5.24.0
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@types/node':
         specifier: ^26.1.1
@@ -73,24 +73,17 @@ packages:
   '@mapbox/tiny-sdf@2.2.0':
     resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
 
-  '@mapbox/unitbezier@0.0.1':
-    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
-
   '@mapbox/unitbezier@1.0.0':
     resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
 
-  '@mapbox/vector-tile@2.0.5':
-    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
-
-  '@mapbox/whoots-js@3.1.0':
-    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
-    engines: {node: '>=6.0.0'}
+  '@mapbox/vector-tile@3.0.0':
+    resolution: {integrity: sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==}
 
   '@maplibre/geojson-vt@6.1.1':
     resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
 
-  '@maplibre/maplibre-gl-style-spec@24.10.0':
-    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
     hasBin: true
 
   '@maplibre/mlt@1.1.12':
@@ -970,8 +963,8 @@ packages:
   mapbox-gl@3.27.0:
     resolution: {integrity: sha512-K8W9LTTjFEJsg9qsnJbKk+zbXrmSqa+nU1EiFXez5gQ0T0RMtylZUelgg1/RE6vCUMvHX0gaYfWU9g2mTWuA0g==}
 
-  maplibre-gl@5.24.0:
-    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+  maplibre-gl@6.0.0:
+    resolution: {integrity: sha512-1wBgEhzTZfA+cDpFdt0fM1mJA5mJ90fifORJ7D8JcKLJCvPT/iTx9bNxkP7DqEYde65DJd7gE7h83khwNRqdyg==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   minimist@1.2.8:
@@ -1025,10 +1018,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pbf@4.0.2:
-    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
-    hasBin: true
 
   pbf@5.1.2:
     resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
@@ -1222,23 +1211,19 @@ snapshots:
 
   '@mapbox/tiny-sdf@2.2.0': {}
 
-  '@mapbox/unitbezier@0.0.1': {}
-
   '@mapbox/unitbezier@1.0.0': {}
 
-  '@mapbox/vector-tile@2.0.5':
+  '@mapbox/vector-tile@3.0.0':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
-      pbf: 4.0.2
-
-  '@mapbox/whoots-js@3.1.0': {}
+      pbf: 5.1.2
 
   '@maplibre/geojson-vt@6.1.1':
     dependencies:
       kdbush: 4.1.0
 
-  '@maplibre/maplibre-gl-style-spec@24.10.0':
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/unitbezier': 1.0.0
@@ -1770,16 +1755,14 @@ snapshots:
 
   mapbox-gl@3.27.0: {}
 
-  maplibre-gl@5.24.0:
+  maplibre-gl@6.0.0:
     dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/point-geometry': 1.1.0
       '@mapbox/tiny-sdf': 2.2.0
-      '@mapbox/unitbezier': 0.0.1
-      '@mapbox/vector-tile': 2.0.5
-      '@mapbox/whoots-js': 3.1.0
+      '@mapbox/unitbezier': 1.0.0
+      '@mapbox/vector-tile': 3.0.0
       '@maplibre/geojson-vt': 6.1.1
-      '@maplibre/maplibre-gl-style-spec': 24.10.0
+      '@maplibre/maplibre-gl-style-spec': 26.2.1
       '@maplibre/mlt': 1.1.12
       '@maplibre/vt-pbf': 4.3.2
       '@types/geojson': 7946.0.16
@@ -1787,7 +1770,7 @@ snapshots:
       gl-matrix: 3.4.4
       kdbush: 4.1.0
       murmurhash-js: 1.0.0
-      pbf: 4.0.2
+      pbf: 5.1.2
       potpack: 2.1.0
       quickselect: 3.0.0
       tinyqueue: 3.0.0
@@ -1861,10 +1844,6 @@ snapshots:
       vite-plus: 0.2.6(@types/node@26.1.1)(@voidzero-dev/vite-plus-core@0.2.6(@types/node@26.1.1)(typescript@7.0.2))(typescript@7.0.2)
 
   pathe@2.0.3: {}
-
-  pbf@4.0.2:
-    dependencies:
-      resolve-protobuf-schema: 2.1.0
 
   pbf@5.1.2:
     dependencies:

--- a/webmap/src/backends/googlemaps.ts
+++ b/webmap/src/backends/googlemaps.ts
@@ -522,6 +522,7 @@ export async function init(reporter: PageReporter, pending: PendingBridgeCalls):
     const tilesListener = liveMap.addListener("tilesloaded", () => {
         if (state.rendered) return;
         state.rendered = true;
+        report("ready", "");
         // Google silently downgrades a VECTOR map to RASTER when the device's
         // WebGL cannot host a vector map (e.g. a low-end head unit with no
         // usable 3D context). Detect the ACTUAL rendering type once tiles are

--- a/webmap/src/backends/googlemaps.ts
+++ b/webmap/src/backends/googlemaps.ts
@@ -168,19 +168,30 @@ export async function init(reporter: PageReporter, pending: PendingBridgeCalls):
     // (heading-up, tilt, 3D). Blank = a flat north-up RASTER map.
     const mapId = gmBridge()?.googleMapsMapId?.() ?? "";
 
-    // A vector map hard-requires WebGL: with no context there is nothing to
-    // render, so report fatal and let the host show a clear notice. A raster
-    // map needs no WebGL, so a missing context there is logged only — the
-    // raster tiles still render and a premature fatal would blank a working
-    // map.
+    // A raster map is server-rendered pixel tiles and needs no WebGL, so a
+    // missing context there is logged only — a premature fatal would blank a
+    // working map.
+    //
+    // A vector map is drawn client-side on the GPU, and Google's own bar for it
+    // is WebGL 2 (their support page tells you to test `getContext("webgl2")`).
+    // Google does NOT fail without it: a vector Map ID silently falls back to
+    // raster. So this fatal is a deliberate product choice, not a technical
+    // necessity — we would rather tell the user their vector opt-in cannot be
+    // honoured than hand them a flat north-up map with no explanation.
+    //
+    // KNOWN GAPS, deliberately left as-is here (behaviour predates the check
+    // against Google's docs):
+    //  - the gate accepts webgl1, so a WebGL-1-only device passes and then gets
+    //    Google's silent raster downgrade — the very outcome the fatal exists to
+    //    avoid;
+    //  - the downgrade is sampled once at the first `tilesloaded` rather than
+    //    subscribed via Google's `renderingtype_changed`, so a later switch
+    //    (e.g. a dynamic-GPU handover) goes unnoticed.
     const gl = webglSupport();
     if (!gl.webgl2 && !gl.webgl1) {
         if (mapId !== "") {
-            // Report and stop: loading the API for the doomed vector page is
-            // wasted work (the host tears the page down on the fatal).
-            // Whether a vector request should instead defer to Google's own
-            // silent raster downgrade (see the tilesloaded handler) is a
-            // separate product decision — the explicit-choice fatal stands.
+            // Report and stop: loading the API for a page the host is about to
+            // tear down is wasted work.
             log("no-webgl-context");
             report("fatal", "no-webgl-context");
             return;

--- a/webmap/src/backends/mapbox.ts
+++ b/webmap/src/backends/mapbox.ts
@@ -129,6 +129,7 @@ export function init(reporter: PageReporter, pending: PendingBridgeCalls): void 
                 if (!liveMap.isStyleLoaded()) return;
                 state.styleLoaded = true;
                 log("rendered");
+                report("ready", "");
                 liveMap.off("render", onFirstRender);
             };
             liveMap.on("render", onFirstRender);

--- a/webmap/src/backends/osm.ts
+++ b/webmap/src/backends/osm.ts
@@ -3,13 +3,26 @@
 // OSM-only style bridge (setStyleUrl / setFeatures with the ACCENT recolour
 // palette and the 3D-buildings / terrain injection); the follow camera and
 // chevron come from the shared follow-camera engine.
-import maplibregl from "maplibre-gl";
+// MapLibre 6 is ESM-only and publishes no default export, so the classes come in
+// by name. `MapLibreMap` is the library's own alias for its `Map` export, which
+// would otherwise shadow the global `Map`.
+import { MapLibreMap, Marker, setWorkerUrl } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
+// MapLibre 6 resolves its worker through `import.meta.url`, which a bundler
+// cannot honour, so every bundled consumer must hand it the URL. `?worker&url`
+// (not a plain `?url`) is required: the published worker imports a sibling
+// chunk, and only the worker transform bundles that sibling in. Without this
+// call the build still succeeds and the page still loads — but the worker URL
+// points at a file Vite never emits, so no tile is ever parsed and the map
+// stays blank. Neither tsc nor the lint/test pass can catch it.
+import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
 import type { PageReporter, PendingBridgeCalls } from "../bridge";
 import { webglSupport } from "../bridge";
 import { chevronHandles } from "../chevron";
 import { createFollowEngine } from "../follow-camera";
 import { type AccentColors, injectFeatures } from "../style";
+
+setWorkerUrl(maplibreWorkerUrl);
 
 const INITIAL_STYLE_URL = "https://tiles.openfreemap.org/styles/positron";
 
@@ -26,12 +39,12 @@ const STYLE_LOAD_FATAL_GRACE_MS = 10_000;
 export function init(reporter: PageReporter, pending: PendingBridgeCalls): void {
     const { log, report, reportErrorThrottled } = reporter;
 
-    // MapLibre renders WebGL 2 or falls back to WebGL 1; neither available is
-    // a definitive never-going-to-render fact — report it and stop.
-    // Constructing the map anyway would only throw a second, noisier fatal
-    // from a page the host is about to tear down.
-    const gl = webglSupport();
-    if (!gl.webgl2 && !gl.webgl1) {
+    // MapLibre 6 dropped the WebGL 1 fallback and only ever acquires a webgl2
+    // context, so a missing one is a definitive never-going-to-render fact —
+    // report it and stop, matching the mapbox backend's gate. Constructing the
+    // map anyway would only throw a second, noisier fatal (a
+    // GPUInitializationError) from a page the host is about to tear down.
+    if (!webglSupport().webgl2) {
         log("no-webgl-context");
         report("fatal", "no-webgl-context");
         return;
@@ -59,7 +72,7 @@ export function init(reporter: PageReporter, pending: PendingBridgeCalls): void 
     };
 
     try {
-        const liveMap = new maplibregl.Map({
+        const liveMap = new MapLibreMap({
             container: "map",
             style: INITIAL_STYLE_URL,
             center: [0, 0],
@@ -217,7 +230,7 @@ export function init(reporter: PageReporter, pending: PendingBridgeCalls): void 
             chevron: chevronHandles(),
             map: liveMap,
             createGeoMarker: (el, lngLat) =>
-                new maplibregl.Marker({
+                new Marker({
                     element: el,
                     rotationAlignment: "map",
                     pitchAlignment: "map",

--- a/webmap/src/backends/osm.ts
+++ b/webmap/src/backends/osm.ts
@@ -82,12 +82,14 @@ export function init(reporter: PageReporter, pending: PendingBridgeCalls): void 
         // Log the first rendered frame once, then detach: "render" fires on
         // every painted frame, so a persistent listener spews ~60 lines/sec
         // into logcat (and the in-app diagnostics tail) during the GPS camera
-        // ease. Diagnostics only — the host detects readiness via
-        // onPageFinished, not this log.
+        // ease. The host learns the page loaded from onPageFinished, but only
+        // this first painted frame proves the map actually renders, so it also
+        // reports `ready` for the MAP diagnostics section.
         const onFirstRender = (): void => {
             if (!liveMap.isStyleLoaded()) return;
             state.styleLoaded = true;
             log("rendered");
+            report("ready", "");
             liveMap.off("render", onFirstRender);
         };
         liveMap.on("render", onFirstRender);

--- a/webmap/src/bridge.ts
+++ b/webmap/src/bridge.ts
@@ -56,9 +56,12 @@ declare global {
 // (no WebGL context, a missing BYO credential, map construction threw);
 // "error" = transient resource failures (tile / style / DEM fetch), log-only
 // on the host; "follow" = camera-follow state flips; "bearing" = throttled
-// camera bearing for the compass overlay. No kind triggers a backend switch —
-// the host keeps the chosen backend (no auto-fallback).
-export type MapEventKind = "fatal" | "error" | "follow" | "bearing";
+// camera bearing for the compass overlay. `ready` marks the first frame the
+// backend actually painted — the host records it for the MAP diagnostics
+// section, which otherwise cannot tell a working map from one that failed
+// silently. No kind triggers a backend switch — the host keeps the chosen
+// backend (no auto-fallback).
+export type MapEventKind = "ready" | "fatal" | "error" | "follow" | "bearing";
 
 export interface PageReporter {
     // Diagnostic logging only (visible via chrome://inspect or the debug

--- a/webmap/src/bridge.ts
+++ b/webmap/src/bridge.ts
@@ -190,11 +190,12 @@ export function installPendingStubs(): PendingBridgeCalls {
     return pending;
 }
 
-// WebGL availability probe. Each backend applies its own policy: MapLibre
-// accepts webgl2 or webgl, mapbox-gl v3 hard-requires webgl2, and a Google
-// raster map needs neither. One canvas per probe: a canvas locks to its first
-// context mode, so asking one canvas for webgl2 then webgl would report a
-// false webgl1=false on every WebGL2-capable device.
+// WebGL availability probe. Each backend applies its own policy: maplibre-gl 6
+// and mapbox-gl 3 both hard-require webgl2 (MapLibre dropped its WebGL 1
+// fallback in 6), while a Google raster map needs neither — only its vector
+// mode does. One canvas per probe: a canvas locks to its first context mode, so
+// asking one canvas for webgl2 then webgl would report a false webgl1=false on
+// every WebGL2-capable device.
 export function webglSupport(): { webgl2: boolean; webgl1: boolean } {
     return {
         webgl2: document.createElement("canvas").getContext("webgl2") != null,

--- a/webmap/src/bridge.ts
+++ b/webmap/src/bridge.ts
@@ -194,11 +194,13 @@ export function installPendingStubs(): PendingBridgeCalls {
 }
 
 // WebGL availability probe. Each backend applies its own policy: maplibre-gl 6
-// and mapbox-gl 3 both hard-require webgl2 (MapLibre dropped its WebGL 1
-// fallback in 6), while a Google raster map needs neither — only its vector
-// mode does. One canvas per probe: a canvas locks to its first context mode, so
-// asking one canvas for webgl2 then webgl would report a false webgl1=false on
-// every WebGL2-capable device.
+// and mapbox-gl 3 both hard-require webgl2 and render nothing without it
+// (MapLibre dropped its WebGL 1 fallback in 6; mapbox-gl made webgl2 mandatory
+// in 3.0). A Google raster map needs no WebGL at all — its tiles are rendered
+// server-side — while a Google VECTOR map treats webgl2 as its bar too, but
+// degrades to raster instead of failing. One canvas per probe: a canvas locks to
+// its first context mode, so asking one canvas for webgl2 then webgl would
+// report a false webgl1=false on every WebGL2-capable device.
 export function webglSupport(): { webgl2: boolean; webgl1: boolean } {
     return {
         webgl2: document.createElement("canvas").getContext("webgl2") != null,


### PR DESCRIPTION
Stacked on #324 (base is `chore/maplibre-gl-v6`), which is what makes this worth
doing now: v6 drops the WebGL 1 fallback, so "the map renders nothing on this
device" moves from theoretical to reachable.

## Problem

A map that fails to render reports a `fatal` over the JS bridge, the host swaps
in the failure notice, and the reason survives **only as a logcat line**. So
today, "why is my map blank?" is answerable from the diagnostics report only if
you read the log tail and already know what `no-webgl-context` means — and the
log tail is a bounded tail that drops the line once enough logging follows it.

The map's *configuration* was already covered — every map setting is a SETTINGS
fact — but nothing reported what the map actually **did**.

## Change

A MAP section, sited after WEBVIEW because the map is that WebView's page. It
carries the runtime outcome rather than restating configuration:

| Fact | Behaviour |
| --- | --- |
| **WebGL 2** | Evaluated against the OpenGL ES 3.0 it maps onto: an ES 2.0 device reads `unavailable (OpenGL ES 2.0, needs 3.0)` as a **WARNING** instead of a neutral number the reader must interpret. Above the floor it says `expected`, not `available` — the platform's GLES version is the capability behind WebGL 2, not a probe of it (a blocklisted driver can still deny a context). |
| **Last failure** | The page's own reason and its age, or `none this session`. Held in `MapRuntimeSignals` beyond the composable's lifetime, so a failure the user has since scrolled past is still in the report. |
| **Failures this session** | Only once there is more than one, so a flapping map is visible without adding a row to the common case. |

The page now also reports a **`ready`** event on the first frame each backend
actually paints (all three backends). `onPageFinished` only proves the entry
module ran, so without it the host cannot distinguish a working map from one
that failed silently.

`MapRuntimeSignals` lives in `data/` because `data/` never imports `ui/`: the
WebView host writes it, the collector reads it.

## What this looks like in a report

```
- Map: WebGL 2: unavailable (OpenGL ES 2.0, needs 3.0)
- Map: Last failure: no-webgl-context (12s ago)
...
## Map

- WebGL 2: unavailable (OpenGL ES 2.0, needs 3.0)
- Last failure: no-webgl-context (12s ago)
```

Both lines are pinned by a test — the issues block *and* the section body, so a
pasted report answers the question on its own.

## Verification

`spotlessCheck`, `assembleDebug`, `lint`, `test` — all pass (777 tests).

- 8 new `MapFactsTest` cases pin the floor comparison (including that `2.9` never
  crosses 3.0, which a string or minor-only comparison would get wrong), the
  unknown-version path, the failure reason + age formatting, and the count-row
  threshold.
- A new `DiagnosticsReportTest` case pins the report output above.
- `DiagnosticsModelTest` pins MAP's position in the section order.
- The compiler enforced the rest: adding `SectionId.MAP` broke the build until
  every exhaustive `when` over it — the report title, the UI card title, and the
  test fixture — handled the new section.

The on-screen card is the shared `SectionPayload.Facts` renderer that GRAPHICS
and WEBVIEW already use, and its title goes through the same compile-checked
`when`; I could not get a clean emulator capture of the card itself (the AVD kept
resetting runtime permissions between installs and a Chrome notification dialog
kept stealing focus), so that one surface is argued from the shared code path
rather than a screenshot.

---

## Update: the WebGL 2 fact is judged against the active backend

The first revision flagged a missing WebGL 2 unconditionally, which would have
warned about a **Google Maps raster** configuration whose map draws perfectly
(raster tiles are rendered server-side — no WebGL involved). Corrected against
each vendor's own documentation:

| Backend | WebGL 2 | Without it | Source |
| --- | --- | --- | --- |
| OSM (maplibre-gl 6) | required | nothing renders | v6 removed the WebGL 1 fallback |
| Mapbox (mapbox-gl 3) | required | nothing renders | v3.0.0 breaking changes: *"Discontinue WebGL 1 support. WebGL 2 is now mandatory"* |
| Google **vector** (Cloud Map ID) | effectively required | **silently falls back to raster** — map still draws, vector opt-in lost | Google's WebGL support page tells you to test `getContext("webgl2")` |
| Google **raster** (no Map ID) | not needed | — | tiles are server-rendered |

Verified locally for Mapbox against the installed `mapbox-gl@3.27.0`: both of
its `getContext(...)` calls ask for `"webgl2"`, and its type definitions
reference `WebGL2RenderingContext` 41 times and `WebGLRenderingContext` zero
times.

The fact now reads one of: `not required (Google Maps raster)`,
`expected (OpenGL ES 3.2)`, `… — this backend cannot render`, or
`… — vector map falls back to raster`. Four new tests pin one case each.

### Comment corrections (no behaviour change)

The same check proved two comments wrong, so they are fixed here:

- `googlemaps.ts` claimed a vector map *"hard-requires WebGL: with no context
  there is nothing to render"*. Google documents the opposite — an automatic
  raster fallback. The fatal is therefore a **product choice** (tell the user
  their vector opt-in cannot be honoured) rather than a technical necessity, and
  now says so.
- Two known gaps in that gate are now written down instead of implied: it accepts
  `webgl1` (so a WebGL-1-only device passes and then gets the very silent
  downgrade the fatal exists to prevent), and the downgrade is sampled once at
  the first `tilesloaded` rather than subscribed via Google's
  `renderingtype_changed`. Both are left as-is in this PR.