### PR TITLE
chore(ci): changelog in nightly notes; close-out comments on fixed issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,12 @@ jobs:
           # ("release not found") yet still blocks the tag_name on create —
           # a deadlock no rerun can clear. Listing sees every release, so this
           # shape cannot wedge; an empty list (first-ever run) simply skips.
+          # Remember what the outgoing nightly pointed at, for the changelog
+          # below. target_commitish can be a branch name on old releases; only
+          # a 40-hex value is usable as a range endpoint.
+          PREVIOUS_NIGHTLY_SHA=$(gh api "repos/$GITHUB_REPOSITORY/releases" \
+            --jq '[.[] | select(.tag_name == "nightly")][0].target_commitish // empty' | grep -E '^[0-9a-f]{40}$' || true)
+          echo "PREVIOUS_NIGHTLY_SHA=$PREVIOUS_NIGHTLY_SHA" >> "$GITHUB_ENV"
           gh api "repos/$GITHUB_REPOSITORY/releases" \
             --jq '.[] | select(.tag_name == "nightly") | .id' |
             while read -r release_id; do
@@ -178,11 +184,27 @@ jobs:
           # exists, so a stale ref would silently pin the new release to the
           # OLD commit. A 404 here just means no tag yet.
           gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly" || true
+          # The release notes carry the commit subjects since the previously
+          # published nightly: the rolling release is the only distribution
+          # channel, so its notes are the only place a reporter can see that
+          # the fix for their issue has shipped. previous_sha comes from the
+          # release listing above (empty on the first-ever run, where the
+          # changelog degrades to just the current subject).
+          {
+            echo "Automated nightly build from ${GITHUB_SHA:0:7} (run #${{ github.run_number }}) on $(date -u +%Y-%m-%d)."
+            echo
+            echo "Changes since the previous nightly:"
+            if [ -n "$PREVIOUS_NIGHTLY_SHA" ] && git cat-file -e "$PREVIOUS_NIGHTLY_SHA" 2>/dev/null; then
+              git log --format='- %s' "$PREVIOUS_NIGHTLY_SHA..$GITHUB_SHA"
+            else
+              git log -1 --format='- %s' "$GITHUB_SHA"
+            fi
+          } > "$RUNNER_TEMP/nightly-notes.md"
           gh release create nightly \
             "$RUNNER_TEMP/femto-car-launcher-nightly.apk" \
             "$RUNNER_TEMP/femto-car-launcher-nightly.aab" \
             --target "$GITHUB_SHA" \
             --title "Nightly ${{ github.run_number }}" \
-            --notes "Automated nightly build from ${GITHUB_SHA:0:7} (run #${{ github.run_number }}) on $(date -u +%Y-%m-%d)." \
+            --notes-file "$RUNNER_TEMP/nightly-notes.md" \
             --prerelease \
             --latest=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,11 @@ in the skill directory; `create-avd.sh` recreates it).
 
 - Conventional Commits for commit messages and PR titles (the PR
   title becomes the squash subject).
+- A PR that resolves a user-filed issue posts a closing comment on
+  that issue: one or two sentences of cause, and the first nightly
+  that carries the fix. The rolling nightly is the only distribution
+  channel, so the issue thread is where a reporter learns their fix
+  shipped; a wordless keyword-close tells them nothing.
 - Merges are rebase + squash; history on `main` stays linear.
   Force-push is denied; update a stale branch via the GitHub
   update-branch API (`gh pr update-branch`).


### PR DESCRIPTION
Follow-up to an audit of how recent issues were handled. Three user-filed
issues (#231, #273, #351) were closed by PR keywords with zero comments, and
the nightly release notes carried a single generated line — so the only
distribution channel never told a reporter that their fix had shipped.

Two changes:

1. **Nightly release notes now list the commit subjects since the previously
   published nightly.** The outgoing nightly's target sha is captured from the
   release listing before the rolling release is deleted; if it is missing or
   not a 40-hex sha (first-ever run, or an old branch-name target), the
   changelog degrades to the current commit's subject. No new failure mode on
   the publish path.

2. **AGENTS.md records the closing-comment convention:** a PR that resolves a
   user-filed issue posts one or two sentences of cause plus the first nightly
   carrying the fix.

## Verification

`spotlessCheck` BUILD SUCCESSFUL (covers the Markdown); the workflow parses as
valid YAML. The changelog block only reshapes the `--notes` input of the
existing `gh release create` call — the delete-by-id / tag-ref-delete sequence
that PR #287 hardened is untouched.
