### PR TITLE
fix(music): watch every media session, not only the one on the card

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/music/MusicSessionRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/music/MusicSessionRepository.kt
@@ -35,6 +35,14 @@ import androidx.media3.session.MediaController as Media3Controller
 
 private const val TAG = "MusicSessionRepo"
 
+/**
+ * The Secure setting listing every enabled notification-listener component,
+ * which is where [NotificationManagerCompat.getEnabledListenerPackages] reads
+ * the grant from. `internal` because the session tests grant it by writing the
+ * same setting, and the name has to be the one place it is spelled.
+ */
+internal const val ENABLED_NOTIFICATION_LISTENERS = "enabled_notification_listeners"
+
 internal class MusicSessionRepository(
     private val context: Context,
 ) {
@@ -61,6 +69,21 @@ internal class MusicSessionRepository(
     private var media3Controller: Media3Controller? = null
     private var media3Future: ListenableFuture<Media3Controller>? = null
     private var media3PackageName: String? = null
+
+    // The session the media3 controller is connected to, or connecting for.
+    // Set when the connect starts, unlike media3PackageName (set on success),
+    // because this one answers "is that session already covered?" for the
+    // watch, which must not restart a connect that is still in flight.
+    private var media3Token: MediaSession.Token? = null
+
+    // Set when a media3 connect fails. The failure leaves media3Token pointing
+    // at the session it was for, so retargetMedia3's "already covered" guard
+    // keeps holding and a session that refuses is not re-attempted on every
+    // playback tick — each attempt is a fresh asynchronous connect that has to
+    // fail or time out on its own. This mark is what lets SessionWatch.rewatch
+    // release the stale state on a membership change instead, the cadence the
+    // retry ran at before the watch kept one controller per session.
+    private var media3ConnectFailed = false
     private var media3Generation = 0
 
     private fun releaseMedia3() {
@@ -70,6 +93,8 @@ internal class MusicSessionRepository(
         media3Future?.let { runCatching { Media3Controller.releaseFuture(it) } }
         media3Future = null
         media3PackageName = null
+        media3Token = null
+        media3ConnectFailed = false
     }
 
     /**
@@ -82,6 +107,7 @@ internal class MusicSessionRepository(
         onChanged: () -> Unit,
     ) {
         releaseMedia3()
+        media3Token = controller.sessionToken
         val generation = media3Generation
         val mainExecutor = ContextCompat.getMainExecutor(context)
         val tokenFuture = SessionToken.createSessionToken(context, controller.sessionToken)
@@ -89,8 +115,10 @@ internal class MusicSessionRepository(
             if (generation != media3Generation) return@addListener
             val token =
                 runCatching { tokenFuture.get() }
-                    .onFailure { Log.w(TAG, "media3 token failed for ${controller.packageName}", it) }
-                    .getOrNull() ?: return@addListener
+                    .onFailure {
+                        Log.w(TAG, "media3 token failed for ${controller.packageName}", it)
+                        media3ConnectFailed = true
+                    }.getOrNull() ?: return@addListener
             val controllerFuture = Media3Controller.Builder(context, token).buildAsync()
             media3Future = controllerFuture
             controllerFuture.addListener({
@@ -102,8 +130,10 @@ internal class MusicSessionRepository(
                 }
                 val connected =
                     runCatching { controllerFuture.get() }
-                        .onFailure { Log.w(TAG, "media3 connect failed for ${controller.packageName}", it) }
-                        .getOrNull() ?: return@addListener
+                        .onFailure {
+                            Log.w(TAG, "media3 connect failed for ${controller.packageName}", it)
+                            media3ConnectFailed = true
+                        }.getOrNull() ?: return@addListener
                 media3Controller = connected
                 media3Future = null
                 media3PackageName = controller.packageName
@@ -148,7 +178,7 @@ internal class MusicSessionRepository(
         val transport = controller.transportControls
         when (command) {
             MusicCommand.PlayPause -> {
-                if (controller.playbackState?.state == PlaybackState.STATE_PLAYING) {
+                if (controller.playbackState.isPlaying()) {
                     transport.pause()
                 } else {
                     transport.play()
@@ -233,80 +263,167 @@ internal class MusicSessionRepository(
 
     private fun activeControllersFlow(): Flow<List<MediaController>> =
         callbackFlow {
-            // The OnActiveSessionsChangedListener only fires when the SET of
-            // sessions changes, so on its own the flow is a one-shot snapshot:
-            // progress, play/pause, and in-session metadata never update. We
-            // additionally register a MediaController.Callback on the primary
-            // controller and re-send the latest controller list on every live
-            // change, so the downstream combine recomputes toNowPlaying.
-            var current: List<MediaController> = emptyList()
-            var watched: MediaController? = null
-            val watcher =
-                object : MediaController.Callback() {
-                    override fun onPlaybackStateChanged(state: PlaybackState?) {
-                        trySend(current)
-                    }
-
-                    override fun onMetadataChanged(metadata: MediaMetadata?) {
-                        trySend(current)
-                    }
-
-                    override fun onSessionDestroyed() {
-                        trySend(current)
-                    }
-
-                    override fun onQueueChanged(queue: MutableList<MediaSession.QueueItem>?) {
-                        trySend(current)
-                    }
-                }
-
-            fun rewatch(controllers: List<MediaController>) {
-                current = controllers
-                val next = selectPrimaryController(controllers)
-                // Re-register only when the active controller changes; unregister
-                // the previous one first so we never leak a stale callback.
-                if (next !== watched) {
-                    runCatching { watched?.unregisterCallback(watcher) }
-                    watched = next
-                    // A refused registration freezes the card on stale metadata
-                    // while it looks healthy; leave a trail.
-                    runCatching { watched?.registerCallback(watcher) }
-                        .onFailure { Log.w(TAG, "registerCallback failed for ${next?.packageName}", it) }
-                    // Shuffle / repeat state only surfaces through the media3
-                    // controller; without it the panel's toggles would stay
-                    // hidden (capability false) for a capable session.
-                    val nextController = next
-                    if (nextController != null) {
-                        connectMedia3(nextController) { trySend(current) }
-                    } else {
-                        releaseMedia3()
-                    }
-                }
-            }
-
+            val watch = SessionWatch { controllers -> trySend(controllers) }
             val sessionsListener =
                 MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
-                    rewatch(controllers.orEmpty())
-                    trySend(current)
+                    watch.rewatch(controllers.orEmpty())
                 }
 
-            runCatching {
-                rewatch(sessionManager.getActiveSessions(componentName))
-                trySend(current)
-                sessionManager.addOnActiveSessionsChangedListener(sessionsListener, componentName)
-            }.onFailure {
-                // Typically a SecurityException before the notification-listener
-                // grant; surface it so a silent "no music" card is diagnosable.
-                Log.w(TAG, "active-session enumeration failed; emitting empty list", it)
-                trySend(emptyList())
-            }
+            // The enumeration and the listener registration are guarded
+            // separately: a throwing enumeration must not skip the
+            // registration, or the subscription sees no session-set change for
+            // as long as it lives. Both calls are gated on the same
+            // notification-listener grant and both throw without it, so keeping
+            // them apart only rescues an enumeration that failed for some other
+            // reason.
+            watch.reenumerate()
+            runCatching { sessionManager.addOnActiveSessionsChangedListener(sessionsListener, componentName) }
+                .onFailure { Log.w(TAG, "active-session listener registration failed", it) }
 
             awaitClose {
-                releaseMedia3()
-                runCatching { watched?.unregisterCallback(watcher) }
+                watch.stop()
                 runCatching { sessionManager.removeOnActiveSessionsChangedListener(sessionsListener) }
             }
         }
+
+    /**
+     * Keeps a [MediaController.Callback] on every active session and re-emits
+     * the watched controllers on each live change.
+     *
+     * [MediaSessionManager.OnActiveSessionsChangedListener] only fires when the
+     * SET of sessions changes, so on its own the flow is a one-shot snapshot:
+     * progress, play/pause, and in-session metadata never update. Watching only
+     * the selected controller was not enough either: an already-active session
+     * whose app already holds the media button starts playing without the
+     * platform pushing any session-set change, and while that session is
+     * neither playing nor paused [selectPrimaryController] picks nothing to
+     * watch at all — so the card sat on stale state until the flow was
+     * collected again.
+     *
+     * Main-thread confined, like the flow that owns it and the media3 state it
+     * drives.
+     */
+    private inner class SessionWatch(
+        private val onChanged: (List<MediaController>) -> Unit,
+    ) : MediaController.Callback() {
+        // Keyed by session token, never by controller identity: getActiveSessions
+        // mints a fresh MediaController per session on every call, so identity
+        // keys would diff each enumeration as "unregister all, register all".
+        private var watched: Map<MediaSession.Token, MediaController> = emptyMap()
+
+        private fun controllers(): List<MediaController> = watched.values.toList()
+
+        /**
+         * Re-read the priority-ordered session list and reconcile the watch set
+         * against it. A failed enumeration — typically a SecurityException
+         * before the notification-listener grant — is logged so a silent "no
+         * music" card stays diagnosable, and re-emits the sessions already
+         * watched, which on the first pass is the empty list the card reads as
+         * "nothing playing".
+         */
+        fun reenumerate() {
+            runCatching { rewatch(sessionManager.getActiveSessions(componentName)) }
+                .onFailure {
+                    Log.w(TAG, "active-session enumeration failed; keeping the sessions already watched", it)
+                    onChanged(controllers())
+                }
+        }
+
+        /** Reconcile the watch set against a fresh enumeration, then emit. */
+        fun rewatch(sessions: List<MediaController>) {
+            val update = reconcileWatchSet(watched, sessions) { it.sessionToken }
+            update.removed.forEach { gone -> runCatching { gone.unregisterCallback(this) } }
+            update.added.forEach { controller ->
+                // A refused registration freezes the card on stale metadata
+                // while it looks healthy; leave a trail.
+                runCatching { controller.registerCallback(this) }
+                    .onFailure { Log.w(TAG, "registerCallback failed for ${controller.packageName}", it) }
+            }
+            watched = update.watched
+            // A membership change is the one cadence worth retrying a failed
+            // media3 connect at: releasing here clears the token the retarget
+            // guard matches on, so the call below attempts the session again.
+            // A playback tick reaches this function too (see
+            // onPlaybackStateChanged), and it is far too frequent to retry on.
+            if (media3ConnectFailed && (update.added.isNotEmpty() || update.removed.isNotEmpty())) {
+                releaseMedia3()
+            }
+            retargetMedia3()
+            onChanged(controllers())
+        }
+
+        /** Drop every registration and the media3 controller with them. */
+        fun stop() {
+            watched.values.forEach { controller -> runCatching { controller.unregisterCallback(this) } }
+            watched = emptyMap()
+            releaseMedia3()
+        }
+
+        /**
+         * Point the media3 controller at the current primary session. Guarded
+         * on the token so a playback tick on the session it already serves does
+         * not tear it down and rebuild it asynchronously, which would blink the
+         * shuffle / repeat affordances off and back on.
+         */
+        private fun retargetMedia3() {
+            runCatching {
+                selectPrimaryController(controllers()).let { primary ->
+                    when {
+                        primary?.sessionToken == media3Token -> Unit
+
+                        // Shuffle / repeat state only surfaces through the media3
+                        // controller; without it the panel's toggles would stay
+                        // hidden (capability false) for a capable session.
+                        primary != null -> connectMedia3(primary) { onChanged(controllers()) }
+
+                        else -> releaseMedia3()
+                    }
+                }
+                // media3 only carries the shuffle / repeat extras, and this runs
+                // on platform callback dispatch as well as from rewatch. A throw
+                // here must cost the extras, not the session flow: an escaping
+                // exception would leave HomeViewModel's catchAsDefault to
+                // complete the music source for good (see its KDoc), freezing
+                // the card until the process restarts.
+            }.onFailure { Log.w(TAG, "media3 retarget failed", it) }
+        }
+
+        override fun onPlaybackStateChanged(state: PlaybackState?) {
+            if (state.isPlaying()) {
+                // Re-read the priority order whenever a session reports
+                // playing. getActiveSessions hands that order out only at call
+                // time, and the platform pushes no session-set change when
+                // playback starts inside a session it already lists — so
+                // without this the launcher keeps ranking by the order of the
+                // last enumeration, and a paused session that was first there
+                // keeps the card while the one the user just resumed plays on
+                // (issue #358).
+                reenumerate()
+            } else {
+                // Anything else re-emits from the controllers already held,
+                // rather than paying an enumeration on a callback that fires
+                // for every pause, stop, and buffering blip. Which of those
+                // controllers is primary can still have moved, which
+                // retargetMedia3 follows on its own.
+                retargetMedia3()
+                onChanged(controllers())
+            }
+        }
+
+        // Metadata and queue changes move neither the set nor the primary
+        // (selection reads playback state alone), so they only re-emit.
+        override fun onMetadataChanged(metadata: MediaMetadata?) = onChanged(controllers())
+
+        override fun onQueueChanged(queue: MutableList<MediaSession.QueueItem>?) = onChanged(controllers())
+
+        override fun onSessionDestroyed() =
+            // The callback names no session, so the only way to learn which one
+            // died is to ask again. The platform normally follows with an
+            // OnActiveSessionsChangedListener push for the same destroy, which
+            // reconciles to the same set and emits once more; paying that twice
+            // beats holding a callback registration on a session that is gone.
+            reenumerate()
+    }
 
     private fun hasPermission(): Boolean =
         context.packageName in NotificationManagerCompat.getEnabledListenerPackages(context)
@@ -383,8 +500,6 @@ internal class MusicSessionRepository(
         }
 
     private companion object {
-        const val ENABLED_NOTIFICATION_LISTENERS = "enabled_notification_listeners"
-
         // The card draws the source icon small (~28 dp); 96 px keeps it crisp on
         // high-density head units without decoding a full-size adaptive icon.
         const val SOURCE_ICON_PIXELS = 96
@@ -408,6 +523,14 @@ internal fun PlaybackState?.isPlayingOrPaused(): Boolean =
     this != null && (isActive() || state == PlaybackState.STATE_PAUSED)
 
 /**
+ * Return `true` when the state is PLAYING. The other half of the pair the card
+ * reasons in, beside [isPlayingOrPaused]: this one answers "is playback running
+ * right now", which decides the transport toggle, the Play / Pause affordance,
+ * and whether a session push is worth re-reading the session priority order for.
+ */
+internal fun PlaybackState?.isPlaying(): Boolean = this?.state == PlaybackState.STATE_PLAYING
+
+/**
  * Pick the first session whose playback state is playing or paused; the caller
  * passes sessions in priority order. Generic over the session type so the
  * selection policy is unit-testable with plain value holders instead of
@@ -417,6 +540,45 @@ internal fun <T> selectPrimarySession(
     sessions: List<T>,
     playbackStateOf: (T) -> PlaybackState?,
 ): T? = sessions.firstOrNull { playbackStateOf(it).isPlayingOrPaused() }
+
+/**
+ * The outcome of [reconcileWatchSet]: the sessions to keep watching, in
+ * enumeration order, plus the registrations to add and drop to get there.
+ */
+internal data class WatchSetUpdate<K, T>(
+    val watched: Map<K, T>,
+    val added: List<T>,
+    val removed: List<T>,
+)
+
+/**
+ * Reconcile the watched sessions against a fresh enumeration, keyed by [keyOf]
+ * instead of by instance identity: the platform mints a new [MediaController]
+ * per session on every enumeration, so an identity-keyed diff reports the whole
+ * set as replaced each pass. A session that survives keeps the instance that
+ * already carries its callback registration.
+ *
+ * Every enumerated session is watched, not only the one the display policy
+ * selects: [selectPrimarySession] skips sessions that are neither playing nor
+ * paused, and one of those starting playback is exactly the change the card has
+ * to notice.
+ *
+ * Generic over the session type so the policy is unit-testable with plain value
+ * holders instead of [MediaController] instances, which cannot be constructed
+ * in JVM tests.
+ */
+internal fun <K, T> reconcileWatchSet(
+    watched: Map<K, T>,
+    sessions: List<T>,
+    keyOf: (T) -> K,
+): WatchSetUpdate<K, T> =
+    sessions.associateBy(keyOf).let { enumerated ->
+        WatchSetUpdate(
+            watched = enumerated.mapValues { (key, session) -> watched[key] ?: session },
+            added = enumerated.filterKeys { it !in watched }.values.toList(),
+            removed = watched.filterKeys { it !in enumerated }.values.toList(),
+        )
+    }
 
 /**
  * Collapse the permission gate and the resolved session into the card state.
@@ -475,7 +637,7 @@ internal fun nowPlayingOf(
             // sourceIcon is resolved downstream off Main (see stateFlow).
             // A paused controller renders with isPlaying=false (Play icon,
             // resumable), but stays on screen via selectPrimaryController.
-            isPlaying = playbackState?.state == PlaybackState.STATE_PLAYING,
+            isPlaying = playbackState.isPlaying(),
             positionMs = playbackState?.position ?: 0L,
             durationMs = metadata.getLong(MediaMetadata.METADATA_KEY_DURATION),
             packageName = packageName,

--- a/app/src/main/java/io/github/seijikohara/femto/data/music/MusicSessionRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/music/MusicSessionRepository.kt
@@ -381,10 +381,12 @@ internal class MusicSessionRepository(
                 }
                 // media3 only carries the shuffle / repeat extras, and this runs
                 // on platform callback dispatch as well as from rewatch. A throw
-                // here must cost the extras, not the session flow: an escaping
-                // exception would leave HomeViewModel's catchAsDefault to
-                // complete the music source for good (see its KDoc), freezing
-                // the card until the process restarts.
+                // here must cost the extras, not more: escaping from the
+                // subscription-time path degrades the whole music card for the
+                // rest of the subscription epoch (HomeViewModel's catchAsDefault
+                // completes the failed source until the next WhileUiSubscribed
+                // restart), and escaping from callback dispatch is an uncaught
+                // main-thread exception — a crash of the HOME app.
             }.onFailure { Log.w(TAG, "media3 retarget failed", it) }
         }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeViewModel.kt
@@ -252,9 +252,11 @@ internal class HomeViewModel(
 // Replace a source failure with that source's neutral value so one broken
 // repository degrades its own card instead of killing the launcher process.
 // Cancellation is rethrown to keep structured concurrency intact. By design the
-// failed source then COMPLETES: its card stays at the neutral value until the
-// process restarts. No automatic retry — a broken system service would turn a
-// retry loop into a battery drain on the head unit.
+// failed source then COMPLETES for the rest of the current subscription epoch:
+// its card stays at the neutral value until WhileUiSubscribed tears the chain
+// down and a later subscriber re-collects the cold sources from scratch. No
+// automatic retry within an epoch — a broken system service would turn a retry
+// loop into a battery drain on the head unit.
 private fun <T> Flow<T>.catchAsDefault(
     source: String,
     default: T,

--- a/app/src/test/java/io/github/seijikohara/femto/data/music/MusicSessionMappingTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/music/MusicSessionMappingTest.kt
@@ -1,9 +1,10 @@
 package io.github.seijikohara.femto.data.music
 
 import android.graphics.Bitmap
-import android.media.MediaMetadata
 import android.media.session.PlaybackState
+import io.github.seijikohara.femto.testfixtures.fakeMediaMetadata
 import io.github.seijikohara.femto.testfixtures.fakeNowPlaying
+import io.github.seijikohara.femto.testfixtures.fakePlaybackState
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
@@ -13,46 +14,15 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-// Robolectric provides real PlaybackState / MediaMetadata builders, so the
-// extracted pure logic is exercised with genuine platform values instead of
-// mocks (MediaController itself stays out of reach — see MusicSessionRepository).
-private fun playbackState(
-    state: Int,
-    positionMs: Long = 0L,
-    speed: Float = 1f,
-    updateTimeMs: Long = 0L,
-    actions: Long = 0L,
-): PlaybackState =
-    PlaybackState
-        .Builder()
-        .setState(state, positionMs, speed, updateTimeMs)
-        .setActions(actions)
-        .build()
-
-private fun metadata(
-    title: String? = null,
-    displayTitle: String? = null,
-    artist: String? = null,
-    album: String? = null,
-    durationMs: Long = 0L,
-    albumArt: Bitmap? = null,
-    art: Bitmap? = null,
-): MediaMetadata =
-    MediaMetadata
-        .Builder()
-        .apply {
-            title?.let { putString(MediaMetadata.METADATA_KEY_TITLE, it) }
-            displayTitle?.let { putString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE, it) }
-            artist?.let { putString(MediaMetadata.METADATA_KEY_ARTIST, it) }
-            album?.let { putString(MediaMetadata.METADATA_KEY_ALBUM, it) }
-            putLong(MediaMetadata.METADATA_KEY_DURATION, durationMs)
-            albumArt?.let { putBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART, it) }
-            art?.let { putBitmap(MediaMetadata.METADATA_KEY_ART, it) }
-        }.build()
-
-/** Plain value holder standing in for a MediaController in selection tests. */
+/**
+ * Plain value holder standing in for a MediaController in selection and
+ * watch-set tests. [name] doubles as the key the watch set is reconciled by —
+ * production keys it by `MediaController.getSessionToken` — so two instances
+ * sharing a name stand for two enumerations of one session.
+ */
 private data class FakeSession(
     val name: String,
     val playbackState: PlaybackState?,
@@ -62,6 +32,11 @@ private fun selectPrimary(sessions: List<FakeSession>): FakeSession? =
     selectPrimarySession(sessions) {
         it.playbackState
     }
+
+private fun reconcile(
+    watched: Map<String, FakeSession>,
+    sessions: List<FakeSession>,
+): WatchSetUpdate<String, FakeSession> = reconcileWatchSet(watched, sessions) { it.name }
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
@@ -78,8 +53,8 @@ class MusicSessionMappingTest {
         val sessions =
             listOf(
                 FakeSession("stateless", playbackState = null),
-                FakeSession("stopped", playbackState(PlaybackState.STATE_STOPPED)),
-                FakeSession("errored", playbackState(PlaybackState.STATE_ERROR)),
+                FakeSession("stopped", fakePlaybackState(PlaybackState.STATE_STOPPED)),
+                FakeSession("errored", fakePlaybackState(PlaybackState.STATE_ERROR)),
             )
 
         assertNull(selectPrimary(sessions))
@@ -89,8 +64,8 @@ class MusicSessionMappingTest {
     fun `selectPrimarySession skips inactive sessions and picks the first playing one`() {
         val sessions =
             listOf(
-                FakeSession("stopped", playbackState(PlaybackState.STATE_STOPPED)),
-                FakeSession("playing", playbackState(PlaybackState.STATE_PLAYING)),
+                FakeSession("stopped", fakePlaybackState(PlaybackState.STATE_STOPPED)),
+                FakeSession("playing", fakePlaybackState(PlaybackState.STATE_PLAYING)),
             )
 
         assertEquals("playing", selectPrimary(sessions)?.name)
@@ -98,7 +73,7 @@ class MusicSessionMappingTest {
 
     @Test
     fun `selectPrimarySession keeps a paused session selectable so it stays resumable`() {
-        val sessions = listOf(FakeSession("paused", playbackState(PlaybackState.STATE_PAUSED)))
+        val sessions = listOf(FakeSession("paused", fakePlaybackState(PlaybackState.STATE_PAUSED)))
 
         assertEquals("paused", selectPrimary(sessions)?.name)
     }
@@ -109,8 +84,8 @@ class MusicSessionMappingTest {
         // playing-or-paused entry wins even when a lower-priority one is playing.
         val sessions =
             listOf(
-                FakeSession("paused", playbackState(PlaybackState.STATE_PAUSED)),
-                FakeSession("playing", playbackState(PlaybackState.STATE_PLAYING)),
+                FakeSession("paused", fakePlaybackState(PlaybackState.STATE_PAUSED)),
+                FakeSession("playing", fakePlaybackState(PlaybackState.STATE_PLAYING)),
             )
 
         assertEquals("paused", selectPrimary(sessions)?.name)
@@ -119,6 +94,81 @@ class MusicSessionMappingTest {
     @Test
     fun `a missing playback state is never playing or paused`() {
         assertFalse((null as PlaybackState?).isPlayingOrPaused())
+    }
+
+    @Test
+    fun `a missing playback state is never playing`() {
+        assertFalse((null as PlaybackState?).isPlaying())
+    }
+
+    // -- reconcileWatchSet ---------------------------------------------------
+    //
+    // These exercise the reconciler on its own. WHICH sessions production hands
+    // it — every enumerated one rather than only the one the card shows, the
+    // issue-#358 fix — is a property of the call site in SessionWatch, and is
+    // pinned in MusicSessionRepositoryTest, which drives the repository through
+    // a real MediaSessionManager.
+
+    @Test
+    fun `reconcileWatchSet adds every session of a first enumeration`() {
+        val playing = FakeSession("playing", fakePlaybackState(PlaybackState.STATE_PLAYING))
+        val stopped = FakeSession("stopped", fakePlaybackState(PlaybackState.STATE_STOPPED))
+
+        val update = reconcile(watched = emptyMap(), sessions = listOf(playing, stopped))
+
+        assertEquals(listOf(playing, stopped), update.added)
+        assertEquals(emptyList(), update.removed)
+        assertEquals(mapOf("playing" to playing, "stopped" to stopped), update.watched)
+    }
+
+    @Test
+    fun `reconcileWatchSet keeps the watched instance when a token re-enumerates`() {
+        // getActiveSessions mints a fresh MediaController per token on every
+        // call, so a same-token re-enumeration must diff to nothing and keep
+        // the instance that already carries the registration.
+        val registered = FakeSession("music", fakePlaybackState(PlaybackState.STATE_STOPPED))
+        val reEnumerated = FakeSession("music", fakePlaybackState(PlaybackState.STATE_PLAYING))
+
+        val update = reconcile(watched = mapOf("music" to registered), sessions = listOf(reEnumerated))
+
+        assertEquals(emptyList(), update.added)
+        assertEquals(emptyList(), update.removed)
+        assertSame(registered, update.watched["music"])
+    }
+
+    @Test
+    fun `reconcileWatchSet removes a departed session`() {
+        val gone = FakeSession("gone", fakePlaybackState(PlaybackState.STATE_PLAYING))
+        val stays = FakeSession("stays", fakePlaybackState(PlaybackState.STATE_PAUSED))
+
+        val update = reconcile(watched = mapOf("gone" to gone, "stays" to stays), sessions = listOf(stays))
+
+        assertEquals(listOf(gone), update.removed)
+        assertEquals(emptyList(), update.added)
+        assertEquals(mapOf("stays" to stays), update.watched)
+    }
+
+    @Test
+    fun `reconcileWatchSet clears the watch set when the enumeration comes back empty`() {
+        val gone = FakeSession("gone", fakePlaybackState(PlaybackState.STATE_PLAYING))
+
+        val update = reconcile(watched = mapOf("gone" to gone), sessions = emptyList())
+
+        assertEquals(listOf(gone), update.removed)
+        assertEquals(emptyMap(), update.watched)
+    }
+
+    @Test
+    fun `reconcileWatchSet keeps the enumeration priority order`() {
+        // The watch set doubles as the emitted controller list, and
+        // selectPrimarySession takes the first playing-or-paused entry, so the
+        // priority order MediaSessionManager returned must survive a rewatch.
+        val first = FakeSession("first", fakePlaybackState(PlaybackState.STATE_PAUSED))
+        val second = FakeSession("second", fakePlaybackState(PlaybackState.STATE_PLAYING))
+
+        val update = reconcile(watched = mapOf("second" to second), sessions = listOf(first, second))
+
+        assertEquals(listOf("first", "second"), update.watched.values.map { it.name })
     }
 
     // -- musicCardStateOf ----------------------------------------------------
@@ -162,7 +212,7 @@ class MusicSessionMappingTest {
     fun `nowPlayingOf uses the metadata title when present`() {
         val result =
             nowPlayingOf(
-                metadata = metadata(title = "Strobe", displayTitle = "Display"),
+                metadata = fakeMediaMetadata(title = "Strobe", displayTitle = "Display"),
                 playbackState = null,
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
@@ -175,7 +225,7 @@ class MusicSessionMappingTest {
     fun `nowPlayingOf falls back to the display title when the title is blank`() {
         val result =
             nowPlayingOf(
-                metadata = metadata(title = " ", displayTitle = "Display"),
+                metadata = fakeMediaMetadata(title = " ", displayTitle = "Display"),
                 playbackState = null,
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
@@ -188,7 +238,7 @@ class MusicSessionMappingTest {
     fun `nowPlayingOf falls back to the source label when both titles are blank`() {
         val result =
             nowPlayingOf(
-                metadata = metadata(title = "", displayTitle = " "),
+                metadata = fakeMediaMetadata(title = "", displayTitle = " "),
                 playbackState = null,
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
@@ -202,7 +252,7 @@ class MusicSessionMappingTest {
         // sourceLabel touches PackageManager in production, so it must stay
         // unevaluated while a usable title exists.
         nowPlayingOf(
-            metadata = metadata(title = "Strobe"),
+            metadata = fakeMediaMetadata(title = "Strobe"),
             playbackState = null,
             packageName = PACKAGE,
             fallbackTitle = { error("fallback resolved despite a usable title") },
@@ -213,8 +263,8 @@ class MusicSessionMappingTest {
     fun `nowPlayingOf is playing only for STATE_PLAYING`() {
         fun isPlayingFor(state: Int): Boolean =
             nowPlayingOf(
-                metadata = metadata(title = "Strobe"),
-                playbackState = playbackState(state),
+                metadata = fakeMediaMetadata(title = "Strobe"),
+                playbackState = fakePlaybackState(state),
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
             ).isPlaying
@@ -228,9 +278,9 @@ class MusicSessionMappingTest {
     fun `nowPlayingOf copies position, speed, and update basis from the playback state`() {
         val result =
             nowPlayingOf(
-                metadata = metadata(title = "Strobe"),
+                metadata = fakeMediaMetadata(title = "Strobe"),
                 playbackState =
-                    playbackState(
+                    fakePlaybackState(
                         PlaybackState.STATE_PLAYING,
                         positionMs = 5_000L,
                         speed = 1.5f,
@@ -249,7 +299,7 @@ class MusicSessionMappingTest {
     fun `nowPlayingOf defaults transport fields when the playback state is null`() {
         val result =
             nowPlayingOf(
-                metadata = metadata(title = "Strobe"),
+                metadata = fakeMediaMetadata(title = "Strobe"),
                 playbackState = null,
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
@@ -266,7 +316,7 @@ class MusicSessionMappingTest {
         val result =
             nowPlayingOf(
                 metadata =
-                    metadata(
+                    fakeMediaMetadata(
                         title = "Strobe",
                         artist = "deadmau5",
                         album = "For Lack of a Better Name",
@@ -289,7 +339,7 @@ class MusicSessionMappingTest {
 
         assertNotNull(
             nowPlayingOf(
-                metadata = metadata(title = "Strobe", albumArt = art),
+                metadata = fakeMediaMetadata(title = "Strobe", albumArt = art),
                 playbackState = null,
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
@@ -297,7 +347,7 @@ class MusicSessionMappingTest {
         )
         assertNull(
             nowPlayingOf(
-                metadata = metadata(title = "Strobe"),
+                metadata = fakeMediaMetadata(title = "Strobe"),
                 playbackState = null,
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
@@ -309,9 +359,9 @@ class MusicSessionMappingTest {
     fun `nowPlayingOf derives seek and queue capabilities from the action bits`() {
         val result =
             nowPlayingOf(
-                metadata = metadata(title = "Strobe"),
+                metadata = fakeMediaMetadata(title = "Strobe"),
                 playbackState =
-                    playbackState(
+                    fakePlaybackState(
                         PlaybackState.STATE_PLAYING,
                         actions = PlaybackState.ACTION_SEEK_TO or PlaybackState.ACTION_SKIP_TO_QUEUE_ITEM,
                     ),
@@ -331,8 +381,11 @@ class MusicSessionMappingTest {
     fun `nowPlayingOf reports no capabilities without matching action bits`() {
         val result =
             nowPlayingOf(
-                metadata = metadata(title = "Strobe"),
-                playbackState = playbackState(PlaybackState.STATE_PLAYING, actions = PlaybackState.ACTION_PLAY_PAUSE),
+                metadata = fakeMediaMetadata(title = "Strobe"),
+                playbackState = fakePlaybackState(
+                    PlaybackState.STATE_PLAYING,
+                    actions = PlaybackState.ACTION_PLAY_PAUSE,
+                ),
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
             )
@@ -347,7 +400,7 @@ class MusicSessionMappingTest {
     fun `nowPlayingOf reports no capabilities when the playback state is null`() {
         val result =
             nowPlayingOf(
-                metadata = metadata(title = "Strobe"),
+                metadata = fakeMediaMetadata(title = "Strobe"),
                 playbackState = null,
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
@@ -366,7 +419,7 @@ class MusicSessionMappingTest {
 
         val result =
             nowPlayingOf(
-                metadata = metadata(title = "Strobe", albumArt = thumb, art = full),
+                metadata = fakeMediaMetadata(title = "Strobe", albumArt = thumb, art = full),
                 playbackState = null,
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
@@ -381,7 +434,7 @@ class MusicSessionMappingTest {
 
         val result =
             nowPlayingOf(
-                metadata = metadata(title = "Strobe"),
+                metadata = fakeMediaMetadata(title = "Strobe"),
                 playbackState = null,
                 packageName = PACKAGE,
                 fallbackTitle = { FALLBACK },
@@ -406,38 +459,46 @@ class MusicSessionMappingTest {
 }
 
 /**
- * State table for [isPlayingOrPaused]: every state that keeps the card on
- * screen (the platform `isActive` set plus STATE_PAUSED) versus the ones that
- * release it.
+ * State table for the two predicates the card reasons in. [isPlayingOrPaused]
+ * decides whether a session keeps the card (the platform `isActive` set plus
+ * STATE_PAUSED); [isPlaying] decides whether playback is running right now,
+ * which drives the Play / Pause affordance and, in SessionWatch, whether a push
+ * is worth re-reading the session priority order for.
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @Config(sdk = [33])
-class IsPlayingOrPausedStateTest(
+class PlaybackStatePredicateTest(
     private val state: Int,
-    private val expected: Boolean,
+    private val keepsCard: Boolean,
+    private val playing: Boolean,
 ) {
     @Test
     fun `keeps the card on screen exactly for playing-or-paused states`() {
-        assertEquals(expected, playbackState(state).isPlayingOrPaused())
+        assertEquals(keepsCard, fakePlaybackState(state).isPlayingOrPaused())
+    }
+
+    @Test
+    fun `reports playback running only for STATE_PLAYING`() {
+        assertEquals(playing, fakePlaybackState(state).isPlaying())
     }
 
     companion object {
         @JvmStatic
-        @ParameterizedRobolectricTestRunner.Parameters(name = "state={0} -> {1}")
+        @ParameterizedRobolectricTestRunner.Parameters(name = "state={0} -> card={1} playing={2}")
         fun params(): List<Array<Any>> =
             listOf(
-                arrayOf(PlaybackState.STATE_PLAYING, true),
-                arrayOf(PlaybackState.STATE_PAUSED, true),
-                arrayOf(PlaybackState.STATE_BUFFERING, true),
-                arrayOf(PlaybackState.STATE_CONNECTING, true),
-                arrayOf(PlaybackState.STATE_FAST_FORWARDING, true),
-                arrayOf(PlaybackState.STATE_REWINDING, true),
-                arrayOf(PlaybackState.STATE_SKIPPING_TO_PREVIOUS, true),
-                arrayOf(PlaybackState.STATE_SKIPPING_TO_NEXT, true),
-                arrayOf(PlaybackState.STATE_SKIPPING_TO_QUEUE_ITEM, true),
-                arrayOf(PlaybackState.STATE_NONE, false),
-                arrayOf(PlaybackState.STATE_STOPPED, false),
-                arrayOf(PlaybackState.STATE_ERROR, false),
+                arrayOf(PlaybackState.STATE_PLAYING, true, true),
+                arrayOf(PlaybackState.STATE_PAUSED, true, false),
+                arrayOf(PlaybackState.STATE_BUFFERING, true, false),
+                arrayOf(PlaybackState.STATE_CONNECTING, true, false),
+                arrayOf(PlaybackState.STATE_FAST_FORWARDING, true, false),
+                arrayOf(PlaybackState.STATE_REWINDING, true, false),
+                arrayOf(PlaybackState.STATE_SKIPPING_TO_PREVIOUS, true, false),
+                arrayOf(PlaybackState.STATE_SKIPPING_TO_NEXT, true, false),
+                arrayOf(PlaybackState.STATE_SKIPPING_TO_QUEUE_ITEM, true, false),
+                arrayOf(PlaybackState.STATE_NONE, false, false),
+                arrayOf(PlaybackState.STATE_STOPPED, false, false),
+                arrayOf(PlaybackState.STATE_ERROR, false, false),
             )
     }
 }

--- a/app/src/test/java/io/github/seijikohara/femto/data/music/MusicSessionRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/music/MusicSessionRepositoryTest.kt
@@ -1,0 +1,185 @@
+package io.github.seijikohara.femto.data.music
+
+import android.app.Application
+import android.content.ComponentName
+import android.media.MediaMetadata
+import android.media.session.MediaController
+import android.media.session.MediaSession
+import android.media.session.MediaSessionManager
+import android.media.session.PlaybackState
+import android.os.Binder
+import android.provider.Settings
+import androidx.core.content.getSystemService
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import io.github.seijikohara.femto.testfixtures.fakeMediaMetadata
+import io.github.seijikohara.femto.testfixtures.fakePlaybackState
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowMediaSessionManager
+import java.lang.reflect.Proxy
+import kotlin.test.assertEquals
+
+/**
+ * Drives [MusicSessionRepository] against a real [MediaSessionManager], so the
+ * watch policy is exercised where it lives: the call site inside SessionWatch,
+ * which decides which sessions carry a callback and when the platform's session
+ * priority order is re-read. The pure helpers those decisions rest on are
+ * covered on their own in MusicSessionMappingTest.
+ *
+ * The repository confines its session work to Main and hands the result to
+ * Dispatchers.Default, so the test needs a main looper that runs by itself:
+ * INSTRUMENTATION_TEST mode gives it one on its own thread, as a device does,
+ * and leaves the test thread free to drive the sessions.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+@LooperMode(LooperMode.Mode.INSTRUMENTATION_TEST)
+class MusicSessionRepositoryTest {
+    private val application: Application = ApplicationProvider.getApplicationContext()
+    private val sessionManager: MediaSessionManager = checkNotNull(application.getSystemService())
+
+    @Before
+    fun grantNotificationListenerAccess() {
+        // Without the grant the card short-circuits to NeedsPermission and
+        // never inspects a session.
+        Settings.Secure.putString(
+            application.contentResolver,
+            ENABLED_NOTIFICATION_LISTENERS,
+            ComponentName(application, MusicSessionListenerService::class.java).flattenToString(),
+        )
+    }
+
+    @Test
+    fun `a session the card would not show still reports the moment it starts playing`() =
+        runTest {
+            // Both sessions are active but stopped, so the display policy picks
+            // neither. Watching only the selected session therefore left no
+            // callback registered anywhere, and nothing reported the start
+            // (issue #358).
+            addSession(IDLE_PACKAGE, PlaybackState.STATE_STOPPED)
+            val resumed = addSession(RESUMED_PACKAGE, PlaybackState.STATE_STOPPED)
+
+            MusicSessionRepository(application).stateFlow().test {
+                assertEquals(MusicCardState.NoActiveSession, awaitItem())
+
+                startPlaying(resumed)
+
+                assertEquals(RESUMED_PACKAGE, playingPackage(awaitItem()))
+            }
+        }
+
+    @Test
+    fun `a resumed session takes the card from the paused one that outranked it`() =
+        runTest {
+            // The head-unit case: a paused session sits ahead of a second one in
+            // priority order, so it owns the card while that one is idle.
+            val paused = addSession(PAUSED_PACKAGE, PlaybackState.STATE_PAUSED)
+            val resumed = addSession(RESUMED_PACKAGE, PlaybackState.STATE_STOPPED)
+
+            MusicSessionRepository(application).stateFlow().test {
+                assertEquals(PAUSED_PACKAGE, playingPackage(awaitItem()))
+
+                // The user resumes the second session from its own app: the
+                // platform re-ranks it first but pushes no session-set change,
+                // so the launcher sees nothing except the playback state.
+                rerank(resumed, paused)
+                startPlaying(resumed)
+
+                assertEquals(RESUMED_PACKAGE, playingPackage(awaitItem()))
+            }
+        }
+
+    private fun playingPackage(state: MusicCardState): String? =
+        (state as? MusicCardState.Playing)?.nowPlaying?.packageName
+
+    /**
+     * Register an active session with the platform, appended to the priority
+     * order [MediaSessionManager.getActiveSessions] hands out.
+     */
+    private fun addSession(
+        packageName: String,
+        state: Int,
+    ): MediaController =
+        mediaController(packageName).also { controller ->
+            shadowOf(controller).setPackageName(packageName)
+            shadowOf(controller).setPlaybackState(fakePlaybackState(state))
+            shadowOf(controller).setMetadata(TRACK)
+            shadowOf(sessionManager).addController(controller)
+        }
+
+    /**
+     * Push a playing state from [controller]'s own app, the way a resume from
+     * outside the launcher arrives: the session's own callback fires and the
+     * session set does not change.
+     */
+    private fun startPlaying(controller: MediaController) =
+        shadowOf(controller).executeOnPlaybackStateChanged(fakePlaybackState(PlaybackState.STATE_PLAYING))
+
+    /**
+     * Re-rank the active sessions without telling anyone. Adding a controller
+     * normally pushes an OnActiveSessionsChanged to every listener, which would
+     * hand the launcher the new order for free; resetting first drops the
+     * controllers and the listeners together, and silently, so the repository
+     * keeps the order it last enumerated.
+     */
+    private fun rerank(vararg sessions: MediaController) {
+        ShadowMediaSessionManager.reset()
+        sessions.forEach { shadowOf(sessionManager).addController(it) }
+    }
+
+    /**
+     * Build a platform [MediaController] over a stub session binder. A
+     * controller cannot be built here the way the platform builds one — it
+     * needs a [MediaSession.Token], and a token needs a session binder — so the
+     * binder is a proxy over the hidden `ISessionController` interface. It
+     * answers the two calls this path makes on it: `asBinder`, which the token
+     * hashes and compares by (the watch set is keyed by token), and
+     * `getPackageName`, which the media3 token lookup rejects when null.
+     */
+    private fun mediaController(packageName: String): MediaController =
+        Class.forName("android.media.session.ISessionController").let { sessionBinderType ->
+            val binder = Binder()
+            val sessionBinder =
+                Proxy.newProxyInstance(sessionBinderType.classLoader, arrayOf(sessionBinderType)) { _, method, _ ->
+                    when (method.name) {
+                        "asBinder" -> binder
+                        "getPackageName" -> packageName
+                        else -> unanswered(method.returnType)
+                    }
+                }
+            MediaController(
+                application,
+                MediaSession.Token::class.java
+                    .getDeclaredConstructor(Int::class.javaPrimitiveType, sessionBinderType)
+                    .newInstance(0, sessionBinder),
+            )
+        }
+
+    // An unanswered binder call still has to return something of the declared
+    // shape: handing null back for a primitive return type throws on unboxing.
+    private fun unanswered(returnType: Class<*>): Any? =
+        when (returnType) {
+            Boolean::class.javaPrimitiveType -> false
+            Int::class.javaPrimitiveType -> 0
+            Long::class.javaPrimitiveType -> 0L
+            else -> null
+        }
+
+    private companion object {
+        const val IDLE_PACKAGE = "com.example.idle"
+        const val PAUSED_PACKAGE = "com.example.paused"
+        const val RESUMED_PACKAGE = "com.example.resumed"
+
+        // toNowPlaying degrades a session with no metadata to NoActiveSession,
+        // so every session here publishes the same track: these tests are about
+        // which session reaches the card, not about what it renders.
+        val TRACK: MediaMetadata = fakeMediaMetadata(title = "Strobe")
+    }
+}

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeMediaMetadata.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeMediaMetadata.kt
@@ -1,0 +1,30 @@
+package io.github.seijikohara.femto.testfixtures
+
+import android.graphics.Bitmap
+import android.media.MediaMetadata
+
+/**
+ * Build a real platform [MediaMetadata] carrying only the keys the caller
+ * names. An omitted key stays absent rather than empty, which is how a sparse
+ * session — a podcast or a radio stream — publishes it.
+ */
+internal fun fakeMediaMetadata(
+    title: String? = null,
+    displayTitle: String? = null,
+    artist: String? = null,
+    album: String? = null,
+    durationMs: Long = 0L,
+    albumArt: Bitmap? = null,
+    art: Bitmap? = null,
+): MediaMetadata =
+    MediaMetadata
+        .Builder()
+        .apply {
+            title?.let { putString(MediaMetadata.METADATA_KEY_TITLE, it) }
+            displayTitle?.let { putString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE, it) }
+            artist?.let { putString(MediaMetadata.METADATA_KEY_ARTIST, it) }
+            album?.let { putString(MediaMetadata.METADATA_KEY_ALBUM, it) }
+            putLong(MediaMetadata.METADATA_KEY_DURATION, durationMs)
+            albumArt?.let { putBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART, it) }
+            art?.let { putBitmap(MediaMetadata.METADATA_KEY_ART, it) }
+        }.build()

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakePlaybackState.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakePlaybackState.kt
@@ -1,0 +1,21 @@
+package io.github.seijikohara.femto.testfixtures
+
+import android.media.session.PlaybackState
+
+/**
+ * Build a real platform [PlaybackState]. Robolectric supplies the genuine
+ * builder, so session tests read the same fields the launcher reads off a live
+ * session instead of a mock's answers.
+ */
+internal fun fakePlaybackState(
+    state: Int,
+    positionMs: Long = 0L,
+    speed: Float = 1f,
+    updateTimeMs: Long = 0L,
+    actions: Long = 0L,
+): PlaybackState =
+    PlaybackState
+        .Builder()
+        .setState(state, positionMs, speed, updateTimeMs)
+        .setActions(actions)
+        .build()


### PR DESCRIPTION
Closes the session-detection gap behind #358: the music card can miss playback
that starts while the launcher is already on screen, and only picks it up after
the dashboard is left and returned to.

## The gap

`MusicSessionRepository` registered its `MediaController.Callback` on ONE
session — whichever `selectPrimaryController` picks — and that selection
excludes `STATE_NONE`, `STOPPED` and `ERROR`. An active-but-idle session
therefore had nothing watching it.

AOSP does push `onActiveSessionsChanged` on session create / destroy /
`setActive`, and on a media-button-session change driven by the audio-playback
monitor, so the platform covers most cases. The uncovered one is narrow but
real: an already-active, non-playing session **whose app is already the
media-button session** starts playing while the launcher is foreground —
typically the same app resuming from stopped. No push, no callback, no re-emit.
The card then stays stale until the flow is re-collected, which is what leaving
the launcher past the `WhileUiSubscribed` grace and coming back does.

## What changed

- **Watch every enumerated session, keyed on `MediaSession.Token`.**
  `getActiveSessions` mints a fresh `MediaController` per token on every call,
  so the previous identity guard never matched: every pass unregistered and
  re-registered everything, and the comment claiming "re-register only when the
  active controller changes" was untrue.
- **Re-enumerate when a session reports `PLAYING`** — and only then. Priority
  order comes out of `getActiveSessions` at call time, and the platform pushes
  no session-set change when playback starts inside a session it already lists.
  Without the refresh, a paused session that ranked first keeps the card while
  the one the user just resumed plays on. Pause / stop / buffering pushes
  re-emit from the controllers already held.
- **Selection policy untouched.** `selectPrimarySession` still takes the first
  playing-or-paused session in the order the platform gave, i.e. the launcher
  trusts the priority order rather than overriding it. This change refreshes
  that order; it does not second-guess it.
- **Registration-order defect fixed.** The initial enumeration and
  `addOnActiveSessionsChangedListener` shared one `runCatching`, so a
  `SecurityException` on the enumeration silently skipped the listener and the
  subscription saw no session-set change for its whole life.
- **The callback path's boundaries are guarded.** The enumeration shares one
  `runCatching` with the reconciliation it feeds, and the media3 retarget has
  its own. Both now run on platform callback dispatch as well as at
  subscription, and a throw escaping the subscription-time path would leave
  `HomeViewModel`'s `catchAsDefault` to complete the music source for the rest
  of the subscription epoch — reproducing the very symptom this PR fixes — and
  a throw escaping platform callback dispatch would be an uncaught main-thread
  exception, i.e. a crash of the HOME app.

## Verification

| Command | Result |
| --- | --- |
| `./gradlew spotlessCheck` | BUILD SUCCESSFUL |
| `./gradlew assembleDebug` | BUILD SUCCESSFUL |
| `./gradlew lint` | BUILD SUCCESSFUL, no new findings |
| `./gradlew test` | 876 tests, 0 failures |

The two load-bearing tests drive the real repository through Robolectric's
`ShadowMediaSessionManager`, not the extracted policy alone, and both were
falsified: restoring the old watch policy fails both, and reverting only the
`PLAYING` re-enumeration fails exactly the one that pins it
(`Expected <com.example.resumed>, actual <com.example.paused>` — the #358
symptom). An earlier draft pinned only the new pure helper and stayed green with
the old call site restored; that test is gone.

No golden re-record: the change is confined to `data/music/`, and the screenshot
suites render from fixture `MusicCardState` / `NowPlaying` values.

## Caveat on the issue

This gap is real and worth closing on its own merits, but it is **not confirmed
to be what the reporter is hitting**. A second mechanism produces an identical
"invisible until refreshed" symptom, and the two are distinguishable by which
state the stuck card shows. A question is posted on #358; if the answer points
at the other mechanism, that needs its own change.

