### PR TITLE
feat(trip): start a new trip automatically after a parked gap

### DIFF
--- a/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCollector.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCollector.kt
@@ -82,6 +82,7 @@ internal fun locationSettingsFacts(location: LocationSettings): List<DiagnosticF
         entry("Location interval", "${location.intervalMillis} ms"),
         entry("Location min distance", "${location.minUpdateDistanceMeters} m"),
         entry("Background ranging", "${location.backgroundRangingEnabled}"),
+        entry("Trip auto-reset", location.tripAutoReset.name),
         entry("Track recording", "${location.trackRecordingEnabled}"),
         entry("Track retention", location.trackRetention.name),
     )

--- a/app/src/main/java/io/github/seijikohara/femto/data/display/SettingsSectionId.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/display/SettingsSectionId.kt
@@ -81,10 +81,9 @@ internal enum class SettingsSectionId(
         ),
     ),
 
-    // Every Location-section row (quality, interval, min distance, background
-    // ranging) persists in the LOCATION store, not DisplayPreferences — an
-    // empty set here; SettingsViewModel resets it entirely via the other-store
-    // call for this section.
+    // Every Location-section row persists in the LOCATION store (LocationPreferences),
+    // not DisplayPreferences — an empty set here; SettingsViewModel resets it
+    // entirely via the other-store call for this section.
     LOCATION(emptySet()),
 
     PANELS(

--- a/app/src/main/java/io/github/seijikohara/femto/data/location/LocationGraph.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/LocationGraph.kt
@@ -58,6 +58,7 @@ internal class LocationGraph private constructor(
             // sees exactly the fixes trip math accepts — same lifecycle, no
             // second collector on the shared location flow.
             trackTap = TripFixTap { location, tripId -> trackLog.offer(location, tripId) },
+            autoReset = preferences.settings.map { it.tripAutoReset }.distinctUntilChanged(),
         )
 
     fun locationFlow(): Flow<Location?> = locationRepository.locationFlow()

--- a/app/src/main/java/io/github/seijikohara/femto/data/location/LocationPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/LocationPreferences.kt
@@ -51,7 +51,40 @@ internal const val DEFAULT_BACKGROUND_RANGING_ENABLED = false
  */
 internal const val DEFAULT_TRACK_RECORDING_ENABLED = true
 
-private const val MILLIS_PER_DAY = 24L * 60 * 60 * 1_000
+private const val MILLIS_PER_MINUTE = 60L * 1_000
+private const val MILLIS_PER_HOUR = 60 * MILLIS_PER_MINUTE
+private const val MILLIS_PER_DAY = 24 * MILLIS_PER_HOUR
+
+/**
+ * When the trip meter starts a new trip on its own. [OFF] keeps the original
+ * contract — one trip from reset tap to reset tap. The timed options end a
+ * trip once no GPS fix has been accepted for that long: the next fix opens a
+ * new one. That is the parked-gap rule car trip computers apply to their
+ * "since start" memory — a fuel or shopping stop continues the trip, an
+ * overnight park does not — and it is the one boundary every device class
+ * shares: an AI box cold-boots per drive, a head unit may sleep through many
+ * ignition cycles, a phone reopens the launcher several times per drive, so
+ * neither process nor Activity lifetime can stand in for "one drive". Hours
+ * rather than minutes so a navigation app held in front for a while (no fix
+ * reaches the launcher without background ranging) does not split a drive.
+ * The 2 h default sits at the short end of the OEM range, so a commute and
+ * its return read as two trips.
+ */
+internal enum class TripAutoResetSetting(
+    val parkedGapMs: Long?,
+) {
+    OFF(null),
+    MINUTES_30(30 * MILLIS_PER_MINUTE),
+    HOURS_1(MILLIS_PER_HOUR),
+    HOURS_2(2 * MILLIS_PER_HOUR),
+    HOURS_4(4 * MILLIS_PER_HOUR),
+    HOURS_12(12 * MILLIS_PER_HOUR),
+    ;
+
+    companion object {
+        val Default = HOURS_2
+    }
+}
 
 /**
  * How long recorded track points are kept before pruning. A privacy knob, not
@@ -84,6 +117,7 @@ internal data class LocationSettings(
     val intervalMillis: Long,
     val minUpdateDistanceMeters: Int,
     val backgroundRangingEnabled: Boolean,
+    val tripAutoReset: TripAutoResetSetting,
     val trackRecordingEnabled: Boolean,
     val trackRetention: TrackRetentionSetting,
 ) {
@@ -94,6 +128,7 @@ internal data class LocationSettings(
                 intervalMillis = DEFAULT_LOCATION_INTERVAL_MS,
                 minUpdateDistanceMeters = DEFAULT_LOCATION_MIN_DISTANCE_M,
                 backgroundRangingEnabled = DEFAULT_BACKGROUND_RANGING_ENABLED,
+                tripAutoReset = TripAutoResetSetting.Default,
                 trackRecordingEnabled = DEFAULT_TRACK_RECORDING_ENABLED,
                 trackRetention = TrackRetentionSetting.Default,
             )
@@ -115,6 +150,8 @@ internal interface LocationSettingsStore {
     suspend fun setMinUpdateDistanceMeters(value: Int)
 
     suspend fun setBackgroundRangingEnabled(value: Boolean)
+
+    suspend fun setTripAutoReset(value: TripAutoResetSetting)
 
     suspend fun setTrackRecordingEnabled(value: Boolean)
 
@@ -140,6 +177,7 @@ internal class LocationPreferences(
                     minUpdateDistanceMeters = prefs[MIN_DISTANCE_KEY] ?: DEFAULT_LOCATION_MIN_DISTANCE_M,
                     backgroundRangingEnabled =
                         prefs[BACKGROUND_RANGING_KEY] ?: DEFAULT_BACKGROUND_RANGING_ENABLED,
+                    tripAutoReset = prefs[TRIP_AUTO_RESET_KEY].toEnumOr(TripAutoResetSetting.Default),
                     trackRecordingEnabled =
                         prefs[TRACK_RECORDING_KEY] ?: DEFAULT_TRACK_RECORDING_ENABLED,
                     trackRetention = prefs[TRACK_RETENTION_KEY].toEnumOr(TrackRetentionSetting.Default),
@@ -162,6 +200,10 @@ internal class LocationPreferences(
         context.locationDataStore.editOrLog(TAG) { it[BACKGROUND_RANGING_KEY] = value }
     }
 
+    override suspend fun setTripAutoReset(value: TripAutoResetSetting) {
+        context.locationDataStore.editOrLog(TAG) { it[TRIP_AUTO_RESET_KEY] = value.name }
+    }
+
     override suspend fun setTrackRecordingEnabled(value: Boolean) {
         context.locationDataStore.editOrLog(TAG) { it[TRACK_RECORDING_KEY] = value }
     }
@@ -182,6 +224,7 @@ internal class LocationPreferences(
         val INTERVAL_KEY = longPreferencesKey("location_interval_ms")
         val MIN_DISTANCE_KEY = intPreferencesKey("location_min_distance_m")
         val BACKGROUND_RANGING_KEY = booleanPreferencesKey("background_ranging_enabled")
+        val TRIP_AUTO_RESET_KEY = stringPreferencesKey("trip_auto_reset")
         val TRACK_RECORDING_KEY = booleanPreferencesKey("track_recording_enabled")
         val TRACK_RETENTION_KEY = stringPreferencesKey("track_retention")
     }

--- a/app/src/main/java/io/github/seijikohara/femto/data/location/LocationPreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/LocationPreferences.kt
@@ -64,11 +64,12 @@ private const val MILLIS_PER_DAY = 24 * MILLIS_PER_HOUR
  * overnight park does not — and it is the one boundary every device class
  * shares: an AI box cold-boots per drive, a head unit may sleep through many
  * ignition cycles, a phone reopens the launcher several times per drive, so
- * neither process nor Activity lifetime can stand in for "one drive". Hours
- * rather than minutes so a navigation app held in front for a while (no fix
- * reaches the launcher without background ranging) does not split a drive.
- * The 2 h default sits at the short end of the OEM range, so a commute and
- * its return read as two trips.
+ * neither process nor Activity lifetime can stand in for "one drive". The
+ * default is hours rather than minutes so a navigation app held in front for
+ * a while (no fix reaches the launcher without background ranging) does not
+ * split a drive; 2 h sits at the short end of the OEM range, so a commute and
+ * its return read as two trips. The 30-minute option suits a launcher that
+ * stays in front, or one paired with background ranging.
  */
 internal enum class TripAutoResetSetting(
     val parkedGapMs: Long?,

--- a/app/src/main/java/io/github/seijikohara/femto/data/location/TripRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/TripRepository.kt
@@ -256,8 +256,15 @@ internal class TripRepository(
                         }
 
                         TripSignal.Reset -> {
-                            startNextTrip()
+                            resetAccumulators()
+                            // Emit first so the tap's zeros never wait on the disk;
+                            // then write through (not a fire-and-forget enqueue) so
+                            // the zeros and the bumped trip id are durable before
+                            // the next signal — which is only processed once this
+                            // handler returns — and a crash after this can never
+                            // resurrect the old totals or reuse the previous id.
                             emit(snapshot())
+                            store.write(persisted())
                         }
 
                         is TripSignal.AutoResetChanged -> {
@@ -409,11 +416,12 @@ internal class TripRepository(
         store.write(persisted())
     }
 
-    // Ends the current trip and opens the next: shared by the user's tap and the
-    // parked-gap rule so both leave the same durable footprint. Write-through
-    // (not a fire-and-forget enqueue) so the zeros and the bumped trip id are
-    // durable before the next signal: a crash after this can never resurrect the
-    // old totals or reuse the previous trip's id.
+    // The parked-gap boundary: ends the current trip and opens the next one, with
+    // the zeros and the bumped trip id written through before the caller accrues
+    // or logs the boundary fix — so a crash can never resurrect the old totals or
+    // reuse the previous trip's id under an already-committed track point. The
+    // user's tap (the Reset branch) takes the same two steps with its emit in
+    // between, so the tap's zeros never wait on the disk write.
     private suspend fun startNextTrip() {
         resetAccumulators()
         store.write(persisted())

--- a/app/src/main/java/io/github/seijikohara/femto/data/location/TripRepository.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/TripRepository.kt
@@ -10,7 +10,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -97,25 +99,46 @@ import kotlinx.coroutines.withContext
  * The GPS anchor is deliberately NOT restored: `elapsedRealtimeNanos` is
  * boot-relative, so the first fix of the new process re-anchors and the
  * dead period contributes neither time nor distance (the same semantics
- * as an unknown-onset gap). The user's reset tap is therefore the only
- * deliberate way a trip ends; a restart merely pauses it.
+ * as an unknown-onset gap). A restart alone merely pauses a trip; only
+ * the user's reset tap or the parked-gap rule below ends one.
  *
- * A trip spans reset to reset. [TripState.startedAtEpochMs] marks the
- * wall-clock time of the first GPS fix accepted after a reset (not the
- * tap itself — the car may sit parked long after it), which is also the
- * first point the track logger sees for the trip: [trackTap] is invoked
- * for every RECORDABLE fix from inside the merged collect (never the
- * upstream producer — that would read the trip id on a different
- * coroutine and race a concurrent reset), tagged with the current trip
- * id, a monotonic counter that increments on each reset and delimits
- * reset-to-reset trips in the track log. A fix whose effective speed is
- * an implausible teleport is not recordable: it is excluded from the
- * track log for the same reason the trip math refuses it.
+ * A trip ends at the user's reset tap or, when [TripAutoResetSetting] is
+ * timed, at a parked gap: the first fix accepted after no fix was
+ * accepted for the configured span opens the next trip (zeros, bumped
+ * id, its own start) exactly as a tap would. The span is measured on the
+ * boot clock while this process has seen a fix — immune to wall-clock
+ * corrections, and it keeps counting through a head unit's deep sleep —
+ * and on the wall clock only for the first gap after a process restart,
+ * against the persisted `Location.time` of the last fix, the one stamp
+ * that survives a reboot. A negative span is never a gap. The check also
+ * runs as each subscription window opens, so a trip parked past the gap
+ * ends before the first fix arrives and the dashboard shows the next
+ * drive's zeros through the GNSS warm-up rather than the previous
+ * drive's totals. The setting arrives as a third merged signal on the
+ * same sequence, and is re-read as the window opens (a Settings change
+ * while the dashboard was away had no live collector to reach it).
+ * Accrual pauses while the launcher is fully backgrounded without
+ * background ranging, so a navigation app held in front longer than the
+ * gap ends the trip on return — background ranging keeps the fixes, and
+ * so the trip, flowing.
  *
- * Location fixes and explicit [reset] requests are merged into a single
- * stream consumed by one sequential `collect`, so the plain (non-atomic)
- * accumulator fields are only ever read and written from that one
- * sequence — a reset can never interleave with an accrual.
+ * [TripState.startedAtEpochMs] marks the wall-clock time of the first GPS
+ * fix accepted after a trip boundary (not the tap itself — the car may
+ * sit parked long after it), which is also the first point the track
+ * logger sees for the trip: [trackTap] is invoked for every RECORDABLE
+ * fix from inside the merged collect (never the upstream producer — that
+ * would read the trip id on a different coroutine and race a concurrent
+ * reset), tagged with the current trip id, a monotonic counter that
+ * increments at each boundary and delimits trips in the track log. A fix
+ * whose effective speed is an implausible teleport is not recordable: it
+ * is excluded from the track log for the same reason the trip math
+ * refuses it.
+ *
+ * Location fixes, explicit [reset] requests, and setting changes are
+ * merged into a single stream consumed by one sequential `collect`, so
+ * the plain (non-atomic) accumulator fields are only ever read and
+ * written from that one sequence — a reset can never interleave with an
+ * accrual.
  *
  * Accrual still *pauses* while fully backgrounded — there is no eager
  * always-on GPS scope here — but the running total survives the gap and
@@ -136,6 +159,13 @@ internal class TripRepository(
     // Boot-clock source for the arrival-staleness filter; tests inject a fixed
     // value so fixture nanos stay deterministic.
     private val nowElapsedRealtimeNanos: () -> Long = SystemClock::elapsedRealtimeNanos,
+    // The trip meter's auto-reset setting, observed live on the accrual
+    // sequence (see class KDoc). Production wires the Location settings store;
+    // the default keeps tests that only exercise trip math on the shipped rule.
+    private val autoReset: Flow<TripAutoResetSetting> = flowOf(TripAutoResetSetting.Default),
+    // Wall-clock source for the parked-gap check before this process has seen a
+    // fix (class KDoc); tests inject a fixed instant.
+    private val nowEpochMs: () -> Long = System::currentTimeMillis,
 ) {
     // Hoisted out of the cold flow {} so the running total survives a
     // WhileSubscribed stop/restart; see the class KDoc.
@@ -145,6 +175,16 @@ internal class TripRepository(
     private var currentSpeedMs = 0.0
     private var startedAtEpochMs: Long? = null
     private var tripId = 0L
+
+    // Stamps of the last accepted fix for the parked-gap rule: the boot-clock
+    // one is this process's only (never restored — it is boot-relative), the
+    // wall-clock one is persisted and covers the first gap after a restart.
+    private var lastFixEpochMs: Long? = null
+    private var lastFixElapsedNanos: Long? = null
+
+    // The configured parked gap; null while auto-reset is off. Read as each
+    // window opens and updated by the merged setting signal.
+    private var parkedGapMs: Long? = null
 
     // Whether currentSpeedMs has been published at least once this trip.
     // Distinguishes a real standstill (0.0 from a stationary fix) from the
@@ -169,7 +209,14 @@ internal class TripRepository(
 
     fun stateFlow(): Flow<TripState> =
         flow {
+            // Read as the window opens, not only via the merged signal below: a
+            // Settings change while the dashboard was away had no live collector
+            // to reach the field, and the first fix must not race the re-delivery.
+            parkedGapMs = autoReset.first().parkedGapMs
             restoreOnce()
+            // A trip parked past the gap ends as the window opens (class KDoc),
+            // so the replay below already shows the next drive's zeros.
+            if (parkedGapElapsed(atNanos = nowElapsedRealtimeNanos(), atEpochMs = nowEpochMs())) startNextTrip()
             // Replay the running total to a (re)subscriber instead of a
             // hardcoded Initial, so distance does not appear to reset to
             // zero when the window reopens.
@@ -185,29 +232,36 @@ internal class TripRepository(
                     .filterNot { arrivedStale(it) }
                     .map { TripSignal.Fix(it) }
             val resets: Flow<TripSignal> = resetSignals.map { TripSignal.Reset }
+            val settings: Flow<TripSignal> = autoReset.map { TripSignal.AutoResetChanged(it) }
             try {
-                merge(fixes, resets).collect { signal ->
+                merge(fixes, resets, settings).collect { signal ->
                     when (signal) {
                         is TripSignal.Fix -> {
+                            val fix = signal.location
+                            // The first fix after a parked gap opens the next trip
+                            // before it is accrued or logged, so the bumped id is
+                            // durable before the trip's first track point.
+                            if (parkedGapElapsed(atNanos = fix.elapsedRealtimeNanos, atEpochMs = fix.time)) {
+                                startNextTrip()
+                            }
                             // Tap here, on the single sequence, so the trip id the
                             // track logger reads is the one this fix accrues into,
                             // totally ordered with resets (see class KDoc). Skip
                             // implausible teleports the trip math rejects.
-                            if (accrue(signal.location)) {
-                                trackTap.onFix(signal.location, tripId)
+                            if (accrue(fix)) {
+                                trackTap.onFix(fix, tripId)
                             }
                             emit(snapshot())
-                            maybePersist(signal.location.elapsedRealtimeNanos)
+                            maybePersist(fix.elapsedRealtimeNanos)
                         }
 
                         TripSignal.Reset -> {
-                            resetAccumulators()
+                            startNextTrip()
                             emit(snapshot())
-                            // Write-through (not a fire-and-forget enqueue) so the
-                            // zeros and the bumped trip id are durable before the
-                            // next signal: a crash after this can never resurrect
-                            // the old totals or reuse the previous trip's id.
-                            store.write(persisted())
+                        }
+
+                        is TripSignal.AutoResetChanged -> {
+                            parkedGapMs = signal.setting.parkedGapMs
                         }
                     }
                 }
@@ -238,6 +292,7 @@ internal class TripRepository(
         totalMeters = persisted.totalMeters
         totalSeconds = persisted.totalSeconds
         startedAtEpochMs = persisted.startedAtEpochMs
+        lastFixEpochMs = persisted.lastFixEpochMs
         tripId = persisted.tripId
         restored = true
     }
@@ -252,6 +307,10 @@ internal class TripRepository(
     // whether the fix is recordable — true for any trustworthy position, false
     // only for an implausible teleport (which neither accrues nor is logged).
     private fun accrue(current: Location): Boolean {
+        // Every accepted fix, moving or not, re-arms the parked-gap rule: a
+        // receiver that keeps fixing is a car that is on, not one that is parked.
+        lastFixEpochMs = current.time
+        lastFixElapsedNanos = current.elapsedRealtimeNanos
         if (startedAtEpochMs == null) {
             // The trip starts at its first accepted fix — the same fix the
             // track logger records first — not at the reset tap; see class KDoc.
@@ -350,16 +409,44 @@ internal class TripRepository(
         store.write(persisted())
     }
 
+    // Ends the current trip and opens the next: shared by the user's tap and the
+    // parked-gap rule so both leave the same durable footprint. Write-through
+    // (not a fire-and-forget enqueue) so the zeros and the bumped trip id are
+    // durable before the next signal: a crash after this can never resurrect the
+    // old totals or reuse the previous trip's id.
+    private suspend fun startNextTrip() {
+        resetAccumulators()
+        store.write(persisted())
+    }
+
+    // Whether the parked gap has elapsed by [atNanos] on the boot clock or, when
+    // this process has not yet seen a fix, by [atEpochMs] on the wall clock
+    // against the persisted stamp (class KDoc). A negative span — a clock that
+    // ran backward, a dead RTC booting into the past — is never a parked gap.
+    private fun parkedGapElapsed(
+        atNanos: Long,
+        atEpochMs: Long,
+    ): Boolean {
+        val gapMs = parkedGapMs ?: return false
+        val spanMs =
+            lastFixElapsedNanos?.let { (atNanos - it) / NANOS_PER_MILLI }
+                ?: lastFixEpochMs?.let { atEpochMs - it }
+                ?: return false
+        return spanMs >= gapMs
+    }
+
     private fun resetAccumulators() {
         // Drop the anchor too so the trip restarts cleanly from the next fix
         // rather than charging the gap between the reset and that fix.
         lastLocation = null
+        lastFixEpochMs = null
+        lastFixElapsedNanos = null
         totalMeters = 0.0
         totalSeconds = 0.0
         currentSpeedMs = 0.0
         speedEstablished = false
         startedAtEpochMs = null
-        // The next reset-to-reset trip begins; the track log keys points on this.
+        // The next trip begins; the track log keys points on this.
         tripId += 1
     }
 
@@ -376,20 +463,27 @@ internal class TripRepository(
             totalMeters = totalMeters,
             totalSeconds = totalSeconds,
             startedAtEpochMs = startedAtEpochMs,
+            lastFixEpochMs = lastFixEpochMs,
             tripId = tripId,
         )
 
-    // Merged input to the single accrual sequence: a GPS location fix or a reset.
+    // Merged input to the single accrual sequence: a GPS location fix, a reset,
+    // or a change of the auto-reset setting.
     private sealed interface TripSignal {
         data class Fix(
             val location: Location,
         ) : TripSignal
 
         data object Reset : TripSignal
+
+        data class AutoResetChanged(
+            val setting: TripAutoResetSetting,
+        ) : TripSignal
     }
 
     private companion object {
         const val NANOS_PER_SECOND = 1_000_000_000.0
+        const val NANOS_PER_MILLI = 1_000_000L
 
         // Must be strictly positive; covers same-instant emissions where
         // the boot clock didn't advance.

--- a/app/src/main/java/io/github/seijikohara/femto/data/location/TripState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/TripState.kt
@@ -3,9 +3,11 @@ package io.github.seijikohara.femto.data.location
 /**
  * Cumulative trip metrics for the dashboard's speed overlay.
  *
- * A trip spans reset to reset: the totals survive process restarts (persisted
- * via [TripStateStore]) and only the user's reset tap starts a new trip.
- * `distanceMeters` is the total ground distance covered this trip.
+ * A trip runs from one boundary to the next — the user's reset tap or, with
+ * [TripAutoResetSetting] timed, the first fix after the car sat parked past the
+ * configured gap; the totals survive process restarts (persisted via
+ * [TripStateStore]). `distanceMeters` is the total ground distance covered
+ * this trip.
  * `avgSpeedMs` is the overall trip average — total distance divided by the
  * total tracked time, including time spent stopped (only untracked gaps, e.g.
  * the app backgrounded or the process dead, are excluded at the repository
@@ -13,7 +15,7 @@ package io.github.seijikohara.femto.data.location
  * reported fix speed when the GPS chip supplies one, otherwise the
  * position-derived speed so the hero numeral still moves on speed-less HALs.
  * `startedAtEpochMs` is the wall-clock time of the trip's first accepted GPS
- * fix — null until one lands after a reset (or on the very first run).
+ * fix — null until one lands after a boundary (or on the very first run).
  *
  * All metrics default to zero so the speed overlay always renders; a fresh
  * subscriber sees the running total (or `Initial` before the first

--- a/app/src/main/java/io/github/seijikohara/femto/data/location/TripStatePreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/TripStatePreferences.kt
@@ -73,9 +73,13 @@ internal fun Double?.orZeroWhenUnusable(): Double = this?.takeIf { it.isFinite()
 private fun MutablePreferences.setOrRemove(
     key: Preferences.Key<Long>,
     value: Long?,
-) = when (value) {
-    null -> remove(key)
-    else -> set(key, value)
+) {
+    // A statement, not an expression: remove() returns the old value and set()
+    // Unit, so the expression form would infer Any for a side-effect helper.
+    when (value) {
+        null -> remove(key)
+        else -> set(key, value)
+    }
 }
 
 /** DataStore-backed accessor for [PersistedTrip]. */

--- a/app/src/main/java/io/github/seijikohara/femto/data/location/TripStatePreferences.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/data/location/TripStatePreferences.kt
@@ -2,6 +2,7 @@ package io.github.seijikohara.femto.data.location
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
@@ -17,15 +18,18 @@ private const val TAG = "TripStatePreferences"
  * Trip accumulator snapshot persisted across process restarts.
  *
  * Only the fields that stay meaningful in a new process are stored: the
- * running totals, the trip-start wall-clock time, and the trip counter.
- * The GPS anchor and the current speed are deliberately absent — the anchor's
- * `elapsedRealtimeNanos` is boot-relative (worthless after a reboot) and the
- * speed re-establishes from the first live fix.
+ * running totals, the trip-start wall-clock time, the wall-clock time of the
+ * last accepted fix (the anchor for the parked-gap auto-reset, which must span
+ * a reboot), and the trip counter. The GPS anchor and the current speed are
+ * deliberately absent — the anchor's `elapsedRealtimeNanos` is boot-relative
+ * (worthless after a reboot) and the speed re-establishes from the first live
+ * fix.
  */
 internal data class PersistedTrip(
     val totalMeters: Double,
     val totalSeconds: Double,
     val startedAtEpochMs: Long?,
+    val lastFixEpochMs: Long?,
     val tripId: Long,
 ) {
     companion object {
@@ -34,6 +38,7 @@ internal data class PersistedTrip(
                 totalMeters = 0.0,
                 totalSeconds = 0.0,
                 startedAtEpochMs = null,
+                lastFixEpochMs = null,
                 tripId = 0L,
             )
     }
@@ -63,6 +68,16 @@ private val Context.tripStateDataStore: DataStore<Preferences> by preferencesDat
 // Internal so the guard is JVM-unit-testable without real DataStore IO.
 internal fun Double?.orZeroWhenUnusable(): Double = this?.takeIf { it.isFinite() && it >= 0.0 } ?: 0.0
 
+// A null optional field is an absent key, not a stored sentinel, so the read
+// path's plain `prefs[KEY]` yields null for it.
+private fun MutablePreferences.setOrRemove(
+    key: Preferences.Key<Long>,
+    value: Long?,
+) = when (value) {
+    null -> remove(key)
+    else -> set(key, value)
+}
+
 /** DataStore-backed accessor for [PersistedTrip]. */
 internal class TripStatePreferences(
     private val context: Context,
@@ -75,6 +90,7 @@ internal class TripStatePreferences(
                     totalMeters = prefs[TOTAL_METERS_KEY].orZeroWhenUnusable(),
                     totalSeconds = prefs[TOTAL_SECONDS_KEY].orZeroWhenUnusable(),
                     startedAtEpochMs = prefs[STARTED_AT_KEY],
+                    lastFixEpochMs = prefs[LAST_FIX_KEY],
                     tripId = prefs[TRIP_ID_KEY] ?: 0L,
                 )
             }.first()
@@ -83,10 +99,8 @@ internal class TripStatePreferences(
         context.tripStateDataStore.editOrLog(TAG) { prefs ->
             prefs[TOTAL_METERS_KEY] = value.totalMeters
             prefs[TOTAL_SECONDS_KEY] = value.totalSeconds
-            when (val startedAt = value.startedAtEpochMs) {
-                null -> prefs.remove(STARTED_AT_KEY)
-                else -> prefs[STARTED_AT_KEY] = startedAt
-            }
+            prefs.setOrRemove(STARTED_AT_KEY, value.startedAtEpochMs)
+            prefs.setOrRemove(LAST_FIX_KEY, value.lastFixEpochMs)
             prefs[TRIP_ID_KEY] = value.tripId
         }
     }
@@ -95,6 +109,7 @@ internal class TripStatePreferences(
         val TOTAL_METERS_KEY = doublePreferencesKey("trip_total_meters")
         val TOTAL_SECONDS_KEY = doublePreferencesKey("trip_total_seconds")
         val STARTED_AT_KEY = longPreferencesKey("trip_started_at_epoch_ms")
+        val LAST_FIX_KEY = longPreferencesKey("trip_last_fix_epoch_ms")
         val TRIP_ID_KEY = longPreferencesKey("trip_id")
     }
 }

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsUiState.kt
@@ -26,6 +26,7 @@ import io.github.seijikohara.femto.data.display.UiScale
 import io.github.seijikohara.femto.data.location.LocationQualitySetting
 import io.github.seijikohara.femto.data.location.LocationSettings
 import io.github.seijikohara.femto.data.location.TrackRetentionSetting
+import io.github.seijikohara.femto.data.location.TripAutoResetSetting
 
 /** State for the in-app settings screen: the persisted display + font choices. */
 internal data class SettingsUiState(
@@ -88,6 +89,7 @@ internal data class SettingsUiState(
     val locationIntervalMillis: Long,
     val locationMinDistanceMeters: Int,
     val backgroundRangingEnabled: Boolean,
+    val tripAutoReset: TripAutoResetSetting,
     val trackRecordingEnabled: Boolean,
     val trackRetention: TrackRetentionSetting,
     val trackExport: TrackExportState = TrackExportState.Idle,
@@ -157,6 +159,7 @@ internal data class SettingsUiState(
                 locationIntervalMillis = LocationSettings.Default.intervalMillis,
                 locationMinDistanceMeters = LocationSettings.Default.minUpdateDistanceMeters,
                 backgroundRangingEnabled = LocationSettings.Default.backgroundRangingEnabled,
+                tripAutoReset = LocationSettings.Default.tripAutoReset,
                 trackRecordingEnabled = LocationSettings.Default.trackRecordingEnabled,
                 trackRetention = LocationSettings.Default.trackRetention,
                 mapBackend = DisplaySettings.Default.mapBackend,
@@ -353,6 +356,10 @@ internal sealed interface SettingsAction {
 
     data class SetBackgroundRanging(
         val value: Boolean,
+    ) : SettingsAction
+
+    data class SetTripAutoReset(
+        val value: TripAutoResetSetting,
     ) : SettingsAction
 
     data class SetTrackRecording(

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/SettingsViewModel.kt
@@ -122,6 +122,7 @@ internal class SettingsViewModel(
                 locationIntervalMillis = location.intervalMillis,
                 locationMinDistanceMeters = location.minUpdateDistanceMeters,
                 backgroundRangingEnabled = location.backgroundRangingEnabled,
+                tripAutoReset = location.tripAutoReset,
                 trackRecordingEnabled = location.trackRecordingEnabled,
                 trackRetention = location.trackRetention,
                 availableCalendars = catalog.calendars,
@@ -324,6 +325,10 @@ internal class SettingsViewModel(
 
                 is SettingsAction.SetBackgroundRanging -> {
                     locationPreferences.setBackgroundRangingEnabled(action.value)
+                }
+
+                is SettingsAction.SetTripAutoReset -> {
+                    locationPreferences.setTripAutoReset(action.value)
                 }
 
                 is SettingsAction.SetTrackRecording -> {

--- a/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/LocationSection.kt
+++ b/app/src/main/java/io/github/seijikohara/femto/ui/settings/components/LocationSection.kt
@@ -12,6 +12,7 @@ import com.composables.icons.lucide.Trash2
 import io.github.seijikohara.femto.R
 import io.github.seijikohara.femto.data.location.LocationQualitySetting
 import io.github.seijikohara.femto.data.location.TrackRetentionSetting
+import io.github.seijikohara.femto.data.location.TripAutoResetSetting
 import io.github.seijikohara.femto.ui.settings.SettingsAction
 import io.github.seijikohara.femto.ui.settings.SettingsUiState
 import io.github.seijikohara.femto.ui.settings.TrackExportState
@@ -75,6 +76,22 @@ internal fun LocationSection(
         checked = uiState.backgroundRangingEnabled,
         onCheckedChange = { onAction(SettingsAction.SetBackgroundRanging(it)) },
         summary = stringResource(R.string.settings_background_ranging_desc),
+    )
+    // The trip meter's parked-gap rule (TripAutoResetSetting's KDoc has the
+    // rationale); "Never" keeps one trip until the user taps Reset.
+    ChoiceRow(
+        title = stringResource(R.string.settings_group_trip_auto_reset),
+        options =
+            listOf(
+                TripAutoResetSetting.OFF to stringResource(R.string.settings_trip_auto_reset_off),
+                TripAutoResetSetting.MINUTES_30 to stringResource(R.string.settings_trip_auto_reset_30m),
+                TripAutoResetSetting.HOURS_1 to stringResource(R.string.settings_trip_auto_reset_1h),
+                TripAutoResetSetting.HOURS_2 to stringResource(R.string.settings_trip_auto_reset_2h),
+                TripAutoResetSetting.HOURS_4 to stringResource(R.string.settings_trip_auto_reset_4h),
+                TripAutoResetSetting.HOURS_12 to stringResource(R.string.settings_trip_auto_reset_12h),
+            ),
+        selected = uiState.tripAutoReset,
+        onSelect = { onAction(SettingsAction.SetTripAutoReset(it)) },
     )
     SwitchRow(
         title = stringResource(R.string.settings_group_track_recording),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -393,6 +393,13 @@
     <string name="settings_location_min_distance_desc">Skip updates closer than this to the last position; 0 delivers every fix.</string>
     <string name="settings_group_background_ranging">Background ranging</string>
     <string name="settings_background_ranging_desc">Keep measuring distance and average speed while you use another app, such as navigation. Runs continuous GPS with an ongoing notification, so it uses more power.</string>
+    <string name="settings_group_trip_auto_reset">Start a new trip automatically</string>
+    <string name="settings_trip_auto_reset_off">Never (tap Reset only)</string>
+    <string name="settings_trip_auto_reset_30m">After 30 min parked</string>
+    <string name="settings_trip_auto_reset_1h">After 1 h parked</string>
+    <string name="settings_trip_auto_reset_2h">After 2 h parked</string>
+    <string name="settings_trip_auto_reset_4h">After 4 h parked</string>
+    <string name="settings_trip_auto_reset_12h">After 12 h parked</string>
     <string name="settings_group_track_recording">Track recording</string>
     <string name="settings_track_recording_desc">Record position, speed, bearing, and altitude while driving, for later visualization. The history stays on this device.</string>
     <string name="settings_group_track_retention">Keep track history</string>

--- a/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCompletenessTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/diagnostics/SettingsFactsCompletenessTest.kt
@@ -1,23 +1,37 @@
 package io.github.seijikohara.femto.data.diagnostics
 
 import io.github.seijikohara.femto.data.display.DisplaySettings
+import io.github.seijikohara.femto.data.location.LocationSettings
 import org.junit.Test
 import java.lang.reflect.Modifier
 import kotlin.test.assertEquals
 
 /**
- * Completeness drift guard for the SETTINGS dump: every [DisplaySettings] field
- * must surface as a fact, so a field added without a matching fact is caught
- * here instead of silently vanishing from every diagnostics report — the same
- * guard [io.github.seijikohara.femto.data.display.SettingsSectionIdTest] applies
- * to section keys.
+ * Completeness drift guard for the SETTINGS dump: every [DisplaySettings] and
+ * [LocationSettings] field must surface as a fact, so a field added without a
+ * matching fact is caught here instead of silently vanishing from every
+ * diagnostics report — the same guard
+ * [io.github.seijikohara.femto.data.display.SettingsSectionIdTest] applies to
+ * section keys.
  *
- * [propertyToFactLabel] is the bridge: facts that fold several fields into one
- * row (e.g. the light/dark map schemes) repeat the label. Reflection over the
- * data class's declared properties (Java reflection — kotlin-reflect is not on
- * the classpath) is the authoritative set the bridge is checked against.
+ * [propertyToFactLabel] and [locationPropertyToFactLabel] are the bridges: facts
+ * that fold several fields into one row (e.g. the light/dark map schemes) repeat
+ * the label. Reflection over the data class's declared properties (Java
+ * reflection — kotlin-reflect is not on the classpath) is the authoritative set
+ * each bridge is checked against.
  */
 class SettingsFactsCompletenessTest {
+    private val locationPropertyToFactLabel: Map<String, String> =
+        mapOf(
+            "quality" to "Location quality",
+            "intervalMillis" to "Location interval",
+            "minUpdateDistanceMeters" to "Location min distance",
+            "backgroundRangingEnabled" to "Background ranging",
+            "tripAutoReset" to "Trip auto-reset",
+            "trackRecordingEnabled" to "Track recording",
+            "trackRetention" to "Track retention",
+        )
+
     private val propertyToFactLabel: Map<String, String> =
         mapOf(
             "themeMode" to "Theme mode",
@@ -72,13 +86,7 @@ class SettingsFactsCompletenessTest {
 
     @Test
     fun `every DisplaySettings property is mapped to a settings fact`() {
-        val declaredProperties =
-            DisplaySettings::class.java.declaredFields
-                .filterNot { it.isSynthetic || Modifier.isStatic(it.modifiers) }
-                .map { it.name }
-                .toSet()
-
-        assertEquals(declaredProperties, propertyToFactLabel.keys)
+        assertEquals(declaredProperties(DisplaySettings::class.java), propertyToFactLabel.keys)
     }
 
     @Test
@@ -87,4 +95,22 @@ class SettingsFactsCompletenessTest {
 
         assertEquals(propertyToFactLabel.values.toSet(), emittedLabels)
     }
+
+    @Test
+    fun `every LocationSettings property is mapped to a settings fact`() {
+        assertEquals(declaredProperties(LocationSettings::class.java), locationPropertyToFactLabel.keys)
+    }
+
+    @Test
+    fun `the collector emits every mapped location fact label`() {
+        val emittedLabels = locationSettingsFacts(LocationSettings.Default).map { it.label }.toSet()
+
+        assertEquals(locationPropertyToFactLabel.values.toSet(), emittedLabels)
+    }
+
+    private fun declaredProperties(type: Class<*>): Set<String> =
+        type.declaredFields
+            .filterNot { it.isSynthetic || Modifier.isStatic(it.modifiers) }
+            .map { it.name }
+            .toSet()
 }

--- a/app/src/test/java/io/github/seijikohara/femto/data/location/TripRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/location/TripRepositoryTest.kt
@@ -563,11 +563,10 @@ class TripRepositoryTest {
         runTest {
             val store =
                 FakeTripStateStore(
-                    PersistedTrip(
+                    PersistedTrip.Initial.copy(
                         totalMeters = 1_000.0,
                         totalSeconds = 100.0,
                         startedAtEpochMs = 42L,
-                        lastFixEpochMs = null,
                         tripId = 3L,
                     ),
                 )
@@ -586,13 +585,7 @@ class TripRepositoryTest {
         runTest {
             val store =
                 FakeTripStateStore(
-                    PersistedTrip(
-                        totalMeters = 500.0,
-                        totalSeconds = 50.0,
-                        startedAtEpochMs = 42L,
-                        lastFixEpochMs = null,
-                        tripId = 0L,
-                    ),
+                    PersistedTrip.Initial.copy(totalMeters = 500.0, totalSeconds = 50.0, startedAtEpochMs = 42L),
                 )
             val repository = TripRepository(flowOf(), store)
 
@@ -673,16 +666,7 @@ class TripRepositoryTest {
                 awaitItem()
 
                 // The reset writes through synchronously on the accrual sequence.
-                assertEquals(
-                    PersistedTrip(
-                        totalMeters = 0.0,
-                        totalSeconds = 0.0,
-                        startedAtEpochMs = null,
-                        lastFixEpochMs = null,
-                        tripId = 1L,
-                    ),
-                    store.stored,
-                )
+                assertEquals(PersistedTrip.Initial.copy(tripId = 1L), store.stored)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -992,7 +976,7 @@ class TripRepositoryTest {
         runTest {
             val store =
                 FakeTripStateStore(
-                    PersistedTrip(
+                    PersistedTrip.Initial.copy(
                         totalMeters = 1_000.0,
                         totalSeconds = 100.0,
                         startedAtEpochMs = NOON_MS - 600_000L,
@@ -1025,7 +1009,7 @@ class TripRepositoryTest {
             // gap, so the totals stand and the first live fix decides.
             val store =
                 FakeTripStateStore(
-                    PersistedTrip(
+                    PersistedTrip.Initial.copy(
                         totalMeters = 1_000.0,
                         totalSeconds = 100.0,
                         startedAtEpochMs = 42L,
@@ -1096,10 +1080,11 @@ class TripRepositoryTest {
         }
 
     @Test
-    fun `does not start a new trip when the wall clock jumps backward`() =
+    fun `ignores the wall clock once this process has seen a fix`() =
         runTest {
-            // A mid-trip clock correction larger than the gap, backward: a
-            // negative span is not a parked gap, so the trip keeps accruing.
+            // A mid-trip clock correction larger than the gap, backward. The
+            // boot-clock span (10 s) governs in-process, so the wall clock is
+            // never consulted and the trip keeps accruing.
             val flow =
                 flowOf(
                     fakeLocation(latitude = ORIGIN_LAT, timeMs = NOON_MS, speedMps = 11f, elapsedRealtimeNanos = 0L),
@@ -1121,6 +1106,83 @@ class TripRepositoryTest {
                 val second = awaitItem()
                 assertEquals(first.startedAtEpochMs, second.startedAtEpochMs)
                 assertTrue(second.distanceMeters > 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `starts a new trip at the first fix of a process that lands after the parked gap`() =
+        runTest {
+            // The window-open check saw no gap (the clock still reads the last
+            // fix's time), so the first fix decides — on the wall clock, the only
+            // stamp that spans the restart.
+            val store =
+                FakeTripStateStore(
+                    PersistedTrip.Initial.copy(
+                        totalMeters = 1_000.0,
+                        totalSeconds = 100.0,
+                        startedAtEpochMs = 42L,
+                        lastFixEpochMs = NOON_MS,
+                        tripId = 3L,
+                    ),
+                )
+            val nextDrive = NOON_MS + parkedGapMs
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, timeMs = nextDrive, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                )
+
+            TripRepository(
+                flow,
+                store,
+                autoReset = flowOf(TripAutoResetSetting.HOURS_2),
+                nowEpochMs = { NOON_MS },
+            ).stateFlow().test {
+                assertEquals(1_000.0, awaitItem().distanceMeters, 0.0) // restored, no gap yet
+                val fresh = awaitItem()
+                assertEquals(0.0, fresh.distanceMeters, 0.0)
+                assertEquals(nextDrive, fresh.startedAtEpochMs)
+                assertEquals(4L, store.stored.tripId)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `keeps the persisted trip when the first fix of a process predates its last fix`() =
+        runTest {
+            // Clock skew between the old and the new boot: a first fix stamped
+            // before the persisted last fix is a negative span, not a parked gap.
+            val store =
+                FakeTripStateStore(
+                    PersistedTrip.Initial.copy(
+                        totalMeters = 1_000.0,
+                        totalSeconds = 100.0,
+                        startedAtEpochMs = 42L,
+                        lastFixEpochMs = NOON_MS,
+                        tripId = 3L,
+                    ),
+                )
+            val flow =
+                flowOf(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT,
+                        timeMs = NOON_MS - parkedGapMs - 1_000L,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = 0L,
+                    ),
+                )
+
+            TripRepository(
+                flow,
+                store,
+                autoReset = flowOf(TripAutoResetSetting.HOURS_2),
+                nowEpochMs = { NOON_MS },
+            ).stateFlow().test {
+                awaitItem() // restored snapshot
+                val afterFix = awaitItem()
+                assertEquals(42L, afterFix.startedAtEpochMs)
+                assertEquals(1_000.0, afterFix.distanceMeters, 0.0)
+                assertEquals(3L, store.stored.tripId)
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/app/src/test/java/io/github/seijikohara/femto/data/location/TripRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/location/TripRepositoryTest.kt
@@ -1148,6 +1148,56 @@ class TripRepositoryTest {
         }
 
     @Test
+    fun `starts a new trip when the window reopens after the parked gap in the same process`() =
+        runTest {
+            // A head unit that slept through the gap: the process lived on, so the
+            // boot clock carries the span and the replay on re-subscription already
+            // shows the next drive's zeros — before any fix arrives.
+            val source = MutableSharedFlow<Location?>(replay = 0)
+            var bootNanos = 0L
+            val repository =
+                TripRepository(
+                    source,
+                    FakeTripStateStore(),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                    nowElapsedRealtimeNanos = { bootNanos },
+                    autoReset = flowOf(TripAutoResetSetting.HOURS_2),
+                )
+
+            repository.stateFlow().test {
+                awaitItem() // initial snapshot
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT,
+                        timeMs = NOON_MS,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(1),
+                    ),
+                )
+                awaitItem()
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + STEP,
+                        timeMs = NOON_MS + 10_000L,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(2),
+                    ),
+                )
+                assertTrue(awaitItem().distanceMeters > 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            // The boot clock ran past the gap while nobody was subscribed.
+            bootNanos = tenSeconds(2) + millisToNanos(parkedGapMs)
+            repository.stateFlow().test {
+                val replayed = awaitItem()
+                assertEquals(0.0, replayed.distanceMeters, 0.0)
+                assertNull(replayed.startedAtEpochMs)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `keeps the persisted trip when the first fix of a process predates its last fix`() =
         runTest {
             // Clock skew between the old and the new boot: a first fix stamped

--- a/app/src/test/java/io/github/seijikohara/femto/data/location/TripRepositoryTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/data/location/TripRepositoryTest.kt
@@ -7,6 +7,7 @@ import io.github.seijikohara.femto.testfixtures.FakeTripStateStore
 import io.github.seijikohara.femto.testfixtures.fakeLocation
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -562,7 +563,13 @@ class TripRepositoryTest {
         runTest {
             val store =
                 FakeTripStateStore(
-                    PersistedTrip(totalMeters = 1_000.0, totalSeconds = 100.0, startedAtEpochMs = 42L, tripId = 3L),
+                    PersistedTrip(
+                        totalMeters = 1_000.0,
+                        totalSeconds = 100.0,
+                        startedAtEpochMs = 42L,
+                        lastFixEpochMs = null,
+                        tripId = 3L,
+                    ),
                 )
 
             TripRepository(flowOf(), store).stateFlow().test {
@@ -579,7 +586,13 @@ class TripRepositoryTest {
         runTest {
             val store =
                 FakeTripStateStore(
-                    PersistedTrip(totalMeters = 500.0, totalSeconds = 50.0, startedAtEpochMs = 42L, tripId = 0L),
+                    PersistedTrip(
+                        totalMeters = 500.0,
+                        totalSeconds = 50.0,
+                        startedAtEpochMs = 42L,
+                        lastFixEpochMs = null,
+                        tripId = 0L,
+                    ),
                 )
             val repository = TripRepository(flowOf(), store)
 
@@ -661,7 +674,13 @@ class TripRepositoryTest {
 
                 // The reset writes through synchronously on the accrual sequence.
                 assertEquals(
-                    PersistedTrip(totalMeters = 0.0, totalSeconds = 0.0, startedAtEpochMs = null, tripId = 1L),
+                    PersistedTrip(
+                        totalMeters = 0.0,
+                        totalSeconds = 0.0,
+                        startedAtEpochMs = null,
+                        lastFixEpochMs = null,
+                        tripId = 1L,
+                    ),
                     store.stored,
                 )
                 cancelAndIgnoreRemainingEvents()
@@ -805,6 +824,307 @@ class TripRepositoryTest {
             }
         }
 
+    @Test
+    fun `starts a new trip when a fix arrives after the parked gap`() =
+        runTest {
+            val source = MutableSharedFlow<Location?>(replay = 0)
+            val repository =
+                TripRepository(
+                    source,
+                    FakeTripStateStore(),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                    autoReset = flowOf(TripAutoResetSetting.HOURS_2),
+                )
+
+            repository.stateFlow().test {
+                awaitItem() // initial snapshot
+                source.emit(
+                    fakeLocation(latitude = ORIGIN_LAT, timeMs = NOON_MS, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                )
+                awaitItem()
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + STEP,
+                        timeMs = NOON_MS + 10_000L,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(1),
+                    ),
+                )
+                assertTrue(awaitItem().distanceMeters > 0.0)
+
+                // Parked for the whole gap: the next fix opens a new trip (zero
+                // totals, its own start time) instead of extending this one.
+                val nextDrive = NOON_MS + 10_000L + parkedGapMs
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 2 * STEP,
+                        timeMs = nextDrive,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(1) + millisToNanos(parkedGapMs),
+                    ),
+                )
+                val fresh = awaitItem()
+                assertEquals(0.0, fresh.distanceMeters, 0.0)
+                assertEquals(nextDrive, fresh.startedAtEpochMs)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `persists the new trip id before tapping the first fix of an auto-started trip`() =
+        runTest {
+            val source = MutableSharedFlow<Location?>(replay = 0)
+            val store = FakeTripStateStore()
+            // Pair each tapped id with the id durable in the store at that moment.
+            val tapped = mutableListOf<Pair<Long, Long>>()
+            val repository =
+                TripRepository(
+                    source,
+                    store,
+                    trackTap = TripFixTap { _, tripId -> tapped += tripId to store.stored.tripId },
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                    autoReset = flowOf(TripAutoResetSetting.HOURS_2),
+                )
+
+            repository.stateFlow().test {
+                awaitItem() // initial snapshot
+                source.emit(
+                    fakeLocation(latitude = ORIGIN_LAT, timeMs = NOON_MS, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                )
+                awaitItem()
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + STEP,
+                        timeMs = NOON_MS + parkedGapMs,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = millisToNanos(parkedGapMs),
+                    ),
+                )
+                awaitItem()
+                // The auto-started trip's id is written through before its first
+                // point reaches the track log, exactly as a manual reset's is.
+                assertEquals(listOf(0L to 0L, 1L to 1L), tapped)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `keeps the trip when the fix gap is shorter than the parked gap`() =
+        runTest {
+            val source = MutableSharedFlow<Location?>(replay = 0)
+            val repository =
+                TripRepository(
+                    source,
+                    FakeTripStateStore(),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                    autoReset = flowOf(TripAutoResetSetting.HOURS_2),
+                )
+
+            repository.stateFlow().test {
+                awaitItem() // initial snapshot
+                source.emit(
+                    fakeLocation(latitude = ORIGIN_LAT, timeMs = NOON_MS, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                )
+                awaitItem()
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + STEP,
+                        timeMs = NOON_MS + 10_000L,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(1),
+                    ),
+                )
+                val beforeStop = awaitItem()
+
+                // A stop one second short of the gap (fuel, shopping) belongs to
+                // the same trip: the start stands and nothing is re-zeroed.
+                val shortStop = parkedGapMs - 1_000L
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + STEP,
+                        timeMs = NOON_MS + 10_000L + shortStop,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(1) + millisToNanos(shortStop),
+                    ),
+                )
+                val afterStop = awaitItem()
+                assertEquals(beforeStop.startedAtEpochMs, afterStop.startedAtEpochMs)
+                assertEquals(beforeStop.distanceMeters, afterStop.distanceMeters, 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `never starts a new trip on its own while auto-reset is off`() =
+        runTest {
+            val source = MutableSharedFlow<Location?>(replay = 0)
+            val repository =
+                TripRepository(
+                    source,
+                    FakeTripStateStore(),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                    autoReset = flowOf(TripAutoResetSetting.OFF),
+                )
+
+            repository.stateFlow().test {
+                awaitItem() // initial snapshot
+                source.emit(
+                    fakeLocation(latitude = ORIGIN_LAT, timeMs = NOON_MS, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                )
+                val first = awaitItem()
+                // Three days parked: the original reset-to-reset contract holds.
+                val threeDays = 3 * 24 * 60 * 60_000L
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + STEP,
+                        timeMs = NOON_MS + threeDays,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = millisToNanos(threeDays),
+                    ),
+                )
+                assertEquals(first.startedAtEpochMs, awaitItem().startedAtEpochMs)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `starts a new trip on restore when the persisted trip is older than the parked gap`() =
+        runTest {
+            val store =
+                FakeTripStateStore(
+                    PersistedTrip(
+                        totalMeters = 1_000.0,
+                        totalSeconds = 100.0,
+                        startedAtEpochMs = NOON_MS - 600_000L,
+                        lastFixEpochMs = NOON_MS,
+                        tripId = 3L,
+                    ),
+                )
+
+            TripRepository(
+                flowOf(),
+                store,
+                autoReset = flowOf(TripAutoResetSetting.HOURS_2),
+                nowEpochMs = { NOON_MS + parkedGapMs },
+            ).stateFlow().test {
+                // Zeroed before the first emission, so the dashboard never shows
+                // the previous drive's totals while waiting for a fix, and the
+                // bumped id is durable at once.
+                val restored = awaitItem()
+                assertEquals(0.0, restored.distanceMeters, 0.0)
+                assertNull(restored.startedAtEpochMs)
+                assertEquals(4L, store.stored.tripId)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `keeps the persisted trip on restore when the clock reads before its last fix`() =
+        runTest {
+            // A dead RTC boots into the past: the span is negative, not a parked
+            // gap, so the totals stand and the first live fix decides.
+            val store =
+                FakeTripStateStore(
+                    PersistedTrip(
+                        totalMeters = 1_000.0,
+                        totalSeconds = 100.0,
+                        startedAtEpochMs = 42L,
+                        lastFixEpochMs = NOON_MS,
+                        tripId = 3L,
+                    ),
+                )
+
+            TripRepository(
+                flowOf(),
+                store,
+                autoReset = flowOf(TripAutoResetSetting.HOURS_2),
+                nowEpochMs = { NOON_MS - 24 * 60 * 60_000L },
+            ).stateFlow().test {
+                val restored = awaitItem()
+                assertEquals(1_000.0, restored.distanceMeters, 0.0)
+                assertEquals(42L, restored.startedAtEpochMs)
+                assertEquals(3L, store.stored.tripId)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `applies an auto-reset setting change to the next fix`() =
+        runTest {
+            val source = MutableSharedFlow<Location?>(replay = 0)
+            val setting = MutableStateFlow(TripAutoResetSetting.OFF)
+            val repository =
+                TripRepository(
+                    source,
+                    FakeTripStateStore(),
+                    dispatcher = UnconfinedTestDispatcher(testScheduler),
+                    autoReset = setting,
+                )
+
+            repository.stateFlow().test {
+                awaitItem() // initial snapshot
+                source.emit(
+                    fakeLocation(latitude = ORIGIN_LAT, timeMs = NOON_MS, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                )
+                val first = awaitItem()
+                // Off: a fix a whole gap later still extends the trip.
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + STEP,
+                        timeMs = NOON_MS + parkedGapMs,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = millisToNanos(parkedGapMs),
+                    ),
+                )
+                assertEquals(first.startedAtEpochMs, awaitItem().startedAtEpochMs)
+
+                // Switched on mid-flight: the next fix, another gap later, opens a
+                // new trip without a re-subscription.
+                setting.value = TripAutoResetSetting.HOURS_2
+                val later = NOON_MS + 2 * parkedGapMs
+                source.emit(
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + 2 * STEP,
+                        timeMs = later,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = millisToNanos(2 * parkedGapMs),
+                    ),
+                )
+                assertEquals(later, awaitItem().startedAtEpochMs)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `does not start a new trip when the wall clock jumps backward`() =
+        runTest {
+            // A mid-trip clock correction larger than the gap, backward: a
+            // negative span is not a parked gap, so the trip keeps accruing.
+            val flow =
+                flowOf(
+                    fakeLocation(latitude = ORIGIN_LAT, timeMs = NOON_MS, speedMps = 11f, elapsedRealtimeNanos = 0L),
+                    fakeLocation(
+                        latitude = ORIGIN_LAT + STEP,
+                        timeMs = NOON_MS - parkedGapMs - 1_000L,
+                        speedMps = 11f,
+                        elapsedRealtimeNanos = tenSeconds(1),
+                    ),
+                )
+
+            TripRepository(
+                flow,
+                FakeTripStateStore(),
+                autoReset = flowOf(TripAutoResetSetting.HOURS_2),
+            ).stateFlow().test {
+                awaitItem() // initial snapshot
+                val first = awaitItem()
+                val second = awaitItem()
+                assertEquals(first.startedAtEpochMs, second.startedAtEpochMs)
+                assertTrue(second.distanceMeters > 0.0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private companion object {
         const val ORIGIN_LAT = 35.6580
 
@@ -816,10 +1136,19 @@ class TripRepositoryTest {
         // accumulated delta clears the trust floor).
         const val SMALL_STEP = STEP / 20
 
+        // An arbitrary wall-clock instant for fixes whose Location.time matters.
+        const val NOON_MS = 1_700_000_000_000L
+
+        // The configured parked gap, read off the setting so the fixture can
+        // never drift from the production threshold.
+        val parkedGapMs: Long = checkNotNull(TripAutoResetSetting.HOURS_2.parkedGapMs)
+
         // n * 10 s expressed in boot-clock nanoseconds.
         fun tenSeconds(n: Long): Long = n * 10_000_000_000L
 
         // n * 250 ms expressed in boot-clock nanoseconds.
         fun quarterSecond(n: Long): Long = n * 250_000_000L
+
+        fun millisToNanos(ms: Long): Long = ms * 1_000_000L
     }
 }

--- a/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeLocationSettingsStore.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/testfixtures/FakeLocationSettingsStore.kt
@@ -4,6 +4,7 @@ import io.github.seijikohara.femto.data.location.LocationQualitySetting
 import io.github.seijikohara.femto.data.location.LocationSettings
 import io.github.seijikohara.femto.data.location.LocationSettingsStore
 import io.github.seijikohara.femto.data.location.TrackRetentionSetting
+import io.github.seijikohara.femto.data.location.TripAutoResetSetting
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -32,6 +33,8 @@ internal class FakeLocationSettingsStore(
         state.update {
             it.copy(backgroundRangingEnabled = value)
         }
+
+    override suspend fun setTripAutoReset(value: TripAutoResetSetting) = state.update { it.copy(tripAutoReset = value) }
 
     override suspend fun setTrackRecordingEnabled(value: Boolean) =
         state.update {

--- a/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/seijikohara/femto/ui/settings/SettingsViewModelTest.kt
@@ -24,6 +24,7 @@ import io.github.seijikohara.femto.data.fonts.FontSlot
 import io.github.seijikohara.femto.data.fonts.FontSource
 import io.github.seijikohara.femto.data.location.LocationQualitySetting
 import io.github.seijikohara.femto.data.location.LocationSettings
+import io.github.seijikohara.femto.data.location.TripAutoResetSetting
 import io.github.seijikohara.femto.testfixtures.FakeCalendarPreferencesStore
 import io.github.seijikohara.femto.testfixtures.FakeDisplaySettingsStore
 import io.github.seijikohara.femto.testfixtures.FakeDockSettingsStore
@@ -604,6 +605,26 @@ class SettingsViewModelTest {
             advanceUntilIdle()
             assertEquals(GoogleMapType.SATELLITE, vm.uiState.value.googleMapsMapType)
             assertEquals(true, vm.uiState.value.googleMapsTraffic)
+        }
+
+    @Test
+    fun `SetTripAutoReset writes the value to the store`() =
+        runTest(dispatcher) {
+            viewModel().onAction(SettingsAction.SetTripAutoReset(TripAutoResetSetting.OFF))
+            advanceUntilIdle()
+            assertEquals(TripAutoResetSetting.OFF, locationStore.settings.first().tripAutoReset)
+        }
+
+    @Test
+    fun `SetTripAutoReset surfaces in uiState`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            backgroundScope.launch { vm.uiState.collect { } }
+            advanceUntilIdle()
+
+            vm.onAction(SettingsAction.SetTripAutoReset(TripAutoResetSetting.HOURS_12))
+            advanceUntilIdle()
+            assertEquals(TripAutoResetSetting.HOURS_12, vm.uiState.value.tripAutoReset)
         }
 
     @Test


### PR DESCRIPTION
## Summary

The trip meter now starts a new trip on its own after the car sat parked past a configurable gap, alongside the existing manual Reset tap. Default: 2 hours. A new Settings → Location row, "Start a new trip automatically", offers Never (the previous reset-to-reset behaviour) / 30 min / 1 h / 2 h / 4 h / 12 h.

## Why

Until now a trip ran from reset tap to reset tap. Nobody taps Reset every morning, so the flyover's trip list held one giant trip and "Since HH:MM" pointed at a time days old. On a head unit or AI box, one drive should be one trip by default.

The boundary is a **gap in accepted GPS fixes**, not the app's lifecycle, because the three device classes disagree about lifecycle: an AI box cold-boots per drive, a built-in head unit deep-sleeps through many ignition cycles (the process lives for days), and a phone reopens the launcher several times per drive. Power loss never delivers an "end" event either. A fix gap is the one signal all three share, and it is the rule car trip computers apply to their "since start" memory: a fuel or shopping stop continues the trip, an overnight park does not.

Hours rather than minutes: with background ranging off, a navigation app held in front stops fixes reaching the launcher, so a minutes-scale gap would split a drive on every long navigation session. That interaction is documented in the `TripRepository` KDoc; background ranging keeps the fixes, and the trip, flowing.

## Design

- `TripAutoResetSetting(parkedGapMs)` in `LocationPreferences` (`location_preferences`, key `trip_auto_reset`); the odometer itself stays in `trip_state`, so a Location-settings reset returns the rule to 2 h without touching the running totals.
- `PersistedTrip.lastFixEpochMs` (`trip_last_fix_epoch_ms`) records the wall-clock time of the last accepted fix, the one stamp that survives a reboot.
- `TripRepository` measures the span on the **boot clock** while the process has seen a fix (immune to wall-clock corrections, keeps counting through deep sleep) and falls back to the wall clock only for the first gap after a process restart. A negative span (a clock that ran backward, a dead RTC booting into the past) is never a gap.
- The check runs on every accepted fix and as each subscription window opens, so a trip parked past the gap ends before the first fix arrives and the dashboard shows the next drive's zeros through GNSS warm-up. The bumped trip id is written through before the new trip's first track point is logged, exactly as a manual reset's is (`startNextTrip()` is shared by both paths).
- The setting reaches the repository as a third merged signal on the single accrual sequence, and is re-read as the window opens so a change made while the dashboard was away is not missed.
- Diagnostics: new "Trip auto-reset" fact; `SettingsFactsCompletenessTest` now guards `LocationSettings` as well as `DisplaySettings`.

## Tests

`TripRepositoryTest` (11 new): new trip after the gap; trip id durable before the first tap; shorter gap keeps the trip; Never keeps it; restore-time reset; dead-RTC restore keeps it; setting change applies to the next fix; the wall clock is ignored once the process has seen a fix; first fix of a process after the gap starts a new trip; first fix of a process that predates the last fix keeps it; same-process window reopen after the gap starts a new trip. `SettingsViewModelTest`: store write + uiState. `SettingsFactsCompletenessTest`: LocationSettings completeness. No settings golden exists, so no screenshot re-record.

## Review follow-ups (commits 3–4)

Two review passes (project-conventions reviewer, bug hunt) found nothing blocking. Their suggestions landed as follow-up commits: the Reset branch emits before its write-through again so the tap's zeros never wait on the disk (only the parked-gap boundary needs write-before-tap); the backward-clock test is named for what it proves; two first-fix-of-a-process cases cover the wall-clock fallback in both directions; a same-process window-reopen case covers the boot-clock entry point; `setOrRemove` is a statement; `PersistedTrip` test literals derive from `Initial`; the `TripAutoResetSetting` KDoc scopes the hours-vs-minutes argument to the default.

One design note the reviewer raised, kept as is: the copy says "After N h parked" while the rule is "no GPS fix accepted for N h". They diverge only with background ranging on, where a car sitting with fixes still flowing never auto-resets. That matches the ignition-off semantics of a car's "since start" memory and keeps an idling wait from splitting a trip.

## Verification

- `./gradlew spotlessCheck` — passed.
- `./gradlew assembleDebug` — BUILD SUCCESSFUL.
- `./gradlew lint` — 11 warnings, all pre-existing; none on changed lines (the one `strings.xml` hit is the untouched `settings_visible_calendars_count` string, shifted by the inserted lines).
- `./gradlew test` — 906 tests, 0 failures.
- TBox-Mock-Play emulator: the new row renders in Settings → Location after Background ranging with the summary "After 2 h parked"; the radio dialog lists all six options with 2 h selected; choosing "Never (tap Reset only)" updates the summary, and choosing 2 h again restores it.

## Notes

- Branch name is the worktree's auto-generated `worktree-trip-auto-reset`; the PR title carries the Conventional Commits subject for the squash.
- The OEM "since start" thresholds cited in the design discussion (roughly 2–4 h) could not be re-confirmed from manufacturer manuals this session; the 2 h default is a product decision, adjustable in Settings.
