### PR TITLE
feat(dock): let the user hide the status icons and choose the dock width

### DIFF
--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardDockTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DashboardDockTest.kt
@@ -354,8 +354,10 @@ class DashboardDockTest {
 
     @Test
     fun the_sole_visible_nav_button_menu_omits_hide() {
-        // canHide is visibleNav.size > 1, so once everything but one button is
-        // hidden the survivor cannot be hidden too — the dock can never render empty.
+        // The nav floor holds: once everything but one button is hidden the
+        // survivor's menu omits Hide, so the dock can never lose its last
+        // actionable button. Status indicators carry no such floor — they are
+        // read-only, so an empty cluster is a layout the design already produces.
         setDock(dockConfig = DockConfig(navHidden = DockNavId.entries.toSet() - DockNavId.APPS))
         rule.onNodeWithContentDescription("Apps").performTouchInput { longClick() }
         rule.onNodeWithText("Hide").assertDoesNotExist()

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DockEditMenuTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DockEditMenuTest.kt
@@ -7,10 +7,10 @@ import io.github.seijikohara.femto.ui.theme.FemtoTheme
 import org.junit.Rule
 import org.junit.Test
 
-// DockEditMenu is shared by the horizontal dock's nav buttons and the vertical
-// rail's nav buttons / status indicators (DashboardDock, DockStatusCluster);
-// these tests pin its orientation-aware move labels directly, without needing
-// a long-press gesture to open it first.
+// DockEditMenu belongs to the status cluster alone (StatusCluster, its only
+// caller); nav buttons long-press into DockNavEditStrip instead. These tests pin
+// its orientation-aware move labels directly, without needing a long-press
+// gesture to open it first.
 class DockEditMenuTest {
     @get:Rule
     val rule = createComposeRule()
@@ -24,7 +24,6 @@ class DockEditMenuTest {
                     onDismiss = {},
                     canMoveLeft = true,
                     canMoveRight = true,
-                    canHide = true,
                     onMoveLeft = {},
                     onMoveRight = {},
                     onHide = {},
@@ -45,14 +44,14 @@ class DockEditMenuTest {
     fun horizontal_menu_keeps_move_left_and_move_right_labels() {
         rule.setContent {
             FemtoTheme {
-                // vertical defaults to false: the horizontal dock bar's existing
-                // behavior must stay byte-identical.
+                // vertical defaults to false — the status cluster as the horizontal
+                // bar hosts it, whose left/right labels predate the rail support
+                // and must stay unchanged.
                 DockEditMenu(
                     expanded = true,
                     onDismiss = {},
                     canMoveLeft = true,
                     canMoveRight = true,
-                    canHide = true,
                     onMoveLeft = {},
                     onMoveRight = {},
                     onHide = {},

--- a/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DockStatusClusterTest.kt
+++ b/app/src/androidTest/java/io/github/seijikohara/femto/ui/home/components/DockStatusClusterTest.kt
@@ -41,7 +41,7 @@ class DockStatusClusterTest {
             .onNodeWithContentDescription("Wi-Fi connected")
             .assert(SemanticsMatcher.keyIsDefined(SemanticsActions.OnLongClick))
             .performSemanticsAction(SemanticsActions.OnLongClick)
-        // Reset dock has no canMoveLeft/canMoveRight/canHide guard, so it always
+        // Reset dock has no canMoveLeft/canMoveRight guard, so it always
         // renders once expanded — proof the menu actually opened.
         rule.onNodeWithText("Reset dock").assertIsDisplayed()
     }

--- a/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/MainActivity.kt
@@ -236,6 +236,7 @@ class MainActivity : ComponentActivity() {
                     is24Hour = resolveIs24Hour(settings.clock),
                     showClockSeconds = settings.showClockSeconds,
                     dockPosition = settings.dockPosition,
+                    dockWidth = settings.dockWidth,
                     dockConfig = dock,
                     driverSide = settings.driverSide,
                     speedUnit = settings.speedUnit.resolved(),

--- a/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCollector.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCollector.kt
@@ -37,6 +37,7 @@ internal fun displaySettingsFacts(display: DisplaySettings): List<DiagnosticFact
         entry("Clock seconds", "${display.showClockSeconds}"),
         entry("Fullscreen", display.fullscreen.name),
         entry("Dock position", display.dockPosition.name),
+        entry("Dock width", display.dockWidth.name),
         entry("Driver side", display.driverSide.name),
         entry("Motion tier", display.motionTier.name),
         entry("Orientation", display.orientation.name),

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplayPreferences.kt
@@ -47,6 +47,8 @@ internal interface DisplaySettingsStore {
 
     suspend fun setDockPosition(value: DockPosition)
 
+    suspend fun setDockWidth(value: DockWidth)
+
     suspend fun setDriverSide(value: DriverSide)
 
     suspend fun setMotionTier(value: MotionTier)
@@ -171,6 +173,7 @@ internal class DisplayPreferences(
                     showClockSeconds = prefs[SHOW_CLOCK_SECONDS_KEY] ?: false,
                     fullscreen = prefs[FULLSCREEN_KEY].toEnumOr(FullscreenSetting.ON),
                     dockPosition = prefs[DOCK_POSITION_KEY].toEnumOr(DockPosition.BOTTOM),
+                    dockWidth = prefs[DOCK_WIDTH_KEY].toEnumOr(DockWidth.COMPACT),
                     driverSide = prefs[DRIVER_SIDE_KEY].toEnumOr(DriverSide.RIGHT),
                     motionTier = prefs[MOTION_TIER_KEY].toEnumOr(MotionTier.STANDARD),
                     orientation = prefs[ORIENTATION_KEY].toEnumOr(OrientationSetting.AUTO),
@@ -243,6 +246,10 @@ internal class DisplayPreferences(
 
     override suspend fun setDockPosition(value: DockPosition) {
         context.displayDataStore.editOrLog(TAG) { it[DOCK_POSITION_KEY] = value.name }
+    }
+
+    override suspend fun setDockWidth(value: DockWidth) {
+        context.displayDataStore.editOrLog(TAG) { it[DOCK_WIDTH_KEY] = value.name }
     }
 
     override suspend fun setDriverSide(value: DriverSide) {
@@ -438,6 +445,7 @@ internal class DisplayPreferences(
         val SHOW_CLOCK_SECONDS_KEY = booleanPreferencesKey("show_clock_seconds")
         val FULLSCREEN_KEY = stringPreferencesKey("fullscreen")
         val DOCK_POSITION_KEY = stringPreferencesKey("dock_position")
+        val DOCK_WIDTH_KEY = stringPreferencesKey("dock_width")
         val DRIVER_SIDE_KEY = stringPreferencesKey("driver_side")
         val MOTION_TIER_KEY = stringPreferencesKey("motion_tier")
         val ORIENTATION_KEY = stringPreferencesKey("orientation")
@@ -499,6 +507,7 @@ internal class DisplayPreferences(
                 SHOW_CLOCK_SECONDS_KEY,
                 FULLSCREEN_KEY,
                 DOCK_POSITION_KEY,
+                DOCK_WIDTH_KEY,
                 DRIVER_SIDE_KEY,
                 MOTION_TIER_KEY,
                 ORIENTATION_KEY,

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/DisplaySettings.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/DisplaySettings.kt
@@ -61,7 +61,34 @@ internal enum class AssistantLaunchSetting { SYSTEM, IN_APP }
  * Which screen edge hosts the dashboard dock. [BOTTOM] and [TOP] render the
  * horizontal bar; [LEFT] and [RIGHT] render it as a vertical rail.
  */
-internal enum class DockPosition { BOTTOM, TOP, LEFT, RIGHT }
+internal enum class DockPosition {
+    BOTTOM,
+    TOP,
+    LEFT,
+    RIGHT,
+    ;
+
+    /**
+     * True on the two edges that draw the horizontal bar — the split
+     * `DashboardDock` dispatches on. Lets a caller gate bar-only behaviour
+     * (e.g. the Dock width setting, which a rail ignores) by asking the
+     * question instead of re-listing the constants.
+     */
+    val hostsHorizontalBar: Boolean get() = this == BOTTOM || this == TOP
+}
+
+/**
+ * How wide the horizontal dock draws itself. [COMPACT] is a centred pill that
+ * wraps its buttons; [EXTENDED] is a full-width bar whose buttons share the
+ * width. [COMPACT] is the default, so a fresh install keeps today's centred
+ * pill — and it means "pill where it fits", not "pill always": the pill is a
+ * fixed footprint, so a bar too narrow for it falls back to [EXTENDED] rather
+ * than clipping its leading / trailing buttons below the automotive tap floor
+ * (AGENTS.md#automotive-overrides). [EXTENDED] shrinks toward that floor instead
+ * and never clips, so it is safe at any width. Only [DockPosition.BOTTOM] /
+ * [DockPosition.TOP] render a horizontal bar; the rails ignore this.
+ */
+internal enum class DockWidth { COMPACT, EXTENDED }
 
 /**
  * Which side the driver sits on. The dashboard anchors its info-dense
@@ -156,6 +183,9 @@ internal data class DisplaySettings(
     val fullscreen: FullscreenSetting,
     // Which screen edge hosts the dashboard dock; BOTTOM is the classic dock.
     val dockPosition: DockPosition,
+    // Whether the horizontal dock draws as a centred pill or a full-width bar.
+    // COMPACT is the default; see DockWidth for why it is not a hard "pill always".
+    val dockWidth: DockWidth,
     // Which side the driver sits on; the dashboard anchors to it. RIGHT is
     // today's layout, unchanged for a fresh install.
     val driverSide: DriverSide,
@@ -264,6 +294,7 @@ internal data class DisplaySettings(
                 showClockSeconds = false,
                 fullscreen = FullscreenSetting.ON,
                 dockPosition = DockPosition.BOTTOM,
+                dockWidth = DockWidth.COMPACT,
                 driverSide = DriverSide.RIGHT,
                 motionTier = MotionTier.STANDARD,
                 orientation = OrientationSetting.AUTO,

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/SettingsSectionId.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/SettingsSectionId.kt
@@ -47,6 +47,7 @@ internal enum class SettingsSectionId(
             DisplayPreferences.FULLSCREEN_KEY,
             DisplayPreferences.KEEP_SCREEN_ON_KEY,
             DisplayPreferences.DOCK_POSITION_KEY,
+            DisplayPreferences.DOCK_WIDTH_KEY,
             DisplayPreferences.DRIVER_SIDE_KEY,
             DisplayPreferences.ASSISTANT_LAUNCH_KEY,
             DisplayPreferences.MOTION_TIER_KEY,

--- a/app/src/main/java/io/github/seijikohara/femto/data/dock/DockPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/dock/DockPreferences.kt
@@ -126,8 +126,22 @@ internal interface DockSettingsStore {
     /** Replace the status-indicator order wholesale. */
     suspend fun setStatusOrder(value: List<DockStatusId>)
 
-    /** Hide [id] if currently shown, show it again if currently hidden. */
+    /**
+     * Hide [id] if currently shown, show it again if currently hidden. Unlike
+     * [toggleNavHidden] there is no keep-one floor: the status cluster is
+     * read-only, so an empty one strands no action, and Settings > Screen can
+     * bring the whole cluster back once no indicator is left to long-press.
+     */
     suspend fun toggleStatusHidden(id: DockStatusId)
+
+    /**
+     * Show every status indicator, or hide every one — the whole-cluster switch
+     * behind Settings > Screen. Showing clears the hidden set rather than
+     * restoring a previous per-indicator selection: that set is the single home
+     * for which indicators show, and remembering a pre-hide subset would need a
+     * second one that could disagree with it.
+     */
+    suspend fun setStatusClusterVisible(visible: Boolean)
 
     /** Swap [id] one step left/earlier (-1) or right/later (+1) within the visible status order. */
     suspend fun moveStatus(
@@ -202,11 +216,17 @@ internal class DockPreferences(
     override suspend fun toggleStatusHidden(id: DockStatusId) {
         context.dockDataStore.editOrLog(TAG) { prefs ->
             val current = resolveDockHidden<DockStatusId>(prefs[STATUS_HIDDEN_KEY])
-            val hiding = id !in current
-            // Keep at least one status indicator, for the same reason as toggleNavHidden.
-            if (hiding && (current + id).containsAll(DockStatusId.entries)) return@editOrLog
-            val updated = if (hiding) current + id else current - id
+            // No keep-one floor here, deliberately: toggleNavHidden's floor keeps the
+            // dock ACTIONABLE, and read-only indicators have nothing to keep reachable.
+            val updated = if (id in current) current - id else current + id
             prefs[STATUS_HIDDEN_KEY] = updated.mapTo(mutableSetOf()) { it.name }
+        }
+    }
+
+    override suspend fun setStatusClusterVisible(visible: Boolean) {
+        context.dockDataStore.editOrLog(TAG) { prefs ->
+            prefs[STATUS_HIDDEN_KEY] =
+                if (visible) mutableSetOf() else DockStatusId.entries.mapTo(mutableSetOf()) { it.name }
         }
     }
 

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeRoute.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.DockWidth
 import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.ui.home.components.DockConfig
@@ -31,6 +32,7 @@ internal fun HomeRoute(
     onEvent: (HomeEvent) -> Unit,
     modifier: Modifier = Modifier,
     dockPosition: DockPosition = DockPosition.BOTTOM,
+    dockWidth: DockWidth = DockWidth.COMPACT,
     dockConfig: DockConfig = DockConfig(),
     driverSide: DriverSide = DriverSide.RIGHT,
     musicShowAlbum: Boolean = true,
@@ -57,6 +59,7 @@ internal fun HomeRoute(
         onAction = viewModel::onAction,
         modifier = modifier,
         dockPosition = dockPosition,
+        dockWidth = dockWidth,
         dockConfig = dockConfig,
         driverSide = driverSide,
         musicShowAlbum = musicShowAlbum,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/HomeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.DockWidth
 import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.ui.home.components.DashboardScaffold
@@ -32,6 +33,7 @@ internal fun HomeScreen(
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
     dockPosition: DockPosition = DockPosition.BOTTOM,
+    dockWidth: DockWidth = DockWidth.COMPACT,
     dockConfig: DockConfig = DockConfig(),
     driverSide: DriverSide = DriverSide.RIGHT,
     musicShowAlbum: Boolean = true,
@@ -54,6 +56,7 @@ internal fun HomeScreen(
         onAction = onAction,
         modifier = Modifier.fillMaxSize(),
         dockPosition = dockPosition,
+        dockWidth = dockWidth,
         dockConfig = dockConfig,
         driverSide = driverSide,
         musicShowAlbum = musicShowAlbum,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
@@ -65,6 +65,7 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.rememberHazeState
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.DockWidth
 import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.data.dock.DockNavId
 import io.github.seijikohara.femto.data.dock.DockStatusId
@@ -130,21 +131,52 @@ private fun compactDockExtent(visibleNavCount: Int): Dp =
 // never clips (see HorizontalDock).
 private val DockStatusSideReserve: Dp = 240.dp
 
+// Whether the dock renders the read-only status cluster along [extent] (the
+// horizontal bar's width, the vertical rail's height): it needs an indicator left
+// to show, and room to spare once the actionable nav has its own (see
+// compactDockExtent). The user can hide every indicator, which drops the cluster
+// and its divider at any extent — and, on the horizontal bar, releases the width
+// the fit test below reserves for it.
+private fun dockShowsStatus(
+    extent: Dp,
+    navCount: Int,
+    statusCount: Int,
+): Boolean = statusCount > 0 && extent >= compactDockExtent(navCount)
+
 // Whether the fixed-margin (pill) horizontal dock fits [availableWidth]: each nav
 // button is MinTouchTarget + two DockButtonMargins wide, plus DockStatusSideReserve
-// when the status cluster shows. Shared by HorizontalDock (to pick the pill vs the
-// weight-shared fallback) and DashboardScaffold (to decide whether the freed
-// bottom-left corner lets the map attribution sit flush there instead of clearing
-// the dock).
-internal fun horizontalDockPillFits(
+// when the status cluster shows.
+private fun horizontalDockPillFits(
     availableWidth: Dp,
     navCount: Int,
+    statusCount: Int,
 ): Boolean {
-    val showStatusCluster = availableWidth >= compactDockExtent(navCount)
     val pillButtonWidth = FemtoDimens.MinTouchTarget + FemtoDimens.DockButtonMargin * 2
-    val requiredPillWidth = pillButtonWidth * navCount + (if (showStatusCluster) DockStatusSideReserve else 0.dp)
-    return requiredPillWidth <= availableWidth
+    val statusReserve = if (dockShowsStatus(availableWidth, navCount, statusCount)) DockStatusSideReserve else 0.dp
+    return pillButtonWidth * navCount + statusReserve <= availableWidth
 }
+
+// Whether the horizontal bar draws as the centred pill: the user's [dockWidth]
+// choice first, then the fit test. Only [DockWidth.COMPACT] can reach the pill, and
+// even then only where it fits — the pill is a fixed footprint, so forcing it onto
+// a narrow bar clips the leading / trailing buttons below FemtoDimens.MinTouchTarget
+// (AGENTS.md#automotive-overrides), while [DockWidth.EXTENDED]'s weight-shared bar
+// shrinks toward that floor and never clips. So the preference can turn the pill
+// OFF anywhere, but never on where the geometry says no.
+//
+// Called from two places: HorizontalDock picks its layout from it, and
+// DashboardScaffold asks it again (through mapCreditClearsDock) to decide whether
+// the freed bottom-left corner lets the map attribution sit flush there instead of
+// clearing the dock. [availableWidth] is the BAR's width, never the viewport's —
+// the bar floats inset by dockFloatPadding, and the scaffold subtracts that before
+// calling. Feeding the two calls different widths is what drops the credit under a
+// full-width bar, so both must stay on this one signature.
+internal fun horizontalDockUsesPill(
+    dockWidth: DockWidth,
+    availableWidth: Dp,
+    navCount: Int,
+    statusCount: Int,
+): Boolean = dockWidth == DockWidth.COMPACT && horizontalDockPillFits(availableWidth, navCount, statusCount)
 
 // One dock nav button's icon / label / action. Shared by the horizontal bar and
 // the vertical rail so the set and order stay identical; [navSpecFor] is the
@@ -197,6 +229,7 @@ internal fun DashboardDock(
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
     position: DockPosition = DockPosition.BOTTOM,
+    dockWidth: DockWidth = DockWidth.COMPACT,
     hazeState: HazeState = rememberHazeState(),
     glassConfig: GlassConfig = GlassConfig(),
     dockConfig: DockConfig = DockConfig(),
@@ -209,6 +242,7 @@ internal fun DashboardDock(
             hazeState = hazeState,
             glassConfig = glassConfig,
             modifier = modifier,
+            dockWidth = dockWidth,
             dockConfig = dockConfig,
             motionTier = motionTier,
         )
@@ -233,6 +267,7 @@ private fun HorizontalDock(
     onAction: (HomeAction) -> Unit,
     hazeState: HazeState,
     glassConfig: GlassConfig,
+    dockWidth: DockWidth,
     modifier: Modifier = Modifier,
     dockConfig: DockConfig = DockConfig(),
     motionTier: MotionTier = MotionTier.STANDARD,
@@ -242,17 +277,19 @@ private fun HorizontalDock(
     // pill is a fixed footprint: on a wide dock it fits and reads as a compact,
     // centred glass pill, but on the reference 853 dp head unit or a portrait
     // phone the nav buttons + status cluster overflow it and the glass clips the
-    // leading / trailing items. When the pill would overflow, fall back to the
-    // weight-shared layout that shrinks the nav toward FemtoDimens.MinTouchTarget
-    // so every button stays reachable and nothing clips
-    // (AGENTS.md#automotive-overrides, AGENTS.md#launcher-behavior). The same choice sizes
-    // the glass: the pill wraps its content (DashboardScaffold centres it), the
-    // fallback fills the width so the weight distribution has room.
+    // leading / trailing items. When the pill would overflow — or the user asked
+    // for DockWidth.EXTENDED — take the weight-shared layout that shrinks the nav
+    // toward FemtoDimens.MinTouchTarget so every button stays reachable and nothing
+    // clips (AGENTS.md#automotive-overrides, AGENTS.md#launcher-behavior); see
+    // horizontalDockUsesPill. The same choice sizes the glass: the pill wraps its
+    // content (DashboardScaffold centres it), the fallback fills the width so the
+    // weight distribution has room.
     BoxWithConstraints(modifier = modifier) {
         // Below the threshold the read-only status cluster yields so the actionable
-        // nav keeps room — see compactDockExtent. Applied in both layouts.
-        val showStatusCluster = maxWidth >= compactDockExtent(visibleNav.size)
-        val pillFits = horizontalDockPillFits(maxWidth, visibleNav.size)
+        // nav keeps room, and an emptied cluster drops at any width — see
+        // dockShowsStatus. Applied in both layouts.
+        val showStatusCluster = dockShowsStatus(maxWidth, visibleNav.size, dockConfig.visibleStatus.size)
+        val usesPill = horizontalDockUsesPill(dockWidth, maxWidth, visibleNav.size, dockConfig.visibleStatus.size)
         // Long-pressing any nav button flips the bar into edit mode (see
         // DockNavEditStrip). The strip wraps its content just like the pill, so
         // the bar keeps its footprint — same width class (pill wraps / fallback
@@ -269,7 +306,7 @@ private fun HorizontalDock(
             modifier =
                 Modifier
                     .height(FemtoDimens.DockThickness)
-                    .then(if (pillFits) Modifier else Modifier.fillMaxWidth())
+                    .then(if (usesPill) Modifier else Modifier.fillMaxWidth())
                     .glassChrome(MaterialTheme.shapes.large, hazeState, glassConfig),
             color = Color.Transparent,
             contentColor = MaterialTheme.colorScheme.onSurface,
@@ -286,7 +323,7 @@ private fun HorizontalDock(
                     onAction = onAction,
                     modifier = Modifier.fillMaxHeight().padding(horizontal = FemtoDimens.DockButtonMargin),
                 )
-            } else if (pillFits) {
+            } else if (usesPill) {
                 // Fixed-margin pill: each button reserves a DockButtonMargin on both
                 // sides, so adjacent buttons sit two margins apart and the first /
                 // last button sits one margin from the bar edge. The row wraps its
@@ -420,88 +457,85 @@ private fun VerticalDock(
     // strip (drag + ×), keeping the status cluster in place. Back exits.
     var editing by remember { mutableStateOf(false) }
     BackHandler(enabled = editing) { editing = false }
-    if (editing) {
-        DockNavEditStrip(
-            navOrder = dockConfig.navOrder,
-            navHidden = dockConfig.navHidden,
-            vertical = true,
-            systemStatus = systemStatus,
-            visibleStatus = dockConfig.visibleStatus,
-            showStatusCluster = dockConfig.visibleStatus.isNotEmpty(),
-            motionTier = motionTier,
-            onAction = onAction,
-            modifier = Modifier.fillMaxSize().padding(vertical = 24.dp),
-        )
-        // Floating Reset + Done toolbar beside the rail (a Popup, so the rail
-        // width is untouched). Back also exits.
-        val toolbarOffsetX = with(LocalDensity.current) { FemtoDimens.MinTouchTarget.roundToPx() }
-        Popup(
-            alignment = Alignment.CenterEnd,
-            offset = IntOffset(toolbarOffsetX, 0),
-            properties = PopupProperties(focusable = false),
-        ) {
-            DockEditToolbar(
-                onReset = { onAction(HomeAction.ResetDock) },
-                onDone = { editing = false },
+    // Both branches take the cluster gate from this one measured height, so edit
+    // mode cannot grow a cluster the rail drops at rest: below compactDockExtent
+    // the nav keeps the height either way (see dockShowsStatus). The rail's inner
+    // margin sits here rather than on each branch for the same reason — the height
+    // measured is the height the content gets.
+    BoxWithConstraints(modifier = Modifier.fillMaxSize().padding(vertical = 24.dp)) {
+        val showStatusCluster = dockShowsStatus(maxHeight, visibleNav.size, dockConfig.visibleStatus.size)
+        if (editing) {
+            DockNavEditStrip(
+                navOrder = dockConfig.navOrder,
+                navHidden = dockConfig.navHidden,
+                vertical = true,
+                systemStatus = systemStatus,
+                visibleStatus = dockConfig.visibleStatus,
+                showStatusCluster = showStatusCluster,
+                motionTier = motionTier,
+                onAction = onAction,
+                modifier = Modifier.fillMaxSize(),
             )
-        }
-    } else {
-        Row {
-            BoxWithConstraints(
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .padding(vertical = 24.dp),
+            // Floating Reset + Done toolbar beside the rail (a Popup, so the rail
+            // width is untouched). Back also exits.
+            val toolbarOffsetX = with(LocalDensity.current) { FemtoDimens.MinTouchTarget.roundToPx() }
+            Popup(
+                alignment = Alignment.CenterEnd,
+                offset = IntOffset(toolbarOffsetX, 0),
+                properties = PopupProperties(focusable = false),
             ) {
-                val showStatusCluster = maxHeight >= compactDockExtent(visibleNav.size)
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
+                DockEditToolbar(
+                    onReset = { onAction(HomeAction.ResetDock) },
+                    onDone = { editing = false },
+                )
+            }
+        } else {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // The slot competing with the status cluster for height; centred so
+                // the capped cluster below sits in the middle of its share instead
+                // of hugging the leading edge on a tall rail — mirrors the
+                // horizontal bar's weight-shared fallback, turned 90 degrees.
+                Box(
+                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
                 ) {
-                    // The slot competing with the status cluster for height; centred so
-                    // the capped cluster below sits in the middle of its share instead
-                    // of hugging the leading edge on a tall rail — mirrors the
-                    // horizontal bar's weight-shared fallback, turned 90 degrees.
-                    Box(
-                        modifier = Modifier.weight(1f).fillMaxWidth(),
-                        contentAlignment = Alignment.Center,
+                    Column(
+                        // Fill the slot up to the cap — see the horizontal bar's
+                        // matching comment above for the rationale.
+                        modifier =
+                            Modifier
+                                .heightIn(max = FemtoDimens.DockNavClusterMaxWidth)
+                                .fillMaxHeight(),
+                        verticalArrangement = Arrangement.SpaceBetween,
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
-                        Column(
-                            // Fill the slot up to the cap — see the horizontal bar's
-                            // matching comment above for the rationale.
-                            modifier =
-                                Modifier
-                                    .heightIn(max = FemtoDimens.DockNavClusterMaxWidth)
-                                    .fillMaxHeight(),
-                            verticalArrangement = Arrangement.SpaceBetween,
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                        ) {
-                            // The same equal-weight sharing as the horizontal bar's fallback,
-                            // on the height instead of the width.
-                            visibleNav.forEach { id ->
-                                key(id) {
-                                    EditableNavButton(
-                                        id = id,
-                                        onAction = onAction,
-                                        onEnterEdit = { editing = true },
-                                        modifier = Modifier.weight(1f),
-                                    )
-                                }
+                        // The same equal-weight sharing as the horizontal bar's fallback,
+                        // on the height instead of the width.
+                        visibleNav.forEach { id ->
+                            key(id) {
+                                EditableNavButton(
+                                    id = id,
+                                    onAction = onAction,
+                                    onEnterEdit = { editing = true },
+                                    modifier = Modifier.weight(1f),
+                                )
                             }
                         }
                     }
-                    if (showStatusCluster) {
-                        VerticalDockDivider()
-                        StatusCluster(
-                            status = systemStatus,
-                            vertical = true,
-                            order = dockConfig.visibleStatus,
-                            onAction = onAction,
-                            motionTier = motionTier,
-                            modifier = Modifier.padding(top = 20.dp),
-                        )
-                    }
+                }
+                if (showStatusCluster) {
+                    VerticalDockDivider()
+                    StatusCluster(
+                        status = systemStatus,
+                        vertical = true,
+                        order = dockConfig.visibleStatus,
+                        onAction = onAction,
+                        motionTier = motionTier,
+                        modifier = Modifier.padding(top = 20.dp),
+                    )
                 }
             }
         }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -36,11 +38,13 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.DockWidth
 import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.MotionTier
 import io.github.seijikohara.femto.data.music.MusicCardState
@@ -68,6 +72,48 @@ internal data class PanelVisibility(
     // overlay is dropped entirely so the map shows uncovered.
     val anyInfoPanel: Boolean get() = calendar || weather || music
 }
+
+// The width a horizontal bar lays out in on a [viewportWidth] dashboard: the
+// viewport less the start and end margins dockFloatPadding insets the floating
+// bar by. Read off dockFloatPadding rather than restating the margin, so the two
+// move together. The layout direction only decides which of the two margins is
+// the start one; their sum — all this needs — is the same either way.
+private fun horizontalDockWidth(
+    viewportWidth: Dp,
+    dockMargin: Dp,
+): Dp {
+    // BOTTOM stands in for either horizontal position: dockFloatPadding gives
+    // BOTTOM and TOP the same start/end margins, and only their sum is read here.
+    val floatPadding = dockFloatPadding(DockPosition.BOTTOM, dockMargin)
+    return viewportWidth -
+        floatPadding.calculateStartPadding(LayoutDirection.Ltr) -
+        floatPadding.calculateEndPadding(LayoutDirection.Ltr)
+}
+
+// Whether the map's bottom-start attribution credit must be lifted clear of the
+// dock instead of sitting flush in the corner as OSM/OpenFreeMap intend. Only a
+// bottom-hosted dock reaches that corner, and only while the bar spans the width:
+// a centred pill leaves the corner free.
+//
+// [viewportWidth] is the dashboard viewport, NOT the bar's own width, so this
+// converts (horizontalDockWidth) before asking horizontalDockUsesPill. That
+// conversion is the whole point of taking [dockMargin]: HorizontalDock answers
+// the same question against the width it was actually given, and handing this
+// one the raw viewport instead put the two answers a float margin apart —
+// enough to disagree in real width bands and leave the credit under a
+// full-width bar. Per-backend map attribution is an invariant here, so this
+// stays a second evaluation of the SAME predicate on the SAME width; changing
+// either side's inputs means changing both.
+internal fun mapCreditClearsDock(
+    dockPosition: DockPosition,
+    dockWidth: DockWidth,
+    viewportWidth: Dp,
+    dockMargin: Dp,
+    navCount: Int,
+    statusCount: Int,
+): Boolean =
+    dockPosition == DockPosition.BOTTOM &&
+        !horizontalDockUsesPill(dockWidth, horizontalDockWidth(viewportWidth, dockMargin), navCount, statusCount)
 
 /**
  * Top-level dashboard layout: the map is the full-screen background and
@@ -117,6 +163,7 @@ internal fun DashboardScaffold(
     onAction: (HomeAction) -> Unit,
     modifier: Modifier = Modifier,
     dockPosition: DockPosition = DockPosition.BOTTOM,
+    dockWidth: DockWidth = DockWidth.COMPACT,
     dockConfig: DockConfig = DockConfig(),
     driverSide: DriverSide = DriverSide.RIGHT,
     spectrum: StateFlow<FloatArray?>? = null,
@@ -138,6 +185,7 @@ internal fun DashboardScaffold(
     glassConfig = glassConfig,
     onAction = onAction,
     dockPosition = dockPosition,
+    dockWidth = dockWidth,
     dockConfig = dockConfig,
     driverSide = driverSide,
     modifier =
@@ -168,6 +216,7 @@ private fun DashboardContent(
     glassConfig: GlassConfig,
     onAction: (HomeAction) -> Unit,
     dockPosition: DockPosition,
+    dockWidth: DockWidth,
     driverSide: DriverSide,
     modifier: Modifier = Modifier,
     dockConfig: DockConfig = DockConfig(),
@@ -275,14 +324,16 @@ private fun DashboardContent(
     // margin + the thickness) so none sit under it.
     val dockExtent = FemtoDimens.DockThickness + outerPad
 
-    // The map's bottom-start attribution credit sits in the bottom-left screen
-    // corner. When the horizontal dock is a centred pill it frees that corner, so
-    // the credit sits flush there (inset 0) as OSM/OpenFreeMap intend; when the pill
-    // would overflow and the dock falls back to a full-width bar (the 853 dp head
-    // unit, portrait phones) the credit is lifted by the dock's footprint so it
-    // clears the bar. Left/right/top docks never cover that corner.
     val attributionBottomInset =
-        if (dockPosition == DockPosition.BOTTOM && !horizontalDockPillFits(maxWidth, dockConfig.visibleNav.size)) {
+        if (mapCreditClearsDock(
+                dockPosition = dockPosition,
+                dockWidth = dockWidth,
+                viewportWidth = maxWidth,
+                dockMargin = outerPad,
+                navCount = dockConfig.visibleNav.size,
+                statusCount = dockConfig.visibleStatus.size,
+            )
+        ) {
             dockExtent
         } else {
             0.dp
@@ -432,6 +483,7 @@ private fun DashboardContent(
         systemStatus = uiState.systemStatus,
         onAction = overlayAction,
         position = dockPosition,
+        dockWidth = dockWidth,
         hazeState = hazeState,
         glassConfig = glassConfig,
         dockConfig = dockConfig,

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DockEditMenu.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DockEditMenu.kt
@@ -19,15 +19,21 @@ import io.github.seijikohara.femto.ui.theme.FemtoDimens
 import io.github.seijikohara.femto.ui.theme.FemtoIcon
 
 /**
- * The dock's long-press edit menu, shared by a nav button ([DashboardDock])
- * and a status-cluster indicator ([StatusCluster]) — same shape as
+ * The status cluster's long-press edit menu ([StatusCluster], its only caller)
+ * — same shape as
  * [io.github.seijikohara.femto.ui.drawer.components.PinnedDock]'s tile menu:
  * Move left / Move right (Move up / Move down when [vertical] — the two rail
  * dock positions reorder along the vertical axis, so a left/right label and
  * arrow would point the wrong way) reorder within the visible order, omitted
- * (not greyed) at the edge the direction cannot reach; Hide drops the item,
- * omitted rather than disabled when it is the last visible one, so the dock
- * can never render empty. Reset dock is always present — the same
+ * (not greyed) at the edge the direction cannot reach; Hide drops the
+ * indicator, with no last-one guard — the cluster is read-only, so hiding every
+ * indicator strands no action, and the Settings > Screen switch brings the
+ * whole cluster back once nothing is left to long-press. The nav buttons keep
+ * their floor and have their own affordance: a long press there opens the
+ * reorder strip (DockNavEditStrip), whose remove badge writes through
+ * [io.github.seijikohara.femto.data.dock.DockSettingsStore.toggleNavHidden] —
+ * which refuses the last visible button, so the dock always keeps one
+ * actionable id. Reset dock is always present — the same
  * [io.github.seijikohara.femto.data.dock.DockSettingsStore.resetToDefaults]
  * call Settings > Screen > Reset dock dispatches — so a user who hid
  * something (or forgot they reordered it) always has a one-tap way back,
@@ -39,14 +45,13 @@ internal fun DockEditMenu(
     onDismiss: () -> Unit,
     canMoveLeft: Boolean,
     canMoveRight: Boolean,
-    canHide: Boolean,
     onMoveLeft: () -> Unit,
     onMoveRight: () -> Unit,
     onHide: () -> Unit,
     onResetDock: () -> Unit,
-    // Rail docks (DockPosition.LEFT / RIGHT) render this same menu for a
-    // vertically stacked nav/status cluster, where onMoveLeft/onMoveRight
-    // (a -1/+1 reorder) move the item up/down, not left/right.
+    // Rail docks (DockPosition.LEFT / RIGHT) stack the status cluster
+    // vertically, so there onMoveLeft/onMoveRight (a -1/+1 reorder) move the
+    // indicator up/down, not left/right.
     vertical: Boolean = false,
 ) = DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
     if (canMoveLeft) {
@@ -82,17 +87,15 @@ internal fun DockEditMenu(
             },
         )
     }
-    if (canHide) {
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.dock_hide)) },
-            modifier = Modifier.sizeIn(minHeight = FemtoDimens.MinTouchTarget),
-            leadingIcon = { FemtoIcon(imageVector = Lucide.EyeOff, contentDescription = null) },
-            onClick = {
-                onHide()
-                onDismiss()
-            },
-        )
-    }
+    DropdownMenuItem(
+        text = { Text(stringResource(R.string.dock_hide)) },
+        modifier = Modifier.sizeIn(minHeight = FemtoDimens.MinTouchTarget),
+        leadingIcon = { FemtoIcon(imageVector = Lucide.EyeOff, contentDescription = null) },
+        onClick = {
+            onHide()
+            onDismiss()
+        },
+    )
     DropdownMenuItem(
         text = { Text(stringResource(R.string.settings_reset_dock)) },
         modifier = Modifier.sizeIn(minHeight = FemtoDimens.MinTouchTarget),

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DockStatusCluster.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DockStatusCluster.kt
@@ -77,7 +77,6 @@ internal fun StatusCluster(
                     vertical = vertical,
                     canMoveLeft = index > 0,
                     canMoveRight = index < order.lastIndex,
-                    canHide = order.size > 1,
                     tier = motionTier,
                     onAction = onAction,
                 )
@@ -105,8 +104,8 @@ internal fun StatusCluster(
 
 /**
  * Wraps one status indicator's rendered content with the long-press dock-edit
- * menu ([DockEditMenu], shared with the dock's nav buttons — Move left/right,
- * or up/down when [vertical] / Hide / Reset dock). Status icons are read-only
+ * menu ([DockEditMenu] — Move left/right, or up/down when [vertical] / Hide /
+ * Reset dock). Status icons are read-only
  * at rest — a tap does nothing — so the long press is wired via a raw
  * [detectTapGestures] rather than `combinedClickable`: the latter would add a
  * "double-tap to activate" semantics action for a control with no click
@@ -130,7 +129,6 @@ private fun EditableStatusIndicator(
     vertical: Boolean,
     canMoveLeft: Boolean,
     canMoveRight: Boolean,
-    canHide: Boolean,
     tier: MotionTier,
     onAction: (HomeAction) -> Unit,
 ) {
@@ -154,7 +152,6 @@ private fun EditableStatusIndicator(
             onDismiss = { menuOpen = false },
             canMoveLeft = canMoveLeft,
             canMoveRight = canMoveRight,
-            canHide = canHide,
             onMoveLeft = { onAction(HomeAction.MoveDockStatus(id, -1)) },
             onMoveRight = { onAction(HomeAction.MoveDockStatus(id, 1)) },
             onHide = { onAction(HomeAction.HideDockStatus(id)) },

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -7,6 +7,7 @@ import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.ClockSetting
 import io.github.seijikohara.femto.data.display.DisplaySettings
 import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.DockWidth
 import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.GoogleMapType
@@ -37,6 +38,20 @@ internal data class SettingsUiState(
     val showClockSeconds: Boolean,
     val fullscreen: FullscreenSetting,
     val dockPosition: DockPosition,
+    val dockWidth: DockWidth,
+    // Whether the dock's status cluster shows any indicator. Derived from the dock
+    // store's hidden set rather than persisted here, so the Screen switch and the
+    // dock's own long-press Hide can never disagree; the write flips the whole set
+    // (DockSettingsStore.setStatusClusterVisible).
+    //
+    // The default sits on the field, not in [Initial] with the DisplaySettings
+    // ones, for the same reason [hasCalendarAccess]'s does: no DisplaySettings
+    // field backs it, and SettingsViewModel's store combine builds the whole
+    // state before the dock flows are folded in — a default in [Initial] alone
+    // would leave that intermediate needing a second literal. True matches the
+    // dock store's read path, which resolves an absent hidden set to "nothing
+    // hidden", so the row reads correctly before the first dock emission.
+    val dockStatusVisible: Boolean = true,
     val driverSide: DriverSide,
     val motionTier: MotionTier,
     val orientation: OrientationSetting,
@@ -106,6 +121,7 @@ internal data class SettingsUiState(
                 showClockSeconds = DisplaySettings.Default.showClockSeconds,
                 fullscreen = DisplaySettings.Default.fullscreen,
                 dockPosition = DisplaySettings.Default.dockPosition,
+                dockWidth = DisplaySettings.Default.dockWidth,
                 driverSide = DisplaySettings.Default.driverSide,
                 motionTier = DisplaySettings.Default.motionTier,
                 orientation = DisplaySettings.Default.orientation,
@@ -192,6 +208,19 @@ internal sealed interface SettingsAction {
 
     data class SetDockPosition(
         val value: DockPosition,
+    ) : SettingsAction
+
+    data class SetDockWidth(
+        val value: DockWidth,
+    ) : SettingsAction
+
+    /**
+     * Show every dock status indicator, or hide every one. Writes the dock's
+     * hidden set (not a DisplaySettings field): that set is the single home for
+     * which indicators show, shared with the dock's long-press Hide.
+     */
+    data class SetDockStatusVisible(
+        val value: Boolean,
     ) : SettingsAction
 
     data class SetDriverSide(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -77,6 +77,7 @@ internal class SettingsViewModel(
                 showClockSeconds = display.showClockSeconds,
                 fullscreen = display.fullscreen,
                 dockPosition = display.dockPosition,
+                dockWidth = display.dockWidth,
                 driverSide = display.driverSide,
                 motionTier = display.motionTier,
                 orientation = display.orientation,
@@ -129,9 +130,21 @@ internal class SettingsViewModel(
             )
         }
 
+    // The Screen switch's checked state, read off the dock store instead of a
+    // boolean of its own: this is DockConfig.visibleStatus.isNotEmpty() expressed
+    // on the two flows it derives from, so a per-indicator Hide from the dock's
+    // long-press menu moves the switch too.
+    private val dockStatusVisible: Flow<Boolean> =
+        combine(dockPreferences.statusOrder, dockPreferences.statusHidden) { order, hidden ->
+            order.any { it !in hidden }
+        }
+
+    // Folded in here rather than into the store combine above, which already holds
+    // kotlinx's five-flow typed overload.
     val uiState: StateFlow<SettingsUiState> =
-        combine(storeState, trackExportState) { state, export -> state.copy(trackExport = export) }
-            .stateIn(viewModelScope, WhileUiSubscribed, SettingsUiState.Initial)
+        combine(storeState, trackExportState, dockStatusVisible) { state, export, statusVisible ->
+            state.copy(trackExport = export, dockStatusVisible = statusVisible)
+        }.stateIn(viewModelScope, WhileUiSubscribed, SettingsUiState.Initial)
 
     fun onAction(action: SettingsAction) {
         // Each branch is a single suspending write; launch once and dispatch.
@@ -167,6 +180,14 @@ internal class SettingsViewModel(
 
                 is SettingsAction.SetDockPosition -> {
                     displayPreferences.setDockPosition(action.value)
+                }
+
+                is SettingsAction.SetDockWidth -> {
+                    displayPreferences.setDockWidth(action.value)
+                }
+
+                is SettingsAction.SetDockStatusVisible -> {
+                    dockPreferences.setStatusClusterVisible(action.value)
                 }
 
                 is SettingsAction.SetDriverSide -> {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/ScreenSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/ScreenSection.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.femto.ui.settings.components
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -7,6 +8,7 @@ import androidx.compose.ui.res.stringResource
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.DockWidth
 import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.MotionTier
@@ -75,6 +77,37 @@ internal fun ScreenSection(
             ),
         selected = uiState.dockPosition,
         onSelect = { onAction(SettingsAction.SetDockPosition(it)) },
+    )
+    // Only the horizontal bar has two widths; a rail is a fixed thickness and
+    // ignores the setting, so the row is hidden there rather than left as a
+    // control that does nothing — the same gating MapSection gives its
+    // backend-specific rows. The stored choice is untouched meanwhile, so moving
+    // the dock back to a bar edge restores it.
+    //
+    // Compact means "pill where it fits" — a bar too narrow for the pill still
+    // draws extended, since the pill would clip its end buttons (see DockWidth).
+    AnimatedVisibility(visible = uiState.dockPosition.hostsHorizontalBar) {
+        ChoiceRow(
+            title = stringResource(R.string.settings_group_dock_width),
+            options =
+                listOf(
+                    DockWidth.COMPACT to stringResource(R.string.settings_dock_width_compact),
+                    DockWidth.EXTENDED to stringResource(R.string.settings_dock_width_extended),
+                ),
+            selected = uiState.dockWidth,
+            onSelect = { onAction(SettingsAction.SetDockWidth(it)) },
+        )
+    }
+    // The whole read-only cluster, in one switch. Per-indicator visibility stays
+    // on the dock's own long-press menu — a second surface for it here could
+    // disagree with the hidden set both of them write. This row is also the only
+    // way back once every indicator is hidden and there is nothing left to
+    // long-press, which is why it sits beside Reset dock.
+    SwitchRow(
+        title = stringResource(R.string.settings_group_dock_status),
+        checked = uiState.dockStatusVisible,
+        onCheckedChange = { onAction(SettingsAction.SetDockStatusVisible(it)) },
+        summary = stringResource(R.string.settings_dock_status_summary),
     )
     // Restores the dock's own nav/status order + hidden sets (a separate
     // DockPreferences store, not this section's DisplaySettings fields), so it

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,6 +258,11 @@
     <string name="settings_dock_top">Top</string>
     <string name="settings_dock_left">Left</string>
     <string name="settings_dock_right">Right</string>
+    <string name="settings_group_dock_width">Dock width</string>
+    <string name="settings_dock_width_compact">Compact</string>
+    <string name="settings_dock_width_extended">Extended</string>
+    <string name="settings_group_dock_status">Status icons</string>
+    <string name="settings_dock_status_summary">Show the status icons beside the dock buttons, where the dock has room for them. Long-press an icon to reorder or hide just that one.</string>
     <string name="settings_group_driver_side">Driver side</string>
     <string name="settings_driver_side_right">Right</string>
     <string name="settings_driver_side_left">Left</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCompletenessTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCompletenessTest.kt
@@ -29,6 +29,7 @@ class SettingsFactsCompletenessTest {
             "showClockSeconds" to "Clock seconds",
             "fullscreen" to "Fullscreen",
             "dockPosition" to "Dock position",
+            "dockWidth" to "Dock width",
             "driverSide" to "Driver side",
             "motionTier" to "Motion tier",
             "orientation" to "Orientation",

--- a/app/src/test/java/io/github/seijikohara/femto/data/display/DisplayPreferencesTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/display/DisplayPreferencesTest.kt
@@ -220,6 +220,7 @@ class DisplayPreferencesTest {
                     fullscreen = DisplaySettings.Default.fullscreen,
                     keepScreenOn = DisplaySettings.Default.keepScreenOn,
                     dockPosition = DisplaySettings.Default.dockPosition,
+                    dockWidth = DisplaySettings.Default.dockWidth,
                     driverSide = DisplaySettings.Default.driverSide,
                     assistantLaunch = DisplaySettings.Default.assistantLaunch,
                     motionTier = DisplaySettings.Default.motionTier,
@@ -335,6 +336,7 @@ class DisplayPreferencesTest {
         setShowClockSeconds(true)
         setFullscreen(FullscreenSetting.OFF)
         setDockPosition(DockPosition.LEFT)
+        setDockWidth(DockWidth.EXTENDED)
         setDriverSide(DriverSide.LEFT)
         setMotionTier(MotionTier.OFF)
         setOrientation(OrientationSetting.PORTRAIT)

--- a/app/src/test/java/io/github/seijikohara/femto/data/dock/DockPreferencesTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/dock/DockPreferencesTest.kt
@@ -159,6 +159,47 @@ class DockPreferencesTest {
         }
 
     @Test
+    fun `toggleStatusHidden hides the last visible indicator`() =
+        runTest {
+            val store = DockPreferences(ApplicationProvider.getApplicationContext())
+            store.resetToDefaults()
+
+            DockStatusId.entries.forEach { store.toggleStatusHidden(it) }
+
+            // No keep-one floor here: the cluster is read-only, so an empty one
+            // strands no action. Contrast `toggleNavHidden refuses to hide the
+            // last visible id`, where the floor keeps the dock actionable.
+            assertEquals(DockStatusId.entries.toSet(), store.statusHidden.first())
+        }
+
+    @Test
+    fun `setStatusClusterVisible flips the whole hidden set at once`() =
+        runTest {
+            val store = DockPreferences(ApplicationProvider.getApplicationContext())
+            store.resetToDefaults()
+
+            store.setStatusClusterVisible(false)
+            assertEquals(DockStatusId.entries.toSet(), store.statusHidden.first())
+
+            store.setStatusClusterVisible(true)
+            assertEquals(emptySet(), store.statusHidden.first())
+        }
+
+    @Test
+    fun `setStatusClusterVisible true also restores indicators hidden one at a time`() =
+        runTest {
+            val store = DockPreferences(ApplicationProvider.getApplicationContext())
+            store.resetToDefaults()
+            store.toggleStatusHidden(DockStatusId.GPS)
+
+            store.setStatusClusterVisible(true)
+
+            // Showing clears the set wholesale rather than restoring the pre-hide
+            // selection: the hidden set is the only home for that fact.
+            assertEquals(emptySet(), store.statusHidden.first())
+        }
+
+    @Test
     fun `moveStatus swaps an id with its right-hand visible neighbor`() =
         runTest {
             val store = DockPreferences(ApplicationProvider.getApplicationContext())

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDisplaySettingsStore.kt
@@ -8,6 +8,7 @@ import io.github.seijikohara.femto.data.display.DisplayPreferences
 import io.github.seijikohara.femto.data.display.DisplaySettings
 import io.github.seijikohara.femto.data.display.DisplaySettingsStore
 import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.DockWidth
 import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.GoogleMapType
@@ -59,6 +60,8 @@ internal class FakeDisplaySettingsStore(
     override suspend fun setFullscreen(value: FullscreenSetting) = state.update { it.copy(fullscreen = value) }
 
     override suspend fun setDockPosition(value: DockPosition) = state.update { it.copy(dockPosition = value) }
+
+    override suspend fun setDockWidth(value: DockWidth) = state.update { it.copy(dockWidth = value) }
 
     override suspend fun setDriverSide(value: DriverSide) = state.update { it.copy(driverSide = value) }
 
@@ -200,6 +203,10 @@ internal class FakeDisplaySettingsStore(
 
             DisplayPreferences.DOCK_POSITION_KEY -> {
                 copy(dockPosition = default.dockPosition)
+            }
+
+            DisplayPreferences.DOCK_WIDTH_KEY -> {
+                copy(dockWidth = default.dockWidth)
             }
 
             DisplayPreferences.DRIVER_SIDE_KEY -> {

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDockSettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeDockSettingsStore.kt
@@ -30,7 +30,19 @@ internal class FakeDockSettingsStore : DockSettingsStore {
     }
 
     override suspend fun toggleNavHidden(id: DockNavId) {
-        navHiddenState.update { if (id in it) it - id else it + id }
+        // Keeps DockPreferences' floor: hiding the last visible nav button is a
+        // no-op there, so a fake without it would let a view-model test hide the
+        // whole nav — the state production cannot reach. The status setters below
+        // deliberately have no such floor, which is the asymmetry under test.
+        navHiddenState.update {
+            if (id in it) {
+                it - id
+            } else if ((it + id).containsAll(DockNavId.entries)) {
+                it
+            } else {
+                it + id
+            }
+        }
     }
 
     override suspend fun moveNav(
@@ -46,6 +58,10 @@ internal class FakeDockSettingsStore : DockSettingsStore {
 
     override suspend fun toggleStatusHidden(id: DockStatusId) {
         statusHiddenState.update { if (id in it) it - id else it + id }
+    }
+
+    override suspend fun setStatusClusterVisible(visible: Boolean) {
+        statusHiddenState.value = if (visible) emptySet() else DockStatusId.entries.toSet()
     }
 
     override suspend fun moveStatus(

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/components/HorizontalDockUsesPillTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/components/HorizontalDockUsesPillTest.kt
@@ -1,0 +1,135 @@
+package io.github.seijikohara.femto.ui.home.components
+
+import androidx.compose.ui.unit.dp
+import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.DockWidth
+import io.github.seijikohara.femto.data.dock.DockNavId
+import io.github.seijikohara.femto.data.dock.DockStatusId
+import io.github.seijikohara.femto.ui.theme.FemtoDimens
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * [horizontalDockUsesPill] is the horizontal bar's layout choice — the centred
+ * wrap-content pill, or the weight-shared full-width bar. Pure dp geometry, so
+ * these run without a composition.
+ *
+ * Every width below is the BAR's own, the figure `HorizontalDock` measures — a
+ * viewport is wider by the dock's float margins, which is what
+ * [MapCreditClearsDockTest] converts. The counts come from the enums, so adding
+ * a dock button or a status indicator re-derives them; the widths do NOT
+ * follow, and are picked to straddle the two thresholds today's seven buttons
+ * put at 672 dp and 912 dp. An eighth button moves both, and the 690 dp case
+ * below would have to be re-picked with them.
+ */
+class HorizontalDockUsesPillTest {
+    private val navCount = DockNavId.entries.size
+    private val statusCount = DockStatusId.entries.size
+
+    @Test
+    fun `COMPACT renders the centred pill on a dock wide enough for it`() =
+        assertTrue(horizontalDockUsesPill(DockWidth.COMPACT, 1280.dp, navCount, statusCount))
+
+    // The direction that is not merely a preference: the pill is a fixed
+    // footprint, so forcing it onto a narrow bar clips the leading / trailing
+    // buttons below the automotive floor (AGENTS.md#automotive-overrides). COMPACT
+    // therefore means "pill where it fits", never "pill always".
+    @Test
+    fun `COMPACT still falls back to the extended bar where the pill would clip`() =
+        assertFalse(horizontalDockUsesPill(DockWidth.COMPACT, 853.dp, navCount, statusCount))
+
+    @Test
+    fun `EXTENDED takes the weight-shared bar even where the pill would fit`() =
+        assertFalse(horizontalDockUsesPill(DockWidth.EXTENDED, 1280.dp, navCount, statusCount))
+
+    // Hiding every status indicator removes the cluster from the bar, so the
+    // width it reserved goes with it — otherwise the pill test would keep
+    // measuring a footprint that is no longer rendered, and the map attribution
+    // would stay lifted to clear a bar that is no longer full-width.
+    @Test
+    fun `hiding the whole status cluster frees the width it reserved`() =
+        assertTrue(horizontalDockUsesPill(DockWidth.COMPACT, 853.dp, navCount, statusCount = 0))
+
+    // Two stages yield to a narrowing bar, and the cluster yields first: below
+    // the status threshold the reserve is already gone, so the pill fits again.
+    @Test
+    fun `a dock too narrow to show the status cluster keeps the pill`() =
+        assertTrue(horizontalDockUsesPill(DockWidth.COMPACT, 690.dp, navCount, statusCount))
+}
+
+/**
+ * [mapCreditClearsDock] decides whether the map's bottom-start credit is lifted
+ * off the corner to clear the dock. It asks the same [horizontalDockUsesPill]
+ * predicate the bar does, but from outside the bar — so it takes the VIEWPORT
+ * width plus the margin the bar floats by, and narrows the one to the other
+ * before asking. These cases pin that conversion as much as the answer:
+ * per-backend map attribution is an invariant in this project, and a credit
+ * hidden under a full-width bar breaks it.
+ */
+class MapCreditClearsDockTest {
+    private val navCount = DockNavId.entries.size
+    private val statusCount = DockStatusId.entries.size
+
+    @Test
+    fun `a centred pill leaves the corner free, so the credit stays flush`() =
+        assertFalse(
+            mapCreditClearsDock(
+                dockPosition = DockPosition.BOTTOM,
+                dockWidth = DockWidth.COMPACT,
+                viewportWidth = 1280.dp,
+                dockMargin = FemtoDimens.ScreenPadding,
+                navCount = navCount,
+                statusCount = statusCount,
+            ),
+        )
+
+    // The mirroring the setting exists for: EXTENDED spans the width at a size
+    // where the pill would have fitted, so the credit has to lift with it.
+    @Test
+    fun `choosing EXTENDED lifts the credit even where the pill would have fitted`() =
+        assertTrue(
+            mapCreditClearsDock(
+                dockPosition = DockPosition.BOTTOM,
+                dockWidth = DockWidth.EXTENDED,
+                viewportWidth = 1280.dp,
+                dockMargin = FemtoDimens.ScreenPadding,
+                navCount = navCount,
+                statusCount = statusCount,
+            ),
+        )
+
+    // TOP is the other horizontal bar, and the one a layout-only check would get
+    // wrong: it spans the width too, but nowhere near the bottom-start corner.
+    @Test
+    fun `a top-hosted bar never covers the corner`() =
+        assertFalse(
+            mapCreditClearsDock(
+                dockPosition = DockPosition.TOP,
+                dockWidth = DockWidth.EXTENDED,
+                viewportWidth = 1280.dp,
+                dockMargin = FemtoDimens.ScreenPadding,
+                navCount = navCount,
+                statusCount = statusCount,
+            ),
+        )
+
+    // The band where the viewport and the bar disagree, and the one that decides
+    // whether this function may take a raw viewport width. A 940 dp viewport
+    // leaves the bar 892 dp once both float margins come off — short of the 912 dp
+    // the pill needs while the status cluster shows — so the bar draws full-width
+    // and the credit must lift. Measuring the viewport instead reads 940, calls it
+    // a pill, and leaves the OSM credit under the bar.
+    @Test
+    fun `the credit measures the bar, not the viewport it floats in`() =
+        assertTrue(
+            mapCreditClearsDock(
+                dockPosition = DockPosition.BOTTOM,
+                dockWidth = DockWidth.COMPACT,
+                viewportWidth = 940.dp,
+                dockMargin = FemtoDimens.ScreenPadding,
+                navCount = navCount,
+                statusCount = statusCount,
+            ),
+        )
+}

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -5,6 +5,7 @@ import io.github.seijikohara.femto.data.display.AccentColor
 import io.github.seijikohara.femto.data.display.AssistantLaunchSetting
 import io.github.seijikohara.femto.data.display.DisplaySettings
 import io.github.seijikohara.femto.data.display.DockPosition
+import io.github.seijikohara.femto.data.display.DockWidth
 import io.github.seijikohara.femto.data.display.DriverSide
 import io.github.seijikohara.femto.data.display.FullscreenSetting
 import io.github.seijikohara.femto.data.display.GoogleMapType
@@ -18,6 +19,7 @@ import io.github.seijikohara.femto.data.display.SpeedUnitSetting
 import io.github.seijikohara.femto.data.display.ThemeMode
 import io.github.seijikohara.femto.data.display.UiScale
 import io.github.seijikohara.femto.data.dock.DockNavId
+import io.github.seijikohara.femto.data.dock.DockStatusId
 import io.github.seijikohara.femto.data.fonts.FontSlot
 import io.github.seijikohara.femto.data.fonts.FontSource
 import io.github.seijikohara.femto.data.location.LocationQualitySetting
@@ -617,6 +619,38 @@ class SettingsViewModelTest {
 
             assertEquals(DockNavId.entries, dockStore.navOrder.first())
             assertEquals(emptySet(), dockStore.navHidden.first())
+        }
+
+    @Test
+    fun `SetDockWidth writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetDockWidth(DockWidth.EXTENDED))
+            advanceUntilIdle()
+            assertEquals(DockWidth.EXTENDED, store.settings.first().dockWidth)
+        }
+
+    @Test
+    fun `SetDockStatusVisible false hides every indicator in the dock store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetDockStatusVisible(false))
+            advanceUntilIdle()
+            assertEquals(DockStatusId.entries.toSet(), dockStore.statusHidden.first())
+        }
+
+    // The switch owns no boolean of its own: it reads the dock store's hidden
+    // set, so a per-indicator hide from the dock's long-press menu moves it too.
+    @Test
+    fun `dockStatusVisible is derived from the dock store's hidden set`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            // Subscribe so WhileUiSubscribed keeps the upstream combine alive across both phases.
+            backgroundScope.launch { vm.uiState.collect { } }
+            advanceUntilIdle()
+            assertEquals(true, vm.uiState.value.dockStatusVisible)
+
+            DockStatusId.entries.forEach { dockStore.toggleStatusHidden(it) }
+            advanceUntilIdle()
+            assertEquals(false, vm.uiState.value.dockStatusVisible)
         }
 
     private fun viewModel() =


### PR DESCRIPTION
Implements items 1 and 2 of #327. Both turned out to need a choice rather than a
new layout, so they ship together — same dock, same settings section, same
plumbing.

## Item 1 — hide the status icons

Per-indicator hide, reorder and "Reset dock" already shipped behind a long-press
on an indicator. Two things stood between that and the request:

- **Hiding the last visible indicator was refused**, with a comment borrowing the
  nav rationale ("the dock must keep at least one actionable id"). Status
  indicators are read-only, so that rationale does not transfer — and a dock with
  no status cluster is already a layout the design produces on its own, since the
  cluster yields below a derived width so the actionable nav keeps room. The
  floor is relaxed for **status only**; nav keeps its floor, and the stale
  comments that stated the old rule are corrected in the same change.
- **Nothing surfaced it.** There is now one switch in Settings → Screen, beside
  "Reset dock". Its state is *derived* from the visible set and its write flips
  the whole set, so the switch and the long-press cannot disagree — the hidden
  set stays the single home for that fact.

## Item 2 — Dock width: Compact / Extended

Not a resurrection: `HorizontalDock` already renders both layouts from one
composable, and the extended bar is what the 853 dp reference head unit shows
today. Only the *selection* changes, from a pure fit test to a preference the fit
test still bounds:

- **Extended** always fits — the weight-shared branch shrinks toward
  `FemtoDimens.MinTouchTarget` and never clips.
- **Compact** keeps the existing overflow fallback. It is not symmetric with
  Extended on purpose: forcing a pill onto a narrow dock clips the leading and
  trailing buttons below the tap-target floor.

**The default is unchanged.** The centred pill was a deliberate outcome of #274;
this adds the option without touching which one you get out of the box.

## A pre-existing mismatch this surfaced

The map-credit decision was fed the **viewport** width while the bar itself lays
out inside its own float margins, so the two disagreed in real width bands and
the OSM/OpenFreeMap credit could end up drawn under an extended bar. Both now
read the same width. The bug predates this change, but the change promotes that
computation to a named function whose entire justification is the attribution
invariant, so it had to hold.

## Verification

| Command | Result |
| --- | --- |
| `./gradlew spotlessCheck` | BUILD SUCCESSFUL |
| `./gradlew assembleDebug` | BUILD SUCCESSFUL |
| `./gradlew lint` | BUILD SUCCESSFUL, no new findings |
| `./gradlew test` | 871 tests, 0 failures |

Every new test was falsified by removing the matching production change and
confirming it goes red — including the width-mismatch regression case, which
fails against the old "measure the viewport" behaviour.

The settings drift guards (`SettingsFactsCompletenessTest`,
`SettingsSectionIdTest`) are satisfied rather than weakened: the new dock-width
setting carries its DataStore key, UI state, section row and diagnostics fact.

## Not verified here

`androidTest` does not run in CI, so the Compose UI tests touched here are not
gated by the merge. The layouts themselves are covered by JVM tests over the
pure fit/visibility functions. A pass on the TBox-Mock-Play AVD is still worth
doing before this reaches users — particularly the extended bar on an ultrawide
panel, where the nav cluster is capped and sits slightly left of screen centre.
