### PR TITLE
fix(dock): cap the extended bar's glass at its content width

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardDock.kt
@@ -131,13 +131,30 @@ private fun compactDockExtent(visibleNavCount: Int): Dp =
 // never clips (see HorizontalDock).
 private val DockStatusSideReserve: Dp = 240.dp
 
+/**
+ * Width past which [DockWidth.EXTENDED]'s glass stops growing and centres.
+ *
+ * The bar's content stops growing first: the nav cluster caps at
+ * [FemtoDimens.DockNavClusterMaxWidth] and the status flank never needs more
+ * than [DockStatusSideReserve], so any glass beyond their sum plus the inner
+ * margins is empty — on an ultrawide panel the full-bleed bar read as a slab
+ * of dead glass around a huddled cluster. Derived from the content, not tuned
+ * to a device: re-derive by growing a constituent, never by editing a literal
+ * here. Every geometry whose bar is narrower than the cap (the 853 dp
+ * reference head unit included) renders exactly as before.
+ */
+internal fun extendedDockMaxWidth(showsStatus: Boolean): Dp =
+    FemtoDimens.DockNavClusterMaxWidth +
+        (if (showsStatus) DockStatusSideReserve else 0.dp) +
+        FemtoDimens.DockButtonMargin * 2
+
 // Whether the dock renders the read-only status cluster along [extent] (the
 // horizontal bar's width, the vertical rail's height): it needs an indicator left
 // to show, and room to spare once the actionable nav has its own (see
 // compactDockExtent). The user can hide every indicator, which drops the cluster
 // and its divider at any extent — and, on the horizontal bar, releases the width
 // the fit test below reserves for it.
-private fun dockShowsStatus(
+internal fun dockShowsStatus(
     extent: Dp,
     navCount: Int,
     statusCount: Int,
@@ -306,8 +323,16 @@ private fun HorizontalDock(
             modifier =
                 Modifier
                     .height(FemtoDimens.DockThickness)
-                    .then(if (usesPill) Modifier else Modifier.fillMaxWidth())
-                    .glassChrome(MaterialTheme.shapes.large, hazeState, glassConfig),
+                    .then(
+                        if (usesPill) {
+                            Modifier
+                        } else {
+                            // Fill the inset band up to the content-derived cap; the
+                            // scaffold's centre alignment centres a capped bar the same
+                            // way it centres the pill (see extendedDockMaxWidth).
+                            Modifier.widthIn(max = extendedDockMaxWidth(showStatusCluster)).fillMaxWidth()
+                        },
+                    ).glassChrome(MaterialTheme.shapes.large, hazeState, glassConfig),
             color = Color.Transparent,
             contentColor = MaterialTheme.colorScheme.onSurface,
         ) {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/home/components/DashboardScaffold.kt
@@ -111,9 +111,15 @@ internal fun mapCreditClearsDock(
     dockMargin: Dp,
     navCount: Int,
     statusCount: Int,
-): Boolean =
-    dockPosition == DockPosition.BOTTOM &&
-        !horizontalDockUsesPill(dockWidth, horizontalDockWidth(viewportWidth, dockMargin), navCount, statusCount)
+): Boolean {
+    if (dockPosition != DockPosition.BOTTOM) return false
+    val barWidth = horizontalDockWidth(viewportWidth, dockMargin)
+    if (horizontalDockUsesPill(dockWidth, barWidth, navCount, statusCount)) return false
+    // A bar wider than the content cap is clamped and centred (see
+    // extendedDockMaxWidth), so it no longer reaches the bottom-start corner and
+    // the credit belongs flush in it again.
+    return barWidth <= extendedDockMaxWidth(dockShowsStatus(barWidth, navCount, statusCount))
+}
 
 /**
  * Top-level dashboard layout: the map is the full-screen background and

--- a/app/src/test/java/io/github/seijikohara/femto/ui/home/components/HorizontalDockUsesPillTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/home/components/HorizontalDockUsesPillTest.kt
@@ -92,7 +92,7 @@ class MapCreditClearsDockTest {
             mapCreditClearsDock(
                 dockPosition = DockPosition.BOTTOM,
                 dockWidth = DockWidth.EXTENDED,
-                viewportWidth = 1280.dp,
+                viewportWidth = 1000.dp,
                 dockMargin = FemtoDimens.ScreenPadding,
                 navCount = navCount,
                 statusCount = statusCount,
@@ -108,6 +108,22 @@ class MapCreditClearsDockTest {
                 dockPosition = DockPosition.TOP,
                 dockWidth = DockWidth.EXTENDED,
                 viewportWidth = 1280.dp,
+                dockMargin = FemtoDimens.ScreenPadding,
+                navCount = navCount,
+                statusCount = statusCount,
+            ),
+        )
+
+    // Past the content cap the extended bar stops growing and centres, so the
+    // bottom-start corner is map again and the credit belongs flush in it.
+    // Before the cap existed this width kept the credit lifted over dead glass.
+    @Test
+    fun `a capped extended bar on an ultrawide leaves the corner to the credit`() =
+        assertFalse(
+            mapCreditClearsDock(
+                dockPosition = DockPosition.BOTTOM,
+                dockWidth = DockWidth.EXTENDED,
+                viewportWidth = 1920.dp,
                 dockMargin = FemtoDimens.ScreenPadding,
                 navCount = navCount,
                 statusCount = statusCount,


### PR DESCRIPTION
Shipped in Nightly 1093, `Dock width: Extended` fills the inset band
unconditionally — faithful to the pre-#274 layout, but on an ultrawide panel it
renders as a slab of dead glass around a huddled nav cluster, because the
content is capped (`DockNavClusterMaxWidth`, the status reserve) while the
glass is not.

Bound the glass at the content-derived width — cluster cap + status flank when
shown + the inner margins — and let the scaffold's centre alignment centre it
the way it centres the pill. The cap is derived, not tuned: re-derive it by
growing a constituent, never by editing a literal.

- Every geometry whose bar is narrower than the cap renders exactly as before —
  the 853 dp reference head unit included, so no golden changes (goldens render
  the default COMPACT, and the fallback bar only appears below the pill
  threshold, which sits under the cap).
- `mapCreditClearsDock` now lifts the OSM/OpenFreeMap credit only while the bar
  actually spans the width; past the cap the corner is map again and the credit
  sits flush. The new test fails against the uncapped behaviour and was
  falsified by bypassing the reach condition.

| Verification | Result |
| --- | --- |
| `./gradlew spotlessCheck` / `assembleDebug` / `lint` | BUILD SUCCESSFUL |
| `./gradlew test` | 894 tests, 0 failures |
| TBox-Mock-Play AVD @ simulated 1920×720 | bar centres at its cap, gutters gone, credit flush |
