### PR TITLE
fix(location): emit a null no-fix signal on a fixless cold start

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/location/LocationRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/LocationRepository.kt
@@ -64,21 +64,31 @@ internal class LocationRepository(
     // degraded precision, and a device without network location still gets GPS. Each provider
     // is guarded by its own runCatching so a SecurityException or a missing provider on one
     // never disturbs the other. A per-provider failure is dropped (no null emission) so a
-    // working provider is never blanked by the other's absence — and neither is an empty
-    // cache: getLastKnownLocation returns null for a provider that has never fixed, and
-    // forwarding that null would blank the fix the other provider just seeded (the
-    // "never emits null once seeded" contract [LocationFreshness] states).
+    // working provider is never blanked by the other's absence — and so is an empty cache
+    // once ANYTHING seeded: getLastKnownLocation returns null for a provider that has never
+    // fixed, and forwarding that null would blank the fix the other provider just delivered
+    // (the "never emits null once seeded" contract [LocationFreshness] states). When NOTHING
+    // seeded, though, one null is emitted deliberately: it is the cold-start "no fix yet"
+    // signal. HomeViewModel combines nine sources and emits only once every one has spoken,
+    // so a location source that stays silent until the first live fix starves the whole
+    // dashboard into its Initial state — no cards, music stuck on the connect CTA, map
+    // unavailable (reproduced on-device against 6cc0bf71).
     @SuppressLint("MissingPermission") // Caller checks fine or coarse location before subscribing.
-    private fun rawLocationFlow(settings: LocationSettings): Flow<Location> =
+    private fun rawLocationFlow(settings: LocationSettings): Flow<Location?> =
         callbackFlow {
             // One listener shared across both registrations; each fix is forwarded verbatim.
             val listener = LocationListenerCompat { location -> trySend(location) }
+            var seeded = false
 
             listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER).forEach { provider ->
                 runCatching {
                     locationManager.getLastKnownLocation(provider)
-                }.onSuccess { cached -> cached?.let { trySend(it) } }
-                    .onFailure { logProviderFailure("getLastKnownLocation", provider, it) }
+                }.onSuccess { cached ->
+                    cached?.let {
+                        seeded = true
+                        trySend(it)
+                    }
+                }.onFailure { logProviderFailure("getLastKnownLocation", provider, it) }
 
                 runCatching {
                     LocationManagerCompat.requestLocationUpdates(
@@ -90,6 +100,8 @@ internal class LocationRepository(
                     )
                 }.onFailure { logProviderFailure("register", provider, it) }
             }
+
+            if (!seeded) trySend(null)
 
             awaitClose { locationManager.removeUpdates(listener) }
         }.flowOn(Dispatchers.Main.immediate)
@@ -111,8 +123,11 @@ internal class LocationRepository(
     // Advancing the baseline is a narrower decision than forwarding the fix: it outlives every
     // collector and only ratchets forward, so [canAnchorRecency] keeps a stamp the boot clock
     // cannot vouch for from pinning it out of reach for the life of the process.
-    private fun Flow<Location>.dropUnusableFixes(): Flow<Location> =
+    private fun Flow<Location?>.dropUnusableFixes(): Flow<Location?> =
         filter { fix ->
+            // The null no-fix signal is not a fix; it passes untested and never
+            // touches the recency baseline.
+            if (fix == null) return@filter true
             val usable = isUsableFix(fix, lastAcceptedElapsedNanos)
             if (usable && canAnchorRecency(fix, nowElapsedRealtimeNanos())) {
                 lastAcceptedElapsedNanos = fix.elapsedRealtimeNanos
@@ -140,7 +155,7 @@ internal class LocationRepository(
     // per-provider registration that a denied-at-start SecurityException killed is
     // retried. onStart(Unit) seeds the first registration; the pair is deliberately
     // not distinctUntilChanged'd so a same-settings refresh still re-registers.
-    private val shared: SharedFlow<Location> =
+    private val shared: SharedFlow<Location?> =
         combine(
             settings.distinctUntilChanged(),
             SystemPermissionSignals.refreshes.onStart { emit(Unit) },

--- a/app/src/test/java/io/github/seijikohara/femto/data/location/LocationRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/location/LocationRepositoryTest.kt
@@ -190,6 +190,63 @@ class LocationRepositoryTest {
         }
 
     @Test
+    fun `emits a null no-fix signal when no provider has a cache`() =
+        runTest {
+            // Cold start on a device that has never fixed: both getLastKnownLocation
+            // calls return null. The flow must still emit SOMETHING — HomeViewModel
+            // combines nine sources and emits only once every one of them has spoken,
+            // so a silent location source starves the whole dashboard into its
+            // Initial state (no cards, music stuck on the connect CTA, map
+            // unavailable) until the first live fix arrives. Reproduced on the
+            // TBox-Mock-Play AVD against 6cc0bf71.
+            val repository =
+                LocationRepository(
+                    application,
+                    flowOf(LocationSettings.Default),
+                    CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+                )
+
+            val emissions = mutableListOf<android.location.Location?>()
+            val collectJob =
+                launch(UnconfinedTestDispatcher(testScheduler)) {
+                    repository.locationFlow().collect { emissions.add(it) }
+                }
+            advanceUntilIdle()
+
+            assertEquals(listOf<android.location.Location?>(null), emissions)
+
+            collectJob.cancel()
+        }
+
+    @Test
+    fun `does not emit the no-fix signal when a provider cache seeded a fix`() =
+        runTest {
+            // The null is a cold-start signal only: once anything seeded, a null
+            // would blank the fix the other provider just delivered — the
+            // "never emits null once seeded" contract LocationFreshness states.
+            seedLastKnown(LocationManager.GPS_PROVIDER, fakeLocation(latitude = 10.0))
+
+            val repository =
+                LocationRepository(
+                    application,
+                    flowOf(LocationSettings.Default),
+                    CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+                )
+
+            val emissions = mutableListOf<android.location.Location?>()
+            val collectJob =
+                launch(UnconfinedTestDispatcher(testScheduler)) {
+                    repository.locationFlow().collect { emissions.add(it) }
+                }
+            advanceUntilIdle()
+
+            assertEquals(1, emissions.size)
+            assertEquals(10.0, emissions.single()?.latitude)
+
+            collectJob.cancel()
+        }
+
+    @Test
     fun `drops a fix whose boot clock sits behind the newest forwarded one`() =
         runTest {
             val settings = MutableStateFlow(LocationSettings.Default)


### PR DESCRIPTION
Fixes a regression introduced by #359 (`6cc0bf71`, in Nightly 1086+): on a
device whose location providers have no cached fix, the entire dashboard
freezes in its Initial state — no cards, the music card stuck on the connect
CTA, "Map unavailable" — until the first live GPS fix arrives.

## Mechanism

#359 stopped forwarding a null `getLastKnownLocation` result, so that an empty
provider cache could not blank a fix the other provider had just seeded. That
was right — but it also removed the only emission a fixless cold start ever
produced. `HomeViewModel` combines nine sources and emits only once every one
of them has spoken; with the location source silent, the combine never fires,
and the address / weather sources derived from it starve too.

Reproduced live on the TBox-Mock-Play AVD against `6cc0bf71`: permissions
granted, notification listener bound, YT Music playing and its media3 handshake
visible in logcat — and the dashboard fully dead. One injected fix brought
every card up at once.

This also poisoned issue #358's A/B test: the reporter compared a July 31 APK
(healthy) against the latest nightly (carrying this regression) and concluded
"new updates" broke music detection. Indoors, with no fix, the latest build's
music card is indeed dead — for this reason, on top of the session-watch gap
PR #360 fixes.

## Fix

Emit one deliberate `null` when **neither** provider had a cache — the
cold-start "no fix yet" signal every consumer already understands. Once
anything seeded, nulls stay dropped, which keeps the contract
`LocationFreshness` states ("never emits null once seeded") true in both
directions. The null passes the sanity gate untested and never touches the
recency baseline.

## Verification

| Command | Result |
| --- | --- |
| `./gradlew spotlessCheck` | BUILD SUCCESSFUL |
| `./gradlew assembleDebug` | BUILD SUCCESSFUL |
| `./gradlew lint` | BUILD SUCCESSFUL, no new findings |
| `./gradlew test` | 858 tests, 0 failures |

The new no-fix test was written first and confirmed red against `6cc0bf71`,
then falsified after the fix: removing only the `trySend(null)` line makes
exactly that test fail. The seeded-path test pins that the null never fires
once a cache exists. On-device: the dead-dashboard state was reproduced on the
AVD before the fix; the emulator's GPS re-injects its last coordinates across
reboots, so the fixless cold boot could not be re-run there against the patched
build without wiping the AVD's Google sign-in — the JVM test carries that pin.
