### PR TITLE
fix(privacy): keep the recorded trip track out of Auto Backup

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Effective date: 2026-06-22**
+**Effective date: 2026-09-10**
 
 Femto Car Launcher ("the app") is an Android home launcher. This policy explains
 what data the app accesses, why, and who it is shared with. The app does **not**
@@ -11,6 +11,7 @@ contain advertising or analytics SDKs, and does **not** sell personal data.
 | Data | Why | Leaves the device? |
 | --- | --- | --- |
 | **Precise / approximate location** | Show the map, the current address, local weather, and trip distance | Yes — see "Third parties" below |
+| **Recorded trip track** (position, speed, bearing, altitude) | Draw the trip visualization and export a GPX file when you ask for one | No — stored on the device only, and excluded from backup (see "Backup") |
 | **Calendar events** (read only) | Show upcoming events on the dashboard | No |
 | **Microphone** | Voice assistant input and the optional music spectrum visualization | The app does not store or transmit audio; voice input is handled by the device's speech recognizer (see below) |
 | **Installed apps** (launcher app list) | Show and launch installed apps | No |
@@ -18,10 +19,19 @@ contain advertising or analytics SDKs, and does **not** sell personal data.
 | **Media playback metadata** | Show the now-playing card | No |
 | **App settings** | Remember your preferences | Device backup only (see "Backup") |
 
-The app stores location, trip, calendar, music, and voice data only in memory
-while running. None of it is written to disk or transmitted, except the location
-coordinates sent to the third-party services below to render the map, address,
-and weather.
+Calendar, music, and voice data are held only in memory while the app runs; none
+of it is written to disk or transmitted. Location coordinates are transmitted, to
+the third-party services listed below, to render the map, the address, and the
+weather.
+
+The one thing the app writes to disk is the recorded trip track. While trip
+recording is on — it is on by default and can be turned off in **Settings →
+Location** — the app stores each position fix, with its speed, bearing, and
+altitude, in a database on the device. That history is kept for 90 days by
+default; **Settings → Location** offers 30 days, 90 days, a year, or no limit,
+and older points are deleted automatically. The history never leaves the device
+on its own: it is excluded from backup and device transfer, and it is sent
+nowhere. Exporting a trip as a GPX file writes it to the location you choose.
 
 ## Third parties
 
@@ -79,7 +89,9 @@ control.
 ## Backup
 
 Android Auto Backup may copy app settings to your Google account. Location-related
-settings are **excluded** from backup and device transfer.
+settings and the recorded trip track are **excluded** from backup and device
+transfer, so neither your position history nor your location settings is copied
+off the device.
 
 ## Children
 

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -7,4 +7,6 @@
 <full-backup-content>
     <!-- display_preferences (incl. the user's BYO Mapbox token / Google Maps key) deliberately stays in backup: both are client-side keys designed to live in distributed apps, and restoring them avoids re-entry on a new head unit. location_preferences stays excluded (position history is not portable state). -->
     <exclude domain="file" path="datastore/location_preferences.preferences_pb" />
+    <!-- The recorded trip track (1 Hz position, speed, bearing, altitude; recording is on by default and the history is kept for 90 days) is the most sensitive data the app holds. Auto Backup includes the database domain by default, which would copy that history to the user's Google account — the opposite of what Settings promises ("The history stays on this device"). -->
+    <exclude domain="database" path="track_log.db" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -9,8 +9,12 @@
     <cloud-backup>
         <!-- display_preferences (incl. the user's BYO Mapbox token / Google Maps key) deliberately stays in backup: both are client-side keys designed to live in distributed apps, and restoring them avoids re-entry on a new head unit. location_preferences stays excluded (position history is not portable state). -->
         <exclude domain="file" path="datastore/location_preferences.preferences_pb" />
+        <!-- The recorded trip track (1 Hz position, speed, bearing, altitude; recording is on by default and the history is kept for 90 days) is the most sensitive data the app holds, and the database domain is backed up by default — so without this the history would be copied to the user's Google account, contradicting what Settings and the privacy policy both promise. -->
+        <exclude domain="database" path="track_log.db" />
     </cloud-backup>
     <device-transfer>
         <exclude domain="file" path="datastore/location_preferences.preferences_pb" />
+        <!-- Excluded from device transfer as well: the track is tied to the vehicle it was recorded in, and a transfer is not a reason to move a position history onto different hardware. -->
+        <exclude domain="database" path="track_log.db" />
     </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
## Summary

The recorded trip track was being copied to the user's Google account, and two places in the product said it was not.

`TrackLogDatabase` is a Room database (`track_log.db`). Auto Backup includes the `database` domain by default, and the backup rules excluded only `datastore/location_preferences.preferences_pb` — so the 1 Hz history of position, speed, bearing and altitude went to Drive. Recording is on by default (`DEFAULT_TRACK_RECORDING_ENABLED`) and the history is kept for 90 days by default (`TrackRetentionSetting.Default`), which makes it the most sensitive data the app holds.

Meanwhile **Settings → Location** says *"The history stays on this device"*, and `PRIVACY.md` said *"None of it is written to disk or transmitted."*

## What changes

- **`backup_rules.xml` / `data_extraction_rules.xml`** exclude `track_log.db` from cloud backup and from device transfer. The Settings promise is now true as written.
- **`PRIVACY.md`** describes the track instead of denying it: what is recorded, that recording is on by default and where to turn it off, the 90-day default retention and the alternatives, that the history is excluded from backup, and that a GPX export writes where the user chooses. A table row is added for it, and the effective date moves to today.

The privacy policy predates trip persistence (it was written 2026-06-22; the track log shipped 2026-07-17), which is how the claim went stale.

## Verification

`spotlessApply`, `assembleDebug`, `lint` and `test` all pass. Lint reports 0 errors and 18 warnings, all pre-existing (six `WebViewClient` render-process notices, one target-API notice, one plurals candidate, and dependency-version notices that fluctuate with upstream releases).

Note for whoever runs the pipeline next: `./gradlew spotlessApply :app:assembleDebug` in one invocation fails on a fresh checkout, because `spotlessMarkdown` picks up `LICENSE.md` under the Node toolchain that `:app:nodeSetup` downloads into `app/.gradle/nodejs/`, which Gradle rejects as an undeclared task dependency. Running the two invocations separately works. Pre-existing, and out of scope here.
