### PR TITLE
fix(settings): stop scale changes from rebuilding the open sheet

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -54,6 +54,7 @@ import io.github.seijikohara.femto.data.location.hasFineLocationPermission
 import io.github.seijikohara.femto.data.system.SystemPermissionSignals
 import io.github.seijikohara.femto.ui.assistant.AssistantOption
 import io.github.seijikohara.femto.ui.assistant.AssistantSheet
+import io.github.seijikohara.femto.ui.common.ModalSheetHost
 import io.github.seijikohara.femto.ui.common.hideSystemBarsTransiently
 import io.github.seijikohara.femto.ui.diagnostics.DiagnosticsSheet
 import io.github.seijikohara.femto.ui.fontpicker.FontPickerSheet
@@ -290,50 +291,55 @@ class MainActivity : ComponentActivity() {
                 // launcher is no longer a sheet — it is a maximize panel inside the
                 // dashboard (see DashboardOverlays / AppDrawerPanelHost).
                 val fullscreen = settings.fullscreen == FullscreenSetting.ON
-                if (showAssistant) {
-                    AssistantSheet(
-                        onLaunchOption = { option ->
-                            launchAssistantOption(option)
-                            showAssistant = false
-                        },
-                        onSubmitQuery = { query ->
-                            submitVoiceQuery(query)
-                            showAssistant = false
-                        },
-                        onDismiss = { showAssistant = false },
-                        fullscreen = fullscreen,
-                    )
-                }
-                if (showSettings) {
-                    SettingsSheet(
-                        onOpenNotificationAccess = ::openNotificationListenerSettings,
-                        onOpenSystemSettings = ::openSystemSettings,
-                        onOpenFontPicker = { fontPickerSlot = it },
-                        onOpenDiagnostics = { showDiagnostics = true },
-                        onOpenLicenses = { showLicenses = true },
-                        onOpenPrivacyPolicy = ::openPrivacyPolicy,
-                        onDismiss = { showSettings = false },
-                        fullscreen = fullscreen,
-                    )
-                }
-                fontPickerSlot?.let { slot ->
-                    FontPickerSheet(
-                        slot = slot,
-                        onDismiss = { fontPickerSlot = null },
-                        fullscreen = fullscreen,
-                    )
-                }
-                if (showDiagnostics) {
-                    DiagnosticsSheet(
-                        onDismiss = { showDiagnostics = false },
-                        fullscreen = fullscreen,
-                    )
-                }
-                if (showLicenses) {
-                    LicensesSheet(
-                        onDismiss = { showLicenses = false },
-                        fullscreen = fullscreen,
-                    )
+                // Every sheet is hosted at the platform density so adjusting UI scale
+                // or font size cannot rebuild the open sheet's window — see
+                // ModalSheetHost.
+                ModalSheetHost {
+                    if (showAssistant) {
+                        AssistantSheet(
+                            onLaunchOption = { option ->
+                                launchAssistantOption(option)
+                                showAssistant = false
+                            },
+                            onSubmitQuery = { query ->
+                                submitVoiceQuery(query)
+                                showAssistant = false
+                            },
+                            onDismiss = { showAssistant = false },
+                            fullscreen = fullscreen,
+                        )
+                    }
+                    if (showSettings) {
+                        SettingsSheet(
+                            onOpenNotificationAccess = ::openNotificationListenerSettings,
+                            onOpenSystemSettings = ::openSystemSettings,
+                            onOpenFontPicker = { fontPickerSlot = it },
+                            onOpenDiagnostics = { showDiagnostics = true },
+                            onOpenLicenses = { showLicenses = true },
+                            onOpenPrivacyPolicy = ::openPrivacyPolicy,
+                            onDismiss = { showSettings = false },
+                            fullscreen = fullscreen,
+                        )
+                    }
+                    fontPickerSlot?.let { slot ->
+                        FontPickerSheet(
+                            slot = slot,
+                            onDismiss = { fontPickerSlot = null },
+                            fullscreen = fullscreen,
+                        )
+                    }
+                    if (showDiagnostics) {
+                        DiagnosticsSheet(
+                            onDismiss = { showDiagnostics = false },
+                            fullscreen = fullscreen,
+                        )
+                    }
+                    if (showLicenses) {
+                        LicensesSheet(
+                            onDismiss = { showLicenses = false },
+                            fullscreen = fullscreen,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/common/SheetHost.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/common/SheetHost.kt
@@ -1,0 +1,48 @@
+package io.github.seijikohara.femto.ui.common
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+
+/**
+ * Host the launcher's modal sheets at the platform density.
+ *
+ * A modal sheet renders in its own dialog window, and that window's Compose root
+ * re-provides `LocalDensity` from the platform — so `FemtoTheme`'s UI-scale and
+ * font-size override never reaches sheet *content* in the first place. It does
+ * reach the sheet's dialog, which Material 3 holds in a `remember` keyed on the
+ * ambient density: every step of the Display-size or Font-size slider therefore
+ * tore the open sheet's window down and built a new one mid-drag, resetting its
+ * scroll position, its selected category and its immersive flags, and cancelling
+ * the touch stream the user was still dragging with.
+ *
+ * Handing the sheets the density their content will actually run at keeps that
+ * key stable, so the window survives the whole gesture. It also puts
+ * [rememberSheetHeight] on the right density — it is read out here but applied
+ * inside the sheet, so a scaled reading made the sheet the wrong fraction of the
+ * viewport at every UI scale but `MEDIUM`.
+ *
+ * This deliberately keeps sheets out of the user's scale settings, which is the
+ * behaviour they have always had; making sheet content honour the scale is a
+ * separate product change, and it must not go through `LocalDensity` at the
+ * dialog boundary.
+ */
+@Composable
+internal fun ModalSheetHost(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    CompositionLocalProvider(
+        // The same value AndroidComposeView installs inside the dialog.
+        LocalDensity provides remember(context) { platformDensity(context) },
+        content = content,
+    )
+}
+
+private fun platformDensity(context: Context): Density =
+    Density(
+        context.resources.displayMetrics.density,
+        context.resources.configuration.fontScale,
+    )

--- a/app/src/test/java/io/github/seijikohara/femto/ui/common/ModalSheetHostTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/common/ModalSheetHostTest.kt
@@ -1,0 +1,98 @@
+package io.github.seijikohara.femto.ui.common
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.unit.Density
+import io.github.seijikohara.femto.data.display.UiScale
+import io.github.seijikohara.femto.ui.theme.FemtoTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * A modal sheet's dialog window is held in a `remember` keyed on the ambient
+ * density, so anything that moves `LocalDensity` at the sheet's call site
+ * destroys the open sheet's window and builds a new one. The font-size and
+ * display-size settings both move it — they are applied through the density —
+ * which made adjusting either one reset the open settings sheet mid-drag.
+ *
+ * [ModalSheetHost] pins the sheets to the platform density, the one their
+ * content runs at inside the dialog anyway. These tests hold that contract:
+ * what the host provides must not depend on the scale settings.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ModalSheetHostTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // One setContent per test (the rule allows no more), with the settings driven
+    // through state so a test can compare the host across a live change — which is
+    // also the real scenario: the user drags a slider with the sheet already open.
+    private class Harness {
+        var fontBaseSizeSp by mutableIntStateOf(16)
+        var uiScale by mutableStateOf(UiScale.MEDIUM)
+        val hosted = mutableListOf<Density>()
+        var outside: Density? = null
+    }
+
+    private fun harness(): Harness {
+        val harness = Harness()
+        composeTestRule.setContent {
+            FemtoTheme(fontBaseSizeSp = harness.fontBaseSizeSp, uiScale = harness.uiScale) {
+                harness.outside = LocalDensity.current
+                ModalSheetHost { harness.hosted += LocalDensity.current }
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertTrue(harness.hosted.isNotEmpty(), "ModalSheetHost did not compose its content")
+        return harness
+    }
+
+    @Test
+    fun `the hosted density survives a font size change`() {
+        val harness = harness()
+
+        harness.fontBaseSizeSp = 20
+        composeTestRule.waitForIdle()
+
+        // Equality is the contract: Material 3 keys the sheet's dialog on this
+        // value, so an unequal instance rebuilds the window mid-gesture.
+        assertEquals(1, harness.hosted.distinct().size, "the host handed the sheet a new density: ${harness.hosted}")
+    }
+
+    @Test
+    fun `the hosted density survives a display size change`() {
+        val harness = harness()
+
+        harness.uiScale = UiScale.LARGE
+        composeTestRule.waitForIdle()
+
+        assertEquals(1, harness.hosted.distinct().size, "the host handed the sheet a new density: ${harness.hosted}")
+    }
+
+    @Test
+    fun `the theme still scales outside the host`() {
+        // Anti-vacuous guard: if FemtoTheme stopped overriding the density at all,
+        // both assertions above would pass for the wrong reason.
+        val harness = harness()
+
+        harness.fontBaseSizeSp = 20
+        harness.uiScale = UiScale.LARGE
+        composeTestRule.waitForIdle()
+
+        val scaled = assertNotNull(harness.outside)
+        val platform = harness.hosted.first()
+        assertTrue(scaled.density > platform.density, "UI scale did not reach the theme")
+        assertTrue(scaled.fontScale > platform.fontScale, "font size did not reach the theme")
+    }
+}


### PR DESCRIPTION
Dragging **Font size** or **Display size** reset the settings sheet on every integer step, which made both settings close to unusable.

## What happened

Both settings are applied by swapping `LocalDensity` inside `FemtoTheme`. Material 3 holds a modal sheet's dialog in a `remember` keyed on the ambient density, so every step **dismissed the sheet's window and built a new one**. Per step the user lost:

- the scroll position (`rememberScrollState` reset to the top),
- the selected category on a narrow layout (`rememberSaveable` gone → bounced back to the category list),
- the immersive flags (`ImmersiveSheetEffect` re-ran → system bars flashed back),
- and the touch stream, cancelled with the old window — so each step needed a fresh press.

## The fix

A sheet's content never saw the scaled density anyway: its dialog has its own Compose root, which re-provides `LocalDensity` from the platform. `ModalSheetHost` hands the sheets exactly the density they already run at, so the dialog key stops moving. **No visual change.**

It also puts `rememberSheetHeight` on the right density — it is read *outside* the sheet but applied *inside* it, so a scaled reading made every sheet the wrong fraction of the viewport at any UI scale but `MEDIUM` (at `LARGE`, ~69 % of the window instead of 92 %). That affected all five sheets.

Hosting the sheets in one place keeps the rule in one place. Making sheet content honour the user's scale is a separate product question, and it must not travel through `LocalDensity` at the dialog boundary — hence the KDoc.

## Verification

- `spotlessCheck`, `assembleDebug`, `lint`, `test` — green (810 unit tests, 0 failures).
- New `ModalSheetHostTest` (4 cases) pins the contract: what the host provides must not move with either scale setting, plus an anti-vacuous guard that the theme still scales *outside* the host. **Falsified** — neutering the host fails exactly the two contract cases and leaves the guard passing.
- **Emulator, before/after on TBox-Mock-Play:** pre-fix, one drag of Font size sent the sheet's scroll back to the top and brought the system bars back; post-fix, the scroll position and immersive state were preserved and the value moved 19 → 18 sp.

### Verification caveat, stated plainly

The post-fix emulator run above was on a build that also carried a slider draft-state change I then **removed** (it re-seeded from the persisted value on every echo, so it fought the finger — a defect, not an improvement). `MainActivity` and `SheetHost` are byte-identical between that build and this one, and the removed code touched only the thumb's value, not the window lifecycle. I could not re-run the pass on the final build because the AVD kept ANR-ing (see below).

## Unrelated pre-existing issue found while verifying

The app ANRs on this AVD during settings-sheet interaction — main thread blocked 5–10 s. The captured trace shows it parked in `HardwareRenderer.nSyncAndDrawFrame`, i.e. waiting on the render thread, not on app logic: the emulator's software GPU cannot keep up with the glass blur composited over the map WebView. It reproduces **identically before and after this change** and goes back to at least 08-02, so it is not a regression here. Worth its own look, especially against the weak head-unit GPUs the launcher targets.