### PR TITLE
feat(map): let the user choose Google Maps raster or vector rendering

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -253,6 +253,7 @@ class MainActivity : ComponentActivity() {
                             mapboxTraffic = settings.mapboxTraffic,
                             googleMapsApiKey = settings.googleMapsApiKey,
                             googleMapsMapId = settings.googleMapsMapId,
+                            googleMapsRendering = settings.googleMapsRendering,
                             googleMapsMapType = settings.googleMapsMapType,
                             googleMapsTraffic = settings.googleMapsTraffic,
                         ),

--- a/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/MapFactsCollector.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/MapFactsCollector.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.SystemClock
 import androidx.core.content.getSystemService
 import io.github.seijikohara.femto.data.display.DisplayPreferences
+import io.github.seijikohara.femto.data.display.GoogleMapsRendering
 import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.map.MapRuntimeSignals
 import kotlinx.coroutines.Dispatchers
@@ -32,11 +33,25 @@ private enum class WebGl2Need { TO_RENDER, FOR_VECTOR, NONE }
 
 private fun webGl2Need(
     backend: MapBackend,
+    googleRendering: GoogleMapsRendering,
     hasGoogleMapId: Boolean,
 ): WebGl2Need =
     when (backend) {
-        MapBackend.OSM, MapBackend.MAPBOX -> WebGl2Need.TO_RENDER
-        MapBackend.GOOGLEMAPS -> if (hasGoogleMapId) WebGl2Need.FOR_VECTOR else WebGl2Need.NONE
+        MapBackend.OSM, MapBackend.MAPBOX -> {
+            WebGl2Need.TO_RENDER
+        }
+
+        // Mirrors `wantsVector` in webmap/src/backends/googlemaps.ts, which is the
+        // page-side home of the same rule: an explicit VECTOR asks for it, AUTO
+        // may get it from the Map ID's cloud configuration, and everything else
+        // renders raster.
+        MapBackend.GOOGLEMAPS -> {
+            when (googleRendering) {
+                GoogleMapsRendering.VECTOR -> WebGl2Need.FOR_VECTOR
+                GoogleMapsRendering.AUTO -> if (hasGoogleMapId) WebGl2Need.FOR_VECTOR else WebGl2Need.NONE
+                GoogleMapsRendering.RASTER -> WebGl2Need.NONE
+            }
+        }
     }
 
 /**
@@ -46,20 +61,22 @@ private fun webGl2Need(
  *
  * Reports what the map DID, not how it is configured: every map setting
  * (backend, style, credentials) is already a SETTINGS fact, and restating it
- * here would be a second home for the same value. [backend] and [hasGoogleMapId]
- * are read only to judge what a missing WebGL 2 actually costs — flagging it
- * unconditionally would warn about a Google raster map that renders perfectly.
+ * here would be a second home for the same value. [backend], [googleRendering]
+ * and [hasGoogleMapId] are read only to judge what a missing WebGL 2 actually
+ * costs — flagging it unconditionally would warn about a Google raster map that
+ * renders perfectly.
  */
 internal fun mapFactsFrom(
     glEsVersion: String?,
     backend: MapBackend,
+    googleRendering: GoogleMapsRendering,
     hasGoogleMapId: Boolean,
     lastFailure: MapRuntimeSignals.MapFailure?,
     failureCount: Int,
     nowElapsedRealtimeMs: Long,
 ): List<DiagnosticFact> =
     buildList {
-        add(webGl2Fact(glEsVersion, webGl2Need(backend, hasGoogleMapId)))
+        add(webGl2Fact(glEsVersion, webGl2Need(backend, googleRendering, hasGoogleMapId)))
         add(lastFailureFact(lastFailure, nowElapsedRealtimeMs))
         if (failureCount > 1) {
             add(DiagnosticFact("Failures this session", FactValue.Text("$failureCount")))
@@ -142,6 +159,7 @@ internal class MapFactsCollector(
                 mapFactsFrom(
                     glEsVersion = context.getSystemService<ActivityManager>()?.deviceConfigurationInfo?.glEsVersion,
                     backend = display.mapBackend,
+                    googleRendering = display.googleMapsRendering,
                     hasGoogleMapId = display.googleMapsMapId.isNotBlank(),
                     lastFailure = MapRuntimeSignals.lastFailureOrNull(),
                     failureCount = MapRuntimeSignals.failureCount(),

--- a/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCollector.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCollector.kt
@@ -68,6 +68,7 @@ internal fun displaySettingsFacts(display: DisplaySettings): List<DiagnosticFact
         entry("Mapbox style", display.mapboxStyle.name),
         entry("Mapbox traffic", "${display.mapboxTraffic}"),
         entry("Mapbox token", display.mapboxAccessToken.secretLabel()),
+        entry("Google Maps rendering", display.googleMapsRendering.name),
         entry("Google Maps type", display.googleMapsMapType.name),
         entry("Google Maps traffic", "${display.googleMapsTraffic}"),
         entry("Google Maps key", display.googleMapsApiKey.secretLabel()),

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
@@ -129,6 +129,8 @@ internal interface DisplaySettingsStore {
 
     suspend fun setGoogleMapsMapId(value: String)
 
+    suspend fun setGoogleMapsRendering(value: GoogleMapsRendering)
+
     suspend fun setGoogleMapsMapType(value: GoogleMapType)
 
     suspend fun setGoogleMapsTraffic(value: Boolean)
@@ -204,6 +206,8 @@ internal class DisplayPreferences(
                     mapboxAccessToken = prefs[MAPBOX_ACCESS_TOKEN_KEY].orEmpty(),
                     googleMapsApiKey = prefs[GOOGLE_MAPS_API_KEY_KEY].orEmpty(),
                     googleMapsMapId = prefs[GOOGLE_MAPS_MAP_ID_KEY].orEmpty(),
+                    googleMapsRendering =
+                        prefs[GOOGLE_MAPS_RENDERING_KEY].toEnumOr(GoogleMapsRendering.AUTO),
                     googleMapsMapType = prefs[GOOGLE_MAPS_MAP_TYPE_KEY].toEnumOr(GoogleMapType.ROADMAP),
                     googleMapsTraffic = prefs[GOOGLE_MAPS_TRAFFIC_KEY] ?: false,
                 )
@@ -395,6 +399,10 @@ internal class DisplayPreferences(
         context.displayDataStore.editOrLog(TAG) { it[GOOGLE_MAPS_MAP_ID_KEY] = value }
     }
 
+    override suspend fun setGoogleMapsRendering(value: GoogleMapsRendering) {
+        context.displayDataStore.editOrLog(TAG) { it[GOOGLE_MAPS_RENDERING_KEY] = value.name }
+    }
+
     override suspend fun setGoogleMapsMapType(value: GoogleMapType) {
         context.displayDataStore.editOrLog(TAG) { it[GOOGLE_MAPS_MAP_TYPE_KEY] = value.name }
     }
@@ -465,6 +473,7 @@ internal class DisplayPreferences(
         val MAPBOX_ACCESS_TOKEN_KEY = stringPreferencesKey("mapbox_access_token")
         val GOOGLE_MAPS_API_KEY_KEY = stringPreferencesKey("google_maps_api_key")
         val GOOGLE_MAPS_MAP_ID_KEY = stringPreferencesKey("google_maps_map_id")
+        val GOOGLE_MAPS_RENDERING_KEY = stringPreferencesKey("google_maps_rendering")
         val GOOGLE_MAPS_MAP_TYPE_KEY = stringPreferencesKey("google_maps_map_type")
         val GOOGLE_MAPS_TRAFFIC_KEY = booleanPreferencesKey("google_maps_traffic")
 
@@ -525,6 +534,7 @@ internal class DisplayPreferences(
                 MAPBOX_ACCESS_TOKEN_KEY,
                 GOOGLE_MAPS_API_KEY_KEY,
                 GOOGLE_MAPS_MAP_ID_KEY,
+                GOOGLE_MAPS_RENDERING_KEY,
                 GOOGLE_MAPS_MAP_TYPE_KEY,
                 GOOGLE_MAPS_TRAFFIC_KEY,
             )

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplaySettings.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplaySettings.kt
@@ -237,7 +237,12 @@ internal data class DisplaySettings(
     val mapboxAccessToken: String = "",
     /** User-supplied Google Maps API key; blank disables the Google Maps backend. */
     val googleMapsApiKey: String = "",
-    /** User-supplied Google Maps Map ID; blank uses the default raster map. */
+    /**
+     * User-supplied Google Maps Map ID. Independent of the rendering mode below:
+     * it carries cloud styling and advanced markers, and only under
+     * [GoogleMapsRendering.AUTO] does its cloud configuration also decide raster
+     * vs vector. Blank is supported in every mode.
+     */
     val googleMapsMapId: String = "",
     // Raster / vector is independent of the Map ID (Maps JS 3.56.10+); AUTO leaves
     // the Map ID's Cloud configuration in charge. See GoogleMapsRendering.

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplaySettings.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplaySettings.kt
@@ -239,6 +239,9 @@ internal data class DisplaySettings(
     val googleMapsApiKey: String = "",
     /** User-supplied Google Maps Map ID; blank uses the default raster map. */
     val googleMapsMapId: String = "",
+    // Raster / vector is independent of the Map ID (Maps JS 3.56.10+); AUTO leaves
+    // the Map ID's Cloud configuration in charge. See GoogleMapsRendering.
+    val googleMapsRendering: GoogleMapsRendering = GoogleMapsRendering.AUTO,
     // Google Maps map type, only meaningful when mapBackend == GOOGLEMAPS.
     val googleMapsMapType: GoogleMapType = GoogleMapType.ROADMAP,
     // Whether to overlay live traffic on the Google Maps map.
@@ -291,6 +294,7 @@ internal data class DisplaySettings(
                 mapboxAccessToken = "",
                 googleMapsApiKey = "",
                 googleMapsMapId = "",
+                googleMapsRendering = GoogleMapsRendering.AUTO,
                 googleMapsMapType = GoogleMapType.ROADMAP,
                 googleMapsTraffic = false,
             )

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/GoogleMapsRendering.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/GoogleMapsRendering.kt
@@ -1,0 +1,18 @@
+package io.github.seijikohara.femto.data.display
+
+/**
+ * How the Google Maps backend asks the Maps JavaScript API to render.
+ *
+ * The API decides this at construction and exposes it as `MapOptions.renderingType`;
+ * an explicit value **overrides** whatever the Cloud Map ID is configured for, so
+ * [AUTO] deliberately sends nothing and leaves that configuration in charge.
+ *
+ * Only a [VECTOR] map supports the launcher's heading-up rotation and tilt — on a
+ * raster map the API reinterprets both (heading applies to aerial imagery only and
+ * snaps to available angles; tilt accepts just 0 or 45 as an imagery-switching
+ * policy), which is why the backend omits them entirely when it renders raster.
+ * Since Maps JS 3.56.10 vector no longer needs a Map ID, so the two are independent
+ * choices. Vector is a *request*: the API silently falls back to raster on a device
+ * that cannot support it, which the backend detects after the first tile load.
+ */
+internal enum class GoogleMapsRendering { AUTO, RASTER, VECTOR }

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/SettingsSectionId.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/SettingsSectionId.kt
@@ -68,6 +68,7 @@ internal enum class SettingsSectionId(
             DisplayPreferences.MAPBOX_ACCESS_TOKEN_KEY,
             DisplayPreferences.GOOGLE_MAPS_API_KEY_KEY,
             DisplayPreferences.GOOGLE_MAPS_MAP_ID_KEY,
+            DisplayPreferences.GOOGLE_MAPS_RENDERING_KEY,
             DisplayPreferences.GOOGLE_MAPS_MAP_TYPE_KEY,
             DisplayPreferences.GOOGLE_MAPS_TRAFFIC_KEY,
             DisplayPreferences.MAP_3D_BUILDINGS_KEY,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapConfig.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/MapConfig.kt
@@ -1,6 +1,7 @@
 package io.github.seijikohara.femto.ui.home.components
 
 import io.github.seijikohara.femto.data.display.GoogleMapType
+import io.github.seijikohara.femto.data.display.GoogleMapsRendering
 import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.display.MapColorScheme
 import io.github.seijikohara.femto.data.display.MapStyleSetting
@@ -30,6 +31,9 @@ internal data class MapConfig(
     // Google Maps-specific fields; ignored when backend != GOOGLEMAPS.
     val googleMapsApiKey: String = "",
     val googleMapsMapId: String = "",
+    // Construction-time for the Maps JS API, so a change rebuilds the WebView
+    // (see WebMapView's effectiveGoogleRendering).
+    val googleMapsRendering: GoogleMapsRendering = GoogleMapsRendering.AUTO,
     val googleMapsMapType: GoogleMapType = GoogleMapType.ROADMAP,
     val googleMapsTraffic: Boolean = false,
     val markerPos: Int = 70,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/WebMapView.kt
@@ -49,6 +49,7 @@ import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.MapPinOff
 import io.github.seijikohara.femto.BuildConfig
 import io.github.seijikohara.femto.R
+import io.github.seijikohara.femto.data.display.GoogleMapsRendering
 import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.display.MapStyleSetting
 import io.github.seijikohara.femto.data.display.MapboxStyle
@@ -152,6 +153,10 @@ internal fun WebMapView(
     val effectiveMapboxToken = if (mapConfig.backend == MapBackend.MAPBOX) mapConfig.mapboxToken else ""
     val effectiveGoogleKey = if (mapConfig.backend == MapBackend.GOOGLEMAPS) mapConfig.googleMapsApiKey else ""
     val effectiveGoogleMapId = if (mapConfig.backend == MapBackend.GOOGLEMAPS) mapConfig.googleMapsMapId else ""
+    // The Maps JS API fixes raster/vector at construction, so a change has to
+    // rebuild the WebView rather than push into the live page.
+    val effectiveGoogleRendering =
+        if (mapConfig.backend == MapBackend.GOOGLEMAPS) mapConfig.googleMapsRendering else GoogleMapsRendering.AUTO
 
     // Renderer-death containment state (see the KDoc): bumping the generation
     // rebuilds the WebView after the renderer process dies; once deaths repeat
@@ -186,7 +191,13 @@ internal fun WebMapView(
     // retry bumps that — so the budget survives its own reloads; a
     // backend/credential change or a connectivity edge refunds it.
     val retryAttempts =
-        remember(mapConfig.backend, effectiveMapboxToken, effectiveGoogleKey, effectiveGoogleMapId) {
+        remember(
+            mapConfig.backend,
+            effectiveMapboxToken,
+            effectiveGoogleKey,
+            effectiveGoogleMapId,
+            effectiveGoogleRendering,
+        ) {
             mutableIntStateOf(0)
         }
     val wasOnline = remember { booleanArrayOf(online) }
@@ -217,6 +228,7 @@ internal fun WebMapView(
             effectiveMapboxToken,
             effectiveGoogleKey,
             effectiveGoogleMapId,
+            effectiveGoogleRendering,
         ) { mutableStateOf(false) }
 
     // Set by a `fatal` bridge event (see the KDoc): the page itself determined it
@@ -228,11 +240,25 @@ internal fun WebMapView(
     // connectivity-recovery reload clears an offline-triggered fatal (Mapbox / Google
     // Maps report one when opened offline) and the rebuilt page gets a fresh online init.
     var liveInitFailed by
-        remember(reloadGeneration, mapConfig.backend, effectiveMapboxToken, effectiveGoogleKey, effectiveGoogleMapId) {
+        remember(
+            reloadGeneration,
+            mapConfig.backend,
+            effectiveMapboxToken,
+            effectiveGoogleKey,
+            effectiveGoogleMapId,
+            effectiveGoogleRendering,
+        ) {
             mutableStateOf(false)
         }
     var lastFatalDetail by
-        remember(reloadGeneration, mapConfig.backend, effectiveMapboxToken, effectiveGoogleKey, effectiveGoogleMapId) {
+        remember(
+            reloadGeneration,
+            mapConfig.backend,
+            effectiveMapboxToken,
+            effectiveGoogleKey,
+            effectiveGoogleMapId,
+            effectiveGoogleRendering,
+        ) {
             mutableStateOf<String?>(null)
         }
     // Bridge callbacks arrive on a WebView-managed background thread; Compose
@@ -318,6 +344,7 @@ internal fun WebMapView(
             effectiveMapboxToken,
             effectiveGoogleKey,
             effectiveGoogleMapId,
+            effectiveGoogleRendering,
         ) {
             val assetLoader =
                 WebViewAssetLoader
@@ -399,6 +426,13 @@ internal fun WebMapView(
                         // rendering; empty string means the default raster map is used.
                         @JavascriptInterface
                         fun googleMapsMapId(): String = mapConfig.googleMapsMapId
+
+                        // Read synchronously by the googlemaps backend module before map
+                        // initialisation: raster/vector is a construction-time option, and an
+                        // explicit value overrides the Map ID's cloud configuration. AUTO sends
+                        // nothing and leaves that configuration in charge.
+                        @JavascriptInterface
+                        fun googleMapsRendering(): String = mapConfig.googleMapsRendering.name
 
                         @JavascriptInterface
                         fun onMapEvent(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -10,6 +10,7 @@ import io.github.seijikohara.femto.data.display.DockPosition
 import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.GoogleMapType
+import io.github.seijikohara.femto.data.display.GoogleMapsRendering
 import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.display.MapColorScheme
 import io.github.seijikohara.femto.data.display.MapStyleSetting
@@ -81,6 +82,7 @@ internal data class SettingsUiState(
     val mapboxAccessToken: String = "",
     val googleMapsApiKey: String = "",
     val googleMapsMapId: String = "",
+    val googleMapsRendering: GoogleMapsRendering = DisplaySettings.Default.googleMapsRendering,
     val googleMapsMapType: GoogleMapType = DisplaySettings.Default.googleMapsMapType,
     val googleMapsTraffic: Boolean = DisplaySettings.Default.googleMapsTraffic,
     val availableCalendars: List<CalendarInfo> = emptyList(),
@@ -147,6 +149,7 @@ internal data class SettingsUiState(
                 mapboxAccessToken = DisplaySettings.Default.mapboxAccessToken,
                 googleMapsApiKey = DisplaySettings.Default.googleMapsApiKey,
                 googleMapsMapId = DisplaySettings.Default.googleMapsMapId,
+                googleMapsRendering = DisplaySettings.Default.googleMapsRendering,
                 googleMapsMapType = DisplaySettings.Default.googleMapsMapType,
                 googleMapsTraffic = DisplaySettings.Default.googleMapsTraffic,
             )
@@ -374,6 +377,10 @@ internal sealed interface SettingsAction {
     ) : SettingsAction
 
     data object ClearGoogleMapsMapId : SettingsAction
+
+    data class SetGoogleMapsRendering(
+        val value: GoogleMapsRendering,
+    ) : SettingsAction
 
     data class SetGoogleMapsMapType(
         val value: GoogleMapType,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -112,6 +112,7 @@ internal class SettingsViewModel(
                 mapboxAccessToken = display.mapboxAccessToken,
                 googleMapsApiKey = display.googleMapsApiKey,
                 googleMapsMapId = display.googleMapsMapId,
+                googleMapsRendering = display.googleMapsRendering,
                 googleMapsMapType = display.googleMapsMapType,
                 googleMapsTraffic = display.googleMapsTraffic,
                 latinFont = font.latin.displayNameOrNull,
@@ -366,6 +367,10 @@ internal class SettingsViewModel(
 
                 SettingsAction.ClearGoogleMapsMapId -> {
                     displayPreferences.setGoogleMapsMapId("")
+                }
+
+                is SettingsAction.SetGoogleMapsRendering -> {
+                    displayPreferences.setGoogleMapsRendering(action.value)
                 }
 
                 is SettingsAction.SetGoogleMapsMapType -> {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/MapSection.kt
@@ -25,6 +25,7 @@ import com.composables.icons.lucide.ChevronRight
 import com.composables.icons.lucide.Lucide
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.GoogleMapType
+import io.github.seijikohara.femto.data.display.GoogleMapsRendering
 import io.github.seijikohara.femto.data.display.MAX_MAP_ZOOM
 import io.github.seijikohara.femto.data.display.MIN_MAP_ZOOM
 import io.github.seijikohara.femto.data.display.MapBackend
@@ -115,6 +116,26 @@ internal fun MapSection(
         }
         AnimatedVisibility(visible = uiState.mapBackend == MapBackend.GOOGLEMAPS) {
             Column {
+                ChoiceRow(
+                    title = stringResource(R.string.settings_google_maps_rendering),
+                    options =
+                        listOf(
+                            GoogleMapsRendering.AUTO to
+                                stringResource(R.string.settings_google_maps_rendering_auto),
+                            GoogleMapsRendering.RASTER to
+                                stringResource(R.string.settings_google_maps_rendering_raster),
+                            GoogleMapsRendering.VECTOR to
+                                stringResource(R.string.settings_google_maps_rendering_vector),
+                        ),
+                    selected = uiState.googleMapsRendering,
+                    onSelect = { onAction(SettingsAction.SetGoogleMapsRendering(it)) },
+                )
+                Text(
+                    text = stringResource(R.string.settings_google_maps_rendering_note),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                )
                 ChoiceRow(
                     title = stringResource(R.string.settings_google_maps_type),
                     options =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -354,6 +354,11 @@
     <string name="settings_google_maps_map_id_hint">Optional. Enter a Map ID created in your Google Cloud console (Map Management) to render a vector map with heading-up rotation, tilt, and 3D. Leave blank for a flat north-up raster map.</string>
     <string name="settings_google_maps_map_id_save">Save</string>
     <string name="settings_google_maps_map_id_clear">Clear</string>
+    <string name="settings_google_maps_rendering">Rendering</string>
+    <string name="settings_google_maps_rendering_auto">Automatic</string>
+    <string name="settings_google_maps_rendering_raster">Raster</string>
+    <string name="settings_google_maps_rendering_vector">Vector</string>
+    <string name="settings_google_maps_rendering_note">Vector adds heading-up rotation and tilt; raster is flat and north-up. Automatic follows the map ID\'s cloud configuration, and renders raster when no map ID is set. Vector needs no map ID, but a device that cannot render it falls back to raster on its own.</string>
     <string name="settings_google_maps_type">Map type</string>
     <string name="settings_google_maps_type_roadmap">Roadmap</string>
     <string name="settings_google_maps_type_satellite">Satellite</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -350,8 +350,8 @@
     <string name="settings_google_maps_key_save">Save</string>
     <string name="settings_google_maps_key_clear">Clear</string>
     <string name="settings_google_maps_map_id">Map ID (optional)</string>
-    <string name="settings_google_maps_map_id_unset">Not set — flat north-up map; tap to enable a vector map</string>
-    <string name="settings_google_maps_map_id_hint">Optional. Enter a Map ID created in your Google Cloud console (Map Management) to render a vector map with heading-up rotation, tilt, and 3D. Leave blank for a flat north-up raster map.</string>
+    <string name="settings_google_maps_map_id_unset">Not set — tap to add one for cloud styling and advanced markers</string>
+    <string name="settings_google_maps_map_id_hint">Optional. Enter a Map ID created in your Google Cloud console (Map Management) for cloud styling and advanced markers. It does not control raster vs vector — the Rendering setting above does, except on Automatic, where the map ID\'s cloud configuration decides.</string>
     <string name="settings_google_maps_map_id_save">Save</string>
     <string name="settings_google_maps_map_id_clear">Clear</string>
     <string name="settings_google_maps_rendering">Rendering</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/MapFactsTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/MapFactsTest.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.data.diagnostics
 
+import io.github.seijikohara.femto.data.display.GoogleMapsRendering
 import io.github.seijikohara.femto.data.display.MapBackend
 import io.github.seijikohara.femto.data.map.MapRuntimeSignals
 import org.junit.Test
@@ -9,11 +10,20 @@ class MapFactsTest {
     private fun facts(
         glEsVersion: String? = "3.2",
         backend: MapBackend = MapBackend.OSM,
+        googleRendering: GoogleMapsRendering = GoogleMapsRendering.AUTO,
         hasGoogleMapId: Boolean = false,
         lastFailure: MapRuntimeSignals.MapFailure? = null,
         failureCount: Int = 0,
         nowElapsedRealtimeMs: Long = 0L,
-    ) = mapFactsFrom(glEsVersion, backend, hasGoogleMapId, lastFailure, failureCount, nowElapsedRealtimeMs)
+    ) = mapFactsFrom(
+        glEsVersion,
+        backend,
+        googleRendering,
+        hasGoogleMapId,
+        lastFailure,
+        failureCount,
+        nowElapsedRealtimeMs,
+    )
 
     @Test
     fun `a WebGL 2 backend below the OpenGL ES floor warns that it cannot render`() {
@@ -42,7 +52,42 @@ class MapFactsTest {
         // report a problem on a map that draws perfectly.
         assertEquals(
             DiagnosticFact("WebGL 2", FactValue.Text("not required (Google Maps raster)")),
-            facts(glEsVersion = "2.0", backend = MapBackend.GOOGLEMAPS, hasGoogleMapId = false).first(),
+            facts(
+                glEsVersion = "2.0",
+                backend = MapBackend.GOOGLEMAPS,
+                googleRendering = GoogleMapsRendering.AUTO,
+                hasGoogleMapId = false,
+            ).first(),
+        )
+    }
+
+    @Test
+    fun `an explicit Google raster choice never warns, even with a Map ID set`() {
+        // RASTER overrides the Map ID's cloud configuration, so the Map ID no
+        // longer implies vector — the pre-setting inference would have warned here.
+        assertEquals(
+            DiagnosticFact("WebGL 2", FactValue.Text("not required (Google Maps raster)")),
+            facts(
+                glEsVersion = "2.0",
+                backend = MapBackend.GOOGLEMAPS,
+                googleRendering = GoogleMapsRendering.RASTER,
+                hasGoogleMapId = true,
+            ).first(),
+        )
+    }
+
+    @Test
+    fun `an explicit Google vector choice warns without a Map ID`() {
+        // Vector no longer needs a Map ID (Maps JS 3.56.10+), so the warning must
+        // not depend on one.
+        assertEquals(
+            FactHealth.WARNING,
+            facts(
+                glEsVersion = "2.0",
+                backend = MapBackend.GOOGLEMAPS,
+                googleRendering = GoogleMapsRendering.VECTOR,
+                hasGoogleMapId = false,
+            ).first().health,
         )
     }
 
@@ -58,7 +103,12 @@ class MapFactsTest {
                     FactHealth.WARNING,
                 ),
             ),
-            facts(glEsVersion = "2.0", backend = MapBackend.GOOGLEMAPS, hasGoogleMapId = true).first(),
+            facts(
+                glEsVersion = "2.0",
+                backend = MapBackend.GOOGLEMAPS,
+                googleRendering = GoogleMapsRendering.AUTO,
+                hasGoogleMapId = true,
+            ).first(),
         )
     }
 

--- a/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCompletenessTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCompletenessTest.kt
@@ -62,6 +62,7 @@ class SettingsFactsCompletenessTest {
             "mapboxStyle" to "Mapbox style",
             "mapboxTraffic" to "Mapbox traffic",
             "mapboxAccessToken" to "Mapbox token",
+            "googleMapsRendering" to "Google Maps rendering",
             "googleMapsMapType" to "Google Maps type",
             "googleMapsTraffic" to "Google Maps traffic",
             "googleMapsApiKey" to "Google Maps key",

--- a/app/src/test/java/io/github/seijikohara/femto/data/display/DisplayPreferencesTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/display/DisplayPreferencesTest.kt
@@ -111,6 +111,7 @@ class DisplayPreferencesTest {
             store.resetToDefaults()
             store.setGoogleMapsApiKey("AIzaTESTKEY")
             store.setGoogleMapsMapId("test-map-id-01")
+            store.setGoogleMapsRendering(GoogleMapsRendering.VECTOR)
             store.setGoogleMapsMapType(GoogleMapType.HYBRID)
             store.setGoogleMapsTraffic(true)
             val settings = store.settings.first()
@@ -256,6 +257,7 @@ class DisplayPreferencesTest {
                     mapboxAccessToken = DisplaySettings.Default.mapboxAccessToken,
                     googleMapsApiKey = DisplaySettings.Default.googleMapsApiKey,
                     googleMapsMapId = DisplaySettings.Default.googleMapsMapId,
+                    googleMapsRendering = DisplaySettings.Default.googleMapsRendering,
                     googleMapsMapType = DisplaySettings.Default.googleMapsMapType,
                     googleMapsTraffic = DisplaySettings.Default.googleMapsTraffic,
                     map3dBuildings = DisplaySettings.Default.map3dBuildings,
@@ -368,6 +370,7 @@ class DisplayPreferencesTest {
         setMapboxAccessToken("pk.mutated")
         setGoogleMapsApiKey("mutated-key")
         setGoogleMapsMapId("mutated-id")
+        setGoogleMapsRendering(GoogleMapsRendering.VECTOR)
         setGoogleMapsMapType(GoogleMapType.HYBRID)
         setGoogleMapsTraffic(true)
         return settings.first()

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -11,6 +11,7 @@ import io.github.seijikohara.femto.data.display.DockPosition
 import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.GoogleMapType
+import io.github.seijikohara.femto.data.display.GoogleMapsRendering
 import io.github.seijikohara.femto.data.display.MAX_MAP_ZOOM
 import io.github.seijikohara.femto.data.display.MIN_MAP_ZOOM
 import io.github.seijikohara.femto.data.display.MapBackend
@@ -139,6 +140,9 @@ internal class FakeDisplaySettingsStore(
     override suspend fun setGoogleMapsApiKey(value: String) = state.update { it.copy(googleMapsApiKey = value) }
 
     override suspend fun setGoogleMapsMapId(value: String) = state.update { it.copy(googleMapsMapId = value) }
+
+    override suspend fun setGoogleMapsRendering(value: GoogleMapsRendering) =
+        state.update { it.copy(googleMapsRendering = value) }
 
     override suspend fun setGoogleMapsMapType(value: GoogleMapType) =
         state.update { it.copy(googleMapsMapType = value) }

--- a/webmap/src/backends/googlemaps.ts
+++ b/webmap/src/backends/googlemaps.ts
@@ -177,10 +177,14 @@ export async function init(reporter: PageReporter, pending: PendingBridgeCalls):
     // to raster on a device that cannot host it, which the tilesloaded handler
     // below detects. Requesting vector no longer needs a Map ID.
     const rendering = gmBridge()?.googleMapsRendering?.() ?? "AUTO";
-    // What we ASK for. AUTO cannot be resolved until the map has loaded, so it
-    // starts optimistic when a Map ID might select vector, and the tilesloaded
-    // handler corrects it either way.
-    const wantsVector = rendering === "VECTOR" || (rendering === "AUTO" && mapId !== "");
+    // Only an EXPLICIT vector choice is a vector request. AUTO's outcome lives in
+    // the Map ID's cloud configuration, which the page cannot read, so guessing
+    // "Map ID means vector" would drive a raster-configured Map ID as vector —
+    // pushing heading/tilt at a map that reinterprets them, and failing the WebGL
+    // gate below on a device where Google would have rendered raster quite
+    // happily. AUTO therefore starts raster and the tilesloaded handler resolves
+    // it from getRenderingType(), which is the only authoritative answer.
+    const wantsVector = rendering === "VECTOR";
 
     // A raster map is server-rendered pixel tiles and needs no WebGL, so a
     // missing context there is logged only — a premature fatal would blank a
@@ -557,16 +561,27 @@ export async function init(reporter: PageReporter, pending: PendingBridgeCalls):
         if (state.rendered) return;
         state.rendered = true;
         report("ready", "");
-        // Google silently downgrades a VECTOR map to RASTER when the device's
-        // WebGL cannot host a vector map (e.g. a low-end head unit with no
-        // usable 3D context). Detect the ACTUAL rendering type once tiles are
-        // in and downgrade our state so updateCamera stops sending
-        // heading/tilt — a raster map rejects them ("not supported on raster
-        // maps") and passing them stops the camera from positioning. easeHome
-        // re-issues a raster camera move + chevron sync.
-        if (state.isVector && liveMap.getRenderingType() === "RASTER") {
-            log("vector-fallback-to-raster");
-            state.isVector = false;
+        // getRenderingType() is the only authoritative answer, and it resolves
+        // only once tiles are in, so reconcile in BOTH directions here.
+        //
+        // Downgrade: Google silently renders RASTER when the device's WebGL
+        // cannot host a vector map (e.g. a low-end head unit with no usable 3D
+        // context), so stop sending heading/tilt — a raster map reinterprets
+        // them and passing them stops the camera from positioning.
+        //
+        // Upgrade: AUTO starts raster because the Map ID's cloud configuration
+        // is unreadable from here, so a Map ID configured for vector arrives as
+        // an upgrade. Nothing needs re-constructing — heading/tilt ride every
+        // updateCamera push, and headingInteractionEnabled already defaults to
+        // false on a vector map, which is what the launcher wants anyway.
+        //
+        // easeHome re-issues a camera move + chevron sync for the resolved mode.
+        const resolved = liveMap.getRenderingType();
+        log(`renderingType=${resolved}`);
+        const resolvedVector = resolved === "VECTOR";
+        if (state.isVector !== resolvedVector) {
+            log(resolvedVector ? "resolved-to-vector" : "vector-fallback-to-raster");
+            state.isVector = resolvedVector;
             easeHome();
         }
         log("rendered");

--- a/webmap/src/backends/googlemaps.ts
+++ b/webmap/src/backends/googlemaps.ts
@@ -59,9 +59,13 @@ interface GoogleMapsFemtoBridge {
     // key. Returns an empty string when unconfigured.
     googleMapsApiKey(): string;
     // Synchronous getter injected by the host; returns the Cloud Map ID the
-    // user supplied (a non-empty value opts into a VECTOR map), or "" for a
-    // raster map.
+    // user supplied, or "" when unconfigured. Independent of the rendering
+    // mode below (Maps JS 3.56.10+ renders vector without a Map ID); the Map ID
+    // still gates advanced markers and cloud styling.
     googleMapsMapId(): string;
+    // Synchronous getter injected by the host; the user's rendering choice as
+    // the Kotlin enum name: "AUTO" | "RASTER" | "VECTOR".
+    googleMapsRendering(): string;
 }
 
 // Minimal type stubs for the Google Maps JS API (CDN-loaded at runtime,
@@ -164,9 +168,19 @@ export async function init(reporter: PageReporter, pending: PendingBridgeCalls):
         return;
     }
 
-    // A non-empty Cloud Map ID = the user opted into a VECTOR map
-    // (heading-up, tilt, 3D). Blank = a flat north-up RASTER map.
     const mapId = gmBridge()?.googleMapsMapId?.() ?? "";
+
+    // The user's explicit choice. AUTO passes no renderingType, leaving the Map
+    // ID's cloud configuration in charge (and, with no Map ID, the API's own
+    // RASTER default); RASTER / VECTOR are passed through and OVERRIDE that
+    // configuration. Vector is only ever a request: the API silently falls back
+    // to raster on a device that cannot host it, which the tilesloaded handler
+    // below detects. Requesting vector no longer needs a Map ID.
+    const rendering = gmBridge()?.googleMapsRendering?.() ?? "AUTO";
+    // What we ASK for. AUTO cannot be resolved until the map has loaded, so it
+    // starts optimistic when a Map ID might select vector, and the tilesloaded
+    // handler corrects it either way.
+    const wantsVector = rendering === "VECTOR" || (rendering === "AUTO" && mapId !== "");
 
     // A raster map is server-rendered pixel tiles and needs no WebGL, so a
     // missing context there is logged only — a premature fatal would blank a
@@ -179,8 +193,7 @@ export async function init(reporter: PageReporter, pending: PendingBridgeCalls):
     // necessity — we would rather tell the user their vector opt-in cannot be
     // honoured than hand them a flat north-up map with no explanation.
     //
-    // KNOWN GAPS, deliberately left as-is here (behaviour predates the check
-    // against Google's docs):
+    // KNOWN GAPS, deliberately left as-is here:
     //  - the gate accepts webgl1, so a WebGL-1-only device passes and then gets
     //    Google's silent raster downgrade — the very outcome the fatal exists to
     //    avoid;
@@ -189,7 +202,7 @@ export async function init(reporter: PageReporter, pending: PendingBridgeCalls):
     //    (e.g. a dynamic-GPU handover) goes unnoticed.
     const gl = webglSupport();
     if (!gl.webgl2 && !gl.webgl1) {
-        if (mapId !== "") {
+        if (wantsVector) {
             // Report and stop: loading the API for a page the host is about to
             // tear down is wasted work.
             log("no-webgl-context");
@@ -205,9 +218,10 @@ export async function init(reporter: PageReporter, pending: PendingBridgeCalls):
     const state = {
         map: undefined as GMMap | undefined,
         trafficLayer: null as GMTrafficLayer | null,
-        // True when the user supplied a Cloud Map ID: render a VECTOR map
-        // (heading-up rotation + tilt). False = RASTER map (north-up only).
-        isVector: mapId !== "",
+        // What the page currently believes it is rendering: VECTOR unlocks
+        // heading-up rotation + tilt, RASTER is flat and north-up. Seeded from
+        // the request and corrected from getRenderingType() once tiles land.
+        isVector: wantsVector,
         // Set to true on the first tilesloaded event; gates fatal error
         // reporting (errors after first render are transient, not key/auth
         // failures).
@@ -306,12 +320,19 @@ export async function init(reporter: PageReporter, pending: PendingBridgeCalls):
     // bottom-right and exposes no supported way to move it, so the split
     // stays as Google places it.
     //
-    // VECTOR (Map ID present): enable host-driven heading-up rotation +
-    // tilt/3D; headingInteractionEnabled is false because heading is driven
+    // renderingType is only sent for an explicit RASTER / VECTOR choice, since
+    // sending it overrides the Map ID's cloud configuration — which is exactly
+    // what AUTO must not do. The Map ID rides along whenever it is set: it is
+    // independent of the rendering mode and still gates advanced markers and
+    // cloud styling, so a raster map keeps it too.
+    //
+    // heading/tilt are vector-only. On a raster map the API reinterprets them
+    // rather than rejecting them (heading applies to aerial imagery and snaps to
+    // available angles; tilt takes only 0 or 45 as an imagery-switching policy),
+    // and passing them stops moveCamera from positioning — so they are omitted
+    // entirely. headingInteractionEnabled stays false because heading is driven
     // solely by the host (north-up vs heading-up), never by user rotation
-    // gestures. RASTER (no Map ID): omit mapId/heading/tilt entirely — a
-    // raster map rejects heading/tilt, and passing them stops moveCamera from
-    // positioning.
+    // gestures.
     const liveMap = new mapsLib.Map(mapEl as HTMLElement, {
         center: { lat: 0, lng: 0 },
         zoom: 1,
@@ -319,7 +340,9 @@ export async function init(reporter: PageReporter, pending: PendingBridgeCalls):
         disableDefaultUI: true,
         gestureHandling: "greedy",
         keyboardShortcuts: false,
-        ...(state.isVector ? { mapId, heading: 0, tilt: 0, headingInteractionEnabled: false } : {}),
+        ...(mapId !== "" ? { mapId } : {}),
+        ...(rendering === "AUTO" ? {} : { renderingType: rendering }),
+        ...(state.isVector ? { heading: 0, tilt: 0, headingInteractionEnabled: false } : {}),
     });
     state.map = liveMap;
     // Traffic layer is created once and toggled on/off via setMap (memoized).


### PR DESCRIPTION
## Problem

The Google backend inferred the rendering mode from the Map ID — non-empty
meant vector — which is **not the API's model**:

- A Map ID configured for **raster** in the Cloud console was still driven as
  vector, so the launcher pushed heading and tilt at a map that reinterprets
  both. (`state.isVector` was only corrected after the first `tilesloaded`.)
- **Vector was unreachable without a Map ID**, even though Maps JS has rendered
  vector without one since **3.56.10** (April 2024: *"Added API to set vector
  mode during `google.maps.Map` instantiation (mapId not required)"*).

## Change

A **Rendering** setting — Automatic / Raster / Vector — mapping onto
[`MapOptions.renderingType`](https://developers.google.com/maps/documentation/javascript/map-rendering-type):

| Choice | What is sent | Effect |
| --- | --- | --- |
| **Automatic** (default) | nothing | The Map ID's cloud configuration decides; with no Map ID the API's own raster default applies. **No existing configuration changes behaviour.** |
| **Raster** | `renderingType: "RASTER"` | Flat, north-up. |
| **Vector** | `renderingType: "VECTOR"` | Heading-up rotation and tilt. No Map ID required. |

Raster and Vector deliberately **override** the cloud configuration — per
Google's docs, *"The `renderingType` option overrides any rendering type
settings made by configuring a map ID."* That override is the point of making
the choice explicit.

Two follow-on corrections fall out of decoupling the axes:

- **The Map ID now rides along in both modes.** It is independent of rendering
  and still gates advanced markers and cloud styling, so a raster map keeps it
  (previously raster meant "no Map ID", so it was dropped).
- **heading/tilt stay vector-only.** On raster the API *reinterprets* rather
  than rejects them — heading applies to aerial imagery and snaps to available
  angles, and tilt accepts only 0 or 45 as an imagery-switching policy — and
  passing them stops `moveCamera` from positioning.

Rendering is fixed at construction (`setRenderingType` exists but no guide
documents a live-switch flow), so the setting joins the Map ID in the **WebView
rebuild key** rather than being pushed into a live page.

The WebGL pre-flight gate now keys off the resolved request instead of the Map
ID, and the **MAP diagnostics fact mirrors the same rule** — so an explicit
raster choice no longer warns about WebGL the map does not need.

## Verification

`spotlessCheck`, `assembleDebug`, `lint`, `test` (774 tests) — all pass,
including the three settings drift guards (persisted-key set, per-section reset
precision, settings-dump completeness), each of which required the new field.

**On the TBox-Mock-Play emulator, with a Map ID configured:**

| Setting | Result |
| --- | --- |
| Automatic | vector (the Map ID's cloud config wins) |
| Raster | **flat, north-up, Map ID still set** — proving the override |
| Vector | vector again |

Three new `MapFactsTest` cases pin the diagnostics rule: an explicit raster
choice with a Map ID set reports "not required" (the old inference would have
warned), and an explicit vector choice warns *without* a Map ID (vector no
longer needs one).